### PR TITLE
Updated dcw-gmt from 1.1.2-1 to 1.1.3-1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/dcw-gmt.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/dcw-gmt.info
@@ -1,8 +1,8 @@
 Package: dcw-gmt
-Version: 1.1.2
+Version: 1.1.3
 Revision: 1
 Source: ftp://ftp.soest.hawaii.edu/gmt/dcw-gmt-%v.tar.gz
-Source-MD5: 45c99d30026742dbc0b1644ea64f496d
+Source-MD5: 57b9bf8f6c266fbc379ebe75ce78c3d4
 Recommends: gmt
 CompileScript: echo "Moving files..."
 InstallScript: <<
@@ -27,5 +27,5 @@ DescPort: <<
 <<
 License: GPL
 DocFiles: LICENSE.TXT README.TXT
-Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
+Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 Homepage: http://gmt.soest.hawaii.edu


### PR DESCRIPTION
This is to update the Fink package to upstream's version 1.1.3