### PR TITLE
Viennarna cleanup

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/mongodb.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/mongodb.info
@@ -1,22 +1,22 @@
 Package: mongodb
 Version: 2.4.14
-Revision: 1
+Revision: 3
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Homepage: http://www.mongodb.org
 License: OSI-Approved
-# AGPL 3.0
+# Mostly AGPL 3.0, some Apache 2.0
 
 Description: High-performance NoSQL implementation
 
 Source: http://downloads.mongodb.org/src/%n-src-r%v.tar.gz
 Source-MD5: eb7fc91246e51b68f68a958b02cb7880
-PatchFile: mongodb.patch
-PatchFile-MD5: 991588f62ffc77a0a37df401389b319f
+PatchFile: %n.patch
+PatchFile-MD5: 5f5d99bf505721d7453a194f1cbf6b79
 PatchScript: <<
 	sed 's|@FINK_PREFIX@|%p|g' < %{PatchFile} | patch -p1
 <<
 BuildDepends: <<
-	boost1.55-nopython,
+	boost1.63-nopython,
 	fink-package-precedence,
 	libpcap1,
 	libpcre1,
@@ -24,13 +24,13 @@ BuildDepends: <<
 	scons
 <<
 Depends: <<
-	boost1.55-nopython-shlibs,
+	boost1.63-nopython-shlibs,
 	libpcap1-shlibs,
 	libpcre1-shlibs,
 	libsnappy1-shlibs
 <<
-SetCPPFLAGS: -MD -I%p/opt/boost-1_55/include
-SetLDFLAGS: -L%p/opt/boost-1_55/lib
+SetCPPFLAGS: -MD -I%p/opt/boost-1_63/include
+SetLDFLAGS: -L%p/opt/boost-1_63/lib
 CompileScript: <<
 	scons  --use-system-boost --use-system-pcre --use-system-snappy --usev8 all $MAKEFLAGS
 	fink-package-precedence --depfile-ext='\.d' .
@@ -42,7 +42,16 @@ InstallScript: <<
 	cp mongosniff mongostat mongotop %i/bin
 	chmod 0755 %i/bin/*
 <<
-
+DocFiles: APACHE-2.0.txt CONTRIBUTING.rst GNU-AGPL-3.0.txt README
 DescPackaging: <<
 	Former maintainer: Sjors Gielen <fink-mongodb@sjorsgielen.nl>
+
+	Fix some python strictness in SCons* files.
+
+	Lots of pointer-comparison fixes analogous to FreeBSD's fix
+	for clang>=4.0. See:
+	https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=216213
+
+	Fixes for boost1.63, including
+	https://jira.mongodb.org/browse/SERVER-14930
 <<

--- a/10.9-libcxx/stable/main/finkinfo/database/mongodb.patch
+++ b/10.9-libcxx/stable/main/finkinfo/database/mongodb.patch
@@ -1,72 +1,6 @@
-diff -Nurd mongodb-src-r2.4.8-orig/src/mongo/db/fts/stemmer.cpp mongodb-src-r2.4.8/src/mongo/db/fts/stemmer.cpp
---- mongodb-src-r2.4.8-orig/src/mongo/db/fts/stemmer.cpp	2013-11-07 13:48:29.000000000 +0100
-+++ mongodb-src-r2.4.8/src/mongo/db/fts/stemmer.cpp	2013-11-07 15:23:25.000000000 +0100
-@@ -17,6 +17,7 @@
- */
- 
- #include <string>
-+#include <cstdlib>
- 
- #include "mongo/db/fts/stemmer.h"
- 
-diff -Nurd mongodb-src-r2.4.8-orig/src/mongo/dbtests/documentsourcetests.cpp mongodb-src-r2.4.8/src/mongo/dbtests/documentsourcetests.cpp
---- mongodb-src-r2.4.8-orig/src/mongo/dbtests/documentsourcetests.cpp	2013-11-07 13:48:29.000000000 +0100
-+++ mongodb-src-r2.4.8/src/mongo/dbtests/documentsourcetests.cpp	2013-11-07 16:20:02.000000000 +0100
-@@ -583,7 +583,7 @@
-         };
- 
-         struct ValueCmp {
--            bool operator()(const Value& a, const Value& b) {
-+            bool operator()(const Value& a, const Value& b) const {
-                 return Value::compare( a, b ) < 0;
-             }
-         };
-diff -Nurd mongodb-src-r2.4.8-orig/src/mongo/platform/unordered_map.h mongodb-src-r2.4.8/src/mongo/platform/unordered_map.h
---- mongodb-src-r2.4.8-orig/src/mongo/platform/unordered_map.h	2013-11-07 13:48:29.000000000 +0100
-+++ mongodb-src-r2.4.8/src/mongo/platform/unordered_map.h	2013-11-07 13:52:00.000000000 +0100
-@@ -18,7 +18,8 @@
- // NOTE(acm): Before gcc-4.7, __cplusplus is always defined to be 1,
- // so we can't reliably detect C++11 support by exclusively checking
- // the value of __cplusplus.
--#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
-+//#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
-+#if 1
- 
- #include <unordered_map>
- 
-diff -Nurd mongodb-src-r2.4.8-orig/src/mongo/platform/unordered_set.h mongodb-src-r2.4.8/src/mongo/platform/unordered_set.h
---- mongodb-src-r2.4.8-orig/src/mongo/platform/unordered_set.h	2013-11-07 13:48:29.000000000 +0100
-+++ mongodb-src-r2.4.8/src/mongo/platform/unordered_set.h	2013-11-07 14:24:38.000000000 +0100
-@@ -18,7 +18,8 @@
- // NOTE(acm): Before gcc-4.7, __cplusplus is always defined to be 1,
- // so we can't reliably detect C++11 support by exclusively checking
- // the value of __cplusplus.
--#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
-+//#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
-+#if 1
- 
- #include <unordered_set>
- 
-diff -Nurd mongodb-src-r2.4.8-orig/src/third_party/s2/hash.h mongodb-src-r2.4.8/src/third_party/s2/hash.h
---- mongodb-src-r2.4.8-orig/src/third_party/s2/hash.h	2013-11-07 13:48:30.000000000 +0100
-+++ mongodb-src-r2.4.8/src/third_party/s2/hash.h	2013-11-07 15:42:44.000000000 +0100
-@@ -7,13 +7,8 @@
- #include "mongo/platform/unordered_set.h"
- #define hash_set mongo::unordered_set
- 
--#if defined OS_LINUX || defined OS_MACOSX || defined __sunos__ || defined __freebsd__
--#define HASH_NAMESPACE_START namespace std { namespace tr1 {
--#define HASH_NAMESPACE_END }}
--#elif defined OS_WINDOWS
- #define HASH_NAMESPACE_START namespace std {
- #define HASH_NAMESPACE_END }
--#endif
- 
- // Places that hash-related functions are defined:
- // end of s2cellid.h for hashing on S2CellId
 diff -Nurd mongodb-src-r2.4.14-orig/SConstruct mongodb-src-r2.4.14/SConstruct
---- mongodb-src-r2.4.14-orig/SConstruct	2015-04-27 11:18:57.000000000 -0500
-+++ mongodb-src-r2.4.14/SConstruct	2015-09-12 15:37:59.000000000 -0500
+--- mongodb-src-r2.4.14-orig/SConstruct	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/SConstruct	2018-05-06 23:32:40.000000000 -0400
 @@ -512,20 +512,8 @@
      darwin = True
      platform = "osx" # prettier than darwin
@@ -89,9 +23,36 @@ diff -Nurd mongodb-src-r2.4.14-orig/SConstruct mongodb-src-r2.4.14/SConstruct
  
  elif os.sys.platform.startswith("linux"):
      linux = True
+@@ -710,6 +698,8 @@
+                          "-Wall",
+                          "-Wsign-compare",
+                          "-Wno-unknown-pragmas",
++                         "-Wno-unused-private-field",
++                         "-Wno-unused-local-typedef",
+                          "-Winvalid-pch"] )
+     # env.Append( " -Wconversion" ) TODO: this doesn't really work yet
+     if linux:
+@@ -886,7 +876,7 @@
+     elif get_option('allocator') == 'system':
+         pass
+     else:
+-        print "Invalid --allocator parameter: \"%s\"" % get_option('allocator')
++        print( "Invalid --allocator parameter: \"%s\"" % get_option('allocator') )
+         Exit(1)
+ 
+     if has_option("heapcheck"):
+@@ -1156,7 +1146,7 @@
+     filenames = [x for x in filenames if x.startswith(prefix)]
+     to_keep = [x for x in filenames if x.endswith(".tgz") or x.endswith(".zip")][-2:]
+     for filename in [x for x in filenames if x not in to_keep]:
+-        print "removing %s" % filename
++        print( "removing %s" % filename )
+         try:
+             shutil.rmtree(filename)
+         except:
 diff -Nurd mongodb-src-r2.4.14-orig/distsrc/client/SConstruct mongodb-src-r2.4.14/distsrc/client/SConstruct
