### PR TITLE
fltk13-aqua 1.3.4

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/fltk13-aqua.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/fltk13-aqua.info
@@ -1,6 +1,6 @@
 Package: fltk13-aqua
-Version: 1.3.3
-Revision: 3
+Version: 1.3.4
+Revision: 1
 Maintainer: None <fink-devel@lists.sourceforge.net>
 #
 Description: GUI toolkit (Aqua graphics)
@@ -40,12 +40,6 @@ Patch to show actual compiling commands, not synopses of them.
 
 Don't continue if any make target fails.
 
-Patch to avoid chmod +x on libraries.
-
-Patch for libjpeg9 as described in http://www.fltk.org/str.php?L2920.
-
-Patch fluid/Fl_Type.h for stricter clang from Xcode 5.1+.
-
 As of 1.3.3-3:  Patch FL/mac.h to assume Fl_Font.H is in FL/ rather 
 				than in ../src, and manually install that header
 				After install in root directory, comment out XUtf8FontStruct 
@@ -71,39 +65,58 @@ As of 1.3.3-3:  Patch FL/mac.h to assume Fl_Font.H is in FL/ rather
 Homepage: http://www.fltk.org/
 License: LGPL
 #
-BuildDepends: libjpeg9, libpng16, fink ( >= 0.30.0 )
-Depends: %N-shlibs (= %v-%r), macosx, libjpeg9-shlibs, libpng16-shlibs
+BuildDepends: <<
+	fink ( >= 0.30.0 ),
+	libjpeg9,
+	libpng16
+<<
+Depends: <<
+	%N-shlibs (= %v-%r),
+	libjpeg9-shlibs,
+	libpng16-shlibs,
+	macosx
+<<
 Conflicts: fltk-x11, fltk, fltk-aqua, fltk13-x11
 Replaces: fltk-x11, fltk, fltk-aqua, fltk13-x11
 BuildDependsOnly: true
 #
-Source: http://fltk.org/pub/fltk/%v/fltk-%v-source.tar.gz
+Source: http://fltk.org/pub/fltk/%v/fltk-%v-2-source.tar.gz
 #
-SourceDirectory: fltk-%v
-Source-MD5: 9ccdb0d19dc104b87179bd9fd10822e3
-Source-Checksum: SHA1(873aac49b277149e054b9740378e2ca87b0bd435)
+SourceDirectory: fltk-%v-2
+Source-MD5: b8e291343357e49dd81a22408744e400
+Source-Checksum: SHA1(239f0d915c80c0be91dad3f64dacbfad82133bee)
 
 PatchFile: %n.patch
-PatchFile-MD5: 8186277b500f61fef0d1430233a6fef1
+PatchFile-MD5: 7def8a4cb4ac70620b47bab56667e20e
 
 PatchScript: <<
 #!/bin/sh -ev
   sed 's|@FINKPREFIX@|%p|' %{PatchFile} | patch -p1
-  perl -pi -e 's/\*l=0/*l/g' fluid/Fl_Type.h
-  mv fltk-config.in fltk-config.in.old
-  sed 's: prefix=$optarg: prefix=$optarg; includedir=${prefix}/include:' < fltk-config.in.old > fltk-config.in
-  mv fluid/Makefile fluid/Makefile.old
-  sed 's;$(bindir)/fltk-config;$(bindir)/fltk-config --prefix=$(prefix);' < fluid/Makefile.old > fluid/Makefile
+  #perl -pi -e 's/\*l=0/*l/g' fluid/Fl_Type.h
+  #mv fltk-config.in fltk-config.in.old
+  #sed 's: prefix=$optarg: prefix=$optarg; includedir=${prefix}/include:' < fltk-config.in.old > fltk-config.in
+  #mv fluid/Makefile fluid/Makefile.old
+  #sed 's;$(bindir)/fltk-config;$(bindir)/fltk-config --prefix=$(prefix);' < fluid/Makefile.old > fluid/Makefile
+  # Don't print the silent versions of the compiler commands
   perl -ni -e 'print unless /echo.*COMMAND/' src/Makefile
