### PR TITLE
gmt5: virtualize explicit /sw in cmake sources by %p

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/gmt5.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gmt5.info
@@ -21,6 +21,10 @@ Recommends: %n-doc
 NoSetCPPFLAGS: true
 NoSetLDFLAGS: true
 
+PatchScript: <<
+# Virtualize explicit '/sw' in sources
+  perl -pi -e 's,/sw,%p,g' cmake/modules/*.cmake
+<<
 CompileScript: <<
   #!/bin/sh -ev
   mkdir build


### PR DESCRIPTION
This is similar to what Daniel did in some other packages.
I did not update the revision number since this does not affect the package content for those who use /sw.