### PR TITLE
Pylint update (including dependencies for py36)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/astroid-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/astroid-py.info
@@ -1,13 +1,12 @@
-Info2: <<
+Info3: <<
 
 Package: astroid-py%type_pkg[python]
-# Need lazy-object-proxy-py36
-Type: python (2.7 3.4 3.5)
-Version: 1.4.9
+Type: python (2.7 3.4 3.5 3.6)
+Version: 1.6.3
 Revision: 1
 
-Source: https://pypi.python.org/packages/55/14/be963877c2f336c6df8a77457f47163fd55427c0344bab2ba3f940d4edb8/astroid-%v.tar.gz
-Source-MD5: a57438971de05eb801b82eae59c05217
+Source: https://pypi.io/packages/source/a/astroid/astroid-%v.tar.gz
+Source-MD5: 7d7dc000b25f0cbfcca20cb9a8dc0310
 
 BuildDepends: setuptools-tng-py%type_pkg[python]
 Depends: <<
@@ -30,5 +29,5 @@ DescDetail: <<
 The aim of this module is to provide a common base representation of
 Python source code for projects such as pyreverse or pylint.
 <<
-# Info2
+# Info3
 <<

--- a/10.9-libcxx/stable/main/finkinfo/devel/pylint-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/pylint-py.info
@@ -77,10 +77,12 @@ personal feature.
 << 
 
 DescPackaging: <<
-Added Sphinx build of HTML docs, changed names of versioned executables to
-standard -py%type_pkg[python] scheme (pylint-gui no longer included).
-2to3 treatment of sources no longer required. 3 test failures.
+Added Sphinx build of HTML docs, changed names of versioned executables
+to standard -py%type_pkg[python] scheme (pylint-gui no longer included).
+2to3 treatment of sources no longer required.
 Added cleanup of byte-compiled files to InstallScript.
+3 test failures on Python 3.x, > 222 (basically the entire test_stdlib)
+mostly unicode-related on 2.7.14.
 <<
 
 # Info3

--- a/10.9-libcxx/stable/main/finkinfo/devel/pylint-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/pylint-py.info
@@ -76,13 +76,8 @@ customizable, and you can easily write a small plugin to add a
 personal feature.
 << 
 
-DescPackaging: <<
-Added Sphinx build of HTML docs, changed names of versioned executables
-to standard -py%type_pkg[python] scheme (pylint-gui no longer included).
-2to3 treatment of sources no longer required.
-Added cleanup of byte-compiled files to InstallScript.
-3 test failures on Python 3.x, > 222 (basically the entire test_stdlib)
-mostly unicode-related on 2.7.14.
+DescPort: <<
+Patched Sphinx build scripts to ensure correct Python executable is used.
 <<
 
 # Info3

--- a/10.9-libcxx/stable/main/finkinfo/devel/pylint-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/pylint-py.info
@@ -1,55 +1,63 @@
-Info2: <<
+Info3: <<
 
 Package: pylint-py%type_pkg[python]
-# Needs isort-py36
-Type: python (2.7 3.4 3.5)
-Version: 1.6.5
+Type: python (2.7 3.4 3.5 3.6)
+Version: 1.8.4
 Revision: 1
 Source: https://pypi.io/packages/source/p/pylint/pylint-%v.tar.gz
-Source-MD5: 31da2185bf59142479e4fa16d8a9e347
+Source-MD5: a69d02563a64400b2c766bef39fece92
 
 Depends: <<
   python%type_pkg[python],
-  astroid-py%type_pkg[python] (>= 1.4.9-1),
+  astroid-py%type_pkg[python] (>= 1.6.3-1),
   isort-py%type_pkg[python] (>= 4.2.5-1),
   mccabe-py%type_pkg[python],
   six-py%type_pkg[python],
   (%type_raw[python] = 2.7) backports.functools-lru-cache-py%type_pkg[python],
   (%type_raw[python] = 2.7) configparser-py%type_pkg[python]
 <<
+BuildDepends: setuptools-tng-py%type_pkg[python], sphinx-py%type_pkg[python]
 
 Description: Analyzes Python code for bugs and quality
 Maintainer: Kurt Schwehr <goatbar@users.sf.net>
 Homepage: http://www.logilab.org/projects/pylint
-DocFiles: COPYING DEPENDS README.rst PKG-INFO
+DocFiles: COPYING DEPENDS README.rst PKG-INFO doc/_build/html
 CompileScript: <<
