### PR TITLE
pil-py: Install headers #included by own Imaging.h.

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/pil-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/pil-py.info
@@ -5,7 +5,7 @@ Package: pil-py%type_pkg[python]
 Type: python (2.7 3.4 3.5 3.6)
 
 Version: 5.0.0
-Revision: 1
+Revision: 2
 Description: Python Imaging Library
 DescDetail: <<
 The Python Imaging Library (PIL) adds image processing capabilities to
@@ -68,7 +68,7 @@ InstallScript: <<
  mkdir -p %i/share/doc/%n
  cp -R docs/ %i/share/doc/%n/html
  mkdir -p %i/include/python%type_raw[python]/PIL
- cp -f src/libImaging/ImPlatform.h src/libImaging/Imaging.h %i/include/python%type_raw[python]/PIL
+ cp -f src/libImaging/{Imaging.h,ImPlatform.h,ImagingUtils.h,ImDib.h} %i/include/python%type_raw[python]/PIL
 <<
 DocFiles: README.rst
 License: OSI-Approved


### PR DESCRIPTION
Debian bug report: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=879788

Imaging.h #includes ImagingUtils.h, so it needs to be installed. This is Debian's fix:
````
	install -o root -g root -m 644 \
		src/libImaging/Imaging.h \
		src/libImaging/ImagingUtils.h \
		src/libImaging/ImPlatform.h \
		src/libImaging/ImDib.h \
		debian/python-pil/usr/include/python$*
````
which I adapted.