### PR TITLE
Remove Depends:pkgconfig that is no longer needed

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/lcms.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/lcms.info
@@ -1,12 +1,12 @@
 Package: lcms
 Version: 1.19
-Revision: 1
+Revision: 2
 Source: mirror:sourceforge:%n/%n/%v/%n-%v.tar.gz
 Source-MD5: 8af94611baf20d9646c7c2c285859818
 SourceDirectory: %n-%v
 License: LGPL
 BuildDepends: libjpeg9 (>= 9-3), libtiff5
-Depends: %N-shlibs (= %v-%r), pkgconfig
+Depends: %N-shlibs (= %v-%r)
 BuildDependsOnly: true
 ConfigureParams: --mandir=%i/share/man --disable-dependency-tracking
 PatchScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/graphics/lcms2.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/lcms2.info
@@ -1,11 +1,11 @@
 Package: lcms2
 Version: 2.7
-Revision: 1
+Revision: 2
 Source: mirror:sourceforge:lcms/%v/%n-%v.tar.gz
 Source-MD5: 06c1626f625424a811fb4b5eb070839d
 License: OSI-Approved
 BuildDepends: libjpeg9, libtiff5, fink-package-precedence
-Depends: %N-shlibs (= %v-%r), pkgconfig
+Depends: %N-shlibs (= %v-%r)
 BuildDependsOnly: true
 ConfigureParams: --mandir=%i/share/man
 InfoTest: TestScript: make check || exit 2

--- a/10.9-libcxx/stable/main/finkinfo/libs/fuse4x-dev.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/fuse4x-dev.info
@@ -1,12 +1,11 @@
 Package: fuse4x-dev
 Version: 0.10.0
-Revision: 3
+Revision: 4
 BuildDependsOnly: true
 BuildDepends: <<
-  autoconf2.6, automake1.14, gettext-tools, libiconv-dev, libtool2,
+  autoconf2.6, automake1.15, gettext-tools, libiconv-dev, libtool2,
   fink-package-precedence
 <<
-Depends: pkgconfig
 Source: https://github.com/fuse4x/fuse/tarball/fuse4x_0_10_0
 Source-MD5: 10bacfd8318714de72a95e8baf62d6cd
 SourceRename: fuse4x-fuse-%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/libs/libapr.0-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libapr.0-shlibs.info
@@ -1,6 +1,6 @@
 Package: libapr.0-shlibs
 Version: 1.6.2
-Revision: 1
+Revision: 2
 
 BuildDepends: pkgconfig
 Replaces: libapr0-shlibs
@@ -57,7 +57,7 @@ Shlibs: <<
 
 SplitOff: <<
   Package: libapr.0-dev
-  Depends: %N (= %v-%r), pkgconfig
+  Depends: %N (= %v-%r)
   Conflicts: apr-common (<< 1:0-0), apr-ssl-common (<< 1:0-0), apr-dev, apr-ssl-dev (<< 1:0-0), apr (<< 1:0-0), apr-ssl (<< 1:0-0), libapr-dev (<< 1:0-0)
   Replaces: apr-common (<< 1:0-0), apr-ssl-common (<< 1:0-0), apr-dev, apr-ssl-dev (<< 1:0-0), apr (<< 1:0-0), apr-ssl (<< 1:0-0), libapr-dev (<< 1:0-0)
   BuildDependsOnly: True

--- a/10.9-libcxx/stable/main/finkinfo/libs/libaprutil.0-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libaprutil.0-shlibs.info
@@ -1,6 +1,6 @@
 Package: libaprutil.0-shlibs
 Version: 1.6.0
-Revision: 2
+Revision: 3
 
 Depends: <<
 	db53-aes-shlibs,
@@ -93,7 +93,7 @@ SplitOff: <<
   Package: libaprutil.0-dev
   Conflicts: apr-common (<< 1:0-0), apr-ssl-common (<< 1:0-0), aprutil-dev (<< 1:0-0), libaprutil-dev (<< 1:0-0)
   Replaces: apr-common (<< 1:0-0), apr-ssl-common (<< 1:0-0), aprutil-dev (<< 1:0-0), libaprutil-dev (<< 1:0-0)
-  Depends: %N (= %v-%r), pkgconfig
+  Depends: %N (= %v-%r)
   BuildDependsOnly: True
   Description: Headers and static libraries for APRUTIL
   Files: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/neon27.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/neon27.info
@@ -1,15 +1,15 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Package: neon27
 Version: 0.30.1
-Revision: 2
+Revision: 3
 Description: HTTP/WebDAV client library with a C API
 # Really LGPL but links to openssl100
 License: Restrictive
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 
 # Dependencies:
