### PR TITLE
update pyephem-py to latest upstream version. 

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pyephem-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pyephem-py.info
@@ -1,12 +1,12 @@
 Info2: <<
 Package: pyephem-py%type_pkg[python]
-Version: 3.7.5.3
+Version: 3.7.6.0
 Revision: 1
-Type: python (2.7)
-Maintainer: Kevin Horton <khorton01@rogers.com>
+Type: python (2.7 3.4)
+Maintainer: Kevin Horton <khorton02@gmail.com>
 Depends: python%type_pkg[python]
-Source: http://pypi.python.org/packages/source/p/pyephem/pyephem-%v.tar.gz
-Source-MD5: 46b101da152bb109b1137263b150f390
+Source: https://pypi.io/packages/source/p/pyephem/pyephem-%v.tar.gz
+Source-MD5: 3d6c19d92a2a80fef87770f3e2007453
 CompileScript: %p/bin/python%type_raw[python] setup.py build
 InstallScript: <<
  %p/bin/python%type_raw[python] setup.py install --root=%d
@@ -18,7 +18,7 @@ InstallScript: <<
  # /bin/cp test %i/share/doc/%n/
  /bin/cp -R ephem/doc %i/share/doc/%n/
  /bin/mkdir -p %i/include/python%type_raw[python]/libastro-%v/
- /bin/cp libastro-3.7.5/*.h %i/include/python%type_raw[python]/libastro-%v/
+ /bin/cp libastro-3.7.6/*.h %i/include/python%type_raw[python]/libastro-%v/
 <<
 DocFiles: ephem/doc/CHANGELOG.rst COPYING LICENSE-GPL LICENSE-LGPL README.rst PKG-INFO
 Description: The astronomy library for Python
@@ -39,4 +39,6 @@ DescUsage: <<
 <<
 License: LGPL
 Homepage: http://rhodesmill.org/pyephem/
+<<
+
 <<


### PR DESCRIPTION
update pyephem-py to latest upstream version.  Tested on macOS 10.13 with python 2.7 & 3.4.  Builds with fink -m