### PR TITLE
xrootd4: new version and misc packaging fixes

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/xrootd4.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xrootd4.info
@@ -1,16 +1,23 @@
 Package: xrootd4
-Version: 4.5.0
-Revision: 4
+Version: 4.8.1
+Revision: 1
 Description: Distributed access to data repositories
 GCC: 4.0
 
 BuildDepends: <<
   cmake,
-  openssl100-dev,
+  fink (>= 0.28),
+  fink-package-precedence,
+  readline7,
+  libiconv-dev,
+  libxml2 (>= 2.9.1-1),
+  openssl110-dev,
   swig
 <<
 Depends: <<
-  openssl100-shlibs
+  readline7-shlibs,
+  libxml2-shlibs (>= 2.9.1-1),
+  openssl110-shlibs
 <<
 Conflicts: <<
   root5 (<<5.32.00-1),
@@ -23,10 +30,14 @@ Provides: xrootd
 Replaces: xrootd
 
 Source: http://xrootd.org/download/v%v/xrootd-%v.tar.gz
-Source-MD5: d485df3d4a991e1c35efa4bf9ef663d7
+Source-MD5: a307973f7f43b0cc2688dfe502e17709
 
+# dmacks: patch for broken readline test:
+#   https://github.com/xrootd/xrootd/pull/652
+# dmacks: fix some .dylib/.so confusion:
+#   https://github.com/xrootd/xrootd/issues/653
 PatchFile: %n.patch
-PatchFile-MD5: 2a7c84ac55f33585d46139afa0e4a23a
+PatchFile-MD5: fc615d3906321ef0aed383e4918176c8
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 
 CompileScript: <<
@@ -34,16 +45,20 @@ CompileScript: <<
   mkdir build
   cd build
   cmake -DCMAKE_INSTALL_PREFIX=%p \
-    -DPERL_EXECUTABLE=/usr/bin/perl -DPERL_INCLUDE_PATH=/System/Library/Perl/5.12/darwin-thread-multi-2level/CORE \
-    -DPERL_LIBRARY=/System/Library/Perl/5.12/darwin-thread-multi-2level/CORE/libperl.dylib \
-    -DOPENSSL_INCLUDE_DIR=%p/include -DOPENSSL_LIB_DIR=%p/lib \
+    -DOPENSSL_INCLUDE_DIR=%p/include \
     -DENABLE_PYTHON=no \
     -DOPENSSL_CRYPTO_LIBRARY:FILEPATH=%p/lib/libcrypto.dylib \
     -DOPENSSL_INCLUDE_DIR:PATH=%p/include \
     -DOPENSSL_SSL_LIBRARY:FILEPATH=%p/lib/libssl.dylib \
+    -DREADLINE_INCLUDE_DIR:PATH=%p/include \
+    -DREADLINE_LIB:FILEPATH=%p/lib/libreadline.dylib \
     -DCMAKE_VERBOSE_MAKEFILE=ON \
+    -DCMAKE_C_FLAGS:STRING=-MD \
+    -DCMAKE_CXX_FLAGS:STRING=-MD \
     ..
   make
+  cd ..
+  fink-package-precedence --depfile-ext='\.d' --prohibit-bdep=%n-dev .
 <<
 
 InstallScript: <<
@@ -51,6 +66,7 @@ InstallScript: <<
   cd build
   make install DESTDIR=%d
 <<
+DocFiles: COPYING* LICENSE README
 
 RuntimeVars: <<
   XRDSYS: %p
@@ -66,7 +82,8 @@ Shlibs: <<
   %p/lib/libXrdPosix.2.dylib                   2.0.0 %n (>=4.0.0-1)
   %p/lib/libXrdPosixPreload.1.dylib            1.0.0 %n (>=4.0.0-1)
   %p/lib/libXrdServer.2.dylib                  2.0.0 %n (>=4.5.0-1)
