### PR TITLE
Kill xmkmf on 10.13

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/xmkmf.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/xmkmf.info
@@ -1,6 +1,8 @@
 Package: xmkmf
 Version: 1.0.6
 Revision: 1304
+# No llvm-gcc* on 10.13 XMKMFHS
+Distribution: 10.9, 10.10, 10.11, 10.12
 Description: X11 legacy build tools
 License: BSD
 Maintainer:  Dave Morrison <drm@finkproject.org>

--- a/10.9-libcxx/stable/main/finkinfo/graphics/gocr.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/gocr.info
@@ -1,8 +1,8 @@
 Package: gocr 
 Version: 0.50
-Revision: 2
+Revision: 3
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Depends: netpbm11-shlibs, libjpeg-bin, transfig-graphicx
+Depends: netpbm11-shlibs, libjpeg-bin, fig2dev
 BuildDepends: netpbm11
 #Source: mirror:sourceforge:jocr/%n-%v.tar.gz
 Source: http://www-e.uni-magdeburg.de/jschulen/ocr/%n-%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/graphics/gocr.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/gocr.info
@@ -2,7 +2,7 @@ Package: gocr
 Version: 0.50
 Revision: 3
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Depends: netpbm11-shlibs, libjpeg-bin, fig2dev
+Depends: netpbm11-shlibs, libjpeg-bin, fig2dev | transfig-graphicx | transfig-epsfig
 BuildDepends: netpbm11
 #Source: mirror:sourceforge:jocr/%n-%v.tar.gz
 Source: http://www-e.uni-magdeburg.de/jschulen/ocr/%n-%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/graphics/tgif.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/tgif.info
@@ -1,6 +1,8 @@
 Package: tgif
 Version: 4.2.5
 Revision: 3
+# No llvm-gcc* on 10.13 XMKMFHS
+Distribution: 10.9, 10.10, 10.11, 10.12
 
 BuildConflicts: libxt, libxt-flat
 BuildDepends: <<

--- a/10.9-libcxx/stable/main/finkinfo/graphics/transfig.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/transfig.info
@@ -2,9 +2,26 @@ Info2: <<
 Package: transfig%type_pkg[epsfig]
 Version: 3.2.5d
 Revision: 1015
+# No llvm-gcc* on 10.13 XMKMFHS
+Distribution: 10.9, 10.10, 10.11, 10.12
 Type: epsfig (-epsfig -graphicx)
-Depends: x11, libjpeg-bin, libpng16-shlibs, libtiff-bin, netpbm-bin (>= 10.12-3), x11-shlibs
-BuildDepends: libpng16, x11-dev, fink-buildenv-modules (>= 0.1.3-1), fink (>= 0.30.0), xmkmf (>= 1.0.2-3), flag-sort, llvm-gcc42 | llvm-gcc
+Depends: <<
+	libjpeg-bin,
+	libpng16-shlibs,
+	libtiff-bin,
+	netpbm-bin (>= 10.12-3),
+	x11-shlibs,
+	x11
+<<
+BuildDepends: <<
+	fink (>= 0.30.0),
+	fink-buildenv-modules (>= 0.1.3-1),
+	flag-sort,
+	libpng16,
+	llvm-gcc42 | llvm-gcc,
+	x11-dev,
+	xmkmf (>= 1.0.2-3)
+<<
 Conflicts: transfig-epsfig, transfig-graphicx, fig2dev
 Replaces: transfig, transfig-epsfig, transfig-graphicx, fig2dev
 Provides: transfig

--- a/10.9-libcxx/stable/main/finkinfo/graphics/xrmap.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/xrmap.info
@@ -1,6 +1,8 @@
 Package: xrmap
 Version: 2.33
 Revision: 10
+# No llvm-gcc* on 10.13 XMKMFHS
+Distribution: 10.9, 10.10, 10.11, 10.12
 Source: ftp://ftp.ac-grenoble.fr/ge/geosciences/%n/%n-%v.tar.bz2
 Source-MD5: c743f0c90699227d5bdba4984e3edf77
 Source2: ftp://ftp.ac-grenoble.fr/ge/geosciences/%n/data/CIA_WDB2.jpd.bz2
@@ -8,9 +10,27 @@ Source2Rename: CIA_WDB2-20050830.jpd.bz2
 Source2-MD5: 8b5255a685bbb5eef2f86df182731a32
 Source3: ftp://ftp.ac-grenoble.fr/ge/geosciences/%n/data/flags-2.7-xpm_150.tar.bz2
 Source3-MD5: d28ad6d057e824f80673de27d0c94c16