-Depends: %N-shlibs (= %v-%r), pkgconfig (>= 0.20-1)
-BuildDepends: libxml2 (>= 2.6.30-1), openssl100-dev (>= 1.0.2g-1), libiconv-dev (>= 1.12-3), libgettext8-dev, libproxy1
+Depends: %N-shlibs (= %v-%r)
+BuildDepends: libxml2 (>= 2.6.30-1), openssl100-dev (>= 1.0.2g-1), libiconv-dev (>= 1.12-3), libgettext8-dev, libproxy1, pkgconfig
 Conflicts: neon-ssl, neon, neon19, neon19-ssl, neon21, neon21-ssl, neon22, neon22-ssl, neon23, neon23-ssl, neon24, neon24-ssl, neon25, neon26, neon27
 Replaces: neon-ssl, neon, neon19, neon19-ssl, neon21, neon21-ssl, neon22, neon22-ssl, neon23, neon23-ssl, neon24, neon24-ssl, neon25, neon26, neon27
 BuildDependsOnly: True

--- a/10.9-libcxx/stable/main/finkinfo/libs/protobuf-c.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/protobuf-c.info
@@ -1,6 +1,6 @@
 Package: protobuf-c
 Version: 0.15
-Revision: 2
+Revision: 3
 Description: Protocol Buffers from Google for C
 License: BSD
 
@@ -31,7 +31,7 @@ SplitOff: <<
 
 Splitoff2: <<
   Package: protobuf-c-dev
-  Depends: pkgconfig, protobuf-c-shlibs (>= %v-1)
+  Depends: protobuf-c-shlibs (>= %v-1)
   BuildDependsOnly: true
   Files: <<
     include

--- a/10.9-libcxx/stable/main/finkinfo/libs/protobuf.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/protobuf.info
@@ -1,6 +1,6 @@
 Package: protobuf
 Version: 2.4.1
-Revision: 2
+Revision: 3
 Description: Protocol Buffers from Google
 License: BSD
 
@@ -39,7 +39,7 @@ SplitOff: <<
 
 Splitoff2: <<
   Package: protobuf7-dev
-  Depends: pkgconfig, protobuf7-shlibs (>= %v-1)
+  Depends: protobuf7-shlibs (>= %v-1)
   BuildDependsOnly: true
   Files: <<
     include

--- a/10.9-libcxx/stable/main/finkinfo/utils/clamav.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/clamav.info
@@ -1,7 +1,7 @@
 Info3: <<
 Package: clamav
 Version: 0.99.2
-Revision: 1
+Revision: 2
 
 Description: Clam Anti-Virus scanner
 DescDetail: <<
@@ -55,7 +55,8 @@ BuildDepends: <<
   libncurses5,
   libtool2,
   openssl100-dev,
-  libpcre1
+  libpcre1,
+  pkgconfig
 <<
 Depends: <<
   clamav8-shlibs (=%v-%r),
@@ -180,8 +181,7 @@ SplitOff3: <<
   Description: Developer files for ClamAV
   Package: clamav8-dev
   Depends: <<
-    clamav (=%v-%r),
-    pkgconfig
+    clamav (=%v-%r)
   <<
   Provides: clamav-dev
   BuildDependsOnly: true

--- a/10.9-libcxx/stable/main/finkinfo/utils/lhasa.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/lhasa.info
@@ -1,6 +1,6 @@
 Package: lhasa
 Version: 0.3.1
-Revision: 1
+Revision: 2
 Description: LHA/LHarc LArc archives (De-)Compressor
 License: OSI-Approved
 
@@ -50,9 +50,8 @@ SplitOff: <<
 Splitoff2: <<
   Package: %n0-dev
   Description: Files for compiling against liblhasa
-  Depends: pkgconfig, lhasa0-shlibs (= %v-%r)
+  Depends: lhasa0-shlibs (= %v-%r)
   BuildDependsOnly: True
-  Recommends: pkgconfig
   Files: <<
   include
   lib/pkgconfig


### PR DESCRIPTION
We used to need this when .pc used some new syntax to assure a
pkg-config that processed it properly, but no currently supported
distro has ever had a version of pkg-config older than the one that
supports it. Current practice is not to have this dependency solely
because there is a .pc file, and there are other programs now that
could be used instead. Only retain in cases where a program in the
.deb actually runs the pkg-config program.

Affected package-sets:
* @bcully: fuse4x-dev, osxfuse
* @danielj7: libpar.0-dev, libaprutil.0-dev, neon27
* @kamischi: lhasa0-dev, protobuf-c-dev, protobuf7-dev
* Martin Costabel: lcms, lcms2
* @mommsen: clamav8-dev
