### PR TITLE
Updates for rpy2-py building against R3.4

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tzlocal-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tzlocal-py.info
@@ -1,0 +1,50 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info3: <<
+
+Package: tzlocal-py%type_pkg[python]
+Version: 1.5.1
+
+Revision: 1
+Homepage: https://github.com/regebro/tzlocal
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+Type: python (2.7 3.4 3.5 3.6)
+Depends: python%type_pkg[python], pytz-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
+BuildDepends: setuptools-tng-py%type_pkg[python]
+
+Source: https://pypi.io/packages/source/t/tzlocal/tzlocal-%v.tar.gz
+Source-MD5: 4553be891efa0812c4adfb0c6e818eec
+Source-Checksum: SHA256(4ebeb848845ac898da6519b9b31879cf13b6626f7184c496037b818e238f2c4e)
+
+CompileScript: python%type_raw[python] setup.py build 
+
+InstallScript: python%type_raw[python] setup.py install --root=%d
+
+InfoTest: <<
+	# 1 Failure on test_symlink_localtime()
+	TestDepends: mock-py%type_pkg[python] (>= 2.0.0-1)
+	TestScript: %p/bin/python%type_raw[python] setup.py test || exit 1
+	TestSuiteSize: small
+<<
+
+DocFiles: README.rst CHANGES.txt LICENSE.txt
+
+License: OSI-Approved
+Description: TZinfo object for the local timezone
+DescDetail: <<
+Python module returning a `tzinfo` object with the local timezone information
+under Unix and Win-32. It requires `pytz`, and returns `pytz` `tzinfo` objects.
+This module attempts to fix a glaring hole in `pytz`, that there is no way to
+get the local timezone information, unless you know the zoneinfo name, and
+under several Linux distros that's hard or impossible to figure out.
+Also, with Windows different timezone system using pytz isn't of much use
+unless you separately configure the zoneinfo timezone name.
+With `tzlocal` you only need to call `get_localzone()` and you will get a
+`tzinfo` object with the local time zone info. On some Unices you will still
+not get to know what the timezone name is, but you don't need that when you
+have the tzinfo file. However, if the timezone name is readily available it
+will be used.
+<<
+
+
+# Info3
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dbplyr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dbplyr-r.info
@@ -1,0 +1,64 @@
+Info2: <<
+
+Package: cran-dbplyr-r%type_pkg[rversion]
+Distribution: <<
+	(%type_pkg[rversion] = 32 ) 10.9,
+	(%type_pkg[rversion] = 32 ) 10.10,
+	(%type_pkg[rversion] = 32 ) 10.11,
+	(%type_pkg[rversion] = 32 ) 10.12
+<<
+Type: rversion (3.4 3.3 3.2 3.1)
+Version: 1.2.1
+Revision: 1
+Description: 'dplyr' Back End for Databases
+Homepage: https://cran.r-project.org/packages=dbplyr
+License: BSD
+Maintainer: None <fink-devel@lists.sourceforge.net>
+Source: http://cran.r-project.org/src/contrib/dbplyr_%v.tar.gz
+Source-MD5: 3132707768f771374209ae65fd9055de
+SourceDirectory: dbplyr
+Depends: <<
+	( %type_raw[rversion] >= 3.4 ) r-base%type_pkg[rversion] (>= 3.4.0-2),
+	( %type_raw[rversion] = 3.3 ) r-base%type_pkg[rversion] (>= 3.3.2-2),
+	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.5-2),
+	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-5),
+	cran-dbi-r%type_pkg[rversion] (>=0.7-1),
+	cran-dplyr-r%type_pkg[rversion] (>=0.7.4-1),
+	cran-glue-r%type_pkg[rversion] (>=1.2.0-1),
+	cran-purrr-r%type_pkg[rversion] (>=0.2.4-1),
+	cran-rlang-r%type_pkg[rversion] (>=0.1.6-1),
+	cran-tidyselect-r%type_pkg[rversion] (>=0.2.2-1)
+<<	
+BuildDepends: <<
+	fink (>= 0.27.2),
+	( %type_raw[rversion] >= 3.4 ) r-base%type_pkg[rversion]-dev (>= 3.4.0-2),
+	( %type_raw[rversion] = 3.3 ) r-base%type_pkg[rversion]-dev (>= 3.3.2-2),
+	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
+	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3)
+<<
+GCC: 4.0
+CompileScript: <<
+  #!/bin/sh -ev
+  export TMPDIR=%b/tmp
+  BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
+  
+  pushd ..
+  $BIN_R --verbose CMD build --no-build-vignettes dbplyr
+<<
+InstallScript: <<
+  #!/bin/sh -ev
+  BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
+  
+  mkdir -p %i/lib/R/%type_raw[rversion]/site-library
+  pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library dbplyr
+<<
+DescDetail: <<
+A 'dplyr' back end for databases that allows you to work with remote database
+tables as if they are in-memory data frames. Basic features works with any
+database that has a 'DBI' back end; more advanced features require 'SQL'
+translation to be provided by the package author.
+<<
+DescPackaging: <<
+  R (>=3.1.2)
+<<
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-glue-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-glue-r.info
@@ -2,24 +2,20 @@ Info2: <<
 
 Package: cran-glue-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 31 ) 10.9,
