### PR TITLE
gdcm26 2.6.9

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/gdcm.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gdcm.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: gdcm
-Version: 2.6.1
-Revision: 2
+Version: 2.6.9
+Revision: 1
 Type: maj (2.6)
 Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 Homepage: http://gdcm.sourceforge.net/wiki/index.php/Main_Page
@@ -29,6 +29,7 @@ License: BSD
 
 BuildDepends: <<
 	cmake,
+	docbook-xsl-ns (>= 1.78.1-2),
 	expat1,
 	fink-package-precedence,
 	libopenjpeg1,
@@ -40,18 +41,18 @@ Depends: %N-libsocketxx12-shlibs (= %v-%r), %N%type_pkg[maj]-shlibs (= %v-%r)
 GCC: 4.0
 
 Source: mirror:sourceforge:%n/%n%%202.x/GDCM%%20%v/%n-%v.tar.bz2
-Source-MD5: a8ed0c648d1cf43fc230f786498961c6
-Source-Checksum: SHA1(dda0cdf64d85195763d27e879131cfd7025d07e2)
+Source-MD5: 67f5a94a6800f1854c67c48470e93f70
+Source-Checksum: SHA1(1acfffeff75c3fe67bf22773d924dbb3fd60cfd0)
 
 # Upstream patch for openssl110 and some clang warnings. See:
 #   d7d8c342d5b7f032ac8caf695da018e373f6dfd7
 #   b3013be81ece0b53b8e5c549ca13fa3b01fde038
 #   bd27acc9bbcc077e942e4045e7e7d3d1c50e0435
 PatchFile: %n.patch
-PatchFile-MD5: 6d03c270a41203ea10e3509fbcab117f
+PatchFile-MD5: d6728f0fa825fded13aea136566c0c84
 PatchScript: <<
 	%{default_script}
-	perl -pi -e 's/(-source 1.5)/-target 1.5 \1/' `find . -name CMakeLists.txt`
+	perl -pi -e 's|/etc/xml/catalog|%p$&|g' Utilities/doxygen/CMakeLists.txt
 <<
 
 CompileScript: <<
@@ -87,6 +88,9 @@ make install
 <<
 DescPackaging: <<
 	Docs use TeX for generation, so we aren't building them in this package.
+	docbook-xsl-ns needed to build manpages (otherwise build error). Can disable 
+	their generation by defining "GDCM_BUILD_DOCBOOK_MANPAGES:BOOL=OFF" at config 
+	time.
 	Python bindings don't work yet.
 	Examples use Qt for their build, so we'll pull those into their own package 
 	at some point.

--- a/10.9-libcxx/stable/main/finkinfo/sci/gdcm.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gdcm.patch
@@ -1,42 +1,20 @@
-diff -Nurd -x'*~' gdcm-2.6.1.orig/Source/Common/gdcmOpenSSLP7CryptographicMessageSyntax.cxx gdcm-2.6.1/Source/Common/gdcmOpenSSLP7CryptographicMessageSyntax.cxx
---- gdcm-2.6.1.orig/Source/Common/gdcmOpenSSLP7CryptographicMessageSyntax.cxx	2015-11-02 06:09:31.000000000 -0500
-+++ gdcm-2.6.1/Source/Common/gdcmOpenSSLP7CryptographicMessageSyntax.cxx	2018-01-07 15:16:35.000000000 -0500
-@@ -285,7 +285,7 @@
-   ::PKCS7 *p7;
- #undef PKCS7_SIGNER_INFO
-   ::PKCS7_SIGNER_INFO *si;
--  X509_STORE_CTX cert_ctx;
-+  X509_STORE_CTX *cert_ctx=NULL;
-   X509_STORE *cert_store=NULL;
-   BIO *data,*detached=NULL,*p7bio=NULL;
-   char buf[1024*4];
-@@ -331,6 +331,7 @@
- //  }
+diff -ruN gdcm-2.6.9.orig/Utilities/doxygen/CMakeLists.txt gdcm-2.6.9/Utilities/doxygen/CMakeLists.txt
+--- gdcm-2.6.9.orig/Utilities/doxygen/CMakeLists.txt	2017-06-29 03:22:56.000000000 -0500
++++ gdcm-2.6.9/Utilities/doxygen/CMakeLists.txt	2018-03-14 04:55:14.000000000 -0500
+@@ -267,8 +267,8 @@
  
