### PR TITLE
ncurses-6.0 from tracker

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/base/libncurses6-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/libncurses6-shlibs.info
@@ -1,0 +1,113 @@
+Package: libncurses6-shlibs
+Version: 6.0
+Revision: 1
+
+GCC: 4.0
+Source: ftp://ftp.gnu.org/pub/gnu/ncurses/ncurses-%v.tar.gz
+Source-MD5: ee13d052e1ead260d7c28071f46eefb1
+SourceDirectory: ncurses-%v
+BuildDepends: fink (>= 0.13.0)
+Depends: base-files
+Essential: true
+PatchScript: <<
+#!/bin/sh -ex
+	# apply upstream patchsets
+	for p in patches/*.patch.gz; do
+		gzip -cd $p | patch -p1
+	done
+
+	# Fix warnings in clang by removing some useless compiler
+	# switches (they are not useful for gcc either).
+	perl -pi -e "s/-no-cpp-precomp//" configure
+
+	#Need to remove these entries to avoid failure on case sensitive file systems
+	perl -pi -e "s/hp70092a\|//; s/hp2621a\|//; s/2621a\|//" misc/terminfo.src
+<<
+ConfigureParams: <<
+  --without-ada \
+  --without-pkg-config \
+  --with-shared \
+  --with-debug \
+  --enable-termcap \
+  --mandir=%p/share/man \
+  --with-terminfo-dirs="%p/share/terminfo:/usr/share/terminfo" \
+  --with-default-terminfo-dir="%p/share/terminfo" \
+  --enable-no-padding \
+  --enable-sigwinch \
+  --enable-tcap-names \
+  --enable-hard-tabs \
+  --enable-overwrite \
+  --disable-mixed-case \
+  --libdir=%p/lib/ncurses \
+  cf_cv_typeof_chtype=long \
+  cf_cv_gcc_inline=no
+<<
+NoSetCFLAGS: true
+NoSetLDFLAGS: true
+NoSetCPPFLAGS: true
+UseMaxBuildJobs: false
+InstallScript: <<
+#!/bin/sh -ev
+  make install DESTDIR=%d DYLD_LIBRARY_PATH=`pwd`/lib:`pwd`/lib/ncurses
+# add extra symlinks in the main lib directory
+  ln -s ncurses/libform.6.dylib %i/lib/libform.dylib
+  ln -s ncurses/libmenu.6.dylib %i/lib/libmenu.dylib
+  ln -s ncurses/libncurses.6.dylib %i/lib/libncurses.dylib
+  ln -s ncurses/libpanel.6.dylib %i/lib/libpanel.dylib
+  ln -s ncurses/libncurses.6.dylib %i/lib/libcurses.dylib
+  ln -s ncurses/libncurses.6.dylib %i/lib/libtermcap.dylib
+<<
+SplitOff: <<
+ Package: libncurses6
+ Depends: libncurses6-shlibs (= %v-%r)
+ BuildDependsOnly: true
+ Conflicts: ncurses-dev, libncurses5-64bit, libncurses5
+ Replaces: ncurses-dev, ncurses (<= 5.3-20031018-2), libncurses5-64bit, ncurses (<= 5.7-20100227-1), libncurses5
+ Provides: libncurses6-dev
+ Files: bin/ncurses6-config lib/ncurses/*.a lib/ncurses/libcurses.dylib	lib/ncurses/libform.dylib lib/ncurses/libmenu.dylib lib/ncurses/libncurses.dylib lib/ncurses/libpanel.dylib include lib/libcurses.dylib lib/libform.dylib lib/libmenu.dylib lib/libncurses.dylib lib/libpanel.dylib lib/libtermcap.dylib
+ DocFiles: README ANNOUNCE NEWS INSTALL TO-DO MANIFEST
+ Description: Full-screen ascii drawing library
+<<
+SplitOff2: <<
+ Package: ncurses
+ Depends: libncurses6-shlibs (>= %v-%r)
+ Essential: true
+ Files: bin lib/terminfo share/man share/terminfo
+ DocFiles: README ANNOUNCE NEWS INSTALL TO-DO MANIFEST
+ Description: Executable files for libncurses5
+<<
+Shlibs: <<
+ %p/lib/ncurses/libform.6.dylib 6.0.0 %n (>= 6.0-1)
+ %p/lib/ncurses/libmenu.6.dylib 6.0.0 %n (>= 6.0-1)
+ %p/lib/ncurses/libncurses.6.dylib 6.0.0 %n (>= 6.0-1)
+ %p/lib/ncurses/libpanel.6.dylib 6.0.0 %n (>= 6.0-1)
+<<
+DocFiles: README ANNOUNCE NEWS INSTALL TO-DO MANIFEST
+Description: Shared libraries for libncurses5 package
+DescPort: <<
+More changes by Chris Zubrzycki to be more compatable with apple's lib
+-udates to the (sometimes) monthly releases of ncurses (in patch form)
+
+The --enable-overwrite flag creates the libcurses.dylib symlink.
+
+Must pass cf_cv_typeof_chtype=long to configure to maintain ABI
+compatability for 64-bit library. Otherwise chtype is unsigned long
+in 5.4 but unsigned int in 5.7.
+
+Added patchscript to avoid failure on case sensitive file systems.
+<<
+DescPackaging: <<
+First revision by David Ross.
+Previous versions by Christoph Pfisterer.
+All the hard work in this version done by Chris Zubrzycki.
+Updated to 5.7 by Daniel Johnson.
+
+	Fink needs to mirror Essential packages on its own server).
+
+	Disable pkg-config so we don't need to make it Essential:true
+	(as dependency of Essential:true ncurses). gen-pkgconfig says
+	the *-config scripts are the recommended way anyway.
+<<
+License: OSI-Approved
+Maintainer: Fink Core Group <fink-core@lists.sourceforge.net>
+Homepage: http://www.gnu.org/software/ncurses/ncurses.html

--- a/10.9-libcxx/stable/main/finkinfo/base/libncurses6-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/libncurses6-shlibs.info
@@ -11,11 +11,6 @@ Depends: base-files
 Essential: true
 PatchScript: <<
 #!/bin/sh -ex
-	# apply upstream patchsets
-	for p in patches/*.patch.gz; do
-		gzip -cd $p | patch -p1
-	done
-
 	# Fix warnings in clang by removing some useless compiler
 	# switches (they are not useful for gcc either).
 	perl -pi -e "s/-no-cpp-precomp//" configure
@@ -61,8 +56,20 @@ SplitOff: <<
  Package: libncurses6
  Depends: libncurses6-shlibs (= %v-%r)
  BuildDependsOnly: true
- Conflicts: ncurses-dev, libncurses5-64bit, libncurses5
- Replaces: ncurses-dev, ncurses (<= 5.3-20031018-2), libncurses5-64bit, ncurses (<= 5.7-20100227-1), libncurses5
+ Conflicts: <<
+  ncurses-dev,
+  libncurses5-64bit,
+  libncurses5,
+  libncurses6
+ <<
+ Replaces: <<
+  ncurses-dev,
+  ncurses (<= 5.3-20031018-2),
+  libncurses5-64bit,
+  ncurses (<= 5.7-20100227-1),
+  libncurses5,
+  libncurses6
+ <<
  Provides: libncurses6-dev
  Files: bin/ncurses6-config lib/ncurses/*.a lib/ncurses/libcurses.dylib	lib/ncurses/libform.dylib lib/ncurses/libmenu.dylib lib/ncurses/libncurses.dylib lib/ncurses/libpanel.dylib include lib/libcurses.dylib lib/libform.dylib lib/libmenu.dylib lib/libncurses.dylib lib/libpanel.dylib lib/libtermcap.dylib
  DocFiles: README ANNOUNCE NEWS INSTALL TO-DO MANIFEST

--- a/10.9-libcxx/stable/main/finkinfo/base/libncursesw6.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/libncursesw6.info
@@ -1,12 +1,11 @@
-Package: libncursesw5
-Version: 5.9-20110507
-Revision: 2
+Package: libncursesw6
+Version: 6.0
+Revision: 1
 
 GCC: 4.0
-#Source: ftp://invisible-island.net/ncurses/current/ncurses-%v.tgz
-Source: mirror:sourceforge:fink/ncurses-%v.tgz
-Source-MD5: 49dc7136424f2bdd653439eda63a2375
-SourceDirectory: ncurses-5.9
+Source: ftp://ftp.gnu.org/pub/gnu/ncurses/ncurses-%v.tar.gz
+Source-MD5: ee13d052e1ead260d7c28071f46eefb1
+SourceDirectory: ncurses-%v
 BuildDepends: fink (>= 0.13.0)
 Depends: %N-shlibs (= %v-%r)
 Conflicts: libncursesw5, libncursesw6
@@ -20,8 +19,10 @@ PatchScript: <<
 		gzip -cd $p | patch -p1
 	done
 
-	#Need to remove these entries to avoid failure on case sensitive file systems
+	# Need to remove these entries to avoid failure on case sensitive file systems
 	perl -pi -e "s/hp70092a\|//; s/hp2621a\|//; s/2621a\|//" misc/terminfo.src
+	# Remove unsupported --param max-inline-insns-single=1200 option
+	perl -pi -e  "s/--param max-inline-insns-single=1200//" configure
 <<
 ConfigureParams: <<
   --without-ada \
@@ -60,10 +61,10 @@ SplitOff: <<
  <<
  DocFiles: README ANNOUNCE NEWS INSTALL TO-DO MANIFEST
  Shlibs: <<
-  %p/lib/libformw.5.dylib 5.0.0 %n (>= 5.4-1)
-  %p/lib/libmenuw.5.dylib 5.0.0 %n (>= 5.4-1)
-  %p/lib/libncursesw.5.dylib 5.0.0 %n (>= 5.4-1)
-  %p/lib/libpanelw.5.dylib 5.0.0 %n (>= 5.4-1)
+  %p/lib/libformw.6.dylib 6.0.0 %n (>= 6.0-1)
+  %p/lib/libmenuw.6.dylib 6.0.0 %n (>= 6.0-1)
+  %p/lib/libncursesw.6.dylib 6.0.0 %n (>= 6.0-1)
+  %p/lib/libpanelw.6.dylib 6.0.0 %n (>= 6.0-1)
  <<
  Description: Shared libraries for libncursesw5 package
 <<
@@ -86,7 +87,6 @@ First revision by David Ross.
 Previous versions by Christoph Pfisterer.
 Updated to 5.7 by Daniel Johnson.
 
-	Reroll tarball with upstream patches (in patches/ subdir).
 	Fink needs to mirror Essential packages on its own server).
 
 	Disable pkg-config so we don't need to make it Essential:true
@@ -95,7 +95,7 @@ Updated to 5.7 by Daniel Johnson.
 <<
 DescUsage: <<
 NOTE: Headers are installed into %p/include/ncursesw instead of
-%p/include as with libncurses5. Packages depending on this might
+%p/include as with libncurses6. Packages depending on this might
 need to add %p/include/ncursesw to CPPFLAGS or otherwise make
 adjustments to build properly. All library names end in 'w'.
 <<

--- a/10.9-libcxx/stable/main/finkinfo/base/ncurses.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/ncurses.info
@@ -82,8 +82,20 @@ SplitOff2: <<
  Package: libncurses5
  Depends: libncurses5-shlibs (= %v-%r)
  BuildDependsOnly: true
- Conflicts: ncurses-dev, libncurses5-64bit
- Replaces: ncurses-dev, ncurses (<= 5.3-20031018-2), libncurses5-64bit, ncurses (<= 5.7-20100227-1)
+ Conflicts: <<
+  ncurses-dev,
+  libncurses5-64bit,
+  libncurses5,
+  libncurses6
+ <<
+ Replaces: <<
+  ncurses-dev,
+  ncurses (<= 5.3-20031018-2),
+  libncurses5-64bit,
+  ncurses (<= 5.7-20100227-1),
+  libncurses5,
+  libncurses6
+ <<
  Provides: libncurses5-dev
  Files: bin/ncurses5-config lib/ncurses include lib/libcurses.dylib lib/libform.dylib lib/libmenu.dylib lib/libncurses.dylib lib/libpanel.dylib lib/libtermcap.dylib
  DocFiles: README ANNOUNCE NEWS INSTALL TO-DO MANIFEST


### PR DESCRIPTION
This is a transfer of @jwhowarth's update for ncurses-6 and libncurseswfrom the tracker: https://sourceforge.net/p/fink/package-submissions/4803/ and https://sourceforge.net/p/fink/package-submissions/4804/

Things to figure out:
- the submission uses a new libN, but ./configure has a `--with-abi-version` flag that can be used to set the libN back to 5 as in our current package. Do we want a new libN for ncurses?
- if we do keep the new libN=6, does the ncurses-%v=6 package get to keep its `Essential: true` field?