### PR TITLE
protobuf, protobuf-c, lhasa: removed Deps: pkgconfig

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/protobuf-c.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/protobuf-c.info
@@ -31,7 +31,7 @@ SplitOff: <<
 
 Splitoff2: <<
   Package: protobuf-c-dev
-  Depends: pkgconfig, protobuf-c-shlibs (>= %v-1)
+  Depends: protobuf-c-shlibs (>= %v-1)
   BuildDependsOnly: true
   Files: <<
     include

--- a/10.9-libcxx/stable/main/finkinfo/libs/protobuf.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/protobuf.info
@@ -39,7 +39,7 @@ SplitOff: <<
 
 Splitoff2: <<
   Package: protobuf7-dev
-  Depends: pkgconfig, protobuf7-shlibs (>= %v-1)
+  Depends: protobuf7-shlibs (>= %v-1)
   BuildDependsOnly: true
   Files: <<
     include

--- a/10.9-libcxx/stable/main/finkinfo/utils/lhasa.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/lhasa.info
@@ -50,9 +50,8 @@ SplitOff: <<
 Splitoff2: <<
   Package: %n0-dev
   Description: Files for compiling against liblhasa
-  Depends: pkgconfig, lhasa0-shlibs (= %v-%r)
+  Depends: lhasa0-shlibs (= %v-%r)
   BuildDependsOnly: True
-  Recommends: pkgconfig
   Files: <<
   include
   lib/pkgconfig


### PR DESCRIPTION
Remove dependence on pkgconfig as proposed by dmacks.