### PR TITLE
ucblogo: Fix FTBFS, add debian patches, update deps

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/ucblogo.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/ucblogo.info
@@ -1,29 +1,66 @@
 Package: ucblogo
 Version: 6.0
-Revision: 1
+Revision: 2
 Maintainer: Matthias Neeracher <neeracher@mac.com>
-BuildDepends: x11-dev, tetex3-base, fink (>= 0.24.12-1)
-Depends: x11
+BuildDepends: <<
+	fink (>= 0.32),
+	fink-package-precedence,
+	ghostscript,
+	libncurses5,
+	texinfo,
+	texlive-base,
+	x11-dev
+<<
+Depends: <<
+	libncurses5-shlibs,
+	x11
+<<
 Source: ftp://ftp.cs.berkeley.edu/pub/%n/%n-%v.tar.gz
 Source-MD5: 36a56765b18136c817880c5381af196b
+Source2: mirror:debian:pool/main/u/ucblogo/ucblogo_6.0+dfsg-2.debian.tar.xz
+Source2-MD5: 15fb4a14a7b342ba7096a071d1f44731
 PatchFile: %n.patch
-PatchFile-MD5: dc0c8e788a5d21d6c5e9f120c63443a3
+PatchFile-MD5: 4b215ae96911a01c37c7d922e2e1778a
 PatchScript: <<
-patch -p1 < %{PatchFile}
-rm -rf config.cache csls/CVS docs/ucblogo.info
+#!/bin/sh -ev
+	for file in \
+		documentation.patch \
+		fix_ftbfs.patch \
+		fix_ftbfs_lp64.patch \
+		fix_keyp_64bit.patch \
+		reproducible_build.patch \
+		strip_svn_version.patch \
+		wx3.0.patch \
+	; do
+		echo "applying $file"
+		patch -p1 < ../debian/patches/$file
+	done
+
+	%{default_script}
+
+	rm -rf config.cache csls/CVS docs/ucblogo.info
+
 	# patch *ancient* darwin-ignorant autoconf
 	perl -pi -e 's/(a so sl)/dylib \1/' configure
+	# ...and autoconf2.13-era X11 detection bug
+	perl -pi -e 's/(x_direct_test_library)=Xt/\1=X11/; s/(x_direct_test_function)=XtMalloc/\1=XrmInitialize/' configure
 	# autoconf2.6ish patch for modern XQuartz paths
 	perl -pi -e "s|/usr/lpp/Xamples|/opt/X11|" configure
 <<
+SetCPPFLAGS: -MD
 SetCFLAGS: -Wno-error-return-type -g
+CompileScript: <<
+	%{default_script}
+	fink-package-precedence -depfile-ext='\.d' .
+<<
 InfoDocs: %n.info
 DocFiles: README general-public-license
 Description: Berkeley Logo Interpreter
 DescDetail: <<
 This is an interpreter for the Logo programming language.
 <<
-DescPackaging: InfoDocs give errors, so we patch info files
+DescPackaging: <<
+	Import some Debian patches (whichever ones look useful)
+<<
 License: GPL
 Homepage: http://http.cs.berkeley.edu/~bh/
-

--- a/10.9-libcxx/stable/main/finkinfo/languages/ucblogo.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/ucblogo.patch
@@ -10,20 +10,6 @@ diff -ru ucblogo-6.0-orig/docs/makefile ucblogo-6.0/docs/makefile
  HTMLDIR	      = $(DOCSDIR)/html
  
  all: usermanual.ps usermanual.pdf html/usermanual_1.html ucblogo.info
-diff -ru ucblogo-6.0-orig/docs/usermanual.texi ucblogo-6.0/docs/usermanual.texi
---- ucblogo-6.0-orig/docs/usermanual.texi	2011-07-25 03:07:12.000000000 +0200
-+++ ucblogo-6.0/docs/usermanual.texi	2011-07-25 04:43:28.000000000 +0200
-@@ -14,6 +14,10 @@
- 
- @ifinfo
- @paragraphindent 0
-+@dircategory Text creation and manipulation
-+@direntry
-+* UCB Logo: (ucblogo).      Berkeley Logo interpreter
-+@end direntry
- @end ifinfo
- 
- @finalout
 diff -ru ucblogo-6.0-orig/makefile.in ucblogo-6.0/makefile.in
 --- ucblogo-6.0-orig/makefile.in	2011-07-25 03:07:13.000000000 +0200
 +++ ucblogo-6.0/makefile.in	2011-07-25 03:58:38.000000000 +0200


### PR DESCRIPTION
As found by the bindist http://bindist.finkproject.org/10.13/logs/ucblogo_6.0-1_c644de3780c94d41addb76db2c7a8d50.log the autoconf2.13-era ./configure script broke again. While fixing it, I noticed missing ncurses deps, and added fink-package-precedence to help track it. Debian's ucblogo package had some useful patches (including some we already had), so I pulled them in also.