### PR TITLE
chocolate-doom: upstream fix for FTBFS against current libsamplerate

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/games/chocolate-doom.info
+++ b/10.9-libcxx/stable/main/finkinfo/games/chocolate-doom.info
@@ -1,6 +1,6 @@
 Package: chocolate-doom
 Version: 2.1.0
-Revision: 1
+Revision: 2
 Source: http://www.chocolate-doom.org/downloads/%v/%n-%v.tar.gz
 Source-MD5: b4c4e9063e94f269292a4fa946ebf33c
 License: GPL
@@ -32,7 +32,7 @@ compatibility.
 <<
 DocFiles: AUTHORS COPYING ChangeLog HACKING INSTALL NEWS NOT-BUGS PHILOSOPHY README README.Music README.Strife TODO
 BuildDepends: <<
-  libsamplerate0-dev,
+  libsamplerate0-dev (>= 0.1.9-1),
   libpng16,
   sdl,
   sdl-mixer,
@@ -40,7 +40,7 @@ BuildDepends: <<
   sdl-sound-bin
 <<
 Depends: <<
-  libsamplerate0-shlibs,
+  libsamplerate0-shlibs (>= 0.1.9-1),
   libpng16-shlibs,
   sdl-mixer-shlibs,
   sdl-net-shlibs,
@@ -52,7 +52,14 @@ CompileScript: <<
 %{default_script}
 fink-package-precedence .
 <<
+
+# dmacks: added upstream workaround for new libsamplerate (and dep on
+# it just to be safe)
+# https://github.com/chocolate-doom/chocolate-doom/commit/15b8e6e1e47e4f733f862c16a5c18a3485bd22d4
+PatchFile: %n.patch
+PatchFile-MD5: 3d5aa9ffd0df4e1d83514760408b9758
 PatchScript:<<
+%{default_script}
 perl -pi -e 's,\$\(prefix\)\/games,\$\(prefix\)\/bin,g' src/setup/Makefile.in
 perl -pi -e 's,\$\{exec_prefix\}\/games,\$\{exec_prefix\}\/bin,g' src/Makefile.in
 <<

--- a/10.9-libcxx/stable/main/finkinfo/games/chocolate-doom.patch
+++ b/10.9-libcxx/stable/main/finkinfo/games/chocolate-doom.patch
@@ -1,0 +1,39 @@
+diff -Nurd chocolate-doom-2.1.0.orig/src/i_sdlsound.c chocolate-doom-2.1.0/src/i_sdlsound.c
+--- chocolate-doom-2.1.0.orig/src/i_sdlsound.c	2014-10-22 00:23:29.000000000 -0400
++++ chocolate-doom-2.1.0/src/i_sdlsound.c	2018-02-08 13:00:06.000000000 -0500
+@@ -339,6 +339,7 @@
+                                    int length)
+ {
+     SRC_DATA src_data;
++    float *data_in;
+     uint32_t i, abuf_index=0, clipped=0;
+     uint32_t alen;
+     int retn;
+@@ -346,7 +347,8 @@
+     Mix_Chunk *chunk;
+ 
+     src_data.input_frames = length;
+-    src_data.data_in = malloc(length * sizeof(float));
++    data_in = malloc(length * sizeof(float));
++    src_data.data_in = data_in;
+     src_data.src_ratio = (double)mixer_freq / samplerate;
+ 
+     // We include some extra space here in case of rounding-up.
+@@ -362,7 +364,7 @@
+         // Unclear whether 128 should be interpreted as "zero" or whether a
+         // symmetrical range should be assumed.  The following assumes a
+         // symmetrical range.
+-        src_data.data_in[i] = data[i] / 127.5 - 1;
++        data_in[i] = data[i] / 127.5 - 1;
+     }
+ 
+     // Do the sound conversion
+@@ -430,7 +432,7 @@
+         expanded[abuf_index++] = cvtval_i;
+     }
+ 
+-    free(src_data.data_in);
++    free(data_in);
+     free(src_data.data_out);
+ 
+     if (clipped > 0)


### PR DESCRIPTION
@pierrehenri220 this is yours. I confirmed the bindist build error on my 10.13 and that this upstream patch allows building. There are newer upstream releases in this major-version series and also a new major-version series that I did not test.