### PR TITLE
npth: builddepend on automake1.15

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/npth.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/npth.info
@@ -5,7 +5,7 @@ Source: https://www.gnupg.org/ftp/gcrypt/%n/%n-%v.tar.bz2
 Source-MD5: 9ba2dc4302d2f32c66737c43ed191b1b
 BuildDependsOnly: True
 # flat namespace fix
-BuildDepends: libtool2 (>= 2.4.2-1), autoconf2.6, automake1.15-core
+BuildDepends: libtool2 (>= 2.4.2-1), autoconf2.6, automake1.15
 Depends: %n-shlibs (= %v-%r)
 
 PatchScript: autoreconf -fi


### PR DESCRIPTION
Fixes buld failure reported on fink-beginners