-  %p/lib/libXrdThrottle-4.4.dylib              4.0.0 %n (>=4.5.0-1)
+  %p/lib/libXrdSsiLib.1.dylib                  1.0.0 %n (>=4.8.1-1)
+  %p/lib/libXrdSsiShMap.1.dylib                1.0.0 %n (>=4.8.1-1)
   %p/lib/libXrdUtils.2.dylib                   2.0.0 %n (>=4.5.0-1)
   %p/lib/libXrdXml.2.dylib                     2.0.0 %n (>=4.5.0-1)
 <<
@@ -86,13 +103,15 @@ SplitOff: <<
     lib/libXrdPosix.dylib
     lib/libXrdPosixPreload.dylib
     lib/libXrdServer.dylib
-    lib/libXrdThrottle-4.dylib
+    lib/libXrdSsiLib.dylib
+    lib/libXrdSsiShMap.dylib
     lib/libXrdUtils.dylib
     lib/libXrdXml.dylib
-   <<
+  <<
+  DocFiles: COPYING* LICENSE README
 <<
 
-License: GPL/OpenSSL
+License: LGPL/OpenSSL
 
 DescDetail: <<
   The XROOTD project aims at giving high performance, scalable fault

--- a/10.9-libcxx/stable/main/finkinfo/sci/xrootd4.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xrootd4.patch
@@ -1,17 +1,28 @@
-diff -Naur xrootd.orig/bindings/python/CMakeLists.txt xrootd.new/bindings/python/CMakeLists.txt
---- xrootd.orig/bindings/python/CMakeLists.txt	2016-11-10 16:39:01.000000000 +0100
-+++ xrootd.new/bindings/python/CMakeLists.txt	2017-01-09 15:36:06.000000000 +0100
-@@ -19,5 +19,5 @@
+diff -Naur xrootd-4.8.1.orig/bindings/python/CMakeLists.txt xrootd-4.8.1/bindings/python/CMakeLists.txt
+--- xrootd-4.8.1.orig/bindings/python/CMakeLists.txt	2018-01-18 05:36:21.000000000 -0500
++++ xrootd-4.8.1/bindings/python/CMakeLists.txt	2018-02-06 09:49:45.000000000 -0500
+@@ -26,5 +26,5 @@
  install(
    CODE
    "EXECUTE_PROCESS(
 -    COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install --prefix \$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX} --record PYTHON_INSTALLED)")
 +    COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install --prefix ${CMAKE_INSTALL_PREFIX} --record PYTHON_INSTALLED)")
  
