### PR TITLE
Miktex-tools dependencies

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/text/miktex-tools.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/miktex-tools.info
@@ -28,7 +28,7 @@ Depends: <<
 	libpng16-shlibs (>= 1.6.34),
 	libpotrace0-shlibs,
 	liburiparser1-shlibs,
-	openssl100-shlibs,
+	openssl110-shlibs,
 	pixman-shlibs,
 	popt-shlibs,
 	zziplib13-shlibs
@@ -63,7 +63,7 @@ BuildDepends: <<
 	libpotrace0,
 	liburiparser1,
 	libxslt-bin,
-	openssl100-dev,
+	openssl110-dev,
 	pixman,
 	popt,
 	tetex-base,

--- a/10.9-libcxx/stable/main/finkinfo/text/miktex-tools.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/miktex-tools.info
@@ -1,7 +1,7 @@
 Package: miktex-tools
 # 2.9.6600 has %p/MikTeX Console.app and no obvious way to return to standard path layout
 Version: 2.9.6530
-Revision: 1
+Revision: 2
 Description: MiKTeX package manager tools 
 License: DFSG-Approved
 Maintainer: None <fink-devel@lists.sourceforge.net>
@@ -19,6 +19,7 @@ Depends: <<
 	gd3-shlibs (>= 2.2.5),
 	gmp5-shlibs,
 	libcurl4-shlibs (>= 7.56.1),
+	libgraphite2-shlibs,
 	libicu55-shlibs,
 	libjpeg9-shlibs,
 	liblog4cxx10-shlibs,
@@ -51,6 +52,7 @@ BuildDepends: <<
 	libapr.0-dev,
 	libaprutil.0-dev,
 	libcurl4 (>= 7.56.1),
+	libgraphite2-dev,
 	libhunspell,
 	libicu55-dev,
 	libjpeg9,
@@ -101,6 +103,7 @@ CompileScript: <<
 		-DBZIP2_INCLUDE_DIR:PATH=%p/include \
 		-DBZIP2_LIBRARY_RELEASE:FILEPATH=%p/lib/libbz2.dylib \
 		-DCMAKE_CXX_FLAGS="-MD" \
+		-DCMAKE_C_FLAGS="-MD" \
 		-DCURL_INCLUDE_DIR:PATH=%p/include \
 		-DCURL_LIBRARY:FILEPATH=%p/lib/libcurl.dylib \
 		-DEXPAT_INCLUDE_DIR:PATH=%p/include \
@@ -167,7 +170,8 @@ InstallScript: <<
 	#mkdir -p %i/share/texmf-local
 	#mv %i/texmfs/install/miktex %i/share/texmf-local/
 	#rm -rf %i/texmfs
-	# remove unversioned dylibs
+	# remove unversioned dylibs (some are included private copies
+	# of libraries for which fink doesn't have a suitable version)
 	for DYLIB in app core extractor harfbuzz kpathsea lua52 md5 mspack packagemanager poppler setup teckit texmf trace util web2c; do
 		rm %i/lib/libMiKTeX209-$DYLIB.dylib
 	done
@@ -176,7 +180,6 @@ Shlibs: <<
 	!%p/lib/libMiKTeX209-app.2.dylib
 	!%p/lib/libMiKTeX209-core.3.dylib
 	!%p/lib/libMiKTeX209-extractor.1.dylib
-	!%p/lib/libMiKTeX209-graphite2.1.dylib
 	!%p/lib/libMiKTeX209-harfbuzz.1.dylib
 	!%p/lib/libMiKTeX209-kpathsea.1.dylib
 	!%p/lib/libMiKTeX209-lua52.1.dylib


### PR DESCRIPTION
libgraphite dependency sanity; openssl110 upgrade.

@nieder, I'm just doing this mechanically ("it builds and passes tests"). Is there a reason we might want on-board libgraphite and/or remain with openssl100?