-	(%type_pkg[rversion] = 31 ) 10.10,
-	(%type_pkg[rversion] = 31 ) 10.11,
-	(%type_pkg[rversion] = 31 ) 10.12,
 	(%type_pkg[rversion] = 32 ) 10.9,
 	(%type_pkg[rversion] = 32 ) 10.10,
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.4 3.3 3.2 3.1)
-Version: 1.1.1
+Version: 1.2.0
 Revision: 1
 Description: Interpreted String Literals
-Homepage: http://cran.r-project.org/web/packages/glue/index.html
+Homepage: https://cran.r-project.org/packages=glue
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: http://cran.r-project.org/src/contrib/glue_%v.tar.gz
-Source-MD5: 4ab1ba202703f187f8bd2499f55c73df
+Source-MD5: 77d06b6d86abc882fa1c0599e457c5e2
 SourceDirectory: glue
 Depends: <<
 	fink (>=0.32),

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-purrr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-purrr-r.info
@@ -2,24 +2,20 @@ Info2: <<
 
 Package: cran-purrr-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 31 ) 10.9,
-	(%type_pkg[rversion] = 31 ) 10.10,
-	(%type_pkg[rversion] = 31 ) 10.11,
-	(%type_pkg[rversion] = 31 ) 10.12,
 	(%type_pkg[rversion] = 32 ) 10.9,
 	(%type_pkg[rversion] = 32 ) 10.10,
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.4 3.3 3.2)
-Version: 0.2.3
+Version: 0.2.4
 Revision: 1
 Description: Functional Programming Tools
-Homepage: http://cran.r-project.org/web/packages/purrr/index.html
+Homepage: https://cran.r-project.org/packages=purrr
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: http://cran.r-project.org/src/contrib/purrr_%v.tar.gz
-Source-MD5: 1210ceb1c13a8fc5464b0febd74585d7
+Source-MD5: d9a11e6c14771beb3ebe8f4771a552f3
 SourceDirectory: purrr
 Depends: <<
 	fink (>= 0.27.2), 

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-r6-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-r6-r.info
@@ -13,7 +13,7 @@ Distribution: <<
 <<
 Type: rversion (3.4 3.3 3.2 3.1)
 Version: 2.2.2
-Revision: 1
+Revision: 2
 Description: Classes with reference semantics
 Homepage: http://cran.r-project.org/web/packages/R6/index.html
 License: BSD
@@ -34,14 +34,14 @@ CompileScript: <<
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
-  $BIN_R --verbose CMD build --no-build-vignettes r6
+  $BIN_R --verbose CMD build --no-build-vignettes R6
 <<
 InstallScript: <<
   #!/bin/sh -ev
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   mkdir -p %i/lib/R/%type_raw[rversion]/site-library
-  pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library r6
+  pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library R6
 <<
 DescDetail: <<
 The R6 package allows the creation of classes with reference semantics,

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcpp-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcpp-r.info
@@ -1,37 +1,34 @@
-Info2: <<
+Info3: <<
 
 Package: cran-rcpp-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 31 ) 10.9,
-	(%type_pkg[rversion] = 31 ) 10.10,
-	(%type_pkg[rversion] = 31 ) 10.11,
-	(%type_pkg[rversion] = 31 ) 10.12,
 	(%type_pkg[rversion] = 32 ) 10.9,
 	(%type_pkg[rversion] = 32 ) 10.10,
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.4 3.3 3.2 3.1)
-Version: 0.12.12
+Version: 0.12.16
 Revision: 1
 Description: Seamless R and C++ Integration
 Homepage: http://cran.r-project.org/web/packages/Rcpp/index.html
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: http://cran.r-project.org/src/contrib/Rcpp_%v.tar.gz
-Source-MD5: 97b36a3b567e3438067c4a7d0075fd90
+Source-MD5: ab5107766c63d66065ed1a92a4cab1b7
 SourceDirectory: Rcpp
 Depends: <<
