### PR TITLE
rcs: standard 10.13 fix for gnulib vasnprintf

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/rcs.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/rcs.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: rcs.patch -*-
 Package: rcs
 Version: 5.9.4
-Revision: 1
+Revision: 2
 Description: GNU Revision Control System
 DescDetail: <<
 	The Revision Control System (RCS) manages multiple revisions of
@@ -19,8 +19,9 @@ Source-MD5: ab57933fb214384e69664ec1c81775fc
 
 # Upstream patch http://git.savannah.gnu.org/cgit/rcs.git/commit/?h=p&id=260704a9164dd34cf7128d6b1e88075ffa3be054
 # Fixes build with Xcode 7.
+# dmacks-- also standard 10.13 fix for gnulib's vasnprintf.c
 PatchFile: %n.patch
-PatchFile-MD5: 1a060ddcee23e779f56e317ba8870098
+PatchFile-MD5: f6d7c8b02fcf5e6f51b674de0000e573
 
 BuildDepends: fink (>= 0.32)
 Depends: diffutils

--- a/10.9-libcxx/stable/main/finkinfo/devel/rcs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/devel/rcs.patch
@@ -1,3 +1,15 @@
+diff -Nurd rcs-5.9.4.orig/lib/vasnprintf.c rcs-5.9.4/lib/vasnprintf.c
+--- rcs-5.9.4.orig/lib/vasnprintf.c	2015-01-07 20:12:58.000000000 -0500
++++ rcs-5.9.4/lib/vasnprintf.c	2018-02-17 16:57:58.000000000 -0500
+@@ -4858,7 +4858,7 @@
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if !defined(__APPLE__) && !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';
 diff --git a/src/b-complain.h b/src/b-complain.h
 index 0ffd157..ea0ffc5 100644
 --- a/src/b-complain.h


### PR DESCRIPTION
Per [Fink-users] fink rcs broken on latest High Sierra