- 
-+  cert_ctx=X509_STORE_CTX_new();
-   /* This stuff is being setup for certificate verification.
-    * When using SSL, it could be replaced with a
-    * cert_stre=SSL_CTX_get_cert_store(ssl_ctx); */
-@@ -378,13 +379,14 @@
-       {
-       //si=my_sk_PKCS7_SIGNER_INFO_value(sk,i);
-           si=sk_PKCS7_SIGNER_INFO_value(sk,i);
--      i=PKCS7_dataVerify(cert_store,&cert_ctx,p7bio,p7,si);
-+      i=PKCS7_dataVerify(cert_store,cert_ctx,p7bio,p7,si);
-       if (i <= 0)
-         goto err;
-       else
-         fprintf(stderr,"Signature verified\n");
-       }
-     }
-+  X509_STORE_CTX_free(cert_ctx);
-   X509_STORE_free(cert_store);
- 
-   BIO_free_all(p7bio);
-diff -Nurd -x'*~' gdcm-2.6.1.orig/Utilities/gdcmjpeg/jdcoefct.c gdcm-2.6.1/Utilities/gdcmjpeg/jdcoefct.c
---- gdcm-2.6.1.orig/Utilities/gdcmjpeg/jdcoefct.c	2015-11-02 06:09:31.000000000 -0500
-+++ gdcm-2.6.1/Utilities/gdcmjpeg/jdcoefct.c	2018-01-07 16:02:27.000000000 -0500
+       set(DOCBOOK_REWRITE_PREFIX_FOUND FALSE)
+       foreach(line ${xml_catalog})
+-        string(REGEX MATCH "^.*systemIdStartString=\"http://docbook.sourceforge.net/release/xsl-ns/\".*" out1 ${line})
+-        string(REGEX REPLACE "^.*systemIdStartString=\"http://docbook.sourceforge.net/release/xsl-ns/\".*\"([A-Za-z ]*)\".*" "\\1" output_variable ${line})
++        string(REGEX MATCH "^.*systemIdStartString=\"http://docbook.sourceforge.net/release/xsl-ns/current\".*" out1 ${line})
++        string(REGEX REPLACE "^.*systemIdStartString=\"http://docbook.sourceforge.net/release/xsl-ns/current\".*\"([A-Za-z ]*)\".*" "\\1" output_variable ${line})
+         if(out1)
+           message(STATUS "Your docbook install was found here :${output_variable}")
+           set(DOCBOOK_REWRITE_PREFIX_FOUND TRUE)
+diff -ruN gdcm-2.6.9.orig/Utilities/gdcmjpeg/jdcoefct.c gdcm-2.6.9/Utilities/gdcmjpeg/jdcoefct.c
+--- gdcm-2.6.9.orig/Utilities/gdcmjpeg/jdcoefct.c	2017-06-29 03:22:56.000000000 -0500
++++ gdcm-2.6.9/Utilities/gdcmjpeg/jdcoefct.c	2018-03-14 04:22:09.000000000 -0500
 @@ -418,7 +418,7 @@
    int * coef_bits;
    int * coef_bits_latch;
@@ -46,90 +24,3 @@ diff -Nurd -x'*~' gdcm-2.6.1.orig/Utilities/gdcmjpeg/jdcoefct.c gdcm-2.6.1/Utili
      return FALSE;
  
    /* Allocate latch area if not already done */