-BuildDepends: x11-dev, libjpeg9, libpng16, xmkmf (>= 1.0.2-3), fink-buildenv-modules (>= 0.1.3-1)
-Depends: x11-shlibs, libjpeg9-shlibs, libpng16-shlibs
-Suggests: qtplay, libjpeg9, libpng16, inkscape, imagemagick, dillo, gv
+BuildDepends: <<
+	fink-buildenv-modules (>= 0.1.3-1),
+	libjpeg9,
+	libpng16,
+	x11-dev,
+	xmkmf (>= 1.0.2-3)
+<<
+Depends: <<
+	libjpeg9-shlibs,
+	libpng16-shlibs,
+	x11-shlibs
+<<
+Suggests: <<
+	dillo,
+	gv,
+	imagemagick,
+	inkscape,
+	libjpeg9,
+	libpng16,
+	qtplay
+<<
 PatchFile: %n.patch
 PatchFile-MD5: 30677d5cf025c62917574a20a4699dc8
 UseMaxBuildJobs: False

--- a/10.9-libcxx/stable/main/finkinfo/kde/kdelibs4.info
+++ b/10.9-libcxx/stable/main/finkinfo/kde/kdelibs4.info
@@ -52,6 +52,7 @@ BuildDepends: <<
 	libtiff5,
 	libxml2,
 	libxslt,
+	openssl100-dev,
 	phonon-%type_pkg[kde] (>= 4.5.0-1),
 	pkgconfig (>= 0.23-1),
 	qca2-%type_pkg[kde] (>= 2.0.3-1),
@@ -77,7 +78,7 @@ PatchScript: <<
 #	patch -p1 < %{PatchFile2}
 <<
 PatchFile: kdelibs4.patch
-PatchFile-MD5: 35b78b554a041368777d61d20a829cea
+PatchFile-MD5: 3cc26ad32e381c9f50bd8bf8ad5c72a0
 #PatchFile2: kdelibs4-nativeDialogs.patch
 #PatchFile2-MD5: 4e971c49cffcce6a683d13e68d46499b
 
@@ -336,6 +337,9 @@ Casting from KJS::JSGlobalObject* to KJS::JSObject* failed with clang
 because it missed the definition of JSGlobalObject.
 http://osdir.com/ml/kde-commits/2011-12/msg07115.html
 d1fe2074b4fbc8253a4533a7e6be24b4f5b20b8b
+
+cmake-3.9 fix
+https://cgit.kde.org/kdelibs.git/commit/?h=KDE/4.14&id=57eaf65accb8d058644dc8eee7332e0ec0c1952f
 
 OpenSSL is not linked directly, but is loaded at runtime by libkio.5.dylib.
 So make sure that it at least searches for a libcrypto/libssl that exists on 

--- a/10.9-libcxx/stable/main/finkinfo/kde/kdelibs4.info
+++ b/10.9-libcxx/stable/main/finkinfo/kde/kdelibs4.info
@@ -1,7 +1,7 @@
 Info4: <<
 Package: kdelibs4-%type_pkg[kde]
 Version: 4.14.6
-Revision: 3
+Revision: 4
 Description: KDE4 - Essential libraries
 Type: kde (mac)
 License: GPL/LGPL
@@ -60,8 +60,7 @@ BuildDepends: <<
 	shared-mime-info (>= 0.51-1),
 	soprano-%type_pkg[kde]-dev (>= 2.9.4-1),
 	strigi-dev (>= 0.6.3-1),
-	(%type_pkg[kde] = x11) x11-dev,
-	xmkmf
+	(%type_pkg[kde] = x11) x11-dev
 <<
 BuildConflicts: gamin-dev
 Replaces: %N-shlibs (<< %v-%r)
@@ -261,9 +260,9 @@ SplitOff2: <<
 	Package: %N-dev
 	Description: KDE4 - Essential development files
 	Depends: <<
-		%N (= %v-%r),
-		xmkmf
+		%N (= %v-%r)
 	<<
+	Suggests: xmkmf
 	Replaces: <<
 		kdebase4-runtime-%type_pkg[kde] (<< 4.3.90-1),
 		kdebase4-workspace-%type_pkg[kde]-dev (<< 4.3.0-1)

