### PR TITLE
fix portaudio and pyaudio builds

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pyaudio-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pyaudio-py.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: pyaudio-py%type_pkg[python]
 Type: python (2.7)
 Version: 0.2.7
-Revision: 1
+Revision: 2
 Source: http://people.csail.mit.edu/hubert/pyaudio/packages/pyaudio-%v.tar.gz
 Source-MD5: 41eaa5a027e2a68ac29237018985dfbb
 Homepage: http://people.csail.mit.edu/hubert/pyaudio/
@@ -18,8 +18,8 @@ PyAudio is designed to work with the PortAudio v19 API 2.0. Note that PyAudio
 currently only supports blocking-mode audio I/O. PyAudio is still super-duper
 alpha quality.
 <<
-BuildDepends: python%type_pkg[python], portaudio2 (>= 2.19.0-6)
-Depends: python%type_pkg[python], portaudio2-shlibs (>= 2.19)
+BuildDepends: python%type_pkg[python], portaudio2 (>= 2.19.0-20140130-3)
+Depends: python%type_pkg[python], portaudio2-shlibs (>= 2.19.0-20140130-3)
 
 CompileScript: <<
  %p/bin/python%type_raw[python] setup.py build

--- a/10.9-libcxx/stable/main/finkinfo/sound/portaudio.info
+++ b/10.9-libcxx/stable/main/finkinfo/sound/portaudio.info
@@ -22,6 +22,8 @@ autoconf
 chmod +x configure
 # replace uint32 with pa_uint32
 perl -pi -e 's,uint32,pa_uint32,g' */*.c */*.h
+# replace deprecated macro on 10.13
+perl -pi -e 's|verify_noerr|__Verify_noErr|g' pa_mac_core/pa_mac_core.c
 <<
 
 InstallScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/sound/portaudio2.info
+++ b/10.9-libcxx/stable/main/finkinfo/sound/portaudio2.info
@@ -1,6 +1,6 @@
 Package: portaudio2
 Version: 2.19.0-20140130
-Revision: 2
+Revision: 3
 
 Conflicts: portaudio
 Replaces: portaudio
@@ -25,6 +25,8 @@ CompileScript: <<
 
 InstallScript: <<
   make install DESTDIR=%d
+  # install private header that pyaudio needs
+  install -m 644 include/pa_mac_core.h %i/include
   # create libportaudio.2.19.0.dylib
   cd %d/%p/lib; mv libportaudio.2.dylib libportaudio.2.19.0.dylib
   cd %d/%p/lib; ln -s libportaudio.2.19.0.dylib libportaudio.2.dylib


### PR DESCRIPTION
* old portaudio fails on 10.13 and needs to have a macro changed to use non-deprecated version on 10.13
* pyaudio-py (using portaudio2) uses a private header that's normally not installed, so install that and then fix it's build to use the right portaudio2 revision

pyaudio belongs to @skunktrading (hope that's the right Greg Darke).