### PR TITLE
Updated alabaster to 0.7.10 and added py34/py36 versions

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/alabaster-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/alabaster-py.info
@@ -1,20 +1,30 @@
 # -*- coding: ascii; tab-width: 4 -*-
-Info2: <<
+Info3: <<
 Package: alabaster-py%type_pkg[python]
-Version: 0.7.6
+Version: 0.7.10
 Revision: 1
-Type: python (2.7 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Description: Configurable sidebar-enabled Sphinx theme
+DescDetail: <<
+Alabaster is a visually (c)lean, responsive, configurable theme for the Sphinx
+documentation system. It is Python 2+3 compatible.
+It began as a third-party theme, and is still maintained separately, but as of
+Sphinx 1.3, Alabaster is an install-time dependency of Sphinx and is selected
+as the default theme.
+Live examples of this theme can be seen on alabaster.readthedocs.io,
+paramiko.org, fabfile.org and pyinvoke.org.
+<<
 
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 License: BSD
-Homepage: http://pypi.python.org/pypi/alabaster
+Homepage: http://alabaster.readthedocs.io/
 
-Source: https://pypi.python.org/packages/source/a/alabaster/alabaster-%v.tar.gz
-Source-MD5: 169cdce2a96b75bff8cb8a59d938673f
+Source: https://pypi.io/packages/source/a/alabaster/alabaster-%v.tar.gz
+Source-MD5: 7934dccf38801faa105f6e7b4784f493
 
 Depends: python%type_pkg[python], pygments-py%type_pkg[python]
 BuildDepends: fink (>= 0.24.12), setuptools-tng-py%type_pkg[python]
+Suggests: sphinx-py%type_pkg[python] (>= 1.4.8-1)
 
 CompileScript: <<
  %p/bin/python%type_raw[python] setup.py build
@@ -26,4 +36,5 @@ InstallScript: <<
 <<
 
 DocFiles: LICENSE README.rst
+# Info3
 <<


### PR DESCRIPTION
Added versions required for a `Sphinx`-update (see SF package submission [#4723](https://sourceforge.net/p/fink/package-submissions/4723/)).