### PR TITLE
libnewt: Fix a bunch of packaging nits (Issue #162)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libnewt0-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libnewt0-shlibs.info
@@ -99,10 +99,9 @@ perl -pi -e 's/^(automake)/#\1/' autogen.sh
 ###
 ConfigureParams: <<
 --without-gpm-support \
---with-colorsfile=%p/etc/newt/palette
+--with-colorsfile=%p/etc/newt/palette \
+ac_cv_c_tclconfig=%p/lib
 <<
-###
-SetCFLAGS: -I/usr/include/tcl8.6
 ###
 CompileScript: <<
 cp %p/share/automake-1.15/install-sh ./install-sh
@@ -312,3 +311,15 @@ those, you won't need this package.
 License: GPL
 Maintainer: Justin F. Halett <thesin@lists.sourceforge.net>
 Homepage: https://fedorahosted.org/newt/
+DescPackaging: <<
+	Upstream bug about difficulty passing python versions. See:
+	https://pagure.io/newt/issue/3
+	Wish this weren't so monolithic a build to have all pyXX
+	as part of the -shlibs .info
+
+	dmacks: ac_cv_c_tclconfig for self-consistent fink tcl
+	bits. Before 10.13, detected in /usr/lib but then used fink's
+	via default -I/-L, but 10.13 only has tclConfig.sh buried and
+	there is a bug in the detection of it in %p/lib. See:
+	https://pagure.io/newt/issue/5
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/libnewt0-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libnewt0-shlibs.info
@@ -1,6 +1,6 @@
 Package: libnewt0-shlibs
 Version: 0.52.19
-Revision: 1.2
+Revision: 1.3
 ###
 BuildDepends: <<
 	fink (>= 0.32),
@@ -62,11 +62,15 @@ patch -p1 < debian/patches/whiptail-man.patch
 # Patch maintainer scripts
 perl -pi -e 's,/etc,%p/etc,g' debian/*.pre*
 
-perl -pi -e 's,--shared,-bundle -undefined dynamic_lookup,g' Makefile.in
-perl -pi -e 's,-shared,-undefined dynamic_lookup,g' Makefile.in
+perl -pi -e 's,-+shared,-bundle,g unless /-o \$\(LIBNEWTSH\)/' Makefile.in
+# dmacks: restrict this to the pymods because it can mask other
+# linking problems
+perl -pi -e 's/(\$\$PLFLAGS)/\1 -undefined dynamic_lookup/' Makefile.in
 
 # bundles should remain .so
 perl -pi -e 's,snack\.\$\(SOEXT\),snack\.so,g' Makefile.in
+# dmacks: oddly, tcl standardly uses .dylib for dlopen() modules;
+# retaining .so here due to legacy of this fink pkg
 perl -pi -e 's,whiptcl\.\$\(SOEXT\),whiptcl\.so,g' Makefile.in
 perl -pi -e 's,\$\(WHIPTCLLIB\)\.\$\(SOEXT\),\$\(WHIPTCLLIB\)\.so,g' Makefile.in
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/libnewt0-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libnewt0-shlibs.info
@@ -1,6 +1,6 @@
 Package: libnewt0-shlibs
 Version: 0.52.19
-Revision: 1.1
+Revision: 1.2
 ###
 BuildDepends: <<
 	fink (>= 0.32),
@@ -91,6 +91,10 @@ perl -pi -e 's,/usr,%p,' *.py newt.spec nls.h
 # local -L flags might come after global, giving incorrect
 # precedence to libnewt in some already-installed package
 perl -pi -e 's,-L\.,,g; s,-lnewt,libnewt.dylib,g' Makefile.in
+
+# dmacks: fix upstream automake misuse. See:
+# https://pagure.io/newt/issue/4
+perl -pi -e 's/^(automake)/#\1/' autogen.sh
 <<
 ###
 ConfigureParams: <<


### PR DESCRIPTION
Including FTBFS on 10.13 and runtime breakage of tcl mod on all platforms.