### PR TITLE
updated xephem to latest upstream version

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pyephem-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pyephem-py.info
@@ -1,12 +1,12 @@
 Info2: <<
 Package: pyephem-py%type_pkg[python]
-Version: 3.7.5.3
+Version: 3.7.6.0
 Revision: 1
-Type: python (2.7)
-Maintainer: Kevin Horton <khorton01@rogers.com>
+Type: python (2.7 3.4)
+Maintainer: Kevin Horton <khorton02@gmail.com>
 Depends: python%type_pkg[python]
-Source: http://pypi.python.org/packages/source/p/pyephem/pyephem-%v.tar.gz
-Source-MD5: 46b101da152bb109b1137263b150f390
+Source: https://pypi.io/packages/source/p/pyephem/pyephem-%v.tar.gz
+Source-MD5: 3d6c19d92a2a80fef87770f3e2007453
 CompileScript: %p/bin/python%type_raw[python] setup.py build
 InstallScript: <<
  %p/bin/python%type_raw[python] setup.py install --root=%d
@@ -18,7 +18,7 @@ InstallScript: <<
  # /bin/cp test %i/share/doc/%n/
  /bin/cp -R ephem/doc %i/share/doc/%n/
  /bin/mkdir -p %i/include/python%type_raw[python]/libastro-%v/
- /bin/cp libastro-3.7.5/*.h %i/include/python%type_raw[python]/libastro-%v/
+ /bin/cp libastro-3.7.6/*.h %i/include/python%type_raw[python]/libastro-%v/
 <<
 DocFiles: ephem/doc/CHANGELOG.rst COPYING LICENSE-GPL LICENSE-LGPL README.rst PKG-INFO
 Description: The astronomy library for Python

--- a/10.9-libcxx/stable/main/finkinfo/sci/xephem.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xephem.info
@@ -1,16 +1,16 @@
 Package: xephem
-Version: 3.7.6
-Revision: 4
+Version: 3.7.7
+Revision: 1
 BuildDepends: fink-buildenv-modules, fink-package-precedence, libxt-flat, openmotif4, x11-dev
 Depends: libxt-flat-shlibs, openmotif4-shlibs, x11-shlibs
-Source: http://97.74.56.125/free/%n-%v.tar.gz
-Source-MD5: 9b8b7e8892c94587880fec17cd25289e
+Source: http://www.clearskyinstitute.com/xephem/%n-%v.tgz
+Source-MD5: 27c67061a89085bf2b0d4e9deb758a79
 
 Source2: http://www.clearskyinstitute.com/xephem/wmm.cof
 Source2-MD5: 13a643a1cc4726081b5c727689963f3b
 
 PatchFile: %n.patch
-PatchFile-MD5: 3ace95751111752d16b2c41214ba9e91
+PatchFile-MD5: 730c045ab48919c720e01697c8644dac
 PatchScript: <<
 #!/bin/sh -ev
 . %p/sbin/fink-buildenv-helper.sh

--- a/10.9-libcxx/stable/main/finkinfo/sci/xephem.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xephem.patch
@@ -1,16 +1,15 @@
 diff -Nurd -x'*~' xephem-3.7.2.orig/GUI/xephem/Makefile xephem-3.7.2/GUI/xephem/Makefile
 --- xephem-3.7.2.orig/GUI/xephem/Makefile	2006-05-13 19:06:06.000000000 -0400
 +++ xephem-3.7.2/GUI/xephem/Makefile	2007-06-15 00:34:30.000000000 -0400
-@@ -35,8 +35,8 @@
+@@ -35,7 +35,7 @@
  CC = gcc
  CLDFLAGS = -g
- CFLAGS = $(LIBINC) $(CLDFLAGS) -O2 -Wall -I$(MOTIFI) -I/usr/X11R6/include
--LDFLAGS = $(LIBLNK) $(CLDFLAGS) -L$(MOTIFL) -L/usr/X11R6/lib
-+AM_LDFLAGS = $(LIBLNK) $(CLDFLAGS) -L$(MOTIFL) -L/usr/X11R6/lib
+ CFLAGS = $(LIBINC) $(CLDFLAGS) -O2 -Wall -I$(MOTIFI) -I/opt/X11/include
+-LDFLAGS = $(LIBLNK) $(CLDFLAGS) -L$(MOTIFL) -L/opt/X11/lib
++AM_LDFLAGS = $(LIBLNK) $(CLDFLAGS) -L$(MOTIFL) -L/opt/X11/lib
  XLIBS = -lXm -lXp -lXt -lXext -lXmu -lX11
  LIBS = $(XLIBS) $(LIBLIB) -lm
  
- # for ppc Apple OS X to make universal (i386 and ppc binary), requires
 @@ -181,7 +181,7 @@
  all: libs xephem xephem.1
  


### PR DESCRIPTION
Updated xephem to latest upstream version.  Builds on macOS 10.13 with "fink -m xephem".  Functionally tested.

Update:
Whoops - I just realized that this branch didn't have the updated maintainer email address.  I'm not sure how to sort this out now that I have already made the Pull Request.  The maintainer email needs to be khorton02@gmail.com