-#!/bin/bash -ev
-  if [ "%type_pkg[python]" -ge "31" ]; then
-    # Yuck, but this is what they recommend
-    find . ! -path "*/test/*py" -name "*py" -exec 2to3-%type_raw[python] -wn {} \;
-  fi
-  echo Skipping Build
+   #!/bin/bash -ev
+   %p/bin/python%type_raw[python] setup.py build
+   cd doc
+   perl -pi -e 's|(/bin/env) python|$1 %p/bin/python%type_raw[python]|;' exts/*.py
+   make PYTHONPATH=%b/build/lib SPHINXBUILD=%p/bin/sphinx-build%type_raw[python] html
 <<
+
 InstallScript: <<
-#!/bin/bash -ev
+   #!/bin/bash -ev
+   find build pylint/test -name '*.pyc' -exec rm {} \;
    %p/bin/python%type_raw[python] setup.py install --root=%d --prefix=%p
-   for file in pylint pylint-gui symilar epylint pyreverse; do
-       mv %i/bin/${file} %i/bin/${file}%type_pkg[python]
+   for file in pylint symilar epylint pyreverse; do
+       mv %i/bin/${file} %i/bin/${file}-py%type_pkg[python]
    done
 <<
 
 PostInstScript: <<
-  update-alternatives --verbose --install "%p/bin/pylint" pylint "%p/bin/pylint%type_pkg[python]" %type_pkg[python] \
-    --slave "%p/bin/pylint-compile" pylint-gui "%p/bin/pylint-gui%type_pkg[python]" \
-    --slave "%p/bin/symilar" symilar "%p/bin/symilar%type_pkg[python]" \
-    --slave "%p/bin/epylint" epylint "%p/bin/epylint%type_pkg[python]" \
-    --slave "%p/bin/pyreverse" pyreverse "%p/bin/pyreverse%type_pkg[python]"
+  update-alternatives --verbose --install "%p/bin/pylint" pylint "%p/bin/pylint-py%type_pkg[python]" %type_pkg[python] \
+    --slave "%p/bin/symilar" symilar "%p/bin/symilar-py%type_pkg[python]" \
+    --slave "%p/bin/epylint" epylint "%p/bin/epylint-py%type_pkg[python]" \
+    --slave "%p/bin/pyreverse" pyreverse "%p/bin/pyreverse-py%type_pkg[python]"
 <<
 
 PreRmScript: <<
   if [ $1 != "upgrade" ]; then
-    update-alternatives --verbose --remove pylint "%p/bin/pylint%type_pkg[python]"
+    update-alternatives --verbose --remove pylint "%p/bin/pylint-py%type_pkg[python]"
   fi
+<<
+
+InfoTest: <<
+  TestDepends: pytest-py%type_pkg[python]
+  TestScript: <<
+    PYTHONPATH=%b/build/lib %p/bin/pytest-%type_raw[python] || exit 1
+  <<
+  TestSuiteSize: large
 <<
 
 LICENSE: GPL
@@ -68,5 +76,12 @@ customizable, and you can easily write a small plugin to add a
 personal feature.
 << 
 
-# Info2
+DescPackaging: <<
+Added Sphinx build of HTML docs, changed names of versioned executables to
+standard -py%type_pkg[python] scheme (pylint-gui no longer included).
+2to3 treatment of sources no longer required. 3 test failures.
+Added cleanup of byte-compiled files to InstallScript.
+<<
+
+# Info3
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/isort-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/isort-py.info
@@ -1,9 +1,9 @@
 Info2: <<
 
 Package: isort-py%type_pkg[python]
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 
-Version: 4.2.5
+Version: 4.3.4
 Revision: 1
 Description: Sort Python imports
 DescDetail: <<
@@ -13,19 +13,24 @@ utility, Python library and plugins for various editors to quickly
 sort all your imports. It currently cleanly supports Python 2.6 - 3.5
 using pies to achieve this without ugly hacks and/or py2to3.
 <<
-Source: https://pypi.python.org/packages/70/65/49f66364f4ac551ec414e88537b02be439d1d9ea7e1fdd6d526fb8796bf9/isort-%v.tar.gz
-Source-MD5: 71489ebd936429d5bda2af7ae662ed78
+Source: https://pypi.io/packages/source/i/isort/isort-%v.tar.gz
+Source-MD5: fb554e9c8f9aa76e333a03d470a5cf52
 Depends: python%type_pkg[python]
 CompileScript: <<
   %p/bin/python%type_raw[python] setup.py build_ext --include-dirs=%p/include --library-dirs=%p/lib
   %p/bin/python%type_raw[python] setup.py build
 <<
-#InfoTest: <<
-#  TestScript: <<
-#    %p/bin/python%type_raw[python] setup.py test
-#    find ./build -name "*.pyc" -delete
-#  <<
-#<<
+InfoTest: <<
+  TestDepends: pytest-py%type_pkg[python], flake8-py%type_pkg[python]
+  TestScript: <<
+    #!/bin/bash -ev
+    TESTFAIL=0
+    %p/bin/pytest-%type_raw[python] || TESTFAIL=1
+    find ./build -name "*.pyc" -exec rm {} \;
+    exit $TESTFAIL
+  <<
+  TestSuiteSize: small
+<<
 InstallScript: <<
   %p/bin/python%type_raw[python] setup.py install --root=%d
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/lazy-object-proxy-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/lazy-object-proxy-py.info
@@ -1,16 +1,16 @@
-Info2: <<
+Info3: <<
 
 Package: lazy-object-proxy-py%type_pkg[python]
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 
-Version: 1.2.2
+Version: 1.3.1
 Revision: 1
 Description: Fast and thorough lazy object proxy
 DescDetail: <<
 A fast and thorough lazy object proxy.
 <<
-Source: https://pypi.python.org/packages/65/63/b6061968b0f3c7c52887456dfccbd07bec2303296911757d8c1cc228afe6/lazy-object-proxy-%v.tar.gz
-Source-MD5: 841b5592bc12c6ef7e48ed1d7a5f9066
+Source: https://pypi.io/packages/source/l/lazy-object-proxy/lazy-object-proxy-%v.tar.gz
+Source-MD5: e128152b76eb5b9ba759504936139fd0
 
 Depends: python%type_pkg[python]
 CompileScript: <<
@@ -28,6 +28,7 @@ InstallScript: <<
 <<
 DocFiles: PKG-INFO
 License: BSD
-Homepage: https://pypi.python.org/pypi/lazy-object-proxy
+Homepage: https://github.com/ionelmc/python-lazy-object-proxy
 Maintainer: Brendan Cully <fink@brendan.cully.org>
+# Info3
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/wrapt-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/wrapt-py.info
@@ -1,9 +1,9 @@
-Info2: <<
+Info3: <<
 
 Package: wrapt-py%type_pkg[python]
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 
-Version: 1.10.8
+Version: 1.10.11
 Revision: 1
 Description: Decorators, wrappers and monkey patching mod
 DescDetail: <<
@@ -24,8 +24,8 @@ fallback to a pure Python implementation is also provided where a
 target system does not have a compiler to allow the C extension to be
 compiled.
 <<
-Source: https://pypi.python.org/packages/00/dd/dc22f8d06ee1f16788131954fc69bc4438f8d0125dd62419a43b86383458/wrapt-%v.tar.gz
-Source-MD5: 7c2a7e6262acc396ef6528b3d66bd047
+Source: https://pypi.io/packages/source/w/wrapt/wrapt-%v.tar.gz
+Source-MD5: e1346f31782d50401f81c2345b037076
 
 Depends: python%type_pkg[python]
 CompileScript: <<
@@ -34,7 +34,7 @@ CompileScript: <<
 <<
 InfoTest: <<
   TestScript: <<
-    %p/bin/python%type_raw[python] setup.py test
+    %p/bin/python%type_raw[python] setup.py check
     find ./build -name "*.pyc" -delete
   <<
 <<
@@ -43,6 +43,7 @@ InstallScript: <<
 <<
 DocFiles: PKG-INFO
 License: BSD
-Homepage: https://pypi.python.org/pypi/wrapt
+Homepage: https://github.com/GrahamDumpleton/wrapt
 Maintainer: Brendan Cully <fink@brendan.cully.org>
+# Info3
 <<


### PR DESCRIPTION
This is bringing `pylint-py` up to date to the latest upstream `1.8.4` and adds/updates missing dependencies for `type_pkg[python] = 36`.
Built and tested for python 2.7-3.6 on 10.12 and 10.13 - 3 test failures on Python 3.x, > 222 (basically the entire test_stdlib) mostly unicode-related on 2.7.14.
Changed names of versioned executables to standard -py%type_pkg[python] scheme (pylint-gui no longer included). 2to3 treatment of sources no longer required. Added cleanup of byte-compiled files to InstallScript.