-  perl -pi -e 's/\|\| break//' Makefile
-  perl -pi -e 's/ 755 / 644 / if /\/lib.*\.{a,dylib}/' src/Makefile
+  #perl -pi -e 's/\|\| break//' Makefile
+  #perl -pi -e 's/ 755 / 644 / if /\/lib.*\.{a,dylib}/' src/Makefile
+  # don't install manpages (see DescPackaging)
   perl -ni -e 'print unless /mandir\)\/cat/' documentation/Makefile
+  # variantize doc install location
   perl -pi -e 's|share/doc/fltk|share/doc/%n/html|g' configure
-  perl -pi -e 's|from_parent\-\>deparent\(from\) \< 0|\!\(from_parent\-\>deparent\(from\)\)|g' src/Fl_Tree_Item.cxx
+  #perl -pi -e 's|from_parent\-\>deparent\(from\) \< 0|\!\(from_parent\-\>deparent\(from\)\)|g' src/Fl_Tree_Item.cxx
 <<
 #
 GCC: 4.0
-ConfigureParams: --mandir=%p/share/man --libdir=%p/lib/%n/lib --enable-shared --enable-threads --without-links --without-x
+ConfigureParams: <<
+	--mandir=%p/share/man \
+	--libdir=%p/lib/%n/lib \
+	--enable-shared \
+	--enable-threads \
+	--without-links \
+	--without-x
+<<
 SetCXXFLAGS: -O2 -g -std=c++0x
 #
 #### Default CompileScript ####
@@ -127,34 +140,36 @@ AppBundles: fluid/fluid.app
 DocFiles: CHANGES COPYING CREDITS README README.OSX.txt
 #
 Splitoff: <<