-diff -Naur xrootd.orig/cmake/XRootDOSDefs.cmake xrootd.new/cmake/XRootDOSDefs.cmake
---- xrootd.orig/cmake/XRootDOSDefs.cmake	2016-11-10 16:39:01.000000000 +0100
-+++ xrootd.new/cmake/XRootDOSDefs.cmake	2017-01-09 15:33:54.000000000 +0100
-@@ -68,6 +68,7 @@
+diff -Naur xrootd-4.8.1.orig/cmake/FindReadline.cmake xrootd-4.8.1/cmake/FindReadline.cmake
+--- xrootd-4.8.1.orig/cmake/FindReadline.cmake	2018-01-18 05:36:21.000000000 -0500
++++ xrootd-4.8.1/cmake/FindReadline.cmake	2018-02-06 09:49:45.000000000 -0500
+@@ -24,6 +24,7 @@
+     set( CMAKE_REQUIRED_INCLUDES ${READLINE_INCLUDE_DIR} )
+     check_cxx_source_compiles(
+       "
++      #include <stdio.h>
+       #include <readline/readline.h>
+       int main()
+       {
+diff -Naur xrootd-4.8.1.orig/cmake/XRootDOSDefs.cmake xrootd-4.8.1/cmake/XRootDOSDefs.cmake
+--- xrootd-4.8.1.orig/cmake/XRootDOSDefs.cmake	2018-01-18 05:36:21.000000000 -0500
++++ xrootd-4.8.1/cmake/XRootDOSDefs.cmake	2018-02-06 09:49:45.000000000 -0500
+@@ -74,6 +74,7 @@
    set( CMAKE_INSTALL_MANDIR "share/man" )
    set( CMAKE_INSTALL_INCLUDEDIR "include" )
    set( CMAKE_INSTALL_DATADIR "share" )
@@ -19,15 +30,36 @@ diff -Naur xrootd.orig/cmake/XRootDOSDefs.cmake xrootd.new/cmake/XRootDOSDefs.cm
  endif()
  
  #-------------------------------------------------------------------------------
-diff -Naur xrootd.orig/src/XrdPlugins.cmake xrootd.new/src/XrdPlugins.cmake
---- xrootd.orig/src/XrdPlugins.cmake	2016-11-10 16:39:01.000000000 +0100
-+++ xrootd.new/src/XrdPlugins.cmake	2017-01-09 16:07:51.000000000 +0100
-@@ -123,6 +123,8 @@
- set_target_properties(
+diff -Naur xrootd-4.8.1.orig/src/XrdPlugins.cmake xrootd-4.8.1/src/XrdPlugins.cmake
+--- xrootd-4.8.1.orig/src/XrdPlugins.cmake	2018-01-18 05:36:21.000000000 -0500
++++ xrootd-4.8.1/src/XrdPlugins.cmake	2018-02-06 09:51:35.000000000 -0500
+@@ -126,7 +126,7 @@
+ #-------------------------------------------------------------------------------
+ add_library(
    ${LIB_XRD_THROTTLE}
-   PROPERTIES
-+  VERSION   ${PLUGIN_VERSION}
-+  SOVERSION ${PLUGIN_VERSION}
-   INTERFACE_LINK_LIBRARIES ""
-   LINK_INTERFACE_LIBRARIES "" )
+-  SHARED
++  MODULE
+   XrdOfs/XrdOfsFS.cc
+   XrdThrottle/XrdThrottle.hh           XrdThrottle/XrdThrottleTrace.hh
+   XrdThrottle/XrdThrottleFileSystem.cc
+diff -Naur xrootd-4.8.1.orig/src/XrdSsi.cmake xrootd-4.8.1/src/XrdSsi.cmake
+--- xrootd-4.8.1.orig/src/XrdSsi.cmake	2018-01-18 05:36:21.000000000 -0500
++++ xrootd-4.8.1/src/XrdSsi.cmake	2018-02-06 09:53:17.000000000 -0500
+@@ -89,7 +89,7 @@
+ #-------------------------------------------------------------------------------
+ add_library(
+   ${LIB_XRD_SSI}
+-  SHARED
++  MODULE
+   XrdSsi/XrdSsiDir.cc                    XrdSsi/XrdSsiDir.hh
+   XrdSsi/XrdSsiFile.cc                   XrdSsi/XrdSsiFile.hh
+   XrdSsi/XrdSsiFileReq.cc                XrdSsi/XrdSsiFileReq.hh
+@@ -116,7 +116,7 @@
+ #-------------------------------------------------------------------------------
+ add_library(
+   ${LIB_XRD_SSILOG}
+-  SHARED
++  MODULE
+   XrdSsi/XrdSsiLogging.cc
+ )
  


### PR DESCRIPTION
Instrument the build with f-p-p, update (Build)Depends and cmake flags
to get consistent use of fink's libraries (some already missing in old
package, some newly needed in new version).

Resolve some .dylib/.so mixups (NB: some public Shlibs entries removed
compared to previous package; they should have always been private and
.so--not usable by linking by others anyway).

Switch to openssl110.

Adjust license per LICENSE and include licenses in DocFiles

Remove unused (since 4.0.0) perl flags, which haven't been the correct
paths for recent OS X versions anyway.