### PR TITLE
znc: new version

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/net/znc.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/znc.info
@@ -1,17 +1,26 @@
 Package: znc
-Version: 0.206
+Version: 1.6.5
 Revision: 1
 
-BuildDepends: fink (>= 0.24.12), openssl100-dev
-Depends: openssl100-shlibs
+BuildDepends: fink-package-precedence, libicu55-dev, libgnugetopt, openssl110-dev, pkgconfig
+Depends: libicu55-shlibs, libgnugetopt-shlibs, openssl110-shlibs
+GCC: 4.0
 
 Source: http://znc.in/releases/%n-%v.tar.gz
-Source-MD5: b7d3f21da81abaeb553066b0e10beb53
+Source-MD5: ab22e4e94cdd04c5644c4d9213149af0
+PatchScript: <<
+	perl -pi -e 's|/usr/local|%p|g' man/*.1
+<<
 
-DocFiles: AUTHORS LICENSE LICENSE.OpenSSL README.md
+CompileScript: <<
+	./configure %c
+	make V=1
+	fink-package-precedence --depfile-ext='\.dep' --prohibit-bdep=%n .
+<<
+DocFiles: ChangeLog.md LICENSE NOTICE README.md
 
 Description: IRC Bouncer
-DescDetail: <<
+DescUsage: <<
 How does it work?
 
 Install ZNC on your server.
@@ -30,7 +39,6 @@ more help.
 Enjoy! (Profit?)
 <<
 
-License: GPL
+License: BSD
 Homepage: http://wiki.znc.in/ZNC
 Maintainer: Matthias Ringwald <matthias@ringwald.ch>
-


### PR DESCRIPTION
Previous FTBFS on 10.13; easiest fix was to ugprade to the latest
upstream. That also enabled switching to openssl110