### PR TITLE
Fix grammar.y to use bison3 to avoid illegal instruction when making …

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/gnome/libgnomeprint2.2-shlibs-bison3.patch
+++ b/10.9-libcxx/stable/main/finkinfo/gnome/libgnomeprint2.2-shlibs-bison3.patch
@@ -1,0 +1,45 @@
+Bison 3 requires that instances of YYPARSE_PARAM be replaced with
+%parse-param. This in turn alters the arguments of the generated
+yyerror function, so relevant function prototypes have to be updated.
+
+Index: libgnomeprint/grammar.y
+===================================================================
+--- a/libgnomeprint/grammar.y.orig
++++ b/libgnomeprint/grammar.y
+@@ -6,8 +6,6 @@
+ #include <libgnomeprint/types.h>
+ #include <libgnomeprint/gnome-print-filter.h>
+ 
+-#define YYPARSE_PARAM graph
+-
+ static void
+ set_value_from_string (GParamSpec *pspec, GValue *v, const gchar *s)
+ {
+@@ -99,7 +97,7 @@ gnome_print_filter_parse_prop (GnomePrin
+ }
+ 
+ static int yylex (void *lvalp);
+-static int yyerror (const char *s);
++static int yyerror (void *graph, const char *s);
+ %}
+ 
+ %union {
+@@ -116,7 +114,8 @@ static int yyerror (const char *s);
+ %type <f> filter
+ %type <p> pool
+ 
+-%pure_parser
++%define api.pure
++%parse-param {void *graph}
+ 
+ %start graph
+ %%
+@@ -185,7 +184,7 @@ graph: filter {
+ %%
+ 
+ static int
+-yyerror (const char *s)
++yyerror (void *graph, const char *s)
+ {
+ 	return -1;
+ }

--- a/10.9-libcxx/stable/main/finkinfo/gnome/libgnomeprint2.2-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/gnome/libgnomeprint2.2-shlibs.info
@@ -12,8 +12,8 @@ Depends: <<
 	pango1-xft2-ft219-shlibs (>= 1.24.5-4)
 <<
 BuildDepends: <<
-	bison-legacy,
-	fink (>= 0.24.12-1),
+	bison,
+	fink (>= 0.30.0),
 	fink-package-precedence,
 	fontconfig2-dev (>= 2.10.0-1),
 	freetype219 (>= 2.4.11-1),
@@ -36,11 +36,19 @@ Source: mirror:gnome:sources/libgnomeprint/2.18/libgnomeprint-%v.tar.bz2
 Source-MD5: 63b05ffb5386e131487c6af30f4c56ac
 PatchFile: %n.patch
 PatchFile-MD5: a478a870bc6123e7a34683ab2a730849
+PatchFile2: %n-bison3.patch
+PatchFile2-MD5: b0f4419e17a649937ddb0b77e7078709
 SetCFLAGS: -Os
-ConfigureParams: --enable-dependency-tracking --disable-static PKG_CONFIG_PATH="%p/lib/glib-2.0/pkgconfig-strict:$PKG_CONFIG_PATH" F77=no --enable-gtk-doc --without-papi --with-cups
+ConfigureParams: <<
+	--enable-dependency-tracking \
+	--disable-static \
+	PKG_CONFIG_PATH="%p/lib/glib-2.0/pkgconfig-strict:$PKG_CONFIG_PATH" \
+	F77=no \
+	--enable-gtk-doc \
+	--without-papi \
+	--with-cups
+<<
 CompileScript: <<
-#!/bin/sh -ev	
-	export PATH=%p/opt/bison-legacy/bin:$PATH
 	./configure %c
 	make
 	fink-package-precedence --prohibit-bdep libgnomeprint2.2-dev .


### PR DESCRIPTION
…grammar.tab.c with bison-legacy.