--- a/10.9-libcxx/stable/main/finkinfo/kde/kdelibs4.patch
+++ b/10.9-libcxx/stable/main/finkinfo/kde/kdelibs4.patch
@@ -283,3 +283,14 @@ diff -ruNp kdelibs-4.14.6-orig/kross/qts/CMakeLists.txt kdelibs-4.14.6/kross/qts
  
  ########### next target ###############
  
+--- a/kdeui/CMakeLists.txt	2017-12-05 21:07:18.000000000 -0600
++++ b/kdeui/CMakeLists.txt	2017-12-05 21:07:38.000000000 -0600
+@@ -313,8 +313,6 @@
+     add_definitions(-DMAC_USE_OSXKEYCHAIN)
+ else(Q_WS_MAC AND MAC_USE_OSXKEYCHAIN)
+      set(kdeui_LIB_SRCS ${kdeui_LIB_SRCS} util/kwallet.cpp)
+-else(Q_WS_MAC AND MAC_USE_OSXKEYCHAIN)
+-  set(kdeui_LIB_SRCS ${kdeui_LIB_SRCS} util/kwallet.cpp)
+ endif(Q_WS_MAC AND MAC_USE_OSXKEYCHAIN)
+ 
+ if(NOT WINCE)

--- a/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
@@ -2,6 +2,8 @@ Info3: <<
 Package: cernlib2006
 Version: 2006b
 Revision: 28
+# No llvm-gcc* on 10.13 XMKMFHS
+Distribution: 10.9, 10.10, 10.11, 10.12
 Description: Paw and other basic executables
 Depends: <<
   gcc6-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/sci/geant4.9.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/geant4.9.info
@@ -2,6 +2,8 @@ Info3: <<
 Package: geant4.9%type_pkg[cernlib]
 Version: 4.9.4
 Revision: 15
+# No llvm-gcc* on 10.13 XMKMFHS (via cernlib2006)
+Distribution: 10.9, 10.10, 10.11, 10.12
 Type: cernlib (. -cernlib)
 Description: Simulation of particle-matter interaction
 DescDetail: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/plotmtv.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/plotmtv.info
@@ -1,6 +1,8 @@
 Package: plotmtv
 Version: 1.4.4t
 Revision: 3
+# No llvm-gcc* on 10.13 XMKMFHS
+Distribution: 10.9, 10.10, 10.11, 10.12
 Maintainer: None <fink-devel@lists.sourceforge.net>
 BuildDepends: x11-dev, xmkmf (>= 1.0.2-3), llvm-gcc | llvm-gcc42
 Depends: x11, rman

--- a/10.9-libcxx/stable/main/finkinfo/sci/rasmol.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/rasmol.info
@@ -1,6 +1,8 @@
 Package: rasmol
 Version: 2.7.5
 Revision: 3
+# No llvm-gcc* on 10.13 XMKMFHS
+Distribution: 10.9, 10.10, 10.11, 10.12
 BuildDepends: <<
 	llvm-gcc | llvm-gcc42,
 	x11-dev,

--- a/10.9-libcxx/stable/main/finkinfo/utils/canna.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/canna.info
@@ -1,6 +1,8 @@
 Package: canna
 Version: 3.7p3
 Revision: 9
+# No llvm-gcc* on 10.13 XMKMFHS
+Distribution: 10.9, 10.10, 10.11, 10.12
 Replaces: %N (<= 3.5b2-4)
 BuildDepends: x11-dev, passwd-canna (>= 20130103), xmkmf (>= 1.0.2-3), llvm-gcc | llvm-gcc42
 Depends: %N-shlibs (= %v-%r), %N-utils (= %v-%r), %N-server (= %v-%r)

--- a/10.9-libcxx/stable/main/finkinfo/utils/kinput2.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/kinput2.info
@@ -1,6 +1,8 @@
 Package: kinput2
 Version: 3.1
 Revision: 7
+# No llvm-gcc* on 10.13 XMKMFHS
+Distribution: 10.9, 10.10, 10.11, 10.12
 BuildDepends: <<
  canna-dev,
  libxt,

--- a/10.9-libcxx/stable/main/finkinfo/x11/dclock.info
+++ b/10.9-libcxx/stable/main/finkinfo/x11/dclock.info
@@ -1,6 +1,8 @@
 Package: dclock
 Version: 2.2.2
 Revision: 3
+# No llvm-gcc* on 10.13 XMKMFHS
+Distribution: 10.9, 10.10, 10.11, 10.12
 Description: Digital clock for the X11 environment
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>


### PR DESCRIPTION
Fixes #2. I think I got all the primary and secondary dependees on xmkmf.