### PR TITLE
python-ldap-py dependency cleanup

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/python-ldap-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/python-ldap-py.info
@@ -2,19 +2,21 @@ Info2: <<
 Package: python-ldap-py%type_pkg[python]
 Type: python (2.7)
 Version: 2.4.21
-Revision: 1
+Revision: 2
 
-Depends: python%type_pkg[python], openldap24-shlibs, cyrus-sasl2-shlibs, openssl100-shlibs
-BuildDepends: fink (>= 0.24.12), openldap24-dev, cyrus-sasl2-dev, openssl100-dev
+Depends: python%type_pkg[python], openldap24-shlibs
+BuildDepends: fink-package-precedence, openldap24-dev
 
 Source: https://pypi.python.org/packages/source/p/python-ldap/python-ldap-%v.tar.gz
 Source-MD5: 1ce26617e066f412fd5ba95bfba4ba5a
 
 DocFiles: INSTALL LICENCE README TODO
 
-SetLDFLAGS: -lcrypto -lssl -lldap_r -llber -lsasl2
+SetCPPFLAGS: -MD
+SetLDFLAGS: -lldap_r -llber
 CompileScript: <<
   %p/bin/python%type_raw[python] setup.py build
+  fink-package-precedence --depfile-ext='\.d' .
 <<
 
 InstallScript: <<


### PR DESCRIPTION
Remove a bunch of seemingly-unused dependencies (instrumented the
build with f-p-p to help diagnose). Possibly these are long-obsolete
inherited build-depends of the only directly used library or lingering
from older upstream version that used these directly as well.