### PR TITLE
optipng: new version

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/optipng.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/optipng.info
@@ -15,11 +15,11 @@
 # maintainership of) the affected package.
 
 Package: optipng
-Version: 0.7.6
+Version: 0.7.7
 Revision: 1
 Maintainer: Max Horn <max@quendi.de>
 Source: mirror:sourceforge:%n/%n-%v.tar.gz
-Source-MD5: 568e0738358450eca69ecf578d48f26c
+Source-MD5: 211101965baf42fd24a2aa990b7e842e
 CompileScript: ./configure -prefix=%p -mandir=%p/share/man
 InstallScript: make install DESTDIR=%d
 DocFiles: *.txt doc/*.txt doc/*.html


### PR DESCRIPTION
Fink's current 0.7.6 fails to build on 10.13 for me and also in the [bindist for 10.13](http://bindist.finkproject.org/10.13/logs/optipng_0.7.6-1_9ceab30cd68c7fb77253fc36d942c5b6.log). I don't see an error in the 10.11/10.12 bindist. Upstream has a [bug report about it](https://sourceforge.net/p/optipng/patches/9/) that says 10.13 being different than older versions, but that 10.12 would be like 10.13?

The attached upgrades to the new 0.7.7 upstream (which also has some major security fixes), and builds for me on 10.13. Probably should get someone with 10.12 (I don't have it), and maybe something older to test-build, or else have this specifically tagged for 10.13 only for now.