### PR TITLE
viennarna: Separate .info and revision for each different platform-perl version

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/viennarna-10.9.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/viennarna-10.9.info
@@ -1,12 +1,12 @@
 Info2: <<
 Package: viennarna
 Version: 2.1.8
-Revision: 104
+Revision: 4
 Source: http://www.tbi.univie.ac.at/RNA/packages/source/ViennaRNA-%v.tar.gz   
 Source-MD5: 3e47c546857bb18a6f49271250cfde95
 SourceDirectory: ViennaRNA-%v
-Type: perl (5.18.2)
-Distribution: 10.10, 10.11, 10.12, 10.13
+Type: perl (5.16.2)
+Distribution: 10.9
 InfoDocs: RNAlib.info
 ConfigureParams: --mandir=%p/share/man --infodir=%p/share/info    CC=/usr/bin/clang  CXX=/usr/bin/clang++ CFLAGS="-I/usr/include -I%p/include" LDFLAGS="-L/usr/lib"
 Depends: system-perl%type_pkg[perl]


### PR DESCRIPTION
The Type/Distribution was attempting to tie the build results to the
perl version (based on the OS X version) but the result was that the
same %n-%v-%r would use different installation pathnames for different
build-systems. That breaks policy. Instead, separate .info for each
perlversion, so each can have different %r, with bonus of simplifying
the Type and Distribution fields. Now when user moves to newer OS X,
the package self-identifies as needing to be updated.