-	fink (>= 0.27.2), 
-	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion],
+	( %type_raw[rversion] >= 3.4 ) r-base%type_pkg[rversion] (>= 3.4.0-2),
+	( %type_raw[rversion] = 3.3 ) r-base%type_pkg[rversion] (>= 3.3.2-2),
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.0-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-3),
 	gcc5-shlibs,
 	libgettext8-shlibs
 <<
 BuildDepends: <<
-	fink (>= 0.27.2), 
-	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion]-dev,
+	fink (>= 0.27.2),
+	( %type_raw[rversion] >= 3.4 ) r-base%type_pkg[rversion]-dev (>= 3.4.0-2),
+	( %type_raw[rversion] = 3.3 ) r-base%type_pkg[rversion]-dev (>= 3.3.2-2),
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3),
 	gcc5-compiler,
@@ -68,8 +65,8 @@ SplitOff: <<
   Files: lib/R/%type_raw[rversion]/site-library/Rcpp/include
 <<
 Shlibs: <<
-  ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/Rcpp/libs/Rcpp.so 0.0.0 %n (>=0.12.11-1)
-  ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/Rcpp/libs/Rcpp.dylib 0.0.0 %n (>=0.12.11-1)
+  ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/Rcpp/libs/Rcpp.so 0.0.0 %n (>= 0.11.5-1)
+  ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/Rcpp/libs/Rcpp.dylib 0.0.0 %n (>= 0.11.5-1)
 <<
 DescDetail: <<
 The Rcpp package provides R functions as well as a C++ library which
@@ -78,5 +75,5 @@ facilitate the integration of R and C++.
 DescPackaging: <<
   R (>= 3.0.0)
 <<
-
+# Info3
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rlang-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rlang-r.info
@@ -1,25 +1,21 @@
-Info2: <<
+Info3: <<
 
 Package: cran-rlang-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 31 ) 10.9,
-	(%type_pkg[rversion] = 31 ) 10.10,
-	(%type_pkg[rversion] = 31 ) 10.11,
-	(%type_pkg[rversion] = 31 ) 10.12,
 	(%type_pkg[rversion] = 32 ) 10.9,
 	(%type_pkg[rversion] = 32 ) 10.10,
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.4 3.3 3.2 3.1)
-Version: 0.1.2
-Revision: 2
+Version: 0.2.0
+Revision: 1
 Description: Functions for Base Types and Core R
-Homepage: http://cran.r-project.org/web/packages/rlang/index.html
+Homepage: https://cran.r-project.org/packages=rlang
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://cran.r-project.org/src/contrib/rlang_%v.tar.gz
-Source-MD5: 170f8cf7b61898040643515a1746a53a
+Source: https://cran.r-project.org/src/contrib/rlang_%v.tar.gz
+Source-MD5: d2a9f5357a5de6de624b11e6da12275c
 SourceDirectory: rlang
 Depends: <<
 	fink (>= 0.27.2),
