### PR TITLE
updated dbi-pm to latest upstream version

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/dbi-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/dbi-pm.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: dbi-pm%type_pkg[perl]
-Version: 1.639
+Version: 1.640
 Revision: 1
 Epoch: 1
 Description: Perl Database Interface by Tim Bunce
@@ -19,7 +19,7 @@ Depends: <<
 <<
 
 Source: mirror:cpan:modules/by-module/DBI/DBI-%v.tar.gz
-Source-MD5: f9bf9775b3dbaabc4630b2b29941aa89
+Source-MD5: 47d37079ba164908a65fb86f8179cb74
 PatchScript: <<
 #!/bin/sh -ev
 	perlversion=%type_raw[perl]


### PR DESCRIPTION
Updated dbi-pm to latest upstream version.  Builds with fink -m on macOS 10.13.