### PR TITLE
New upstream version and some cleanup of the package for clamav

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/utils/clamav.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/clamav.info
@@ -53,7 +53,7 @@ BuildDepends: <<
   libncurses5,
   libpcre1,
   libtool2 (>= 2.4.2-4),
-  libxml2,
+  libxml2 (>= 2.9.1-1),
   openssl110-dev,
   pkgconfig
 <<
@@ -104,14 +104,13 @@ SplitOff: <<
     bzip2-shlibs,
     libpcre1-shlibs,
     libtool2-shlibs (>= 2.4.2-4),
-    libxml2-shlibs,
+    libxml2-shlibs (>= 2.9.1-1),
     openssl110-shlibs
   <<
-  InstallScript: <<
-    /usr/bin/install -d -m 755 %i/lib
-    /bin/mv %I/lib/libclamav.8.dylib %i/lib
-    /bin/mv %I/lib/libclamunrar.8.dylib %i/lib
-    /bin/mv %I/lib/libclammspack.0.dylib %i/lib
+  Files: <<
+    lib/libclamav.8.dylib
+    lib/libclamunrar.8.dylib
+    lib/libclammspack.0.dylib
   <<
   Shlibs: <<
     %p/lib/libclamav.8.dylib          9.0.0 %n (>= 0.95-1)
@@ -185,13 +184,13 @@ SplitOff3: <<
   <<
   Provides: clamav-dev
   BuildDependsOnly: true
-  InstallScript: <<
-    /bin/mv %I/include %i
-    /usr/bin/install -d -m 755 %i/lib
-    /bin/mv %I/lib/*a %I/lib/*dylib %i/lib/
-    /bin/mv %I/lib/pkgconfig %i/lib
+  Files: <<
+    bin/clamav-config
+    include
+    lib/pkgconfig
+    lib/*a
+    lib/*dylib
   <<
-  Files: bin/clamav-config
 <<
 
 InfoTest: <<

--- a/10.9-libcxx/stable/main/finkinfo/utils/clamav.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/clamav.info
@@ -75,7 +75,7 @@ CompileScript: <<
              --sysconfdir=%p/etc --enable-dependency-tracking --disable-clamav \
              --with-openssl=%p --with-pcre=%p --with-xml=%p
  make
- fink-package-precedence .
+ fink-package-precedence --prohibit-bdep=clamav8-dev .
 <<
 InstallScript: <<
  #!/bin/sh -ev

--- a/10.9-libcxx/stable/main/finkinfo/utils/clamav.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/clamav.info
@@ -1,6 +1,6 @@
 Info3: <<
 Package: clamav
-Version: 0.99.4
+Version: 0.100.0
 Revision: 1
 
 Description: Clam Anti-Virus scanner
@@ -33,9 +33,6 @@ DescPackaging: <<
 
  Original package maintainer was Carsten Klapp
  <carstenklapp@users.sourceforge.net>.
-
- Pass --enable-llvm=no to work around the upstream bug
- https://bugzilla.clamav.net/show_bug.cgi?id=11309.
 <<
 DescPort: <<
  Install virus databases into %p/var/db/clamav instead of default
@@ -46,38 +43,39 @@ Maintainer: Remi Mommsen <remigius.mommsen@cern.ch>
 Homepage: http://www.clamav.net/
 License: GPL/OpenSSL
 Source: http://www.clamav.net/downloads/production/%n-%v.tar.gz
-Source-MD5: b9359b90086948b3c4eb97c84cf4b400
+Source-MD5: 93e8efb489c2afdfca73703b76c24e01
 
 BuildDepends: <<
   fink (>= 0.24.12),
-  bzip2,
+  fink-package-precedence,
   bzip2-dev,
+  libiconv-dev,
   libncurses5,
   libpcre1,
-  libtool2,
+  libtool2 (>= 2.4.2-4),
+  libxml2,
   openssl110-dev,
   pkgconfig
 <<
 Depends: <<
   clamav8-shlibs (=%v-%r),
-  libncurses5-shlibs,
-  openssl110-shlibs,
-  libpcre1-shlibs
+  libncurses5-shlibs
 <<
 
 PatchScript: <<
  %{default_script}
  /usr/bin/sed -i'.bak' -e 's/LC_AGE=1/LC_AGE=0/g' -e 's/-print-multi-os-directory//g' configure*
+ /usr/bin/sed -i'.bak' -e 's/${wl}-flat_namespace ${wl}-undefined ${wl}suppress/${wl}-twolevel_namespace/g' libclamav/libmspack-0.5alpha/configure*
 <<
 
 SetCFLAGS: -O3
 CompileScript: <<
  #!/bin/sh -ev
  ./configure --prefix=%p --mandir=%p/share/man --with-dbdir=%p/var/db/%n \
-             --sysconfdir=%p/etc --disable-dependency-tracking --disable-clamav \
-             --enable-llvm=no \
-             --with-openssl=%p --with-pcre=%p
+             --sysconfdir=%p/etc --enable-dependency-tracking --disable-clamav \
+             --with-openssl=%p --with-pcre=%p --with-xml=%p
  make
+ fink-package-precedence .
 <<
 InstallScript: <<
  #!/bin/sh -ev
@@ -95,28 +93,30 @@ InstallScript: <<
  (cd %i/share/doc/%n; /bin/rm -R Makefile Makefile.am Makefile.in man) || exit 1
  /usr/bin/install -d -m 755 %i/share/doc/%n/test/
  /bin/cp -r test/* %i/share/doc/%n/test/
-
- #Remove CVS directories
- /usr/bin/find %i -name "CVS" -type d -depth -exec rm -rf \{\} \;
 <<
 ConfFiles: %p/etc/clamav-milter.conf %p/etc/freshclam.conf
-DocFiles: AUTHORS BUGS COPYING ChangeLog FAQ NEWS README UPGRADE
+DocFiles: COPYING*
 
 SplitOff: <<
   Description: Shared libraries for ClamAV
   Package: clamav8-shlibs
   Depends: <<
     bzip2-shlibs,
-    libtool2-shlibs
+    libpcre1-shlibs,
+    libtool2-shlibs (>= 2.4.2-4),
+    libxml2-shlibs,
+    openssl110-shlibs
   <<
   InstallScript: <<
     /usr/bin/install -d -m 755 %i/lib
     /bin/mv %I/lib/libclamav.8.dylib %i/lib
     /bin/mv %I/lib/libclamunrar.8.dylib %i/lib
+    /bin/mv %I/lib/libclammspack.0.dylib %i/lib
   <<
   Shlibs: <<
-    %p/lib/libclamav.8.dylib          9.0.0 %n (>= 1.0-1)
-    %p/lib/libclamunrar.8.dylib       9.0.0 %n (>= 1.0-1)
+    %p/lib/libclamav.8.dylib          9.0.0 %n (>= 0.95-1)
+    %p/lib/libclamunrar.8.dylib       9.0.0 %n (>= 0.95-1)
+    %p/lib/libclammspack.0.dylib      2.0.0 %n (>= 0.100-1)
   <<
 <<
 SplitOff2: <<


### PR DESCRIPTION
New upstream version 0.100 of clamav. Cleanup the package to remove obsolete stuff and cleanup dependencies.