### PR TITLE
Add cdo-openmp and update netcdf-cxx4

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
@@ -46,7 +46,6 @@ PatchFile-MD5: 0a8053ec435bd20ad9eefe7ab2abdd4d
 # Compile Phase:
 NoSetLDFLAGS: true
 ConfigureParams: <<
-	--prefix=%p \
 	--with-netcdf=%p \
 	--with-hdf5=%p \
 	--with-szlib=%p \

--- a/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
@@ -1,14 +1,34 @@
-Package: cdo
+Info2: <<
+Package: cdo%type_pkg[-openmp]
 Version: 1.9.2
-Revision: 1
+Revision: 2
 Description: Climate Data Operators
 HomePage: https://code.zmaw.de/projects/cdo
 License: GPL
+Type: gcc (7), -openmp (. -openmp)
+
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 # Prerequisites
-BuildDepends: hdf5.10, hdf5-cpp11, netcdf-c13, szip, eccodes, fink-package-precedence
-Depends: hdf5.10-shlibs, hdf5-cpp11-shlibs, netcdf-c13-shlibs, szip-shlibs, eccodes-shlibs
+BuildDepends: <<
+	hdf5.10,
+	hdf5-cpp11,
+	netcdf-c13,
+	(%type_raw[-openmp] = -openmp) gcc%type_pkg[gcc]-compiler,
+	szip,
+	eccodes,
+	fink-package-precedence
+<<
+Depends: <<
+	hdf5.10-shlibs,
+	hdf5-cpp11-shlibs,
+	netcdf-c13-shlibs,
+	(%type_raw[-openmp] = -openmp) gcc%type_pkg[gcc]-shlibs,
+	szip-shlibs,
+	eccodes-shlibs
+<<
+Conflicts: %{Ni}, %{Ni}-openmp
+Replaces: %{Ni}, %{Ni}-openmp
 
 # Patch
 # Allow for configuration with Yosemite
@@ -18,14 +38,22 @@ PatchScript: <<
 <<
 
 # Unpack Phase:
-Source: https://code.zmaw.de/attachments/download/16035/%n-%v.tar.gz
+Source: https://code.zmaw.de/attachments/download/16035/%{Ni}-%v.tar.gz
 Source-MD5: 38e68d34f0b5b44a52c3241be6831423
-PatchFile: %n.patch
+PatchFile: %{Ni}.patch
 PatchFile-MD5: 0a8053ec435bd20ad9eefe7ab2abdd4d
 
 # Compile Phase:
 NoSetLDFLAGS: true
-ConfigureParams: --prefix=%p --with-netcdf=%p --with-hdf5=%p --with-szlib=%p --with-grib-api=no --with-eccodes=%p
+ConfigureParams: <<
+	--prefix=%p \
+	--with-netcdf=%p \
+	--with-hdf5=%p \
+	--with-szlib=%p \
+	--with-grib-api=no \
+	--with-eccodes=%p \
+	(%type_raw[-openmp] = -openmp) CC=%p/lib/gcc%type_pkg[gcc]/bin/gcc-%type_pkg[gcc] CXX=%p/lib/gcc%type_pkg[gcc]/bin/g++-%type_pkg[gcc]
+<<
 CompileScript: <<
 	%{default_script}
 	fink-package-precedence .
@@ -60,10 +88,12 @@ The following table gives a short overview about the main categories.
 - Field interpolation (remapbil, remapcon, remapdis, ...)
 - Vertical interpolation (ml2pl, ml2hl)
 - Time interpolation (inttime, intyear)
+Use cdo-openmp to include parallelization.
 <<
 
 DescPort: <<
 - configure needs adjustment to avoid Yosemite being seen as Puma.
 - test needs make -j1, otherwise some tests will fail.
 - disabled tsformat.test with nc4 since it miraculously fails.
+<<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-cxx4.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-cxx4.info
@@ -1,16 +1,16 @@
 Package: netcdf-cxx4
 Version: 4.2.1
-Revision: 3
+Revision: 4
 BuildDependsOnly: true
 GCC: 4.0
-Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
+Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Depends: <<
 	%n-shlibs (= %v-%r), 
 	netcdf-bin (>= 4.3.0-2)
 <<
 BuildDepends: <<
-	netcdf-c11,
+	netcdf-c13,
 	doxygen, 
 	fink-package-precedence, 
  	libcurl4,
@@ -62,7 +62,7 @@ InstallScript: <<
 <<
 SplitOff: <<
   Package: %N-shlibs
-  Depends: netcdf-c11-shlibs (>=4.3.0-2)
+  Depends: netcdf-c13-shlibs
   Conflicts: netcdf-absoft-shlibs
   Replaces: <<
   		netcdf-absoft-shlibs, 
@@ -101,6 +101,8 @@ Patch nc-config accordingly.
 
 Bump revision and versioned dependencies on hdf5.7 and netcdf-c7 when HDF5 (hdf5.7) 
 version is updated.
+
+Former Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 <<
 DescPort: <<
 CXXFLAGS=-O2 is essential to avoid debugging mode flags (-g).


### PR DESCRIPTION
I'd like to propose this addition to Fink: cdo-openmp. This provides parallelization through openmp to CDO. I got some requests from Fink users for this.
cdo-openmp uses gcc7-compiler. To avoid that all cdo users need to install gcc7-compiler, I made cdo-openmp as a conflicts/replaces to cdo (and vice versa).
I think it is easy to maintain them in parellel.