### PR TITLE
Convertall update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/convertall.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/convertall.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: convertall
-Version: 0.6.0
+Version: 0.6.1
 Revision: 1
 Type: python (3.4)
 Maintainer: Kevin Horton <khorton02@gmail.com>
@@ -10,7 +10,7 @@ Depends: <<
   pyqt4-mac-py%type_pkg[python] (>= 4.11.3-1) 
 <<
 Source: http://sourceforge.net/projects/convertall/files/%v/convertall-%v.tar.gz
-Source-MD5: b68244fa83ccbdeaf223b9ad22399606
+Source-MD5: c7eb1cd75e665d0e0349855175bc6ad6
 SourceDirectory: ConvertAll
 CompileScript: <<
 echo "Nothing to do in compile phase"

--- a/10.9-libcxx/stable/main/finkinfo/sci/convertall.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/convertall.info
@@ -1,26 +1,27 @@
 Info2: <<
 Package: convertall
-Version: 0.6.1
+Version: 0.7.3
 Revision: 1
 Type: python (3.4)
 Maintainer: Kevin Horton <khorton02@gmail.com>
 Depends: <<
   python%type_pkg[python], 
   python%type_pkg[python]-shlibs, 
-  pyqt4-mac-py%type_pkg[python] (>= 4.11.3-1) 
+  pyqt5-mac-py%type_pkg[python] (>= 5.6-2),
+  qt5-mac-qcocoa-plugin (>=5.7.1-5)
 <<
 Source: http://sourceforge.net/projects/convertall/files/%v/convertall-%v.tar.gz
-Source-MD5: c7eb1cd75e665d0e0349855175bc6ad6
+Source-MD5: 1d2e012d18f12950add237dc7611331a
 SourceDirectory: ConvertAll
 CompileScript: <<
 echo "Nothing to do in compile phase"
 <<
 InstallScript: <<
   #! /bin/sh -ev
-  export PYTHONPATH="%p/lib/qt4-mac/lib/python%type_raw[python]/site-packages:$PYTHONPATH"
+  export PYTHONPATH="%p/lib/qt5-mac/lib/python%type_raw[python]/site-packages:$PYTHONPATH"
   %p/bin/python%type_raw[python] install.py -p %p -b %d
   rm -fr %i/share/doc/convertall
-  perl -pi -e 's|exec|exec env PYTHONPATH="%p/lib/qt4-mac/lib/python%type_raw[python]/site-packages:$PYTHONPATH"|g' %i/bin/convertall
+  perl -pi -e 's|exec|exec env PYTHONPATH="%p/lib/qt5-mac/lib/python%type_raw[python]/site-packages:$PYTHONPATH"|g' %i/bin/convertall
 <<
 License: GPL
 DocFiles: doc/*


### PR DESCRIPTION
Updated convertall to latest upstream version.  Updated dependencies to qt5 as required by latest upstream.  Built on macOS 10.13 with fink -m rebuild convertall.  Functionally tested with no obvious errors.