### PR TITLE
trackballs: Apply upstream patch to build on 10.13

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/games/trackballs.info
+++ b/10.9-libcxx/stable/main/finkinfo/games/trackballs.info
@@ -32,7 +32,7 @@ Depends: <<
 Source: mirror:sourceforge:%n/%n-%v.tar.gz
 Source-MD5: 84e2e8bb68842a636da91673751279a0
 PatchFile: %n.patch
-PatchFile-MD5: f4f35c7b1b36a1872a242acbd5ecad08
+PatchFile-MD5: a1b8244d0d962293d5928bab5e29ff26
 SetLDFLAGS: -framework OpenGL -dylib_file /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib:/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
 ConfigureParams: --mandir='$(prefix)/share/man' --disable-sdltest
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/games/trackballs.info
+++ b/10.9-libcxx/stable/main/finkinfo/games/trackballs.info
@@ -1,6 +1,6 @@
 Package: trackballs
 Version: 1.1.4
-Revision: 1006
+Revision: 1007
 GCC: 4.0
 Maintainer: Matthias Neeracher <neeracher@mac.com>
 BuildDepends: <<
@@ -54,6 +54,10 @@ labyrinth filled with vicious hammers, pools of acid and other
 obstacles the player collects points. When the ball reaches the
 destination it continues to the next, more difficult track - unless
 the time runs out.
+<<
+DescPackaging: <<
+Upstream patch (51a8beba) to glHelp.cc and menuMode.cc to fix
+"'abs' is missing exception specification 'throw()'" on 10.13
 <<
 Homepage: http://trackballs.sourceforge.net
 License: GPL

--- a/10.9-libcxx/stable/main/finkinfo/games/trackballs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/games/trackballs.patch
@@ -37,3 +37,28 @@ diff -ru trackballs-1.1.4-orig/src/Makefile.am trackballs-1.1.4/src/Makefile.am
  trackballs_DEPENDENCIES = @WINRESOURCES@
  
  trackballsIcon.o : trackballsIcon.rc trackballsIcon.ico
+Binary files trackballs-1.1.4-orig/src/.glHelp.cc.un~ and trackballs-1.1.4/src/.glHelp.cc.un~ differ
+Binary files trackballs-1.1.4-orig/src/.menuMode.cc.un~ and trackballs-1.1.4/src/.menuMode.cc.un~ differ
+diff -ruN trackballs-1.1.4-orig/src/glHelp.cc trackballs-1.1.4/src/glHelp.cc
+--- trackballs-1.1.4-orig/src/glHelp.cc	2007-04-07 08:15:09.000000000 -0500
++++ trackballs-1.1.4/src/glHelp.cc	2018-04-29 20:29:16.000000000 -0500
+@@ -129,7 +129,7 @@
+   // why is this removed? should it not be done???
+   glDeleteTextures(1,&texture);  
+ }
+-inline Real abs(Real v) {return v>0.0?v:-v;}
++
+ double mousePointerPhase=0.0;
+ 
+ void tickMouse(Real td) {
+diff -ruN trackballs-1.1.4-orig/src/menuMode.cc trackballs-1.1.4/src/menuMode.cc
+--- trackballs-1.1.4-orig/src/menuMode.cc	2007-04-07 08:16:26.000000000 -0500
++++ trackballs-1.1.4/src/menuMode.cc	2018-04-29 20:30:09.000000000 -0500
+@@ -163,7 +163,6 @@
+   case MENU_EDITOR: GameMode::activate(EditMode::editMode); break;
+   }
+ }
+-inline Real abs(Real v) {return v>0.0?v:-v;}
+ 
+ void MenuMode::idle(Real td) {
+   int w,h,i,x,y;


### PR DESCRIPTION
@microtherion 
On 10.13, trackballs fails to build with this error:
```
g++ -DLOCALEDIR=\"/sw/share/locale\" -DHAVE_CONFIG_H -I. -I.. -DSHARE_DIR=\"/sw/share/trackballs\" -DPACKAGE=\"trackballs\" -DVERSION=\"1.1.4\"  -I/sw/include -I/opt/X11/include  -g -g -O2 -I/sw/include -I/sw/include -D_THREAD_SAFE  -I./ -I../ -DDEFAULT_RESOLUTION=1 -MT trackballs-glHelp.o -MD -MP -MF .deps/trackballs-glHelp.Tpo -c -o trackballs-glHelp.o `test -f 'glHelp.cc' || echo './'`glHelp.cc
glHelp.cc:132:13: error: 'abs' is missing exception specification 'throw()'
inline Real abs(Real v) {return v>0.0?v:-v;}
```
The original SF trackballs has been discontinued, but an active fork at https://trackballs.github.io/ has the patch needed to fix the error.