-diff -Nurd -x'*~' gdcm-2.6.1.orig/Utilities/gdcmjpeg/jdlhuff.c gdcm-2.6.1/Utilities/gdcmjpeg/jdlhuff.c
---- gdcm-2.6.1.orig/Utilities/gdcmjpeg/jdlhuff.c	2015-11-02 06:09:31.000000000 -0500
-+++ gdcm-2.6.1/Utilities/gdcmjpeg/jdlhuff.c	2018-01-07 15:45:03.000000000 -0500
-@@ -123,7 +123,7 @@
- 
- #ifdef AVOID_TABLES
- 
--#define HUFF_EXTEND(x,s)  ((x) < (1<<((s)-1)) ? (x) + (((-1)<<(s)) + 1) : (x))
-+#define HUFF_EXTEND(x,s)  ((x) < (1<<((s)-1)) ? (x) + (((-1u)<<(s)) + 1) : (x))
- 
- #else
- 
-@@ -133,11 +133,11 @@
-   { 0, 0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080,
-     0x0100, 0x0200, 0x0400, 0x0800, 0x1000, 0x2000, 0x4000 };
- 
--static const int extend_offset[16] = /* entry n is (-1 << n) + 1 */
--  { 0, ((-1)<<1) + 1, ((-1)<<2) + 1, ((-1)<<3) + 1, ((-1)<<4) + 1,
--    ((-1)<<5) + 1, ((-1)<<6) + 1, ((-1)<<7) + 1, ((-1)<<8) + 1,
--    ((-1)<<9) + 1, ((-1)<<10) + 1, ((-1)<<11) + 1, ((-1)<<12) + 1,
--    ((-1)<<13) + 1, ((-1)<<14) + 1, ((-1)<<15) + 1 };
-+static const int extend_offset[16] = /* entry n is (-1u << n) + 1 */
-+  { 0, ((-1u)<<1) + 1, ((-1u)<<2) + 1, ((-1u)<<3) + 1, ((-1u)<<4) + 1,
-+    ((-1u)<<5) + 1, ((-1u)<<6) + 1, ((-1u)<<7) + 1, ((-1u)<<8) + 1,
-+    ((-1u)<<9) + 1, ((-1u)<<10) + 1, ((-1u)<<11) + 1, ((-1u)<<12) + 1,
-+    ((-1u)<<13) + 1, ((-1u)<<14) + 1, ((-1u)<<15) + 1 };
- 
- #endif /* AVOID_TABLES */
- 
-diff -Nurd -x'*~' gdcm-2.6.1.orig/Utilities/gdcmjpeg/jdphuff.c gdcm-2.6.1/Utilities/gdcmjpeg/jdphuff.c
---- gdcm-2.6.1.orig/Utilities/gdcmjpeg/jdphuff.c	2015-11-02 06:09:31.000000000 -0500
-+++ gdcm-2.6.1/Utilities/gdcmjpeg/jdphuff.c	2018-01-07 15:45:03.000000000 -0500
-@@ -201,7 +201,7 @@
- 
- #ifdef AVOID_TABLES
- 
--#define HUFF_EXTEND(x,s)  ((x) < (1<<((s)-1)) ? (x) + (((-1)<<(s)) + 1) : (x))
-+#define HUFF_EXTEND(x,s)  ((x) < (1<<((s)-1)) ? (x) + (((-1u)<<(s)) + 1) : (x))
- 
- #else
- 
-@@ -211,11 +211,11 @@
-   { 0, 0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080,
-     0x0100, 0x0200, 0x0400, 0x0800, 0x1000, 0x2000, 0x4000 };
- 
--static const int extend_offset[16] = /* entry n is (-1 << n) + 1 */
--  { 0, ((-1)<<1) + 1, ((-1)<<2) + 1, ((-1)<<3) + 1, ((-1)<<4) + 1,
--    ((-1)<<5) + 1, ((-1)<<6) + 1, ((-1)<<7) + 1, ((-1)<<8) + 1,
--    ((-1)<<9) + 1, ((-1)<<10) + 1, ((-1)<<11) + 1, ((-1)<<12) + 1,
--    ((-1)<<13) + 1, ((-1)<<14) + 1, ((-1)<<15) + 1 };
-+static const int extend_offset[16] = /* entry n is (-1u << n) + 1 */
-+  { 0, ((-1u)<<1) + 1, ((-1u)<<2) + 1, ((-1u)<<3) + 1, ((-1u)<<4) + 1,
-+    ((-1u)<<5) + 1, ((-1u)<<6) + 1, ((-1u)<<7) + 1, ((-1u)<<8) + 1,
-+    ((-1u)<<9) + 1, ((-1u)<<10) + 1, ((-1u)<<11) + 1, ((-1u)<<12) + 1,
-+    ((-1u)<<13) + 1, ((-1u)<<14) + 1, ((-1u)<<15) + 1 };
- 
- #endif /* AVOID_TABLES */
- 
-diff -Nurd -x'*~' gdcm-2.6.1.orig/Utilities/gdcmjpeg/jdshuff.c gdcm-2.6.1/Utilities/gdcmjpeg/jdshuff.c
---- gdcm-2.6.1.orig/Utilities/gdcmjpeg/jdshuff.c	2015-11-02 06:09:31.000000000 -0500
-+++ gdcm-2.6.1/Utilities/gdcmjpeg/jdshuff.c	2018-01-07 15:45:03.000000000 -0500
-@@ -146,7 +146,7 @@
- 
- #ifdef AVOID_TABLES
- 
--#define HUFF_EXTEND(x,s)  ((x) < (1<<((s)-1)) ? (x) + (((-1)<<(s)) + 1) : (x))
-+#define HUFF_EXTEND(x,s)  ((x) < (1<<((s)-1)) ? (x) + (((-1u)<<(s)) + 1) : (x))
- 
- #else
- 
-@@ -156,11 +156,11 @@
-   { 0, 0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080,
-     0x0100, 0x0200, 0x0400, 0x0800, 0x1000, 0x2000, 0x4000 };
- 
--static const int extend_offset[16] = /* entry n is (-1 << n) + 1 */
--  { 0, ((-1)<<1) + 1, ((-1)<<2) + 1, ((-1)<<3) + 1, ((-1)<<4) + 1,
--    ((-1)<<5) + 1, ((-1)<<6) + 1, ((-1)<<7) + 1, ((-1)<<8) + 1,
--    ((-1)<<9) + 1, ((-1)<<10) + 1, ((-1)<<11) + 1, ((-1)<<12) + 1,
--    ((-1)<<13) + 1, ((-1)<<14) + 1, ((-1)<<15) + 1 };
-+static const int extend_offset[16] = /* entry n is (-1u << n) + 1 */
-+  { 0, ((-1u)<<1) + 1, ((-1u)<<2) + 1, ((-1u)<<3) + 1, ((-1u)<<4) + 1,
-+    ((-1u)<<5) + 1, ((-1u)<<6) + 1, ((-1u)<<7) + 1, ((-1u)<<8) + 1,
-+    ((-1u)<<9) + 1, ((-1u)<<10) + 1, ((-1u)<<11) + 1, ((-1u)<<12) + 1,
-+    ((-1u)<<13) + 1, ((-1u)<<14) + 1, ((-1u)<<15) + 1 };
- 
- #endif /* AVOID_TABLES */
- 


### PR DESCRIPTION
Now works with java9.
The current v2.6.1 release needs java5, which is incompatible with java9. v2.6.9 uses java7.
It also now builds the manpages, but can be disabled w/ a simple configure flag.
This is the last 2.6.x release.
