### PR TITLE
Gnome icon theme 2.31.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/gnome/gnome-icon-theme.info
+++ b/10.9-libcxx/stable/main/finkinfo/gnome/gnome-icon-theme.info
@@ -37,6 +37,6 @@ Description: The GNOME icon themes
 DescDetail: <<
 The GNOME icon theme package includes icon theme sets.
 <<
-License: GPL
+License: LGPL
 Maintainer: The Gnome Core Team <fink-gnome-core@lists.sourceforge.net>
 Homepage: http://www.gnome.org/

--- a/10.9-libcxx/stable/main/finkinfo/gnome/gnome-icon-theme.info
+++ b/10.9-libcxx/stable/main/finkinfo/gnome/gnome-icon-theme.info
@@ -15,12 +15,6 @@ Replaces: gnome-vfs (<< 1.0.5), gnome-vfs-ssl (<< 1.0.5), control-center (<< 2.1
 Source: mirror:gnome:sources/%n/2.31/%n-%v.tar.bz2
 Source-MD5: 8e727703343d4c18c73c79dd2009f8ed
 PatchScript: <<
-	# Claims to require git. Not sure why, but that suggests
-	# network access--not allowed in fink build environment.
-	# Therefore also not need deps (or care if auto-detection
-	# fails) for 'git', 'icontool-render', 'inkscape'
-	perl -pi -e 's/allow_rendering=yes/allow_rendering=no/' configure
-
 	perl -pi -e 's/echo -e/echo/g' src/Makefile.in
 <<
 ConfigureParams: DATADIRNAME=share

--- a/10.9-libcxx/stable/main/finkinfo/gnome/gnome-icon-theme.info
+++ b/10.9-libcxx/stable/main/finkinfo/gnome/gnome-icon-theme.info
@@ -1,5 +1,5 @@
 Package: gnome-icon-theme
-Version: 2.30.3
+Version: 2.31.0
 Revision: 1
 Depends: <<
 	default-icon-theme (>= 0.12-1)
@@ -12,8 +12,8 @@ BuildDepends: <<
 	pkgconfig (>= 0.23)
 <<
 Replaces: gnome-vfs (<< 1.0.5), gnome-vfs-ssl (<< 1.0.5), control-center (<< 2.14)
-Source: mirror:gnome:sources/%n/2.30/%n-%v.tar.bz2
-Source-MD5: 77d272e4220c75588418d9bec31eae24
+Source: mirror:gnome:sources/%n/2.31/%n-%v.tar.bz2
+Source-MD5: 8e727703343d4c18c73c79dd2009f8ed
 PatchScript: <<
 	# Claims to require git. Not sure why, but that suggests
 	# network access--not allowed in fink build environment.


### PR DESCRIPTION
Update gnome-icon-theme to 2.31.0, the last of the 2.x series.
Only substantial change is to remove the chunk modifying the `allow_rendering` flag because that's no longer present in the source code and there's no indication of any git still being used in the code.