-Package:  %N-shlibs
-Depends: libjpeg9-shlibs, libpng16-shlibs, macosx
-Conflicts: fltk
-Replaces: fltk
-BuildDependsOnly: false
-Files:  <<
-lib/%N/lib/*.1.3.dylib 
-bin/%N-config
-<<
-Shlibs: <<
-	%p/lib/fltk13-aqua/lib/libfltk.1.3.dylib 			1.3.0 %n (>=1.3.0-1)
-	%p/lib/fltk13-aqua/lib/libfltk_forms.1.3.dylib 		1.3.0 %n (>=1.3.0-1)
-	%p/lib/fltk13-aqua/lib/libfltk_gl.1.3.dylib 		1.3.0 %n (>=1.3.0-1)
-	%p/lib/fltk13-aqua/lib/libfltk_images.1.3.dylib 	1.3.0 %n (>=1.3.0-1)
-<<
-DescUsage: <<
-This package contains the shared libraries.
+Package: %N-shlibs
+	Depends: <<
+		libjpeg9-shlibs,
+		libpng16-shlibs,
+		macosx
+	<<
+	Conflicts: fltk
+	Replaces: fltk
+	BuildDependsOnly: false
+	Files:  <<
+		lib/%N/lib/*.1.3.dylib 
+		bin/%N-config
+	<<
+	Shlibs: <<
+		%p/lib/fltk13-aqua/lib/libfltk.1.3.dylib 			1.3.0 %n (>=1.3.0-1)
+		%p/lib/fltk13-aqua/lib/libfltk_forms.1.3.dylib 		1.3.0 %n (>=1.3.0-1)
+		%p/lib/fltk13-aqua/lib/libfltk_gl.1.3.dylib 		1.3.0 %n (>=1.3.0-1)
+		%p/lib/fltk13-aqua/lib/libfltk_images.1.3.dylib 	1.3.0 %n (>=1.3.0-1)
+	<<
+	DescUsage: <<
+		This package contains the shared libraries.
 
-Any package that Depends on this one and builds an app bundle may need 
-to have the following in a PostInstScript:
+		Any package that Depends on this one and builds an app bundle may need 
+		to have the following in a PostInstScript:
 
-fltk13-aqua-config.aqua --post <name of executable>
+		fltk13-aqua-config.aqua --post <name of executable>
 
-where <name of executable> is the real executable, not just the app bundle.
-This is because even if the package is set up properly, packing the 
-.deb appears to clobber the resource fork.
-
-DocFiles: CHANGES COPYING CREDITS README README.mac
-
-<<
+		where <name of executable> is the real executable, not just the app bundle.
+		This is because even if the package is set up properly, packing the 
+		.deb appears to clobber the resource fork.
+	<<
+	DocFiles: CHANGES COPYING CREDITS README README.OSX.txt
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/fltk13-aqua.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/fltk13-aqua.patch
@@ -1,16 +1,16 @@
-diff -Nurd fltk-1.3.0/configure fltk-1.3.0.patched/configure
---- fltk-1.3.0/configure	2011-06-16 11:50:44.000000000 -0400
-+++ fltk-1.3.0.patched/configure	2011-08-27 16:03:31.000000000 -0400
-@@ -2011,7 +2011,7 @@
-             GLDSONAME="libfltk_gl.$FL_API_VERSION.dylib"
-             IMGDSONAME="libfltk_images.$FL_API_VERSION.dylib"
-             CAIRODSONAME="libfltk_cairo.$FL_API_VERSION.dylib"
+diff -ruN fltk-1.3.4-2/configure fltk-1.3.4-2.patched/configure
+--- fltk-1.3.4-2/configure	2016-11-15 05:57:17.000000000 -0600
++++ fltk-1.3.4-2.patched/configure	2018-03-11 10:15:33.000000000 -0500
+@@ -3828,7 +3828,7 @@
+ 	    GLDSONAME="libfltk_gl.$FL_DSO_VERSION.dylib"
+ 	    IMGDSONAME="libfltk_images.$FL_DSO_VERSION.dylib"
+ 	    CAIRODSONAME="libfltk_cairo.$FL_DSO_VERSION.dylib"
 -	    DSOCOMMAND="\$(CXX) \$(ARCHFLAGS) \$(DSOFLAGS) -dynamiclib -lc -o"
 +	    DSOCOMMAND="\$(CXX) \$(DSOFLAGS) -L@FINKPREFIX@/lib -dynamiclib -lc -o"
  	    ;;
  
- 	SunOS* | UNIX_S*)
-@@ -2123,7 +2123,7 @@
+ 	solaris*)
+@@ -4036,7 +4036,7 @@
  	    ;;
      esac
  
@@ -19,10 +19,10 @@ diff -Nurd fltk-1.3.0/configure fltk-1.3.0.patched/configure
  else
      DSOCOMMAND="echo"
      DSOLINK=""
-diff -Nurd fltk-1.3.0/makeinclude.in fltk-1.3.0.patched/makeinclude.in
---- fltk-1.3.0/makeinclude.in	2010-12-23 09:24:29.000000000 -0500
-+++ fltk-1.3.0.patched/makeinclude.in	2011-08-27 15:35:23.000000000 -0400
-@@ -99,7 +99,7 @@
+diff -ruN fltk-1.3.4-2/makeinclude.in fltk-1.3.4-2.patched/makeinclude.in
+--- fltk-1.3.4-2/makeinclude.in	2015-03-25 15:06:54.000000000 -0500
++++ fltk-1.3.4-2.patched/makeinclude.in	2018-03-11 10:16:16.000000000 -0500
+@@ -102,7 +102,7 @@
  LINKFLTKCAIRO	= @LINKFLTKCAIRO@ $(CAIROLIBS)
  FLTKCAIROOPTION = @FLTKCAIROOPTION@
  LINKSHARED	= @DSOLINK@ @LINKSHARED@ $(IMAGELIBS) $(CAIROLIBS)
@@ -31,7 +31,7 @@ diff -Nurd fltk-1.3.0/makeinclude.in fltk-1.3.0.patched/makeinclude.in
  
  # image libraries to build...
  IMAGEDIRS	= @JPEG@ @ZLIB@ @PNG@
-@@ -140,7 +140,7 @@
+@@ -143,7 +143,7 @@
  UNINSTALL_DESKTOP = @UNINSTALL_DESKTOP@
  
  # Be quiet when building...
@@ -40,197 +40,33 @@ diff -Nurd fltk-1.3.0/makeinclude.in fltk-1.3.0.patched/makeinclude.in
  
  # Build commands and filename extensions...
  .SUFFIXES:	.0 .1 .3 .6 .c .cxx .mm .h .fl .man .o .z $(EXEEXT)
-diff -Nurd fltk-1.3.0/src/Makefile fltk-1.3.0.patched/src/Makefile
---- fltk-1.3.0/src/Makefile	2011-02-06 09:08:08.000000000 -0500
-+++ fltk-1.3.0.patched/src/Makefile	2011-08-27 15:55:17.000000000 -0400
-@@ -292,7 +292,7 @@
+diff -ruN fltk-1.3.4-2/src/Makefile fltk-1.3.4-2.patched/src/Makefile
+--- fltk-1.3.4-2/src/Makefile	2015-03-25 15:06:54.000000000 -0500
++++ fltk-1.3.4-2.patched/src/Makefile	2018-03-11 10:33:13.000000000 -0500
+@@ -291,7 +291,7 @@
  		-install_name $(libdir)/$@ \
- 		-current_version 1.3.0 \
- 		-compatibility_version 1.3.0 \
+ 		-current_version $(FL_VERSION) \
+ 		-compatibility_version $(FL_ABI_VERSION) \
 -		$(FLOBJECTS) -L. $(LDLIBS) -lfltk
 +		$(FLOBJECTS) -L. $(LDLIBS) libfltk.1.3.dylib
  	$(RM) libfltk_forms.dylib
- 	$(LN) libfltk_forms.1.3.dylib libfltk_forms.dylib
+ 	$(LN) libfltk_forms.$(FL_DSO_VERSION).dylib libfltk_forms.dylib
  
-@@ -328,7 +328,7 @@
+@@ -327,7 +327,7 @@
  		-install_name $(libdir)/$@ \
- 		-current_version 1.3.0 \
- 		-compatibility_version 1.3.0 \
+ 		-current_version $(FL_VERSION) \
+ 		-compatibility_version $(FL_ABI_VERSION) \
 -		$(GLOBJECTS) -L. $(GLDLIBS) -lfltk
 +		$(GLOBJECTS) -L. $(GLDLIBS) libfltk.1.3.dylib
  	$(RM) libfltk_gl.dylib
- 	$(LN) libfltk_gl.1.3.dylib libfltk_gl.dylib
+ 	$(LN) libfltk_gl.$(FL_DSO_VERSION).dylib libfltk_gl.dylib
  
-@@ -364,7 +364,7 @@
+@@ -363,7 +363,7 @@
  		-install_name $(libdir)/$@ \
- 		-current_version 1.3.0 \
- 		-compatibility_version 1.3.0 \
+ 		-current_version $(FL_VERSION) \
+ 		-compatibility_version $(FL_ABI_VERSION) \
 -		$(IMGOBJECTS)  -L. $(LDLIBS) $(IMAGELIBS) -lfltk
 +		$(IMGOBJECTS)  -L. $(LDLIBS) $(IMAGELIBS) libfltk.1.3.dylib
  	$(RM) libfltk_images.dylib
- 	$(LN) libfltk_images.1.3.dylib libfltk_images.dylib
+ 	$(LN) libfltk_images.$(FL_DSO_VERSION).dylib libfltk_images.dylib
  
- extern void fl_internal_boxtype(Fl_Boxtype, Fl_Box_Draw_F*);
---- fltk-1.3.2/jpeg/jmorecfg.h.orig	2013-07-19 08:48:14.000000000 -0400
-+++ fltk-1.3.2/jpeg/jmorecfg.h	2013-07-19 08:50:50.000000000 -0400
-@@ -232,14 +232,15 @@
-  * Defining HAVE_BOOLEAN before including jpeglib.h should make it work.
-  */
- 
--#ifndef HAVE_BOOLEAN
--typedef int boolean;
--#endif
--#ifndef FALSE			/* in case these macros already exist */
--#define FALSE	0		/* values of boolean */
-+#ifdef HAVE_BOOLEAN
-+#ifndef FALSE           /* in case these macros already exist */
-+#define FALSE   0       /* values of boolean */
- #endif
- #ifndef TRUE
--#define TRUE	1
-+#define TRUE    1
-+#endif
-+#else
-+typedef enum { FALSE = 0, TRUE = 1 } boolean;
- #endif
- 
- 
---- fltk-1.3.2/src/Fl_JPEG_Image.cxx.orig	2013-07-19 08:46:16.000000000 -0400
-+++ fltk-1.3.2/src/Fl_JPEG_Image.cxx	2013-07-19 08:59:15.000000000 -0400
-@@ -155,7 +155,7 @@
-   
-   jpeg_create_decompress(&dinfo);
-   jpeg_stdio_src(&dinfo, fp);
--  jpeg_read_header(&dinfo, 1);
-+  jpeg_read_header(&dinfo, TRUE);
-   
-   dinfo.quantize_colors      = (boolean)FALSE;
-   dinfo.out_color_space      = JCS_RGB;
-@@ -333,7 +333,7 @@
-   
-   jpeg_create_decompress(&dinfo);
-   jpeg_mem_src(&dinfo, data);
--  jpeg_read_header(&dinfo, 1);
-+  jpeg_read_header(&dinfo, TRUE);
-   
-   dinfo.quantize_colors      = (boolean)FALSE;
-   dinfo.out_color_space      = JCS_RGB;
-diff -uNr fltk-1.3.3.orig/src/Fl_Double_Window.cxx fltk-1.3.3/src/Fl_Double_Window.cxx
---- fltk-1.3.3.orig/src/Fl_Double_Window.cxx	2014-09-23 06:48:36.000000000 -0400
-+++ fltk-1.3.3/src/Fl_Double_Window.cxx	2015-06-18 11:15:31.000000000 -0400
-@@ -283,7 +283,7 @@
-   CGImageRef img = CGImageCreate( sw, sh, 8, 4*8, 4*sw, lut, alpha,
-     src_bytes, 0L, false, kCGRenderingIntentDefault);
-   // fl_push_clip();
--  CGRect rect = { { x, y }, { w, h } };
-+  CGRect rect = { { static_cast<CGFloat>(x), static_cast<CGFloat>(y) }, { static_cast<CGFloat>(w), static_cast<CGFloat>(h) } };
-   Fl_X::q_begin_image(rect, srcx, srcy, sw, sh);
-   CGContextDrawImage(fl_gc, rect, img);
-   Fl_X::q_end_image();
-diff -uNr fltk-1.3.3.orig/src/Fl_Gl_Device_Plugin.cxx fltk-1.3.3/src/Fl_Gl_Device_Plugin.cxx
---- fltk-1.3.3.orig/src/Fl_Gl_Device_Plugin.cxx	2014-01-10 11:50:55.000000000 -0500
-+++ fltk-1.3.3/src/Fl_Gl_Device_Plugin.cxx	2015-06-18 11:15:38.000000000 -0400
-@@ -81,7 +81,7 @@
-   CGContextSaveGState(fl_gc);
-   CGContextTranslateCTM(fl_gc, 0, height);
-   CGContextScaleCTM(fl_gc, 1.0f, -1.0f);
--  CGRect rect = { { x, height - y - glw->h() }, { glw->w(), glw->h() } };
-+  CGRect rect = { { static_cast<CGFloat>(x), static_cast<CGFloat>(height - y - glw->h()) }, { static_cast<CGFloat>(glw->w()), static_cast<CGFloat>(glw->h()) } };
-   Fl_X::q_begin_image(rect, 0, 0, glw->w(), glw->h());
-   CGContextDrawImage(fl_gc, rect, image);
-   Fl_X::q_end_image();
-diff -uNr fltk-1.3.3.orig/src/Fl_Image.cxx fltk-1.3.3/src/Fl_Image.cxx
---- fltk-1.3.3.orig/src/Fl_Image.cxx	2014-10-14 07:53:51.000000000 -0400
-+++ fltk-1.3.3/src/Fl_Image.cxx	2015-06-18 11:15:45.000000000 -0400
-@@ -586,7 +586,7 @@
-     CGDataProviderRelease(src);
-   }
-   if (img->id_ && fl_gc) {
--    CGRect rect = { { X, Y }, { W, H } };
-+    CGRect rect = { { static_cast<CGFloat>(X), static_cast<CGFloat>(Y) }, { static_cast<CGFloat>(W), static_cast<CGFloat>(H) } };
-     Fl_X::q_begin_image(rect, cx, cy, img->w(), img->h());
-     CGContextDrawImage(fl_gc, rect, (CGImageRef)img->id_);
-     Fl_X::q_end_image();
-diff -uNr fltk-1.3.3.orig/src/Fl_Quartz_Printer.mm fltk-1.3.3/src/Fl_Quartz_Printer.mm
---- fltk-1.3.3.orig/src/Fl_Quartz_Printer.mm	2014-10-26 11:23:03.000000000 -0400
-+++ fltk-1.3.3/src/Fl_Quartz_Printer.mm	2015-06-18 11:16:02.000000000 -0400
-@@ -328,7 +328,7 @@
-   CGImageRef img = Fl_X::CGImage_from_window_rect(win, x, y, w, h);
-   if (save_front != win) save_front->show();
-   current->set_current();
--  CGRect rect = { { delta_x, delta_y }, { w, h } };
-+  CGRect rect = { { static_cast<CGFloat>(delta_x), static_cast<CGFloat>(delta_y) }, { static_cast<CGFloat>(w), static_cast<CGFloat>(h) } };
-   Fl_X::q_begin_image(rect, 0, 0, w, h);
-   CGContextDrawImage(fl_gc, rect, img);
-   Fl_X::q_end_image();
-diff -uNr fltk-1.3.3.orig/src/Fl_cocoa.mm fltk-1.3.3/src/Fl_cocoa.mm
---- fltk-1.3.3.orig/src/Fl_cocoa.mm	2014-11-02 16:06:07.000000000 -0500
-+++ fltk-1.3.3/src/Fl_cocoa.mm	2015-06-18 11:16:08.000000000 -0400
-@@ -2744,8 +2744,8 @@
-   int bx, by, bt;
-   get_window_frame_sizes(bx, by, bt);
-   size_range_set = 1;
--  NSSize minSize = { minw, minh + bt };
--  NSSize maxSize = { maxw?maxw:32000, maxh?maxh + bt:32000 };
-+  NSSize minSize = { static_cast<CGFloat>(minw), static_cast<CGFloat>(minh + bt) };
-+  NSSize maxSize = { static_cast<CGFloat>(maxw?maxw:32000), static_cast<CGFloat>(maxh?maxh + bt:32000) };
-   if (i && i->xid) {
-     [i->xid setMinSize:minSize];
-     [i->xid setMaxSize:maxSize];
-@@ -3981,7 +3981,7 @@
-   win->label(title); // put back the window title
-   this->set_current(); // back to the Fl_Paged_Device
-   if (img && to_quartz) { // print the title bar
--    CGRect rect = { { x_offset, y_offset }, { win->w(), bt } };
-+    CGRect rect = { { static_cast<CGFloat>(x_offset), static_cast<CGFloat>(y_offset) }, { static_cast<CGFloat>(win->w()), static_cast<CGFloat>(bt) } };
-     Fl_X::q_begin_image(rect, 0, 0, win->w(), bt);
-     CGContextDrawImage(fl_gc, rect, img);
-     Fl_X::q_end_image();
-@@ -4029,7 +4029,7 @@
-       NSSize size = [title_s sizeWithAttributes:attr];
-       int x = x_offset + win->w()/2 - size.width/2;
-       if (x < x_offset+skip) x = x_offset+skip;
--      NSRect r = {{x, y_offset+bt/2+4}, {win->w() - skip, bt}};
-+      NSRect r = {{static_cast<CGFloat>(x), static_cast<CGFloat>(y_offset+bt/2+4)}, {static_cast<CGFloat>(win->w() - skip), static_cast<CGFloat>(bt)}};
-       [[NSGraphicsContext currentContext] setShouldAntialias:YES];
-       [title_s drawWithRect:r options:(NSStringDrawingOptions)0 attributes:attr]; // 10.4
-       [[NSGraphicsContext currentContext] setShouldAntialias:NO];
-diff -uNr fltk-1.3.3.orig/src/fl_draw_image_mac.cxx fltk-1.3.3/src/fl_draw_image_mac.cxx
---- fltk-1.3.3.orig/src/fl_draw_image_mac.cxx	2012-03-18 14:48:29.000000000 -0400
-+++ fltk-1.3.3/src/fl_draw_image_mac.cxx	2015-06-18 11:16:19.000000000 -0400
-@@ -88,7 +88,7 @@
-                             src, 0L, false, kCGRenderingIntentDefault);
-   // draw the image into the destination context
-   if (img) {
--    CGRect rect = { { X, Y }, { W, H } };
-+    CGRect rect = { { static_cast<CGFloat>(X), static_cast<CGFloat>(Y) }, { static_cast<CGFloat>(W), static_cast<CGFloat>(H) } };
-     Fl_X::q_begin_image(rect, 0, 0, W, H);
-     CGContextDrawImage(fl_gc, rect, img);
-     Fl_X::q_end_image();
-diff -uNr fltk-1.3.3.orig/src/fl_scroll_area.cxx fltk-1.3.3/src/fl_scroll_area.cxx
---- fltk-1.3.3.orig/src/fl_scroll_area.cxx	2014-01-22 15:39:21.000000000 -0500
-+++ fltk-1.3.3/src/fl_scroll_area.cxx	2015-06-18 11:16:27.000000000 -0400
-@@ -144,7 +144,7 @@
- #elif defined(__APPLE_QUARTZ__)
-   CGImageRef img = Fl_X::CGImage_from_window_rect(Fl_Window::current(), src_x, src_y, src_w, src_h);
-   if (img) {
--    CGRect rect = { { dest_x, dest_y }, { src_w, src_h } };
-+    CGRect rect = { { static_cast<CGFloat>(dest_x), static_cast<CGFloat>(dest_y) }, { static_cast<CGFloat>(src_w), static_cast<CGFloat>(src_h) } };
-     Fl_X::q_begin_image(rect, 0, 0, src_w, src_h);
-     CGContextDrawImage(fl_gc, rect, img);
-     Fl_X::q_end_image();
---- fltk-1.3.3.orig/test/menubar.cxx	2015-06-18 11:25:21.000000000 -0400
-+++ fltk-1.3.3/test/menubar.cxx	2015-06-18 11:29:05.000000000 -0400
-@@ -127,9 +127,9 @@
-     {"Italic",	0, 0, 0, 0, 0, FL_ITALIC, 14},
-     {"BoldItalic",0,0,0, 0, 0, FL_BOLD+FL_ITALIC, 14},
-     {"Small",	0, 0, 0, 0, 0, FL_BOLD+FL_ITALIC, 10},
--    {"Emboss",	0, 0, 0, 0, FL_EMBOSSED_LABEL},
--    {"Engrave",	0, 0, 0, 0, FL_ENGRAVED_LABEL},
--    {"Shadow",	0, 0, 0, 0, FL_SHADOW_LABEL},
-+    {"Emboss",	0, 0, 0, 0, static_cast<uchar>(FL_EMBOSSED_LABEL)},
-+    {"Engrave",	0, 0, 0, 0, static_cast<uchar>(FL_ENGRAVED_LABEL)},
-+    {"Shadow",	0, 0, 0, 0, static_cast<uchar>( FL_SHADOW_LABEL)},
-     {"@->",	0, 0, 0, 0, FL_SYMBOL_LABEL},
-     {0},
-   {"&International",0,0,0,FL_SUBMENU},


### PR DESCRIPTION
Upstream now says it explicitly supports 10.11-10.13.
Refresh patch due to upstream changes.
Clean PatchScript of commands that no longer do anything (carried over from long ago versions).