### PR TITLE
Add missing variants to pythonmods

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/pycrypto-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/pycrypto-py.info
@@ -2,7 +2,7 @@
 Info2: <<
 
 Package: pycrypto-py%type_pkg[python]
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 
 Version: 2.6.1
 Revision: 1

--- a/10.9-libcxx/stable/main/finkinfo/database/psycopg2-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/psycopg2-py.info
@@ -6,7 +6,7 @@ Revision: 3
 Description: PostgreSQL database adapter for Python
 License: LGPL
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 
 BuildDepends: python%type_pkg[python],  postgresql94-dev (>= 1:0-0)
 Depends: python%type_pkg[python], postgresql94-shlibs 

--- a/10.9-libcxx/stable/main/finkinfo/database/psycopg2-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/psycopg2-py.info
@@ -1,50 +1,55 @@
 Info2: <<
 
 Package: psycopg2-py%type_pkg[python]
-Version: 2.5.2
-Revision: 3
+Version: 2.7.4
+Revision: 1
 Description: PostgreSQL database adapter for Python
 License: LGPL
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
-Type: python (2.7 3.4 3.5 3.6)
+Type: python (2.7 3.4 3.5 3.6), postgresql (10)
 
-BuildDepends: python%type_pkg[python],  postgresql94-dev (>= 1:0-0)
-Depends: python%type_pkg[python], postgresql94-shlibs 
+BuildDepends: <<
+	python%type_pkg[python],
+	postgresql%type_pkg[postgresql]-dev
+<<
+Depends: <<
+	python%type_pkg[python],
+	postgresql%type_pkg[postgresql]-shlibs 
+<<
+Recommends: postgresql%type_pkg[postgresql], postgis96
 
-Recommends: postgresql94, postgis94
-
-Source-MD5: 53d81793fbab8fee6e732a0425d50047
-Source: http://pypi.python.org/packages/source/p/psycopg2/psycopg2-%v.tar.gz
-
+Source-MD5: 70fc57072e084565a42689d416cf2c5c
+Source-Checksum: SHA256(8bf51191d60f6987482ef0cfe8511bbf4877a5aa7f313d7b488b53189cf26209)
+Source: https://pypi.python.org/packages/source/p/psycopg2/psycopg2-%v.tar.gz
+PatchFile: psycopg2-py.patch
+PatchFile-MD5: 885401f4498e87ae9e8f2b8c6708bed4
+PatchScript: <<
+        patch -p1 < %{PatchFile}
+ <<
 CompileScript: <<
   #!/bin/bash -ev
-  if [ "%type_pkg[python]" -ge "31" ]; then
-    2to3-%type_raw[python] --write --no-diffs .
-  fi
-
   %p/bin/python%type_raw[python] setup.py build
 <<
 
 # Test Phase:
-# Must create role "nobody" or "root" in the database.
-# Also note this can only be run after psycopg2
-# is installed.  Need more magic to run it before.
-# As of September 30, 2006 results are:
-#   Ran 35 tests in 2.196s
-#   FAILED (failures=2, errors=1)
-#   Maintainer Notified.
+# Must create role "fink-bld" in the database.
+# As of May 26, 2018 results are:
+# with max_prepared_transactions = 10 in postgresql.conf 
+# Ran 664 tests in O57.996s
+# OK (skipped=34)
+# phase test: passed
 
 InfoTest: <<
     TestScript: <<
-    	PYTHONPATH=`pwd`/`ls -d build/lib*` %p/bin/python%type_raw[python] tests/test_psycopg2_dbapi20.py || exit 2
+       PYTHONPATH=`pwd`/`ls -d build/lib*` %p/bin/python%type_raw[python] -c "from psycopg2 import tests; tests.unittest.main(defaultTest='tests.test_suite')" --verbose || exit 2
     <<
 <<
 
 #Install Phase:
-DocFiles: AUTHORS INSTALL README NEWS LICENSE
+DocFiles: AUTHORS INSTALL README.rst NEWS LICENSE
 InstallScript: <<
