### PR TITLE
keyring-py 12.2.0 depends on entrypoints-py

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/entrypoints-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/entrypoints-py.info
@@ -1,0 +1,37 @@
+Info3: <<
+
+Package: entrypoints-py%type_pkg[python]
+Type: python (2.7 3.4 3.5 3.6)
+
+Version: 0.2.3
+Revision: 1
+Description: Discover and load entry points from packages
+DescDetail: <<
+Entry points are a way for Python packages to advertise objects with
+some common interface. The most common examples are console_scripts
+entry points, which define shell commands by identifying a Python
+function to run.
+<<
+Source: https://files.pythonhosted.org/packages/27/e8/607697e6ab8a961fc0b141a97ea4ce72cd9c9e264adeb0669f6d194aa626/entrypoints-%v.tar.gz
+Source-MD5: 0d3ad1b0130d91e3596ef3a59f25a56c
+
+Depends: python%type_pkg[python]
+CompileScript: <<
+  %p/bin/python%type_raw[python] setup.py build_ext --include-dirs=%p/include --library-dirs=%p/lib
+  %p/bin/python%type_raw[python] setup.py build
+<<
+InfoTest: <<
+  TestScript: <<
+    %p/bin/python%type_raw[python] setup.py check
+    find ./build -name "*.pyc" -delete
+  <<
+<<
+InstallScript: <<
+  %p/bin/python%type_raw[python] setup.py install --root=%d
+<<
+DocFiles: doc/*
+License: BSD
+Homepage: https://github.com/takluyver/entrypoints
+Maintainer: Brendan Cully <fink@brendan.cully.org>
+# Info3
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/keyring-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/keyring-py.info
@@ -40,7 +40,7 @@ Source: https://pypi.io/packages/source/k/keyring/keyring-%v.tar.gz
 Source-MD5: 01d2706a38bec06d6cb6f76c57a36688
 Source-Checksum: SHA256(4a639773932525ff25225cace20e74580403715b3e00a8ea94a7b121dad1cfac)
 
-Depends: python%type_pkg[python]
+Depends: python%type_pkg[python], entrypoints-py%type_pkg[python]
 BuildDepends: fink (>= 0.24.12), setuptools-tng-py%type_pkg[python], setuptools-scm-py%type_pkg[python] (>= 1.10.1-1)
 
 CompileScript: %p/bin/python%type_raw[python] setup.py build


### PR DESCRIPTION
Adds entrypoints-py so that keyring-py can depend on it. As of the update to keyring-py 12.2.0, the keyring command and library fail at startup with:

```
% /sw/bin/keyring
Traceback (most recent call last):
  File "/sw/bin/keyring", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/sw/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3019, in <module>
    @_call_aside
  File "/sw/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3003, in _call_aside
    f(*args, **kwargs)
  File "/sw/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3032, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/sw/lib/python2.7/site-packages/pkg_resources/__init__.py", line 655, in _build_master
    ws.require(__requires__)
  File "/sw/lib/python2.7/site-packages/pkg_resources/__init__.py", line 963, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/sw/lib/python2.7/site-packages/pkg_resources/__init__.py", line 849, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'entrypoints' distribution was not found and is required by keyring
```

The new module was built with -m.