### PR TITLE
tora: switch pg94->pg96; improve f-p-p use

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/tora.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/tora.info
@@ -1,11 +1,11 @@
 Package: tora
 Version: 2.1.3
-Revision: 2
+Revision: 3
 Description: Oracle, MySQL, and Postgres Interface
 License: GPL
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
 Depends: <<
-	postgresql94-shlibs,
+	postgresql96-shlibs,
 	qscintilla2.11-qt4-mac-shlibs,
 	qt4-base-mac-qtcore-shlibs,
 	qt4-base-mac-qtgui-shlibs,
@@ -17,7 +17,7 @@ BuildDepends: <<
 	cmake,
 	fink-buildenv-modules,
 	fink-package-precedence,
-	postgresql94-dev,
+	postgresql96-dev,
 	qscintilla2.11-qt4-mac,
 	qt4-base-mac,
 	qt4-base-mac-linguist
@@ -41,16 +41,16 @@ CompileScript: <<
 			-DWANT_BUNDLE_STANDALONE=0 \
 			-DWANT_RPM=0 \
 			-DENABLE_PGSQL=1 \
-			-DPOSTGRESQL_INCLUDE_DIR=%p/opt/postgresql-9.4/include \
-			-DPOSTGRESQL_LIBRARIES:FILEPATH=%p/opt/postgresql-9.4/lib/libpq.dylib \
+			-DPOSTGRESQL_INCLUDE_DIR=%p/opt/postgresql-9.6/include \
+			-DPOSTGRESQL_LIBRARIES:FILEPATH=%p/opt/postgresql-9.6/lib/libpq.dylib \
 			-DWANT_INTERNAL_QSCINTILLA=0 \
 			-DUSE_PCH=0 \
 			-DENABLE_DB2=0 \
 			-DENABLE_ORACLE=0 \
 		..
 		make
-		fink-package-precedence --depfile-ext='\.d' .
 	popd
+	fink-package-precedence --depfile-ext='\.d' .
 <<
 InstallScript: <<
 	# use AppBundles to get the .app bundle


### PR DESCRIPTION
Same build transcript for the pg update.

f-p-p had a ton of warnings about files not recognized by dpkg and f-p-p didn't recognize because they were source-distro but in a sister subdir to the one where it was running. f-p-p isn't so smart about out-of-source or even build-subdir setups, so just run it from the main builddir.