### PR TITLE
cmake: fix libidn detection/linking

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/cmake.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/cmake.info
@@ -1,11 +1,11 @@
 Package: cmake
 Version: 3.10.0
-Revision: 1
+Revision: 2
 Source: http://www.cmake.org/files/v3.10/%n-%v.tar.gz
 Source-MD5: f3f8e70ca3055f3cd288f89ff233057e
 License: BSD
-BuildDepends: libidn
-Depends: libidn-shlibs
+BuildDepends: libidn2.0-dev
+Depends: libidn2.0-shlibs
 PatchScript: <<
 # Virtualize explicit '/sw' in sources
   perl -pi -e 's,/sw,%p,g' Modules/*.cmake Modules/Platform/Darwin*.cmake Source/CPack/cmCPack*.h


### PR DESCRIPTION
The package autodetects libidn2 and does not detect libidn; if it does
not detect libidn2, it builds without support for...something. Deps
for libidn suggest intent to support, so switch deps to libidn2.