### PR TITLE
Updates to ECMWF API software

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
@@ -64,7 +64,7 @@ InfoTest: <<
 	TestScript: <<
 		#!/bin/sh -ev
 		cd build
-		PATH=%b/build/bin:/%p/bin:/usr/bin:/bin DYLD_LIBRARY_PATH=%b/build/lib ctest || exit 2
+		PATH=%b/build/bin:%p/bin:/usr/bin:/bin DYLD_LIBRARY_PATH=%b/build/lib ctest || exit 2
 	<<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
@@ -36,6 +36,7 @@ CompileScript: <<
 	mkdir -p build # Need -p in case TestSource was unpacked here first
 	cd build
 	cmake -Wno-dev \
+		-DCMAKE_C_FLAGS:STRING=-MD \
 		-DCMAKE_INSTALL_PREFIX=%p \
 		-DCMAKE_PREFIX_PATH=%p \
 		-DCMAKE_INSTALL_NAME_DIR=%p/lib \
@@ -63,7 +64,7 @@ InfoTest: <<
 	TestScript: <<
 		#!/bin/sh -ev
 		cd build
-		PATH=%b/build/bin:/sw/bin:/usr/bin:/bin DYLD_LIBRARY_PATH=%b/build/lib ctest || exit 2
+		PATH=%b/build/bin:/%p/bin:/usr/bin:/bin DYLD_LIBRARY_PATH=%b/build/lib ctest || exit 2
 	<<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
@@ -23,7 +23,8 @@ BuildDepends: <<
 	libjpeg9,
 	libopenjp2.7,
 	libpng16,
-	netcdf-c13
+	netcdf-c13,
+	fink-package-precedence
 <<
 Depends: %N-shlibs
 Conflicts: grib-api
@@ -54,6 +55,7 @@ CompileScript: <<
 		-DCMAKE_OSX_SYSROOT=/ \
 		..
 	make
+	fink-package-precedence --depfile-ext='\.d' .
 <<
 
 InfoTest: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: eccodes
-Version: 2.6.0
+Version: 2.7.3
 Revision: 1
 Type: gcc (7)
 Description: Coding/encoding ECMWF files, C headers/docs
@@ -9,7 +9,7 @@ License: BSD
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Source: https://software.ecmwf.int/wiki/download/attachments/45757960/%n-%v-Source.tar.gz
-Source-MD5: eec5771c9ced631dabb1411bb1691626
+Source-MD5: 0d2603722bbbd6a7fe70b32cbb24b5ba
 PatchFile: eccodes.patch
 PatchFile-MD5: 43ec7477a96e37e7a951faae7019622b
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/grib-api.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/grib-api.info
@@ -1,5 +1,5 @@
 Package: grib-api
-Version: 1.23.1
+Version: 1.26.1
 Revision: 1
 Description: ECMWF GRIB API
 Homepage: https://software.ecmwf.int/wiki/display/GRIB/Home
@@ -8,17 +8,16 @@ Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Source: https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-%v-Source.tar.gz
 PatchFile: %n.patch
-Source-MD5: 21f938b5ce1b6bf814a166e3b9cf1c98
+Source-MD5: ebe892c026f482460af85221df50f3a1
 PatchFile-MD5: 0448a7a625b66581baab7cc3e5834e71
 
 SourceDirectory: grib_api-%v-Source
 BuildDependsOnly: true
-BuildDepends: libopenjpeg1, libpng16, fink-package-precedence
-Depends: libopenjpeg1-shlibs, libpng16-shlibs, %N-shlibs
+BuildDepends: libopenjp2.7, libpng16, fink-package-precedence
+Depends: libopenjp2.7-shlibs, libpng16-shlibs, %N-shlibs
 Conflicts: eccodes
 Replaces: eccodes
-SetLDFLAGS: -L%p/lib/libopenjpeg
-SetCPPFLAGS: -I%p/include/openjpeg-1.5
+SetCPPFLAGS: -I%p/include/openjpeg-2.1
 UseMaxBuildJobs: false
 
 PatchScript: sed -e 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
@@ -28,10 +27,11 @@ CompileScript: <<
 	fink-package-precedence .
 <<
 InfoTest: <<
-	TestSource: mirror:sourceforge:fink/grib_api-1.16.0-TestData.tar.gz
-	TestSource-MD5: f5fa616eace8170a37fca5e6771ec8b4
+	TestSource: http://download.ecmwf.org/test-data/grib_api/grib_api_test_data.tar.gz
+	TestSource-MD5: 06e435d61be605ed2481744a1528b2d8
 	TestSourceExtractDir: grib_api-%v-Source
 	TestScript: <<
+		#!/bin/sh -ev
 		ln -s libgrib_api.dylib src/libgrib_api.1.dylib
 		DYLD_LIBRARY_PATH=%b/src make check || exit 2
 	<<


### PR DESCRIPTION
This covers the upstream updates to two APIs from ECMWF:
GRIB API 1.26.1 (deprecated but still updated)
ECCODES 2.7.3 (replacement for GRIB API)