### PR TITLE
diffutils: standard 10.13 fix for gnulib vasnprintf

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/utils/diffutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/diffutils.info
@@ -16,10 +16,12 @@
 
 Package: diffutils
 Version: 3.6
-Revision: 1
+Revision: 2
 Maintainer: Max Horn <max@quendi.de>
 Source: mirror:gnu:%n/%n-%v.tar.xz
 Source-MD5: 07cf286672ced26fba54cd0313bdc071
+PatchFile: %n.patch
+PatchFile-MD5: 97d105b97c2fb3b03b0734fcffae8bd1
 BuildDepends: <<
   fink (>= 0.32),
   fink-package-precedence,
@@ -31,10 +33,6 @@ Depends: <<
   libgettext8-shlibs,
   libiconv,
   libsigsegv2-shlibs
-<<
-ConfigureParams: <<
-  --mandir=%p/share/man \
-  --infodir=%p/share/info
 <<
 CompileScript: <<
 #!/bin/sh -ev

--- a/10.9-libcxx/stable/main/finkinfo/utils/diffutils.patch
+++ b/10.9-libcxx/stable/main/finkinfo/utils/diffutils.patch
@@ -1,0 +1,12 @@
+diff -Nurd diffutils-3.6.orig/lib/vasnprintf.c diffutils-3.6/lib/vasnprintf.c
+--- diffutils-3.6.orig/lib/vasnprintf.c	2017-05-18 12:24:03.000000000 -0400
++++ diffutils-3.6/lib/vasnprintf.c	2018-02-17 16:19:47.000000000 -0500
+@@ -4869,7 +4869,7 @@
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if !defined(__APPLE__) && !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';


### PR DESCRIPTION
Prevents runtime (and self-test) segfault. Also remove ConfigureParams path settings that are already the default
in ./configure