### PR TITLE
astng-py3x: call '2to3' with fink prefix and match pythonvariant

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/astng-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/astng-py.info
@@ -11,6 +11,12 @@ Description: Python Abstract Syntax Tree New Generation
 Maintainer: Kurt Schwehr <goatbar@users.sf.net>
 Homepage: http://www.logilab.org/projects/astng
 DocFiles: 
+PatchScript: <<
+   # Need to get correct 3.x and correct vendor (i.e., full path).
+   # Silly for 2.x, but on a codepath only used by 3.x so it's easier
+   # than special-case patching different variants.
+   perl -pi -e "s|'2to3'|'%p/bin/2to3-%type_raw[python]'|" setup.py
+<<
 CompileScript: <<
   echo Skipping Build
 <<


### PR DESCRIPTION
This fixes FTBFS on -py3x and has no effect on -py2x. See http://bindist.finkproject.org/10.13/logs/astng-py34_0.24.3-1_71c13179f47da313f6035b043b5b50c3.log