-	rm -f build/lib*/psycopg2/*.pyc
-	%p/bin/python%type_raw[python] setup.py install --prefix=%p --root=%d
+        find . \( -name \*.pyc -or -name __pycache__ \) -exec rm -rf {} +
+	%p/bin/python%type_raw[python] -B setup.py install --prefix=%p --root=%d
 <<
 
 
@@ -69,8 +74,12 @@ DescPackaging: <<
 In order for the -m maintainer tests to work, you need to
 run these two commands first:
 
-  createdb psycopg2_test
-  createuser root
+  sudo -u postgres createuser fink-bld
+  sudo -u postgres createdb psycopg2_test --owner=fink-bld
+
+To aktivate the "Two-Phase Commit" tests, you need to
+set the property "max_prepared_transactions = 10" 
+in postgresql.conf.
 
 No need for python-mx date module.  Now uses built in datetime.
 <<

--- a/10.9-libcxx/stable/main/finkinfo/database/psycopg2-py.patch
+++ b/10.9-libcxx/stable/main/finkinfo/database/psycopg2-py.patch
@@ -1,0 +1,24 @@
+From ef64493b8913e4069c4422ad14da6de405c445f6 Mon Sep 17 00:00:00 2001
+From: Jon Dufresne <jon.dufresne@gmail.com>
+Date: Sun, 3 Dec 2017 18:47:19 -0800
+Subject: [PATCH] Fix use of "async" in test_cursor.py
+
+"async" will be a keyword starting with Python 3.7. On Python 3.6, use
+of "async" causes a deprecation warning. Use the alias "async_" instead.
+---
+ tests/test_cursor.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/test_cursor.py b/tests/test_cursor.py
+index e896ef94..5c94f422 100755
+--- a/tests/test_cursor.py
++++ b/tests/test_cursor.py
+@@ -553,7 +553,7 @@ def test_external_close_async(self):
+         # Issue #443 is in the async code too. Since the fix is duplicated,
+         # so is the test.
+         control_conn = self.conn
+-        connect_func = lambda: self.connect(async=True)
++        connect_func = lambda: self.connect(async_=True)
+         wait_func = psycopg2.extras.wait_select
+         self._test_external_close(control_conn, connect_func, wait_func)
+ 

--- a/10.9-libcxx/stable/main/finkinfo/devel/astng-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/astng-py.info
@@ -1,7 +1,7 @@
 Info2: <<
 
 Package: astng-py%type_pkg[python]
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Version: 0.24.3
 Revision: 1
 Source: http://ftp.logilab.org/pub/astng/logilab-astng-%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-designer-qt4.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-designer-qt4.info
@@ -1,23 +1,25 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: qscintilla2-designer-qt4-%type_pkg[qt]
-Version: 2.9.2
+Version: 2.10.4
 Revision: 1
 Type: qt (mac x11)
 GCC: 4.0
 Source: mirror:sourceforge:pyqt/QScintilla2/QScintilla-%v/QScintilla_gpl-%v.tar.gz
-Source-MD5: db260651a5e086cc4eee6417172e27e8
+Source-MD5: 48ef316ff1e2a4d45a65d42be146ca39
+Source-Checksum: SHA256(0353e694a67081e2ecdd7c80e1a848cf79a36dbba78b2afa36009482149b022d)
+
 BuildDepends: <<
   ( %type_pkg[qt] = mac) libpng16,
   ( %type_pkg[qt] = mac) openssl100-dev (>= 1.0.2g-1),
   libiconv-dev,
-  qscintilla2.12-qt4-%type_pkg[qt] (>= %v-1),
+  qscintilla2.13-qt4-%type_pkg[qt] (>= %v-1),
   qt4-base-%type_pkg[qt] (>= 4.7.3-1)
 <<
 Depends: <<
   ( %type_pkg[qt] = mac) libpng16-shlibs,
   libiconv,
-  qscintilla2.12-qt4-%type_pkg[qt]-shlibs (>= %v-1),
+  qscintilla2.13-qt4-%type_pkg[qt]-shlibs (>= %v-1),
   qt4-base-%type_pkg[qt]-qtcore-shlibs (>= 4.7.3-1),
   qt4-base-%type_pkg[qt]-qtdesigner-shlibs (>= 4.7.3-1),
   qt4-base-%type_pkg[qt]-qtgui-shlibs (>= 4.7.3-1)
@@ -26,7 +28,7 @@ Depends: <<
 CompileScript: <<
  #!/bin/sh -ev
  cd designer-Qt4Qt5
- %p/lib/qt4-%type_pkg[qt]/bin/qmake designer.pro
+ %p/lib/qt4-%type_pkg[qt]/bin/qmake "CONFIG+=release" designer.pro
  make
 <<
 InstallScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-designer-qt5.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-designer-qt5.info
@@ -1,17 +1,19 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: qscintilla2-designer-qt5-%type_pkg[qt]
-Version: 2.9.2
+Version: 2.10.4
 Revision: 1
 Type: qt (mac)
 GCC: 4.0
 Source: mirror:sourceforge:pyqt/QScintilla2/QScintilla-%v/QScintilla_gpl-%v.tar.gz
-Source-MD5: db260651a5e086cc4eee6417172e27e8
+Source-MD5: 48ef316ff1e2a4d45a65d42be146ca39
+Source-Checksum: SHA256(0353e694a67081e2ecdd7c80e1a848cf79a36dbba78b2afa36009482149b022d)
+
 BuildDepends: <<
   ( %type_pkg[qt] = mac) libpng16,
   ( %type_pkg[qt] = mac) openssl100-dev (>= 1.0.2g-1),
   libiconv-dev,
-  qscintilla2.12-qt5-%type_pkg[qt] (>= %v-1),
+  qscintilla2.13-qt5-%type_pkg[qt] (>= %v-1),
   qt5-%type_pkg[qt]-qtbase (>= 5.6.0-1),
   qt5-%type_pkg[qt]-qtbase-dev-tools (>= 5.6.0-1),
   qt5-%type_pkg[qt]-qtmacextras (>= 5.6.0-1),
@@ -20,7 +22,7 @@ BuildDepends: <<
 Depends: <<
   ( %type_pkg[qt] = mac) libpng16-shlibs,
   libiconv,
-  qscintilla2.12-qt5-%type_pkg[qt]-shlibs (>= %v-1),
+  qscintilla2.13-qt5-%type_pkg[qt]-shlibs (>= %v-1),
   qt5-%type_pkg[qt]-qtcore-shlibs (>= 5.6.0-1),
   qt5-%type_pkg[qt]-qtdesigner-shlibs (>= 5.6.0-1),
   qt5-%type_pkg[qt]-qtgui-shlibs (>= 5.6.0-1),

--- a/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-qt4-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-qt4-py.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: qscintilla2-qt4%type_pkg[qt]-py%type_pkg[python]
 Version: 2.10.4
-Revision: 1
+Revision: 2
 Type: qt (-mac), python (2.7 3.4 3.5 3.6)
 
 GCC: 4.0
@@ -12,12 +12,12 @@ Source-Checksum: SHA256(0353e694a67081e2ecdd7c80e1a848cf79a36dbba78b2afa36009482
 
 BuildDepends: <<
   libpng16,
-  openssl100-dev (>= 1.0.2g-1),
+  openssl100-dev (>= 1.0.2o-1),
   libiconv-dev,
   qscintilla2.13-qt4%type_pkg[qt] (>= %v-1),
   qt4-base%type_pkg[qt] (>= 4.7.3-1),
-  sip-py%type_pkg[python] (>= 4.18-1),
-  sip-py%type_pkg[python]-bin (>= 4.18-1)
+  sip-py%type_pkg[python] (>= 4.19.1-2),
+  sip-py%type_pkg[python]-bin (>= 4.19.8-2)
 <<
 Depends: <<
   libpng16-shlibs,
@@ -25,7 +25,7 @@ Depends: <<
   qscintilla2.13-qt4%type_pkg[qt]-shlibs (>= %v-1),
   qt4-base%type_pkg[qt]-qtcore-shlibs (>= 4.7.3-1),
   qt4-base%type_pkg[qt]-qtgui-shlibs (>= 4.7.3-1),
-  pyqt4-mac-py%type_pkg[python] (>= 4.11.4-1)
+  pyqt4-mac-py%type_pkg[python] (>= 4.12.1-3)
 <<
 
 # Make sure QScintilla2.api file goes in a python-versioned directory.

--- a/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-qt4-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-qt4-py.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: qscintilla2-qt4%type_pkg[qt]-py%type_pkg[python]
 Version: 2.9.2
 Revision: 1
-Type: qt (-mac), python (2.7 3.4 3.5)
+Type: qt (-mac), python (2.7 3.4 3.5 3.6)
 
 GCC: 4.0
 Source: mirror:sourceforge:pyqt/QScintilla2/QScintilla-%v/QScintilla_gpl-%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-qt4-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-qt4-py.info
@@ -1,18 +1,20 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: qscintilla2-qt4%type_pkg[qt]-py%type_pkg[python]
-Version: 2.9.2
+Version: 2.10.4
 Revision: 1
 Type: qt (-mac), python (2.7 3.4 3.5 3.6)
 
 GCC: 4.0
 Source: mirror:sourceforge:pyqt/QScintilla2/QScintilla-%v/QScintilla_gpl-%v.tar.gz
-Source-MD5: db260651a5e086cc4eee6417172e27e8
+Source-MD5: 48ef316ff1e2a4d45a65d42be146ca39
+Source-Checksum: SHA256(0353e694a67081e2ecdd7c80e1a848cf79a36dbba78b2afa36009482149b022d)
+
 BuildDepends: <<
   libpng16,
   openssl100-dev (>= 1.0.2g-1),
   libiconv-dev,
-  qscintilla2.12-qt4%type_pkg[qt] (>= %v-1),
+  qscintilla2.13-qt4%type_pkg[qt] (>= %v-1),
   qt4-base%type_pkg[qt] (>= 4.7.3-1),
   sip-py%type_pkg[python] (>= 4.18-1),
   sip-py%type_pkg[python]-bin (>= 4.18-1)
@@ -20,7 +22,7 @@ BuildDepends: <<
 Depends: <<
   libpng16-shlibs,
   libiconv,
-  qscintilla2.12-qt4%type_pkg[qt]-shlibs (>= %v-1),
+  qscintilla2.13-qt4%type_pkg[qt]-shlibs (>= %v-1),
   qt4-base%type_pkg[qt]-qtcore-shlibs (>= 4.7.3-1),
   qt4-base%type_pkg[qt]-qtgui-shlibs (>= 4.7.3-1),
   pyqt4-mac-py%type_pkg[python] (>= 4.11.4-1)

--- a/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-qt5-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-qt5-py.info
@@ -1,17 +1,19 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: qscintilla2-qt5%type_pkg[qt]-py%type_pkg[python]
-Version: 2.9.2
+Version: 2.10.4
 Revision: 1
 Type: qt (-mac), python (2.7 3.4 3.5 3.6)
 GCC: 4.0
 Source: mirror:sourceforge:pyqt/QScintilla2/QScintilla-%v/QScintilla_gpl-%v.tar.gz
-Source-MD5: db260651a5e086cc4eee6417172e27e8
+Source-MD5: 48ef316ff1e2a4d45a65d42be146ca39
+Source-Checksum: SHA256(0353e694a67081e2ecdd7c80e1a848cf79a36dbba78b2afa36009482149b022d)
+
 BuildDepends: <<
   libpng16,
   openssl100-dev (>= 1.0.2g-1),
   libiconv-dev,
-  qscintilla2.12-qt5%type_pkg[qt] (>= %v-1),
+  qscintilla2.13-qt5%type_pkg[qt] (>= %v-1),
   qt5%type_pkg[qt]-qtbase (>= 5.6.0-1),
   qt5%type_pkg[qt]-qtbase-dev-tools (>= 5.6.0-1),
   qt5%type_pkg[qt]-qtmacextras (>= 5.6.0-1),
@@ -23,7 +25,7 @@ Depends: <<
   libiconv,
   pyqt5-mac-py%type_pkg[python] (>= 5.6-1),
   python%type_pkg[python],
-  qscintilla2.12-qt5%type_pkg[qt]-shlibs (>= %v-1),
+  qscintilla2.13-qt5%type_pkg[qt]-shlibs (>= %v-1),
   qt5%type_pkg[qt]-qtcore-shlibs (>= 5.6.0-1),
   qt5%type_pkg[qt]-qtgui-shlibs (>= 5.6.0-1),
   qt5%type_pkg[qt]-qtmacextras-shlibs (>= 5.6.0-1),

--- a/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-qt5-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-qt5-py.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: qscintilla2-qt5%type_pkg[qt]-py%type_pkg[python]
 Version: 2.10.4
-Revision: 1
+Revision: 2
 Type: qt (-mac), python (2.7 3.4 3.5 3.6)
 GCC: 4.0
 Source: mirror:sourceforge:pyqt/QScintilla2/QScintilla-%v/QScintilla_gpl-%v.tar.gz
@@ -11,19 +11,19 @@ Source-Checksum: SHA256(0353e694a67081e2ecdd7c80e1a848cf79a36dbba78b2afa36009482
 
 BuildDepends: <<
   libpng16,
-  openssl100-dev (>= 1.0.2g-1),
+  openssl100-dev (>= 1.0.2o-1),
   libiconv-dev,
   qscintilla2.13-qt5%type_pkg[qt] (>= %v-1),
   qt5%type_pkg[qt]-qtbase (>= 5.6.0-1),
   qt5%type_pkg[qt]-qtbase-dev-tools (>= 5.6.0-1),
   qt5%type_pkg[qt]-qtmacextras (>= 5.6.0-1),
-  sip-py%type_pkg[python] (>= 4.18-1),
-  sip-py%type_pkg[python]-bin (>= 4.18-1)
+  sip-py%type_pkg[python] (>= 4.19.8-2),
+  sip-py%type_pkg[python]-bin (>= 4.19.8-2)
 <<
 Depends: <<
   libpng16-shlibs,
   libiconv,
-  pyqt5-mac-py%type_pkg[python] (>= 5.6-1),
+  pyqt5-mac-py%type_pkg[python] (>= 5.10.1-3),
   python%type_pkg[python],
   qscintilla2.13-qt5%type_pkg[qt]-shlibs (>= %v-1),
   qt5%type_pkg[qt]-qtcore-shlibs (>= 5.6.0-1),

--- a/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-qt5-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2-qt5-py.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: qscintilla2-qt5%type_pkg[qt]-py%type_pkg[python]
 Version: 2.9.2
 Revision: 1
-Type: qt (-mac), python (2.7 3.4 3.5)
+Type: qt (-mac), python (2.7 3.4 3.5 3.6)
 GCC: 4.0
 Source: mirror:sourceforge:pyqt/QScintilla2/QScintilla-%v/QScintilla_gpl-%v.tar.gz
 Source-MD5: db260651a5e086cc4eee6417172e27e8

--- a/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2.11-qt5.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2.11-qt5.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: qscintilla2.11-qt5-%type_pkg[qt]
 Version: 2.8.4
-Revision: 3
+Revision: 4
 Distribution: 10.9, 10.10
 Type: qt (mac)
 GCC: 4.0
@@ -17,8 +17,8 @@ BuildDepends: <<
   qt5-%type_pkg[qt]-qtbase-dev-tools (>= 5.4.1-1),
   qt5-%type_pkg[qt]-qtmacextras (>= 5.4.1-1)
 <<
-Conflicts: qscintilla2.11-qt5-%type_pkg[qt], qscintilla2.12-qt5-%type_pkg[qt]
-Replaces: qscintilla2.11-qt5-%type_pkg[qt], qscintilla2.12-qt5-%type_pkg[qt]
+Conflicts: qscintilla2.11-qt5-%type_pkg[qt], qscintilla2.12-qt5-%type_pkg[qt], qscintilla2.13-qt5-%type_pkg[qt]
+Replaces: qscintilla2.11-qt5-%type_pkg[qt], qscintilla2.12-qt5-%type_pkg[qt], qscintilla2.13-qt5-%type_pkg[qt]
 BuildDependsOnly: true
 UseMaxBuildJobs: true
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2.13-qt4.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2.13-qt4.info
@@ -1,0 +1,60 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+Package: qscintilla2.13-qt4-%type_pkg[qt]
+Version: 2.10.4
+Revision: 1
+Type: qt (mac x11)
+GCC: 4.0
+Source: mirror:sourceforge:pyqt/QScintilla2/QScintilla-%v/QScintilla_gpl-%v.tar.gz
+Source-MD5: 48ef316ff1e2a4d45a65d42be146ca39
+Source-Checksum: SHA256(0353e694a67081e2ecdd7c80e1a848cf79a36dbba78b2afa36009482149b022d)
+
+Depends: %N-shlibs (>= %v-%r)
+BuildDepends: <<
+  (%type_pkg[qt] = mac) libpng16,
+  (%type_pkg[qt] = mac) openssl100-dev (>= 1.0.2g-1),
+  libiconv-dev,
+  qt4-base-%type_pkg[qt] (>= 4.7.3-1),
+  (%type_pkg[qt] = x11) x11-dev
+<<
+Conflicts: qscintilla2-qt4-%type_pkg[qt], qscintilla2.6-qt4-%type_pkg[qt], qscintilla2.8-qt4-%type_pkg[qt], qscintilla2.11-qt4-%type_pkg[qt], qscintilla2.12-qt4-%type_pkg[qt], qscintilla2.13-qt4-%type_pkg[qt]
+Replaces: qscintilla2-qt4-%type_pkg[qt], qscintilla2.6-qt4-%type_pkg[qt], qscintilla2.8-qt4-%type_pkg[qt], qscintilla2.11-qt4-%type_pkg[qt], qscintilla2.12-qt4-%type_pkg[qt], qscintilla2.13-qt4-%type_pkg[qt]
+BuildDependsOnly: true
+UseMaxBuildJobs: true
+CompileScript: <<
+ #!/bin/sh -ev
+ cd Qt4Qt5
+ %p/lib/qt4-%type_pkg[qt]/bin/qmake "CONFIG+=release" qscintilla.pro
+ # Something seems broken with qt4-x11 qmake.
+ if [ %type_pkg[qt] = x11 ]; then
+ 	perl -pi -e 's,install_name	libqscintilla2_qt4.13.dylib,install_name	%p/lib/qt4-x11/lib/libqscintilla2_qt4.13.dylib,' Makefile
+ fi
+ make
+<<
+InstallScript: <<
+  #!/bin/sh -ev
+  cd Qt4Qt5
+  INSTALL_ROOT=%d make install
+  <<
+SplitOff: <<
+ Package: %N-shlibs
+ Depends: <<
+   (%type_pkg[qt] = mac) libpng16-shlibs,
+   libiconv,
+   qt4-base-%type_pkg[qt]-qtcore-shlibs (>= 4.7.3-1),
+   qt4-base-%type_pkg[qt]-qtgui-shlibs (>= 4.7.3-1),
+   (%type_pkg[qt] = x11) x11-shlibs
+ <<
+ Files: lib/qt4-%type_pkg[qt]/lib/libqscintilla2_qt4.13*dylib
+ Shlibs: %p/lib/qt4-%type_pkg[qt]/lib/libqscintilla2_qt4.13.dylib 13.1.0 %n (>= 2.10.4-1)
+ DocFiles: ChangeLog LICENSE NEWS README
+<<
+Description: Qt port Scintilla C++ editor class
+DescPackaging: <<
+ Previously maintained by Dave Reiser <dbreiser@users.sourceforge.net>
+<<
+DocFiles: ChangeLog LICENSE NEWS README
+License: GPL
+Homepage: http://www.riverbankcomputing.co.uk/software/qscintilla
+Maintainer:  Daniel Johnson <daniel@daniel-johnson.org>
+<<

--- a/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2.13-qt5.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2.13-qt5.info
@@ -1,12 +1,14 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
-Package: qscintilla2.12-qt5-%type_pkg[qt]
-Version: 2.9.2
-Revision: 2
+Package: qscintilla2.13-qt5-%type_pkg[qt]
+Version: 2.10.4
+Revision: 1
 Type: qt (mac)
 GCC: 4.0
 Source: mirror:sourceforge:pyqt/QScintilla2/QScintilla-%v/QScintilla_gpl-%v.tar.gz
-Source-MD5: db260651a5e086cc4eee6417172e27e8
+Source-MD5: 48ef316ff1e2a4d45a65d42be146ca39
+Source-Checksum: SHA256(0353e694a67081e2ecdd7c80e1a848cf79a36dbba78b2afa36009482149b022d)
+
 Depends: %N-shlibs (>= %v-%r)
 BuildDepends: <<
   (%type_pkg[qt] = mac) libpng16,
@@ -24,7 +26,7 @@ CompileScript: <<
  #!/bin/sh -ev
  cd Qt4Qt5
  %p/lib/qt5-%type_pkg[qt]/bin/qmake qscintilla.pro
- perl -pi -e 's,install_name	libqscintilla2.12.dylib,install_name	%p/lib/qt5-%type_pkg[qt]/lib/libqscintilla2.12.dylib,' Makefile
+ perl -pi -e 's,install_name	libqscintilla2_qt5.13.dylib,install_name	%p/lib/qt5-%type_pkg[qt]/lib/libqscintilla2_qt5.13.dylib,' Makefile
  make
 <<
 InstallScript: <<
@@ -43,8 +45,8 @@ SplitOff: <<
    qt5-%type_pkg[qt]-qtprintsupport-shlibs (>= 5.6.0-1),
    qt5-%type_pkg[qt]-qtwidgets-shlibs (>= 5.6.0-1)
  <<
- Files: lib/qt5-%type_pkg[qt]/lib/libqscintilla2.12*dylib
- Shlibs: %p/lib/qt5-%type_pkg[qt]/lib/libqscintilla2.12.dylib 12.0.0 %n (>= 2.9.1-1)
+ Files: lib/qt5-%type_pkg[qt]/lib/libqscintilla2_qt5.13*dylib
+ Shlibs: %p/lib/qt5-%type_pkg[qt]/lib/libqscintilla2_qt5.13.dylib 13.1.0 %n (>= 2.10.4-1)
  DocFiles: ChangeLog LICENSE NEWS README
 <<
 Description: Qt port Scintilla C++ editor class

--- a/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2.8-qt4.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/qscintilla2.8-qt4.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: qscintilla2.8-qt4-%type_pkg[qt]
 Version: 2.6.2
-Revision: 5
+Revision: 6
 Type: qt (mac x11)
 GCC: 4.0
 Source: http://www.riverbankcomputing.com/static/Downloads/QScintilla2/QScintilla-gpl-%v.tar.gz
@@ -15,8 +15,8 @@ BuildDepends: <<
   qt4-base-%type_pkg[qt] (>= 4.7.3-1),
   (%type_pkg[qt] = x11) x11-dev
 <<
-Conflicts: qscintilla2-qt4-%type_pkg[qt], qscintilla2.6-qt4-%type_pkg[qt], qscintilla2.8-qt4-%type_pkg[qt], qscintilla2.11-qt4-%type_pkg[qt], qscintilla2.12-qt4-%type_pkg[qt]
-Replaces: qscintilla2-qt4-%type_pkg[qt], qscintilla2.6-qt4-%type_pkg[qt], qscintilla2.8-qt4-%type_pkg[qt], qscintilla2.11-qt4-%type_pkg[qt], qscintilla2.12-qt4-%type_pkg[qt]
+Conflicts: qscintilla2-qt4-%type_pkg[qt], qscintilla2.6-qt4-%type_pkg[qt], qscintilla2.8-qt4-%type_pkg[qt], qscintilla2.11-qt4-%type_pkg[qt], qscintilla2.12-qt4-%type_pkg[qt], qscintilla2.13-qt5-%type_pkg[qt]
+Replaces: qscintilla2-qt4-%type_pkg[qt], qscintilla2.6-qt4-%type_pkg[qt], qscintilla2.8-qt4-%type_pkg[qt], qscintilla2.11-qt4-%type_pkg[qt], qscintilla2.12-qt4-%type_pkg[qt], qscintilla2.13-qt5-%type_pkg[qt]
 BuildDependsOnly: true
 UseMaxBuildJobs: true
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/magicdate-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/magicdate-py.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: magicdate-py%type_pkg[python]
 Version: 0.1.3
 Revision: 2
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Description: Fuzzy date handling for python
 DescDetail: <<
 Convert fuzzy date to a datetime object.

--- a/10.9-libcxx/stable/main/finkinfo/libs/pyserial-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pyserial-py.info
@@ -3,7 +3,7 @@ Package: pyserial-py%type_pkg[python]
 Version: 2.7
 Revision: 1
 
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Description: Python access to serial ports
 License: OSI-Approved
 Homepage: http://pyserial.sourceforge.net/

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/3to2-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/3to2-py.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: 3to2-py%type_pkg[python]
 Version: 1.1a4
 Revision: 1
-Type: python (3.4 3.5)
+Type: python (3.4 3.5 3.6)
 
 Description: Refactor python 3.x syntax into 2.x syntax
 DescDetail: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bottleneck-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bottleneck-py.info
@@ -3,7 +3,7 @@ Package: bottleneck-py%type_pkg[python]
 Version: 1.0.0
 Revision: 1
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
-Type: python (2.7 3.4)
+Type: python (2.7 3.4 3.5 3.6)
 Depends: python%type_pkg[python], numpy-py%type_pkg[python] (>= 1.9.1)
 Recommends: scipy-py%type_pkg[python]
 Source: https://pypi.python.org/packages/source/B/Bottleneck/Bottleneck-%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/cchardet-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/cchardet-py.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: cchardet-py%type_pkg[python]
 Version: 1.0.0
 Revision: 1
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 
 Description: Universal encoding detector
 DescDetail: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/fasteners-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/fasteners-py.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: fasteners-py%type_pkg[python]
 Version: 0.14.1
 Revision: 6
-Type: python (2.7 3.4)
+Type: python (2.7 3.4 3.5 3.6)
 
 Description: Python package providing useful locks
 License: BSD

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/frosted-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/frosted-py.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: frosted-py%type_pkg[python]
 Version: 1.4.1
 Revision: 1
-Type: python (2.7 3.4)
+Type: python (2.7 3.4 3.5 3.6)
 
 Description: Fork of pyflakes
 DescDetail: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/hglib-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/hglib-py.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: hglib-py%type_pkg[python]
 Version: 1.7
 Revision: 1
-Type: python (2.7 3.4)
+Type: python (2.7 3.4 3.5 3.6)
 
 Description: Mercurial Python library
 DescDetail: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/jdcal-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/jdcal-py.info
@@ -6,7 +6,7 @@ Version: 1.0
 Revision: 1
 Homepage: https://pypi.python.org/pypi/jdcal
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Depends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
 BuildDepends: setuptools-tng-py%type_pkg[python]
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/monotonic-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/monotonic-py.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: monotonic-py%type_pkg[python]
 Version: 1.3
 Revision: 5
-Type: python (2.7 3.4)
+Type: python (2.7 3.4 3.5 3.6)
 
 Description: Function time.monotonic() for Python 2&<3.3
 License: BSD

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/nbconvert-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/nbconvert-py.info
@@ -5,7 +5,7 @@ Version: 4.1.0
 Revision: 1
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 License: BSD
-Type: python (2.7 3.5)
+Type: python (2.7 3.5 3.6)
 Homepage: https://pypi.python.org/pypi/nbconvert
 # https://pypi.python.org/packages/source/n/nbconvert/nbconvert-4.1.0.tar.gz#md5=58ee16f5da0dd2976ff992511d6bfb43
 Source: https://pypi.python.org/packages/source/n/nbconvert/nbconvert-%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/nbformat-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/nbformat-py.info
@@ -5,7 +5,7 @@ Version: 4.0.1
 Revision: 1
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 License: BSD
-Type: python (2.7 3.5)
+Type: python (2.7 3.5 3.6)
 Homepage: https://pypi.python.org/pypi/nbformat
 # https://pypi.python.org/packages/source/n/nbformat/nbformat-4.0.1.tar.gz#md5=684c4dc3c6fd8036fd1ae1c908003e23
 Source: https://pypi.python.org/packages/source/n/nbformat/nbformat-%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/ntplib-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/ntplib-py.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: ntplib-py%type_pkg[python]
 Version: 0.3.2
 Revision: 1
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Description: Pure python network time library
 DescDetail: <<
 This module offers a simple interface to query NTP servers from

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/openpyxl-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/openpyxl-py.info
@@ -6,7 +6,7 @@ Version: 2.3.5
 Revision: 1
 Homepage: https://pythonhosted.org/openpyxl/
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Depends: <<
   python%type_pkg[python],
   jdcal-py%type_pkg[python],

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/param-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/param-py.info
@@ -4,7 +4,7 @@ Package: param-py%type_pkg[python]
 Version: 1.4.1
 Revision: 1
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Depends: python%type_pkg[python]
 BuildDepends: cython-py%type_pkg[python]
 Source: https://pypi.io/packages/source/p/param/param-%v.zip

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pyephem-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pyephem-py.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: pyephem-py%type_pkg[python]
 Version: 3.7.6.0
 Revision: 1
-Type: python (2.7 3.4)
+Type: python (2.7 3.4 3.5 3.6)
 Maintainer: Kevin Horton <khorton02@gmail.com>
 Depends: python%type_pkg[python]
 Source: https://pypi.io/packages/source/p/pyephem/pyephem-%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pyodbc-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pyodbc-py.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: pyodbc-py%type_pkg[python]
 Version: 3.0.10
 Revision: 2
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Description: Connect to ODBC database drivers
 DescDetail: <<
 pyodbc is a Python module that allows you to use ODBC to connect to

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pystemmer-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pystemmer-py.info
@@ -3,7 +3,7 @@ Package: pystemmer-py%type_pkg[python]
 Version: 1.3.0
 Revision: 1
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Depends: python%type_pkg[python], six-py%type_pkg[python]
 BuildDepends: cython-py%type_pkg[python]
 Source: http://pypi.python.org/packages/source/P/PyStemmer/PyStemmer-%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pysvn-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pysvn-py.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: pysvn-py%type_pkg[python]
 Version: 1.9.0
 Revision: 1
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 
 Description: Python SVN Extension
 DescDetail: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pytoml-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pytoml-py.info
@@ -1,7 +1,7 @@
 Info2: <<
 
 Package: pytoml-py%type_pkg[python]
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 
 Version: 0.1.11
 Revision: 1

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/simplegeneric-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/simplegeneric-py.info
@@ -7,7 +7,7 @@ Maintainer:  Kurt Schwehr <goatbar@users.sourceforge.net>
 HomePage: https://pypi.python.org/pypi/simplegeneric
 License: BSD
 
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Depends: python%type_pkg[python]
 
 Description: Simple generic functions

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/typing-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/typing-py.info
@@ -6,7 +6,8 @@ Description: Type Hints for Python
 License: OSI-Approved
 # Free to update, modify, and take over.
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
-Type: python (2.7 3.4 3.5 3.6)
+# included in python core starting at python35
+Type: python (2.7 3.4)
 Depends: <<
 	python%type_pkg[python]
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/typing-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/typing-py.info
@@ -6,7 +6,7 @@ Description: Type Hints for Python
 License: OSI-Approved
 # Free to update, modify, and take over.
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
-Type: python (2.7 3.4)
+Type: python (2.7 3.4 3.5 3.6)
 Depends: <<
 	python%type_pkg[python]
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/versiontools-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/versiontools-py.info
@@ -5,7 +5,7 @@ Revision: 1
 Description: Replacement for plain tuple used in _version_
 License: LGPL
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
-Type: python (2.7 3.5 3.6)
+Type: python (2.7 3.5 3.6 3.6)
 Depends: <<
 	python%type_pkg[python]
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/xlrd-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/xlrd-py.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: xlrd-py%type_pkg[python]
 Version: 0.9.4
 Revision: 1
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Source: http://pypi.python.org/packages/source/x/xlrd/xlrd-%v.tar.gz
 Source-MD5: 911839f534d29fe04525ef8cd88fe865
 Depends: python%type_pkg[python]

--- a/10.9-libcxx/stable/main/finkinfo/net/amqplib-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/amqplib-py.info
@@ -5,7 +5,7 @@ Version: 1.0.2
 Revision: 1
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 License: LGPL
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Homepage: http://pypi.python.org/pypi/amqplib/
 Source: http://pypi.python.org/packages/source/a/amqplib/amqplib-%v.tgz
 Source-MD5: 5c92f17fbedd99b2b4a836d4352d1e2f

--- a/10.9-libcxx/stable/main/finkinfo/sci/geojson-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/geojson-py.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: geojson-py%type_pkg[python]
 Version: 1.0.9
 Revision: 1
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 
 Source: http://pypi.python.org/packages/source/g/geojson/geojson-%v.tar.gz
 Source-MD5: 94880d993dba8b184de122c5a84fa329

--- a/10.9-libcxx/stable/main/finkinfo/sci/holoviews-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/holoviews-py.info
@@ -2,7 +2,7 @@ Info3: <<
 Package: holoviews-py%type_pkg[python]
 Version: 1.6.2
 Revision: 1
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
 
 Source: https://pypi.io/packages/source/h/holoviews/holoviews-%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/sci/pandas-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/pandas-py.info
@@ -2,7 +2,7 @@ Info3: <<
 Package: pandas-py%type_pkg[python]
 Version: 0.19.2
 Revision: 1
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Description: Data analysis, time series,and statistics
 DescDetail: <<
 Providing fast, flexible, and expressive data structures designed to

--- a/10.9-libcxx/stable/main/finkinfo/sci/pytables-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/pytables-py.info
@@ -4,7 +4,7 @@ Package: pytables-py%type_pkg[python]
 Version: 3.2.2
 Revision: 2
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Depends: python%type_pkg[python], numpy-py%type_pkg[python] (>= 1.7.1-1), numexpr-py%type_pkg[python] (>= 2.2.2-1), bzip2-shlibs, lzo2-shlibs, hdf5.10-shlibs, hdf5-cpp11-shlibs
 BuildDepends: bzip2-dev, lzo2, cython-py%type_pkg[python] (>= 0.13-1), hdf5.10, hdf5-cpp11, ( %type_pkg[python] <= 27 ) sphinx-py%type_pkg[python] (>= 1.2.3-1)
 CustomMirror: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/shapely-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/shapely-py.info
@@ -4,7 +4,7 @@ Version: 1.5.8
 Revision: 1
 Homepage: https://pypi.python.org/pypi/Shapely
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Depends: python%type_pkg[python], libgeos3.4.2-shlibs (>= 3.4.2-1)
 
 BuildDepends: setuptools-tng-py%type_pkg[python], libgeos3.4.2

--- a/10.9-libcxx/stable/main/finkinfo/sci/uncertainties-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/uncertainties-py.info
@@ -3,7 +3,7 @@ Package: uncertainties-py%type_pkg[python]
 Version: 2.4.8.1
 Revision: 1
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Description: Transparent calculations with uncertainties
 Depends: python%type_pkg[python], numpy-py%type_pkg[python] (>= 1.9.0), setuptools-tng-py%type_pkg[python]
 BuildDepends: fink (>= 0.24.12)

--- a/10.9-libcxx/stable/main/finkinfo/web/django-localflavor-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/django-localflavor-py.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: django-localflavor-py%type_pkg[python]
-Type: python (2.7 3.4)
+Type: python (2.7 3.4 3.5 3.6)
 Version: 1.1
 Revision: 1
 

--- a/10.9-libcxx/stable/main/finkinfo/web/django-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/django-py.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: django-py%type_pkg[python]
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Version: 1.9.1
 Revision: 1
 

--- a/10.9-libcxx/stable/main/finkinfo/web/genshi-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/genshi-py.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: genshi-py%type_pkg[python]
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Version: 0.7
 Revision: 1
 Depends: python%type_pkg[python]

--- a/10.9-libcxx/stable/main/finkinfo/web/httplib2-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/httplib2-py.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: httplib2-py%type_pkg[python]
 Version: 0.9
 Revision: 1
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Source: https://pypi.python.org/packages/source/h/httplib2/httplib2-%v.tar.gz
 Source-MD5: 09d8e8016911fc40e2e4c58f1aa3ec24
 Depends: python%type_pkg[python]

--- a/10.9-libcxx/stable/main/finkinfo/web/zopeinterface-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/zopeinterface-py.info
@@ -13,7 +13,7 @@ Source: http://pypi.python.org/packages/source/z/zope.interface/zope.interface-%
 Source-MD5: 04298faeaa70b4f3b23fa2ae8987262c
 Source2: http://www.zope.org/Products/Zope/LICENSE.txt
 Source2-MD5: 638c27dc9783a4820f57829a4d856703
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6)
 Depends: python%type_pkg[python]
 
 CompileScript: %p/bin/python%type_raw[python] setup.py build


### PR DESCRIPTION
These patches add -py35 and -py36 to python modules that were only present in lower -py3X variants. I omitted obsolete ones, and ones that have known issues, PR filed, or are work in progress elsewhere. Is it worth backporting *-py36 to -py35 and -py34 for completeness, or do we not really care about those lower python3X any more? Should one or both be turned off?

Affected maintainers: @bcully, @danielj7, @dhomeier, @khorton, @nieder, Scott Hannahs