---- mongodb-src-r2.4.14-orig/distsrc/client/SConstruct	2015-04-27 11:18:57.000000000 -0500
-+++ mongodb-src-r2.4.14/distsrc/client/SConstruct	2015-09-12 15:33:42.000000000 -0500
+--- mongodb-src-r2.4.14-orig/distsrc/client/SConstruct	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/distsrc/client/SConstruct	2018-05-06 17:00:34.000000000 -0400
 @@ -62,7 +62,7 @@
  darwin = False
  
@@ -101,9 +62,196 @@ diff -Nurd mongodb-src-r2.4.14-orig/distsrc/client/SConstruct mongodb-src-r2.4.1
      nix = True
      darwin = True
  elif sys.platform in ("linux2", "linux3"):
+diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/SConscript mongodb-src-r2.4.14/src/mongo/SConscript
+--- mongodb-src-r2.4.14-orig/src/mongo/SConscript	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/SConscript	2018-05-06 17:10:16.000000000 -0400
+@@ -814,7 +814,7 @@
+ module_banner_filenames = set([f.name for f in env['MODULE_BANNERS']])
+ if not len(module_banner_filenames) == len(env['MODULE_BANNERS']):
+     # TODO: Be nice and identify conflicts in error.
+-    print "ERROR: Filename conflicts exist in module banners."
++    print( "ERROR: Filename conflicts exist in module banners." )
+     Exit(-1)
+ 
+ # Build a set of directories containing module banners, and use that
+diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/client/connpool.h mongodb-src-r2.4.14/src/mongo/client/connpool.h
+--- mongodb-src-r2.4.14-orig/src/mongo/client/connpool.h	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/client/connpool.h	2018-05-06 17:22:25.000000000 -0400
+@@ -301,7 +301,7 @@
+             return _conn;
+         }
+ 
+-        bool ok() const { return _conn > 0; }
++        bool ok() const { return _conn != 0; }
+ 
+         string getHost() const { return _host; }
+ 
+diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/db/client.h mongodb-src-r2.4.14/src/mongo/db/client.h
+--- mongodb-src-r2.4.14-orig/src/mongo/db/client.h	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/db/client.h	2018-05-06 23:22:47.000000000 -0400
+@@ -243,6 +243,6 @@
+     inline Client::GodScope::~GodScope() { cc()._god = _prev; }
+ 
+ 
+-    inline bool haveClient() { return currentClient.get() > 0; }
++    inline bool haveClient() { return currentClient.get() != 0; }
+ 
+ };
+diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/db/fts/fts_matcher.cpp mongodb-src-r2.4.14/src/mongo/db/fts/fts_matcher.cpp
+--- mongodb-src-r2.4.14-orig/src/mongo/db/fts/fts_matcher.cpp	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/db/fts/fts_matcher.cpp	2018-05-06 23:56:13.000000000 -0400
+@@ -117,7 +117,7 @@
+                 if ( t.type != Token::TEXT )
+                     continue;
+                 string word = tolowerString( _stemmer.stem( t.data ) );
+-                if ( _query.getNegatedTerms().count( word ) > 0 )
++                if ( _query.getNegatedTerms().count( word ) != 0 )
+                     return true;
+             }
+             return false;
+@@ -230,7 +230,7 @@
+          * @param haystack, raw string to be parsed
+          */
+         bool FTSMatcher::_phraseMatches( const string& phrase, const string& haystack ) const {
+-            return strcasestr( haystack.c_str(), phrase.c_str() ) > 0;
++            return strcasestr( haystack.c_str(), phrase.c_str() ) != 0;
+         }
+ 
+ 
+diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/db/fts/stemmer.cpp mongodb-src-r2.4.14/src/mongo/db/fts/stemmer.cpp
+--- mongodb-src-r2.4.14-orig/src/mongo/db/fts/stemmer.cpp	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/db/fts/stemmer.cpp	2018-05-06 17:00:34.000000000 -0400
+@@ -17,6 +17,7 @@
+ */
+ 
+ #include <string>
++#include <cstdlib>
+ 
+ #include "mongo/db/fts/stemmer.h"
+ 
+diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/db/namespace.h mongodb-src-r2.4.14/src/mongo/db/namespace.h
+--- mongodb-src-r2.4.14-orig/src/mongo/db/namespace.h	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/db/namespace.h	2018-05-06 22:44:12.000000000 -0400
+@@ -31,7 +31,7 @@
+         Namespace(const StringData& ns) { *this = ns; }
+         Namespace& operator=(const StringData& ns);
+ 
+-        bool hasDollarSign() const { return strchr( buf , '$' ) > 0;  }
++        bool hasDollarSign() const { return strchr( buf , '$' ) != 0;  }
+         void kill() { buf[0] = 0x7f; }
+         bool operator==(const char *r) const { return strcmp(buf, r) == 0; }
+         bool operator==(const Namespace& r) const { return strcmp(buf, r.buf) == 0; }
+diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/db/ops/update_internal.cpp mongodb-src-r2.4.14/src/mongo/db/ops/update_internal.cpp
+--- mongodb-src-r2.4.14-orig/src/mongo/db/ops/update_internal.cpp	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/db/ops/update_internal.cpp	2018-05-06 23:13:05.000000000 -0400
+@@ -1425,7 +1425,7 @@
+                     continue;
+                 }
+ 
+-                _hasDynamicArray = _hasDynamicArray || strstr( fieldName , ".$" ) > 0;
++                _hasDynamicArray = _hasDynamicArray || strstr( fieldName , ".$" ) != 0;
+ 
+                 Mod m;
+                 m.init( op , f , forReplication );
+diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/db/pdfile.cpp mongodb-src-r2.4.14/src/mongo/db/pdfile.cpp
+--- mongodb-src-r2.4.14-orig/src/mongo/db/pdfile.cpp	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/db/pdfile.cpp	2018-05-07 11:29:51.000000000 -0400
+@@ -30,6 +30,7 @@
+ #include <algorithm>
+ #include <boost/filesystem/operations.hpp>
+ #include <boost/optional/optional.hpp>
++#include <boost/utility/in_place_factory.hpp>
+ #include <list>
+ 
+ #include "mongo/base/counter.h"
+diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/dbtests/documentsourcetests.cpp mongodb-src-r2.4.14/src/mongo/dbtests/documentsourcetests.cpp
+--- mongodb-src-r2.4.14-orig/src/mongo/dbtests/documentsourcetests.cpp	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/dbtests/documentsourcetests.cpp	2018-05-06 17:00:34.000000000 -0400
+@@ -583,7 +583,7 @@
+         };
+ 
+         struct ValueCmp {
+-            bool operator()(const Value& a, const Value& b) {
++            bool operator()(const Value& a, const Value& b) const {
+                 return Value::compare( a, b ) < 0;
+             }
+         };
+diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/dbtests/jsobjtests.cpp mongodb-src-r2.4.14/src/mongo/dbtests/jsobjtests.cpp
+--- mongodb-src-r2.4.14-orig/src/mongo/dbtests/jsobjtests.cpp	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/dbtests/jsobjtests.cpp	2018-05-07 00:37:16.000000000 -0400
+@@ -1894,7 +1894,7 @@
+                 }
+                 catch ( std::exception& e ) {
+                     state = 2;
+-                    ASSERT( strstr( e.what() , "_id: 5" ) > 0 );
++                    ASSERT( strstr( e.what() , "_id: 5" ) != 0 );
+                 }
+                 free( crap );
+                 ASSERT_EQUALS( 2 , state );
+diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/platform/unordered_map.h mongodb-src-r2.4.14/src/mongo/platform/unordered_map.h
+--- mongodb-src-r2.4.14-orig/src/mongo/platform/unordered_map.h	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/platform/unordered_map.h	2018-05-06 17:00:34.000000000 -0400
+@@ -18,7 +18,8 @@
+ // NOTE(acm): Before gcc-4.7, __cplusplus is always defined to be 1,
+ // so we can't reliably detect C++11 support by exclusively checking
+ // the value of __cplusplus.
+-#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
++//#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
++#if 1
+ 
+ #include <unordered_map>
+ 
+diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/platform/unordered_set.h mongodb-src-r2.4.14/src/mongo/platform/unordered_set.h
+--- mongodb-src-r2.4.14-orig/src/mongo/platform/unordered_set.h	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/platform/unordered_set.h	2018-05-06 17:00:34.000000000 -0400
+@@ -18,7 +18,8 @@
+ // NOTE(acm): Before gcc-4.7, __cplusplus is always defined to be 1,
+ // so we can't reliably detect C++11 support by exclusively checking
+ // the value of __cplusplus.
+-#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
++//#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
++#if 1
+ 
+ #include <unordered_set>
+ 
+diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/s/d_state.cpp mongodb-src-r2.4.14/src/mongo/s/d_state.cpp
+--- mongodb-src-r2.4.14-orig/src/mongo/s/d_state.cpp	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/s/d_state.cpp	2018-05-06 23:14:41.000000000 -0400
+@@ -418,7 +418,7 @@
+         if ( ! shardingState.hasVersion( ns ) )
+             return false;
+ 
+-        return ShardedConnectionInfo::get(false) > 0;
++        return ShardedConnectionInfo::get(false) != 0;
+     }
+ 
+     class UnsetShardingCommand : public MongodShardCommand {
+diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/s/shard.h mongodb-src-r2.4.14/src/mongo/s/shard.h
+--- mongodb-src-r2.4.14-orig/src/mongo/s/shard.h	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/s/shard.h	2018-05-06 17:22:50.000000000 -0400
+@@ -283,7 +283,7 @@
+             _finishedInit = true;
+         }
+         
+-        bool ok() const { return _conn > 0; }
++        bool ok() const { return _conn != 0; }
+ 
+         /**
+            this just passes through excpet it checks for stale configs
+diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/shell/linenoise_utf8.h mongodb-src-r2.4.14/src/mongo/shell/linenoise_utf8.h
+--- mongodb-src-r2.4.14-orig/src/mongo/shell/linenoise_utf8.h	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/shell/linenoise_utf8.h	2018-05-07 11:00:14.000000000 -0400
+@@ -17,6 +17,7 @@
+ 
+ #include <boost/smart_ptr/scoped_array.hpp>
+ #include <string.h>
++#include <algorithm>
+ 
+ namespace linenoise_utf8 {
+ 
 diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/util/compress.cpp mongodb-src-r2.4.14/src/mongo/util/compress.cpp
---- mongodb-src-r2.4.14-orig/src/mongo/util/compress.cpp	2015-04-27 11:18:57.000000000 -0500
-+++ mongodb-src-r2.4.14/src/mongo/util/compress.cpp	2015-09-12 15:39:05.000000000 -0500
+--- mongodb-src-r2.4.14-orig/src/mongo/util/compress.cpp	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/mongo/util/compress.cpp	2018-05-06 17:00:34.000000000 -0400
 @@ -18,7 +18,7 @@
  
  #include "mongo/util/compress.h"
@@ -113,9 +261,26 @@ diff -Nurd mongodb-src-r2.4.14-orig/src/mongo/util/compress.cpp mongodb-src-r2.4
  
  namespace mongo {
  
+diff -Nurd mongodb-src-r2.4.14-orig/src/third_party/s2/hash.h mongodb-src-r2.4.14/src/third_party/s2/hash.h
+--- mongodb-src-r2.4.14-orig/src/third_party/s2/hash.h	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/third_party/s2/hash.h	2018-05-06 17:00:34.000000000 -0400
+@@ -7,13 +7,8 @@
+ #include "mongo/platform/unordered_set.h"
+ #define hash_set mongo::unordered_set
+ 
+-#if defined OS_LINUX || defined OS_MACOSX || defined __sunos__ || defined __freebsd__
+-#define HASH_NAMESPACE_START namespace std { namespace tr1 {
+-#define HASH_NAMESPACE_END }}
+-#elif defined OS_WINDOWS
+ #define HASH_NAMESPACE_START namespace std {
+ #define HASH_NAMESPACE_END }
+-#endif
+ 
+ // Places that hash-related functions are defined:
+ // end of s2cellid.h for hashing on S2CellId
 diff -Nurd mongodb-src-r2.4.14-orig/src/third_party/v8/SConscript mongodb-src-r2.4.14/src/third_party/v8/SConscript
---- mongodb-src-r2.4.14-orig/src/third_party/v8/SConscript	2015-04-27 11:18:57.000000000 -0500
-+++ mongodb-src-r2.4.14/src/third_party/v8/SConscript	2015-09-12 15:40:46.000000000 -0500
+--- mongodb-src-r2.4.14-orig/src/third_party/v8/SConscript	2015-04-27 12:18:57.000000000 -0400
++++ mongodb-src-r2.4.14/src/third_party/v8/SConscript	2018-05-06 17:00:34.000000000 -0400
 @@ -47,9 +47,9 @@
    'gcc': {
      'all': {

--- a/10.9-libcxx/stable/main/finkinfo/devel/mercurial-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/mercurial-py.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: mercurial.info -*-
 Info2: <<
 Package: mercurial-py%type_pkg[python]
-Version: 4.5.3
+Version: 4.6
 Revision: 1
 Type: python (2.7)
 Depends: python%type_pkg[python], ca-bundle
@@ -13,7 +13,9 @@ Replaces: chg (<< 0.3-1)
 # pyopenssl-py%type_pkg[python] is needed by hgweb for ssl support.
 Suggests: bzr-py%type_pkg[python], darcs, git, arch-tla, monotone, svn-swig-py%type_pkg[python], svn19, pygments-py%type_pkg[python], pyopenssl-py%type_pkg[python]
 Source: http://www.mercurial-scm.org/release/mercurial-%v.tar.gz
-Source-MD5: 065c73bf523b76666710f10ae6e2fe8a
+Source-MD5: c5ff220fba5f5bda93e6679e4ce57e0c
+Source-Checksum: SHA256(56ae3b10201adae37ad97fbd759cf3cea4ebe64c57641c059978c7a706ee6b49)
+
 PatchScript: <<
 	%{default_script}
 	perl -pi -e 's|/etc/|%p/etc/|g' doc/hg.1* doc/hgrc.5*

--- a/10.9-libcxx/stable/main/finkinfo/devel/mercurial.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/mercurial.info
@@ -1,6 +1,6 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: mercurial-py.info -*-
 Package: mercurial
-Version: 4.5.3
+Version: 4.6
 Revision: 1
 Description: Lightweight distributed SCM
 DescUsage: <<

--- a/10.9-libcxx/stable/main/finkinfo/gnome/gnome-icon-theme.info
+++ b/10.9-libcxx/stable/main/finkinfo/gnome/gnome-icon-theme.info
@@ -37,6 +37,6 @@ Description: The GNOME icon themes
 DescDetail: <<
 The GNOME icon theme package includes icon theme sets.
 <<
-License: GPL
+License: LGPL
 Maintainer: The Gnome Core Team <fink-gnome-core@lists.sourceforge.net>
 Homepage: http://www.gnome.org/

--- a/10.9-libcxx/stable/main/finkinfo/gnome/gnome-icon-theme.info
+++ b/10.9-libcxx/stable/main/finkinfo/gnome/gnome-icon-theme.info
@@ -15,12 +15,6 @@ Replaces: gnome-vfs (<< 1.0.5), gnome-vfs-ssl (<< 1.0.5), control-center (<< 2.1
 Source: mirror:gnome:sources/%n/2.31/%n-%v.tar.bz2
 Source-MD5: 8e727703343d4c18c73c79dd2009f8ed
 PatchScript: <<
-	# Claims to require git. Not sure why, but that suggests
-	# network access--not allowed in fink build environment.
-	# Therefore also not need deps (or care if auto-detection
-	# fails) for 'git', 'icontool-render', 'inkscape'
-	perl -pi -e 's/allow_rendering=yes/allow_rendering=no/' configure
-
 	perl -pi -e 's/echo -e/echo/g' src/Makefile.in
 <<
 ConfigureParams: DATADIRNAME=share

--- a/10.9-libcxx/stable/main/finkinfo/gnome/gnome-icon-theme.info
+++ b/10.9-libcxx/stable/main/finkinfo/gnome/gnome-icon-theme.info
@@ -1,5 +1,5 @@
 Package: gnome-icon-theme
-Version: 2.30.3
+Version: 2.31.0
 Revision: 1
 Depends: <<
 	default-icon-theme (>= 0.12-1)
@@ -12,8 +12,8 @@ BuildDepends: <<
 	pkgconfig (>= 0.23)
 <<
 Replaces: gnome-vfs (<< 1.0.5), gnome-vfs-ssl (<< 1.0.5), control-center (<< 2.14)
-Source: mirror:gnome:sources/%n/2.30/%n-%v.tar.bz2
-Source-MD5: 77d272e4220c75588418d9bec31eae24
+Source: mirror:gnome:sources/%n/2.31/%n-%v.tar.bz2
+Source-MD5: 8e727703343d4c18c73c79dd2009f8ed
 PatchScript: <<
 	# Claims to require git. Not sure why, but that suggests
 	# network access--not allowed in fink build environment.

--- a/10.9-libcxx/stable/main/finkinfo/languages/guile22.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/guile22.info
@@ -1,10 +1,10 @@
 Info3: <<
 Package: guile22
-Version: 2.2.2
-Revision: 3
+Version: 2.2.3
+Revision: 1
 BuildDepends: <<
 	# llvm33,
-	fink (>= 0.28),
+	fink (>= 0.32),
 	fink-package-precedence,
 	gc (>= 7.2d-2),
 	gettext-tools,
@@ -28,8 +28,10 @@ Depends: <<
 # prevent from building against old installed library
 # BuildConflicts: guile22-dev
 GCC: 4.0
-Source: mirror:gnu:guile/guile-%v.tar.gz
-Source-MD5: 1185b45bd1500838c508738c1bff4049
+Source: mirror:gnu:guile/guile-%v.tar.xz
+Source-MD5: 8d31f236b2b6c792a799d6e38d6dfc5f
+Source2: http://archive.ubuntu.com/ubuntu/pool/universe/g/guile-2.2/guile-2.2_%v+1-3build2.debian.tar.xz
+Source2-MD5: 4da4158d2978b821714d7d11a266b83e
 #PatchFile: %n.patch
 #PatchFile-MD5: 2dbc4ca9cc216dd0418b0482f8a8d3a6
 PatchScript: <<
@@ -67,6 +69,10 @@ echo 'export PATH="%p/share/guile/2.2/scripts/binoverride:$PATH"'
 echo 'eval "$@"'
 } > guile22-build
 chmod +x guile22-build
+# apply debian patches, which mostly deal with known possible failing tests
+for patch in ../debian/patches/*.patch; do
+	patch -p1 < $patch
+done
 <<
 # gl_cv_func_svid_putenv=yes
 ConfigureParams: <<
@@ -138,7 +144,7 @@ SplitOff: <<
   <<
   DocFiles: COPYING.LESSER
   Shlibs: <<
-  %p/lib/libguile-2.2.1.dylib 4.0.0 %n (>= 2.2.2-1)
+  %p/lib/libguile-2.2.1.dylib 5.0.0 %n (>= 2.2.3-1)
   <<
   Description: Shared libraries for guile22
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/viennarna-10.9.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/viennarna-10.9.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: viennarna
 Version: 2.1.8
 Revision: 7
-Source: http://www.tbi.univie.ac.at/RNA/packages/source/ViennaRNA-%v.tar.gz   
+Source: http://www.tbi.univie.ac.at/RNA/packages/source/ViennaRNA-%v.tar.gz
 Source-MD5: 3e47c546857bb18a6f49271250cfde95
 SourceDirectory: ViennaRNA-%v
 Type: perl (5.16.2)
@@ -167,7 +167,7 @@ CompileScript: <<
   ./configure %c --prefix=%p PerlCmd=/usr/bin/perl PythonCmd=/usr/bin/python
   make V=1
   fink-package-precedence --prohibit-bdep=%n-dev .
-  fink-package-precedence --prohibit-bdep=%n-dev --no-libs -depfile-ext='\.d' .
+  fink-package-precedence --prohibit-bdep=%n-dev --no-libs --depfile-ext='\.d' .
 <<
 InfoTest: <<
   TestScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/viennarna-10.9.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/viennarna-10.9.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: viennarna
 Version: 2.1.8
-Revision: 4
+Revision: 5
 Source: http://www.tbi.univie.ac.at/RNA/packages/source/ViennaRNA-%v.tar.gz   
 Source-MD5: 3e47c546857bb18a6f49271250cfde95
 SourceDirectory: ViennaRNA-%v
@@ -11,6 +11,10 @@ InfoDocs: RNAlib.info
 ConfigureParams: --mandir=%p/share/man --infodir=%p/share/info    CC=/usr/bin/clang  CXX=/usr/bin/clang++ CFLAGS="-I/usr/include -I%p/include" LDFLAGS="-L/usr/lib"
 Depends: system-perl%type_pkg[perl]
 #BuildDepends: graphviz
+BuildDepends: <<
+  doxygen,
+  texlive-base
+<<
 UpdatePOD: true
 Description: RNA structural prediction
 DescDetail: <<
@@ -147,8 +151,13 @@ perl -pi -e 's|ersion 1.6|ersion 2.1.8|g' man/RNAlib.info
 CompileScript: <<
 #!/bin/zsh -efv
 export ARCHFLAGS=''
-  ./configure %c --prefix=%p PerlCmd=/usr/bin/perl
+  ./configure %c --prefix=%p PerlCmd=/usr/bin/perl PythonCmd=/usr/bin/python
 make
+<<
+InfoTest: <<
+  TestScript: <<
+    make check || exit 2
+  <<
 <<
 InstallScript: <<
 #!/bin/zsh -efv

--- a/10.9-libcxx/stable/main/finkinfo/sci/viennarna-10.9.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/viennarna-10.9.info
@@ -1,18 +1,24 @@
 Info2: <<
 Package: viennarna
 Version: 2.1.8
-Revision: 6
+Revision: 7
 Source: http://www.tbi.univie.ac.at/RNA/packages/source/ViennaRNA-%v.tar.gz   
 Source-MD5: 3e47c546857bb18a6f49271250cfde95
 SourceDirectory: ViennaRNA-%v
 Type: perl (5.16.2)
 Distribution: 10.9
-ConfigureParams: --mandir=%p/share/man --infodir=%p/share/info    CC=/usr/bin/clang  CXX=/usr/bin/clang++ CFLAGS="-I/usr/include -I%p/include" LDFLAGS="-L/usr/lib"
-Depends: system-perl%type_pkg[perl]
+#only in unused codepaths of static-only lib:
+#Depends: gd2-shlibs, x11
+Depends: <<
+  system-perl%type_pkg[perl]
+<<
 #BuildDepends: graphviz
 BuildDepends: <<
   doxygen,
-  texlive-base
+  gd2,
+  fink-package-precedence,
+  texlive-base,
+  x11-dev
 <<
 GCC: 4.0
 UpdatePOD: true
@@ -143,17 +149,25 @@ For more detailed information on these please enter the command
 info RNA or visit the website 
 http://www.tbi.univie.ac.at/RNA/manpages.html
 <<
+# dmacks--fixed a ton of -I ordering and local -L flags so that
+# external libs are correctly detected and build-directory files are
+# correctly used
+PatchFile: %n.patch
+PatchFile-MD5: 1fb2358ece4980f5a0c2118329e28346
 PatchScript: <<
 #!/bin/zsh -efv
-perl -pi -e 's|ersion 1.6|ersion 2.1.8|g' README
-perl -pi -e 's|ersion 1.6|ersion 2.1.8|g' man/RNAlib.info
-perl -pi -e 's|(\* libRNA.a)( \(texinfo\).)|\1:\2|' man/RNAlib.info
+  %{default_script}
+  perl -pi -e 's|ersion 1.6|ersion 2.1.8|g' README
+  perl -pi -e 's|ersion 1.6|ersion 2.1.8|g' man/RNAlib.info
+  perl -pi -e 's|(\* libRNA.a)( \(texinfo\).)|\1:\2|' man/RNAlib.info
 <<
 CompileScript: <<
 #!/bin/zsh -efv
-export ARCHFLAGS=''
+  export ARCHFLAGS=''
   ./configure %c --prefix=%p PerlCmd=/usr/bin/perl PythonCmd=/usr/bin/python
-make
+  make V=1
+  fink-package-precedence --prohibit-bdep=%n-dev .
+  fink-package-precedence --prohibit-bdep=%n-dev --no-libs -depfile-ext='\.d' .
 <<
 InfoTest: <<
   TestScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/viennarna-10.9.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/viennarna-10.9.info
@@ -1,13 +1,12 @@
 Info2: <<
 Package: viennarna
 Version: 2.1.8
-Revision: 5
+Revision: 6
 Source: http://www.tbi.univie.ac.at/RNA/packages/source/ViennaRNA-%v.tar.gz   
 Source-MD5: 3e47c546857bb18a6f49271250cfde95
 SourceDirectory: ViennaRNA-%v
 Type: perl (5.16.2)
 Distribution: 10.9
-InfoDocs: RNAlib.info
 ConfigureParams: --mandir=%p/share/man --infodir=%p/share/info    CC=/usr/bin/clang  CXX=/usr/bin/clang++ CFLAGS="-I/usr/include -I%p/include" LDFLAGS="-L/usr/lib"
 Depends: system-perl%type_pkg[perl]
 #BuildDepends: graphviz
@@ -15,6 +14,7 @@ BuildDepends: <<
   doxygen,
   texlive-base
 <<
+GCC: 4.0
 UpdatePOD: true
 Description: RNA structural prediction
 DescDetail: <<
@@ -147,6 +147,7 @@ PatchScript: <<
 #!/bin/zsh -efv
 perl -pi -e 's|ersion 1.6|ersion 2.1.8|g' README
 perl -pi -e 's|ersion 1.6|ersion 2.1.8|g' man/RNAlib.info
+perl -pi -e 's|(\* libRNA.a)( \(texinfo\).)|\1:\2|' man/RNAlib.info
 <<
 CompileScript: <<
 #!/bin/zsh -efv
@@ -174,12 +175,15 @@ make -j1 install DESTDIR=%d INSTALLPRIVLIB=%p/lib/perl5/%type_raw[perl]/ INSTALL
 SplitOff: <<
 Package: %N-dev
 BuildDependsOnly: True
+Replaces: %N
 Files: <<
-include/*.h
-include/ViennaRNA/*.h
+include
 lib/libg2.a
 lib/libRNA.a
+lib/pkgconfig
+share/info
 <<
+InfoDocs: RNAlib.info
 <<
 ###############################################################################
 DocFiles: AUTHORS ChangeLog COPYING INSTALL INSTALL.configure NEWS README THANKS

--- a/10.9-libcxx/stable/main/finkinfo/sci/viennarna.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/viennarna.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: viennarna
 Version: 2.1.8
 Revision: 107
-Source: http://www.tbi.univie.ac.at/RNA/packages/source/ViennaRNA-%v.tar.gz   
+Source: http://www.tbi.univie.ac.at/RNA/packages/source/ViennaRNA-%v.tar.gz
 Source-MD5: 3e47c546857bb18a6f49271250cfde95
 SourceDirectory: ViennaRNA-%v
 Type: perl (5.18.2)
@@ -167,7 +167,7 @@ CompileScript: <<
   ./configure %c --prefix=%p PerlCmd=/usr/bin/perl PythonCmd=/usr/bin/python
   make V=1
   fink-package-precedence --prohibit-bdep=%n-dev .
-  fink-package-precedence --prohibit-bdep=%n-dev --no-libs -depfile-ext='\.d' .
+  fink-package-precedence --prohibit-bdep=%n-dev --no-libs --depfile-ext='\.d' .
 <<
 InfoTest: <<
   TestScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/viennarna.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/viennarna.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: viennarna
 Version: 2.1.8
-Revision: 104
+Revision: 105
 Source: http://www.tbi.univie.ac.at/RNA/packages/source/ViennaRNA-%v.tar.gz   
 Source-MD5: 3e47c546857bb18a6f49271250cfde95
 SourceDirectory: ViennaRNA-%v
@@ -11,6 +11,10 @@ InfoDocs: RNAlib.info
 ConfigureParams: --mandir=%p/share/man --infodir=%p/share/info    CC=/usr/bin/clang  CXX=/usr/bin/clang++ CFLAGS="-I/usr/include -I%p/include" LDFLAGS="-L/usr/lib"
 Depends: system-perl%type_pkg[perl]
 #BuildDepends: graphviz
+BuildDepends: <<
+  doxygen,
+  texlive-base
+<<
 UpdatePOD: true
 Description: RNA structural prediction
 DescDetail: <<
@@ -147,8 +151,13 @@ perl -pi -e 's|ersion 1.6|ersion 2.1.8|g' man/RNAlib.info
 CompileScript: <<
 #!/bin/zsh -efv
 export ARCHFLAGS=''
-  ./configure %c --prefix=%p PerlCmd=/usr/bin/perl
+  ./configure %c --prefix=%p PerlCmd=/usr/bin/perl PythonCmd=/usr/bin/python
 make
+<<
+InfoTest: <<
+  TestScript: <<
+    make check || exit 2
+  <<
 <<
 InstallScript: <<
 #!/bin/zsh -efv

--- a/10.9-libcxx/stable/main/finkinfo/sci/viennarna.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/viennarna.info
@@ -1,18 +1,24 @@
 Info2: <<
 Package: viennarna
 Version: 2.1.8
-Revision: 106
+Revision: 107
 Source: http://www.tbi.univie.ac.at/RNA/packages/source/ViennaRNA-%v.tar.gz   
 Source-MD5: 3e47c546857bb18a6f49271250cfde95
 SourceDirectory: ViennaRNA-%v
 Type: perl (5.18.2)
 Distribution: 10.10, 10.11, 10.12, 10.13
-ConfigureParams: --mandir=%p/share/man --infodir=%p/share/info    CC=/usr/bin/clang  CXX=/usr/bin/clang++ CFLAGS="-I/usr/include -I%p/include" LDFLAGS="-L/usr/lib"
-Depends: system-perl%type_pkg[perl]
+#only in unused codepaths of static-only lib:
+#Depends: gd2-shlibs, x11
+Depends: <<
+  system-perl%type_pkg[perl]
+<<
 #BuildDepends: graphviz
 BuildDepends: <<
   doxygen,
-  texlive-base
+  gd2,
+  fink-package-precedence,
+  texlive-base,
+  x11-dev
 <<
 GCC: 4.0
 UpdatePOD: true
@@ -143,17 +149,25 @@ For more detailed information on these please enter the command
 info RNA or visit the website 
 http://www.tbi.univie.ac.at/RNA/manpages.html
 <<
+# dmacks--fixed a ton of -I ordering and local -L flags so that
+# external libs are correctly detected and build-directory files are
+# correctly used
+PatchFile: %n.patch
+PatchFile-MD5: 1fb2358ece4980f5a0c2118329e28346
 PatchScript: <<
 #!/bin/zsh -efv
-perl -pi -e 's|ersion 1.6|ersion 2.1.8|g' README
-perl -pi -e 's|ersion 1.6|ersion 2.1.8|g' man/RNAlib.info
-perl -pi -e 's|(\* libRNA.a)( \(texinfo\).)|\1:\2|' man/RNAlib.info
+  %{default_script}
+  perl -pi -e 's|ersion 1.6|ersion 2.1.8|g' README
+  perl -pi -e 's|ersion 1.6|ersion 2.1.8|g' man/RNAlib.info
+  perl -pi -e 's|(\* libRNA.a)( \(texinfo\).)|\1:\2|' man/RNAlib.info
 <<
 CompileScript: <<
 #!/bin/zsh -efv
-export ARCHFLAGS=''
+  export ARCHFLAGS=''
   ./configure %c --prefix=%p PerlCmd=/usr/bin/perl PythonCmd=/usr/bin/python
-make
+  make V=1
+  fink-package-precedence --prohibit-bdep=%n-dev .
+  fink-package-precedence --prohibit-bdep=%n-dev --no-libs -depfile-ext='\.d' .
 <<
 InfoTest: <<
   TestScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/viennarna.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/viennarna.info
@@ -1,13 +1,12 @@
 Info2: <<
 Package: viennarna
 Version: 2.1.8
-Revision: 105
+Revision: 106
 Source: http://www.tbi.univie.ac.at/RNA/packages/source/ViennaRNA-%v.tar.gz   
 Source-MD5: 3e47c546857bb18a6f49271250cfde95
 SourceDirectory: ViennaRNA-%v
 Type: perl (5.18.2)
 Distribution: 10.10, 10.11, 10.12, 10.13
-InfoDocs: RNAlib.info
 ConfigureParams: --mandir=%p/share/man --infodir=%p/share/info    CC=/usr/bin/clang  CXX=/usr/bin/clang++ CFLAGS="-I/usr/include -I%p/include" LDFLAGS="-L/usr/lib"
 Depends: system-perl%type_pkg[perl]
 #BuildDepends: graphviz
@@ -15,6 +14,7 @@ BuildDepends: <<
   doxygen,
   texlive-base
 <<
+GCC: 4.0
 UpdatePOD: true
 Description: RNA structural prediction
 DescDetail: <<
@@ -147,6 +147,7 @@ PatchScript: <<
 #!/bin/zsh -efv
 perl -pi -e 's|ersion 1.6|ersion 2.1.8|g' README
 perl -pi -e 's|ersion 1.6|ersion 2.1.8|g' man/RNAlib.info
+perl -pi -e 's|(\* libRNA.a)( \(texinfo\).)|\1:\2|' man/RNAlib.info
 <<
 CompileScript: <<
 #!/bin/zsh -efv
@@ -174,12 +175,15 @@ make -j1 install DESTDIR=%d INSTALLPRIVLIB=%p/lib/perl5/%type_raw[perl]/ INSTALL
 SplitOff: <<
 Package: %N-dev
 BuildDependsOnly: True
+Replaces: %N
 Files: <<
-include/*.h
-include/ViennaRNA/*.h
+include
 lib/libg2.a
 lib/libRNA.a
+lib/pkgconfig
+share/info
 <<
+InfoDocs: RNAlib.info
 <<
 ###############################################################################
 DocFiles: AUTHORS ChangeLog COPYING INSTALL INSTALL.configure NEWS README THANKS

--- a/10.9-libcxx/stable/main/finkinfo/sci/viennarna.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/viennarna.patch
@@ -1,0 +1,139 @@
+diff -Nurd -x'*~' ViennaRNA-2.1.8.orig/Kinfold/configure ViennaRNA-2.1.8/Kinfold/configure
+--- ViennaRNA-2.1.8.orig/Kinfold/configure	2018-05-08 11:39:54.000000000 -0400
++++ ViennaRNA-2.1.8/Kinfold/configure	2018-05-08 11:47:01.000000000 -0400
+@@ -3938,7 +3938,7 @@
+ fi
+ 
+ if [ -d ../lib ] && [ "$ac_VRNA_includes" = "../H" ]; then
+-  ac_VRNA_lib=../lib
++  ac_VRNA_lib=../lib/libRNA.a
+ fi
+ 
+ if test -z "$ac_VRNA_lib"; then
+@@ -3954,9 +3954,6 @@
+   done
+ done
+ fi # $ac_VRNA_lib = NO
+-if test $ac_VRNA_lib; then
+-  LDFLAGS="-L$ac_VRNA_lib $LDFLAGS"
+-fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result:  headers in \"$ac_VRNA_includes\" and library... \"$ac_VRNA_lib\"" >&5
+ $as_echo " headers in \"$ac_VRNA_includes\" and library... \"$ac_VRNA_lib\"" >&6; }
+ 
+@@ -4553,7 +4550,14 @@
+ 
+ 
+ 
+-LIBS="-lRNA ${LIBS}"
++if test $ac_VRNA_lib; then
++  if test -d $ac_VRNA_lib; then
++    LDFLAGS="-L$ac_VRNA_lib $LDFLAGS"
++    LIBS="-lRNA ${LIBS}"
++  else
++    LIBS="$ac_VRNA_lib $LIBS"
++  fi
++fi
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for an ANSI C-conforming const" >&5
+ $as_echo_n "checking for an ANSI C-conforming const... " >&6; }
+diff -Nurd -x'*~' ViennaRNA-2.1.8.orig/RNAforester/configure ViennaRNA-2.1.8/RNAforester/configure
+--- ViennaRNA-2.1.8.orig/RNAforester/configure	2018-05-08 11:39:54.000000000 -0400
++++ ViennaRNA-2.1.8/RNAforester/configure	2018-05-08 11:40:08.000000000 -0400
+@@ -4212,18 +4212,18 @@
+ 
+   LDFLAGS="-L$withval -R$withval ${LDFLAGS}"
+ else
+-  LDFLAGS="-L../../lib -L../../ViennaRNA ${LDFLAGS} ${OPENMP_CXXFLAGS}"
++  LDFLAGS="${LDFLAGS} ${OPENMP_CXXFLAGS}"
+   if test -r "../lib/fold.c"; then
+     $as_echo "#define HAVE_LIBRNA 1" >>confdefs.h
+ 
+-    LIBS="-lRNA ${LIBS}"
++    LIBS="../../lib/libRNA.a ${LIBS}"
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: using (to be built) libRNA.a in ../lib" >&5
+ $as_echo "using (to be built) libRNA.a in ../lib" >&6; }
+   else
+     if test -r "../ViennaRNA/fold.c"; then
+       $as_echo "#define HAVE_LIBRNA 1" >>confdefs.h
+ 
+-      LIBS="-lRNA ${LIBS}"
++      LIBS="../../ViennaRNA/libRNA.a ${LIBS}"
+       { $as_echo "$as_me:${as_lineno-$LINENO}: result: using (to be built) libRNA.a in ../ViennaRNA" >&5
+ $as_echo "using (to be built) libRNA.a in ../ViennaRNA" >&6; }
+     fi
+@@ -4876,11 +4876,10 @@
+ fi
+ 
+ 
+-CPPFLAGS="$save_CPPFLAGS -I../g2-0.70/include/ "
+-LDFLAGS="-L../g2-0.70 ${LDFLAGS}"
++CPPFLAGS="-I../g2-0.70/include $save_CPPFLAGS"
+ 
+ if ${HAVE_LIBG2}; then
+-  LIBS="-lg2 ${LIBS}"
++  LIBS="../g2-0.70/libg2.a ${LIBS}"
+ fi
+ 
+ 
+diff -Nurd -x'*~' ViennaRNA-2.1.8.orig/RNAforester/g2-0.70/Makefile.in ViennaRNA-2.1.8/RNAforester/g2-0.70/Makefile.in
+--- ViennaRNA-2.1.8.orig/RNAforester/g2-0.70/Makefile.in	2018-05-08 11:39:54.000000000 -0400
++++ ViennaRNA-2.1.8/RNAforester/g2-0.70/Makefile.in	2018-05-08 11:40:08.000000000 -0400
+@@ -23,7 +23,7 @@
+ 
+ CC           = @CC@
+ CFLAGS       = 
+-INCLUDES     = -I./src @CFLAGS@ @DEFS@
++INCLUDES     = -I./src @CPPFLAGS@ @CFLAGS@ @DEFS@ -MD
+ INSTALL      = @INSTALL@
+ INSTALL_DATA = @INSTALL_DATA@
+ FIND         = @FIND@
+diff -Nurd -x'*~' ViennaRNA-2.1.8.orig/RNAforester/g2-0.70/demo/Makefile.in ViennaRNA-2.1.8/RNAforester/g2-0.70/demo/Makefile.in
+--- ViennaRNA-2.1.8.orig/RNAforester/g2-0.70/demo/Makefile.in	2018-05-08 11:39:54.000000000 -0400
++++ ViennaRNA-2.1.8/RNAforester/g2-0.70/demo/Makefile.in	2018-05-08 11:40:08.000000000 -0400
+@@ -25,7 +25,7 @@
+ 
+ CFLAGS = -I../src -I../src/X11 -I../src/PS -I../src/Win32 -I../src/GD -I../src/FIG @CFLAGS@ @DEFS@
+ CXXFLAGS = -I../src -I../src/X11 -I../src/PS -I../src/Win32 -I../src/GD/ -I../src/FIG @CXXFLAGS@ @DEFS@
+-LDFLAGS = -L.. -lg2 @LDFLAGS@
++LDFLAGS = ../libg2.a @LDFLAGS@
+ 
+ @DO_PS@DEMO_PS = simple_PS
+ @DO_FIG@DEMO_FIG = simple_FIG
+diff -Nurd -x'*~' ViennaRNA-2.1.8.orig/RNAforester/g2-0.70/g2_perl/Makefile.PL ViennaRNA-2.1.8/RNAforester/g2-0.70/g2_perl/Makefile.PL
+--- ViennaRNA-2.1.8.orig/RNAforester/g2-0.70/g2_perl/Makefile.PL	2018-05-08 11:39:54.000000000 -0400
++++ ViennaRNA-2.1.8/RNAforester/g2-0.70/g2_perl/Makefile.PL	2018-05-08 11:40:08.000000000 -0400
+@@ -4,7 +4,7 @@
+ WriteMakefile(
+     'NAME'	=> 'G2',
+     'VERSION_FROM' => 'G2.pm', # finds $VERSION
+-    'LIBS'	=> ['-L./.. -lg2   -L/usr/local/lib -lm -lX11 -lgd'],  # e.g., '-lm' 
++    'LIBS'	=> ['../libg2.a -lm -lX11 -lgd'],  # e.g., '-lm' 
+     'DEFINE'	=> '-DPACKAGE_NAME=\"\" -DPACKAGE_TARNAME=\"\" -DPACKAGE_VERSION=\"\" -DPACKAGE_STRING=\"\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DLINUX=1 -DDO_PS=1 -DDO_FIG=1 -DDO_X11=1 -DDO_GD=1 -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_LIMITS_H=1',                   # e.g., '-DHAVE_SOMETHING' 
+     'INC'	=> '-I./../include',           # e.g., '-I/usr/local/include' 
+ );
+diff -Nurd -x'*~' ViennaRNA-2.1.8.orig/RNAforester/g2-0.70/perl/Makefile.PL ViennaRNA-2.1.8/RNAforester/g2-0.70/perl/Makefile.PL
+--- ViennaRNA-2.1.8.orig/RNAforester/g2-0.70/perl/Makefile.PL	2018-05-08 11:39:54.000000000 -0400
++++ ViennaRNA-2.1.8/RNAforester/g2-0.70/perl/Makefile.PL	2018-05-08 11:40:08.000000000 -0400
+@@ -2,8 +2,8 @@
+ 
+ # =====> PATHS: CHECK AND ADJUST <=====
+ my @INC     = qw(-I../src  -I../src/win32 -I../src/PS -I../src/GD); 
+-my @LIBPATH = qw(-L../Debug -L../../gd-1.8.4);
+-my @LIBS    = qw(-lg2);
++my @LIBPATH = qw(-L../Debug);
++my @LIBS    = qw(../../gd-1.8.4/libg2.a);
+ 
+ # FEATURE FLAGS
+ warn "\nPlease choose the features that match how g2 was built:\n";
+diff -Nurd -x'*~' ViennaRNA-2.1.8.orig/Utils/Makefile.in ViennaRNA-2.1.8/Utils/Makefile.in
+--- ViennaRNA-2.1.8.orig/Utils/Makefile.in	2018-05-08 11:39:54.000000000 -0400
++++ ViennaRNA-2.1.8/Utils/Makefile.in	2018-05-08 11:40:08.000000000 -0400
+@@ -330,7 +330,7 @@
+ GENGETOPT_CMDL = ct2db_cmdl.c ct2db_cmdl.h
+ GENGETOPT_FILES = ct2db.ggo
+ EXTRA_DIST = $(pscript) Fold ${GENGETOPT_FILES} ${GENGETOPT_CMDL}
+-LDADD = -L../lib -lRNA -lm
++LDADD = ../lib/libRNA.a -lm
+ AM_CPPFLAGS = -I$(srcdir)/../H
+ ct2db_SOURCES = ct2db_cmdl.c ct2db.c
+ all: all-am


### PR DESCRIPTION
It didn't pass -m (self-test), and while fixing that I added f-p-p and looked at the ./configure output and found lots of other oddities. There are lots of upstream build-toolchain poor practices, and fixing them reduced the amount and fragility of the build overall and the other workarounds in the packaging.

I see there is a new upstream, which claims to be more portable in its library building, so maybe we would get .dylib and/or improved other aspects of the build process. I can look at it if anyone is interested, but for now, just need to get this thing buildable.