@@ -70,5 +66,5 @@ the condition system, and core `Tidyverse' features like tidy evaluation.
 DescPackaging: <<
   R (>= 3.1.0)
 <<
-
+# Info3
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rsqlite-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rsqlite-r.info
@@ -1,4 +1,4 @@
-Info2: <<
+Info3: <<
 
 Package: cran-rsqlite-r%type_pkg[rversion]
 Distribution: <<
@@ -12,18 +12,22 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.4 3.3 3.2 3.1)
-Version: 1.0.0
-Revision: 2
+Version: 2.0
+Revision: 1
 Description: SQLite interface for R
-Homepage: http://cran.r-project.org/web/packages/RSQLite/index.html
+Homepage: http://rsqlite.r-dbi.org/
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: https://cran.r-project.org/src/contrib/Archive/RSQLite/RSQLite_%v.tar.gz
-Source-MD5: e6cbe2709612b687c13a10d30c7bad45
+Source: https://cran.r-project.org/src/contrib/RSQLite_%v.tar.gz
+Source-MD5: 63842410e78ccdfc52d4ee97992521d5
 SourceDirectory: RSQLite
 Depends: <<
 	r-base%type_pkg[rversion],
-	cran-dbi-r%type_pkg[rversion] (>= 0.3.1),
+	cran-bit64-r%type_pkg[rversion],
+	cran-blob-r%type_pkg[rversion] (>= 1.1.0-1),
+	cran-memoise-r%type_pkg[rversion],
+	cran-dbi-r%type_pkg[rversion] (>= 0.4-1),
+	cran-rcpp-r%type_pkg[rversion] (>= 0.12.7-1),
 	libgettext8-shlibs
 <<
 BuildDepends: <<
@@ -55,13 +59,6 @@ InstallScript: <<
 	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/RSQLite/libs/RSQLite.so %i/lib/R/%type_raw[rversion]/site-library/RSQLite/libs/RSQLite.so
   fi
 <<
-SplitOff: <<
-  Package: %N-dev
-  Description: Headers for CRAN RSQLite
-  BuildDependsOnly: true
-  Depends: %N (=%v-%r)
-  Files: lib/R/%type_raw[rversion]/site-library/RSQLite/include
-<<
 Shlibs: <<
   ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/RSQLite/libs/RSQLite.so 0.0.0 %n (>= 1.0.0-1)
   ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/RSQLite/libs/RSQLite.dylib 0.0.0 %n (>= 1.0.0-1)
@@ -73,6 +70,7 @@ package. The source for the SQLite engine (version 3.7.17) is included.
 <<
 DescPackaging: <<
   R (>= 3.1.0)
+  sqlite headers no longer included in 2.0; removed -dev SplitOff
 <<
-
+# Info3
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tidyselect-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tidyselect-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.4 3.3 3.2)
-Version: 0.2.0
+Version: 0.2.4
 Revision: 1
 Description: Select from a Set of Strings
-Homepage: https://cran.r-project.org/web/packages/tidyselect/index.html
+Homepage: https://cran.r-project.org/packages=tidyselect
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: https://cran.r-project.org/src/contrib/tidyselect_%v.tar.gz
-Source-MD5: c265f271254bfe52c253f6644b811e6d
+Source-MD5: fa3bfe6ea9f0e98a20e950788ea9573d
 SourceDirectory: tidyselect
 Depends: <<
 	fink (>= 0.27.2), 

--- a/10.9-libcxx/stable/main/finkinfo/sci/rpy2-py-2.8.6.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/rpy2-py-2.8.6.info
@@ -1,14 +1,14 @@
 Info2: <<
 
 Package: rpy2-py%type_pkg[python]
-Version: 2.9.1
+Version: 2.8.6
 Revision: 1
 Description: Python module to access R (3.4) functions
 License: OSI-Approved
 Homepage: http://rpy2.bitbucket.org
 Maintainer: BABA Yoshihiko <babayoshihiko@mac.com>
 
-Type: python (3.4 3.5 3.6)
+Type: python (2.7 3.4 3.5 3.6)
 
 BuildDepends: fink (>= 0.24.12-1), r-base34-dev, r-base34, libicu55-dev
 Depends: <<
@@ -21,11 +21,19 @@ Depends: <<
 <<
 Recommends: cran-ggplot2-r34, cran-hexbin-r34, pandas-py%type_pkg[python]
 
-#Source: https://bitbucket.org/rpy2/rpy2/get/RELEASE_2_9_1.tar.bz2
-#SourceDirectory: rpy2-rpy2-3e21887cfd62
-Source: https://pypi.io/packages/source/r/rpy2/rpy2-%v.tar.gz
-Source-MD5: 9125c69560677f9c59c5ff434a1474e4
-PatchScript: perl -pi -e 's|(_get_r_home\()(\))|${1}"%p/Library/Frameworks/R.framework/Versions/3.4/Resources/bin/R")|' setup.py
+Source: https://bitbucket.org/rpy2/rpy2/get/RELEASE_2_8_6.tar.bz2
+SourceDirectory: rpy2-rpy2-4b7a35dbe68f
+Source-MD5: c31b89bb585c22b29a79e3a9b244df12
+#Source: https://pypi.io/packages/source/r/rpy2/rpy2-%v.tar.gz
+PatchScript: <<
+#!/bin/bash -ev
+  perl -pi -e 's|(_get_r_home\()(\))|${1}"%p/Library/Frameworks/R.framework/Versions/3.4/Resources/bin/R")|' setup.py
+  # unicode tests are marked skip for Python 2, but unittest.loader still throws a LoadTestsFailure
+  # on detecting the non-ASCII chars, so remove them here:
+  if [ %type_pkg[python] -lt 30 ]; then
+    perl -pi -e "s/(u\'..+\')/'_unicode_'/g;" rpy/rinterface/tests/test_Sexp{Closure,Environment}.py
+  fi
+<<
 
 SetLDFLAGS: -L%p/Library/Frameworks/R.framework/Versions/3.4/Resources/lib -undefined dynamic_lookup
 
@@ -66,10 +74,8 @@ DescPort: <<
 Added singledispatch-py dependency for py27 type.
 Patched setup.py to find R executable in %p/Library/Frameworks, but it has
 to be in PATH at runtime, therefore r-base dependency.
-1 test error related to pandas (if installed), 10 more with dplyr (which
-probably simply are not run when cran-rsqlite-r34 is not installed, so leaving
-the two in as test dependencies). Minimum required version for dplyr is quoted
-as 0.7.4, so cran-dplyr-r34 may need an update.
+Removed unicode strings in tests for py27 type, because otherwise unittest
+will already fail on loading.
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/rpy2-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/rpy2-py.info
@@ -1,7 +1,7 @@
-Info2: <<
+Info3: <<
 
 Package: rpy2-py%type_pkg[python]
-Version: 2.9.2
+Version: 2.9.3
 Revision: 1
 Description: Python module to access R (3.4) functions
 License: OSI-Approved
@@ -17,6 +17,7 @@ Depends: <<
 	numpy-py%type_pkg[python] (>= 1.3.0-7), 
 	libicu55-shlibs, 
 	six-py%type_pkg[python], 
+	tzlocal-py%type_pkg[python], 
 	( %type_pkg[python] <= 33 ) singledispatch-py%type_pkg[python] (>= 3.4.0-1)
 <<
 Recommends: cran-ggplot2-r34, cran-hexbin-r34, pandas-py%type_pkg[python]
@@ -24,10 +25,10 @@ Recommends: cran-ggplot2-r34, cran-hexbin-r34, pandas-py%type_pkg[python]
 #Source: https://bitbucket.org/rpy2/rpy2/get/RELEASE_2_9_1.tar.bz2
 #SourceDirectory: rpy2-rpy2-3e21887cfd62
 Source: https://pypi.io/packages/source/r/rpy2/rpy2-%v.tar.gz
-Source-MD5: 05d0b5c79b3f6cfada2560a269dc95ba
+Source-MD5: 87025d5b8dfdb1d9cbda0dcd6bdb6085
+Source-Checksum: SHA256(1b72958e683339ea0c3bd9f73738e9ece2da8da8008a10e2e0c68fc7864e9361)
 PatchScript: <<
   perl -pi -e 's|(_get_r_home\()(\))|${1}"%p/Library/Frameworks/R.framework/Versions/3.4/Resources/bin/R")|' setup.py
-  perl -pi -e 's/(warnings.warn..No file.*etc_timezone\))/$1\n        import time\n        timezone = pytz.timezone(time.tzname[0])/;' rpy/robjects/pandas2ri.py
 <<
 
 SetLDFLAGS: -L%p/Library/Frameworks/R.framework/Versions/3.4/Resources/lib -undefined dynamic_lookup
@@ -52,7 +53,8 @@ InfoTest: <<
   cran-lazyeval-r34,
   cran-plyr-r34,
   cran-rsqlite-r34 (>= 2.0-1),
-  cran-survival-r34
+  cran-survival-r34,
+  pandas-py%type_pkg[python]
  <<
  TestScript: <<
   #!/bin/bash -ev
@@ -80,9 +82,10 @@ DescPort: <<
 Added singledispatch-py dependency for py27 type.
 Patched setup.py to find R executable in %p/Library/Frameworks, but it has
 to be in PATH at runtime, therefore r-base dependency.
-Fixed pandas test failure throwing a timezone error due to missing /etc/timezone.
+pandas2ri load failure in version 2.9.2 resolved by new tzlocal dependency.
 Test suite runs 448 tests without Errors, but interpreter segfaults (on 10.12
 throwing tons of errors "ATSFontGetFileReference failed: error -120.")
 <<
 
+# Info3
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/rpy2-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/rpy2-py.info
@@ -1,7 +1,7 @@
 Info2: <<
 
 Package: rpy2-py%type_pkg[python]
-Version: 2.9.1
+Version: 2.9.2
 Revision: 1
 Description: Python module to access R (3.4) functions
 License: OSI-Approved
@@ -24,25 +24,39 @@ Recommends: cran-ggplot2-r34, cran-hexbin-r34, pandas-py%type_pkg[python]
 #Source: https://bitbucket.org/rpy2/rpy2/get/RELEASE_2_9_1.tar.bz2
 #SourceDirectory: rpy2-rpy2-3e21887cfd62
 Source: https://pypi.io/packages/source/r/rpy2/rpy2-%v.tar.gz
-Source-MD5: 9125c69560677f9c59c5ff434a1474e4
-PatchScript: perl -pi -e 's|(_get_r_home\()(\))|${1}"%p/Library/Frameworks/R.framework/Versions/3.4/Resources/bin/R")|' setup.py
+Source-MD5: 05d0b5c79b3f6cfada2560a269dc95ba
+PatchScript: <<
+  perl -pi -e 's|(_get_r_home\()(\))|${1}"%p/Library/Frameworks/R.framework/Versions/3.4/Resources/bin/R")|' setup.py
+  perl -pi -e 's/(warnings.warn..No file.*etc_timezone\))/$1\n        import time\n        timezone = pytz.timezone(time.tzname[0])/;' rpy/robjects/pandas2ri.py
+<<
 
 SetLDFLAGS: -L%p/Library/Frameworks/R.framework/Versions/3.4/Resources/lib -undefined dynamic_lookup
 
 CompileScript: <<
-#!/bin/bash -ev
+  #!/bin/bash -ev
   %p/bin/python%type_raw[python] setup.py build
 <<
 InstallScript: <<
-#!/bin/bash -ev
+  #!/bin/bash -ev
   find %b/build/lib.macosx-*-%type_raw[python] -name '*.py[oc]' -exec rm {} \;
   %p/bin/python%type_raw[python] setup.py install --root=%d --install-data=%i/lib/python%type_raw[python]/r-base --no-compile 
 <<
 
 InfoTest: <<
- TestDepends: cran-ggplot2-r34 (>= 1.0.1), cran-dplyr-r34 (>= 0.7.2-1), cran-rsqlite-r34
+ TestDepends: <<
+  cran-colorspace-r34,
+  cran-dbplyr-r34 (>= 1.2.1-1),
+  cran-dplyr-r34 (>= 0.7.2-1),
+  cran-ggplot2-r34 (>= 1.0.1),
+  cran-lattice-r34,
+  cran-lazyeval-r34,
+  cran-plyr-r34,
+  cran-rsqlite-r34 (>= 2.0-1),
+  cran-survival-r34
+ <<
  TestScript: <<
-  PYTHONPATH=$(ls -d %b/build/lib.macosx-*-%type_raw[python]) %p/bin/python%type_raw[python] -B -m rpy2.tests
+  #!/bin/bash -ev
+  PYTHONPATH=$(ls -d %b/build/lib.macosx-*-%type_raw[python]) %p/bin/python%type_raw[python] -B -m rpy2.tests || exit 1
  <<
  TestSuiteSize: small
 <<
@@ -66,10 +80,9 @@ DescPort: <<
 Added singledispatch-py dependency for py27 type.
 Patched setup.py to find R executable in %p/Library/Frameworks, but it has
 to be in PATH at runtime, therefore r-base dependency.
-1 test error related to pandas (if installed), 10 more with dplyr (which
-probably simply are not run when cran-rsqlite-r34 is not installed, so leaving
-the two in as test dependencies). Minimum required version for dplyr is quoted
-as 0.7.4, so cran-dplyr-r34 may need an update.
+Fixed pandas test failure throwing a timezone error due to missing /etc/timezone.
+Test suite runs 448 tests without Errors, but interpreter segfaults (on 10.12
+throwing tons of errors "ATSFontGetFileReference failed: error -120.")
 <<
 
 <<


### PR DESCRIPTION
Update to 2.8.6 (last version with Python 2.7 support) and 2.9.1
(for the Python 3.x types); upgraded R dependencies to 3.4 to help resolve #17.
Tested and built on 10.12 and 10.13; note that some of the tests use pandas-py*, if present.
The 2.9.1 version (`rpy2-py.info`) may need an update of `cran-dplyr-r34` to 0.7.4 (at least for the tests), but I haven't upped the Depends yet.