### PR TITLE
staden: build-time portability vs tklib and local-lib linking

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/staden.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/staden.info
@@ -45,13 +45,17 @@ Source: mirror:sourceforge:%n/%n/%vb11/%n-%vb11-2016-src.tar.gz
 Source-MD5: ae59565ded12242c4c2728fbf2e185a7
 Source-Checksum: SHA1(a51f0a004961511734a05fd54d8b2b1b0cfd6e32)
 GCC: 4.0
+# Version-agnostic check for tklib (clone other ac_stubs/)
+# A ton of direct linking to .dylib file rather than builddir -L
+PatchFile: %n.patch
+PatchFile-MD5: fb05a1b664031d9c6e64bea4ae09098a
 SetCFLAGS: -MD
 UseMaxBuildJobs: false
 ConfigureParams: <<
 	--with-tcl=%p/lib \
 	--with-tk=%p/lib \
 	--with-io_lib=%p \
-	--with-tklib=%p/lib/tklib0.5 \
+	--with-tklib=%p/lib \
 	--with-iwidgets=%p/lib \
 	--with-itcl=%p/lib \
 	--with-itk=%p/lib

--- a/10.9-libcxx/stable/main/finkinfo/sci/staden.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/staden.patch
@@ -1,0 +1,101 @@
+diff -Nurd staden-2.0.0b11-2016-src.orig/configure staden-2.0.0b11-2016-src/configure
+--- staden-2.0.0b11-2016-src.orig/configure	2018-02-25 23:55:54.000000000 -0500
++++ staden-2.0.0b11-2016-src/configure	2018-02-26 01:33:47.000000000 -0500
+@@ -10382,7 +10382,7 @@
+ 
+   # Look in the place we requested and also in some standard best-guess
+   # locations.
+-  for i in "$_tklib_with" /usr/share/tcl*/tklib* /usr/share/tklib* /usr/local/tklib*
++  for i in $_tklib_with/tklib* $_tklib_with /usr/share/tcl*/tklib* /usr/share/tklib* /usr/local/tklib*
+   do
+     if test -d "$i/tablelist"
+     then
+diff -Nurd staden-2.0.0b11-2016-src.orig/gap5/Makefile staden-2.0.0b11-2016-src/gap5/Makefile
+--- staden-2.0.0b11-2016-src.orig/gap5/Makefile	2018-02-25 23:55:55.000000000 -0500
++++ staden-2.0.0b11-2016-src/gap5/Makefile	2018-02-26 01:33:53.000000000 -0500
+@@ -22,7 +22,7 @@
+ #CFLAGS += -DVALGRIND
+ #CFLAGS += -D_FORTIFY_SOURCE=2 -fstack-protector
+ 
+-GAP5_LIB=-lgap5
++GAP5_LIB=$(L)/libgap5.dylib
+ 
+ #
+ # Building the programs
+diff -Nurd staden-2.0.0b11-2016-src.orig/global.mk staden-2.0.0b11-2016-src/global.mk
+--- staden-2.0.0b11-2016-src.orig/global.mk	2018-02-25 23:55:55.000000000 -0500
++++ staden-2.0.0b11-2016-src/global.mk	2018-02-26 01:33:47.000000000 -0500
+@@ -93,12 +93,12 @@
+ 
+ CLD_PROG	= $(CC)
+ CXXLD_PROG	= $(CXX)
+-CLDFLAGS	= $(CLDFLAGS_S) $(CLDOPTDEBUG) $(LINK_PATHFLAG)$(L) $(CLDFLAGS_E)
+-CXXLDFLAGS      = $(CLDFLAGS_S) $(CLDOPTDEBUG) $(LINK_PATHFLAG)$(L) $(CLDFLAGS_E)
++CLDFLAGS	= $(CLDFLAGS_S) $(CLDOPTDEBUG) $(CLDFLAGS_E)
++CXXLDFLAGS      = $(CLDFLAGS_S) $(CLDOPTDEBUG) $(CLDFLAGS_E)
+ CLD		= $(CLD_PROG) $(CLDFLAGS)
+ CXXLD           = $(CXXLD_PROG) $(CXXLDFLAGS)
+ FLD_PROG	= $(F77)
+-FLDFLAGS	= $(FLDFLAGS_S) $(FOPTDEBUG) $(LINK_PATHFLAG)$(L) $(FLDFLAGS_E)
++FLDFLAGS	= $(FLDFLAGS_S) $(FOPTDEBUG) $(FLDFLAGS_E)
+ FLD		= $(FLD_PROG) $(FLDFLAGS)
+ GAP4SH_LD       = $(FLD) $(FLDFLAGS)
+ LINKF		= $(FLD) $(FLDFLAGS) $(FOBJFLAG) args $(LIBSF)
+@@ -147,7 +147,7 @@
+ 		$(LINK_LIBFLAG)$(CORBA_VER)$(LIB_EXT)
+ endif
+ MATH_LIB     = $(MATH_LIB_S) -lm $(MATH_LIB_E)
+-MISC_LIB     = $(MISC_LIB_S) $(LINK_LIBFLAG)misc$(LIB_EXT) $(MISC_LIB_E)
++MISC_LIB     = $(MISC_LIB_S) $(L)/libmisc.dylib $(MISC_LIB_E)
+ TCL_LIB	     = $(TCL_LIB_S) $(LINK_PATHFLAG)$(TCLBIN) $(LINK_LIBFLAG)tcl$(TCLVERS)$(LIB_EXT) $(MATH_LIB) \
+ 	           $(TCL_LIB_E)
+ TK_LIB	     = $(TK_LIB_S) $(LINK_PATHFLAG)$(TKBIN) $(LINK_LIBFLAG)tk$(TKVERS)$(LIB_EXT) $(TCL_LIB) $(TK_LIB_E)
+@@ -156,21 +156,21 @@
+ ITK_LIB	     = $(ITK_LIB_S) $(LINK_PATHFLAG)$(ITKBIN) $(LINK_LIBFLAG)itk$(ITKVERS)$(LIB_EXT) $(ITCL_LIB) $(ITK_LIB_E)
+ TT_LIB	     = $(TT_LIB_S) $(TTBIN:%=-L%) $(TT_LIBRARY) $(TT_LIB_E)
+ # io-utils and read libraries have now been merged into one.
+-SCF_LIB	     = $(SCF_LIB_S) $(LINK_LIBFLAG)scf$(LIB_EXT) $(LINK_LIBFLAG)io-utils$(LIB_EXT) $(SCF_LIB_E)
+-EXP_LIB	     = $(EXP_LIB_S) $(LINK_LIBFLAG)exp$(LIB_EXT) $(LINK_LIBFLAG)io-utils$(LIB_EXT) $(EXP_LIB_E)
+-G_LIB	     = $(G_LIB_S) $(LINK_LIBFLAG)g$(LIB_EXT) $(G_LIB_E)
+-GAP_LIB	     = $(GAP_LIB_S) $(LINK_LIBFLAG)gap$(LIB_EXT) $(GAP_LIB_E)
++SCF_LIB	     = $(SCF_LIB_S) $(L)/libscf.dylib $(L)/libio-utils.dylib $(SCF_LIB_E)
++EXP_LIB	     = $(EXP_LIB_S) $(L)/libexp.dylib $(L)/libio-utils.dylib $(EXP_LIB_E)
++G_LIB	     = $(G_LIB_S) $(L)/libg.dylib $(G_LIB_E)
++GAP_LIB	     = $(GAP_LIB_S) $(L)/libgap.dylib $(GAP_LIB_E)
+ TCLUTILS_LIB =
+-TKUTILS_LIB  = $(TKUTILS_LIB_S) $(LINK_LIBFLAG)tk_utils$(LIB_EXT) $(TKUTILS_LIB_E)
+-TEXTUTILS_LIB= $(TEXTUTILS_LIB_S) $(LINK_LIBFLAG)text_utils$(LIB_EXT) $(TEXTUTILS_LIB_E)
+-SEQUTILS_LIB = $(SEQUTILS_LIB_S) $(LINK_LIBFLAG)seq_utils$(LIB_EXT) $(SEQUTILS_LIB_E)
+-SEQLIB_LIB   = $(SEQLIB_LIB_S) $(LINK_LIBFLAG)seqlib$(LIB_EXT) $(SEQ_LIB_E)
+-SPIN_LIB     = $(SPIN_LIB_S) $(LINK_LIBFLAG)spin$(LIB_EXT) $(SPIN_LIB_E)
+-COPYREADS_LIB = $(COPYREADS_LIB_S) $(LINK_LIBFLAG)copy_reads$(LIB_EXT) $(COPYREADS_LIB_E)
++TKUTILS_LIB  = $(TKUTILS_LIB_S) $(L)/libtk_utils.dylib $(TKUTILS_LIB_E)
++TEXTUTILS_LIB= $(TEXTUTILS_LIB_S) $(L)/libtext_utils.dylib $(TEXTUTILS_LIB_E)
++SEQUTILS_LIB = $(SEQUTILS_LIB_S) $(L)/libseq_utils.dylib $(SEQUTILS_LIB_E)
++SEQLIB_LIB   = $(SEQLIB_LIB_S) $(L)/libseqlib.dylib $(SEQ_LIB_E)
++SPIN_LIB     = $(SPIN_LIB_S) $(L)/libspin.dylib $(SPIN_LIB_E)
++COPYREADS_LIB = $(COPYREADS_LIB_S) $(L)/libcopy_reads.dylib $(COPYREADS_LIB_E)
+ SCFEXPIO_LIB = $(SCFEXPIO_LIB_S) $(LINK_PATHFLAG)$(SRCROOT)/fakii/scf_exp_io/$(O) $(LINK_LIBFLAG)scf_exp_io$(LIB_EXT) $(SCFEXPIO_LIB_E)
+ ZLIB_LIB     = $(ZLIB_LIB_S) $(LINK_LIBFLAG)z$(LIB_EXT) $(ZLIB_LIB_E)
+-MUT_LIB      = $(MUT_LIB_S) $(LINK_LIBFLAG)mutlib$(LIB_EXT) $(MUT_LIB_E)
+-P3_LIB	     = $(P3_LIB_S)  $(LINK_LIBFLAG)primer3$(LIB_EXT) $(P3_LIB_E)
++MUT_LIB      = $(MUT_LIB_S) $(L)/libmutlib.dylib $(MUT_LIB_E)
++P3_LIB	     = $(P3_LIB_S)  $(L)/libprimer3.dylib $(P3_LIB_E)
+ 
+ 
+ # Standard chunks to add to the compile line
+diff -Nurd staden-2.0.0b11-2016-src.orig/system.mk.in staden-2.0.0b11-2016-src/system.mk.in
+--- staden-2.0.0b11-2016-src.orig/system.mk.in	2018-02-25 23:55:55.000000000 -0500
++++ staden-2.0.0b11-2016-src/system.mk.in	2018-02-26 01:33:47.000000000 -0500
+@@ -71,9 +71,9 @@
+ CXXFLAGS	  = @CXXFLAGS@ $(DEFINES) $(INCLUDES) -DSVN_VERSION="$(SVNVERS)"
+ CPP		  = @CPP@
+ CPPFLAGS	  = @CPPFLAGS@
+-LDFLAGS		  = -L$(L) @LDFLAGS@ @CC_SEARCH_FLAGS@
++LDFLAGS		  = @LDFLAGS@ @CC_SEARCH_FLAGS@
+ #CLDFLAGS	  = -L$(L) -Wl,-rpath-link,$(L) $(subst -L,-Wl$(comma)-rpath-link$(comma),$(filter -L%,$(IOLIB_LIB)))
+-CLDFLAGS	  = -L$(L) @LDFLAGS@ @CC_SEARCH_FLAGS@
++CLDFLAGS	  = @LDFLAGS@ @CC_SEARCH_FLAGS@
+ CXXLDFLAGS	  = $(CLDFLAGS)
+ F77		  = @F77@
+ FFLAGS		  = @FFLAGS@


### PR DESCRIPTION
The package hardcoded the path to the specific version of tklib, whereas other tcl/tk wildcarded it. Wildcard it so tklib can be upgraded without breaking this detection (it appears it is solely for *detection*, not runtime).

The makefiles used -L flags for the local builddir and then -l to find libs therein. That's fragile if -L get mis-ordered or the libs get mis-built (or built in an unexpected order). Instead, hardcode paths to the actual library files.