### PR TITLE
Added missing futures-py dependency to Python2.7 variant of isort-py

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/isort-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/isort-py.info
@@ -1,10 +1,10 @@
-Info2: <<
+Info4: <<
 
 Package: isort-py%type_pkg[python]
 Type: python (2.7 3.4 3.5 3.6)
 
 Version: 4.3.4
-Revision: 1
+Revision: 2
 Description: Sort Python imports
 DescDetail: <<
 isort is a Python utility / library to sort imports alphabetically,
@@ -15,7 +15,7 @@ using pies to achieve this without ugly hacks and/or py2to3.
 <<
 Source: https://pypi.io/packages/source/i/isort/isort-%v.tar.gz
 Source-MD5: fb554e9c8f9aa76e333a03d470a5cf52
-Depends: python%type_pkg[python]
+Depends: python%type_pkg[python], (%type_pkg[python] <= 29) futures-py%type_pkg[python]
 CompileScript: <<
   %p/bin/python%type_raw[python] setup.py build_ext --include-dirs=%p/include --library-dirs=%p/lib
   %p/bin/python%type_raw[python] setup.py build
@@ -24,16 +24,13 @@ InfoTest: <<
   TestDepends: pytest-py%type_pkg[python], flake8-py%type_pkg[python]
   TestScript: <<
     #!/bin/bash -ev
-    TESTFAIL=0
-    %p/bin/pytest-%type_raw[python] || TESTFAIL=1
-    find ./build -name "*.pyc" -exec rm {} \;
-    exit $TESTFAIL
+    %p/bin/pytest-%type_raw[python] || exit 1
   <<
   TestSuiteSize: small
 <<
 InstallScript: <<
+  find ./build -name "*.pyc" -exec rm {} \;
   %p/bin/python%type_raw[python] setup.py install --root=%d
-
   mv %i/bin/isort %i/bin/isort-py%type_pkg[python]
 <<
 PostInstScript: <<
@@ -47,6 +44,8 @@ PreRmScript: <<
 <<
 DocFiles: PKG-INFO
 License: BSD
-Homepage: https://pypi.python.org/pypi/isort
+Homepage: https://github.com/timothycrosley/isort
 Maintainer: Brendan Cully <fink@brendan.cully.org>
+
+# Info4
 <<


### PR DESCRIPTION
In `4.3.4` `isort-py` (updated in #130) added an import from `concurrent.futures`; the `py27` variant needs the backport in `futures-py` for this. 3 test failures remaining.