### PR TITLE
pylint: depend on singledispatch-py for python 2.7

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/pylint-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/pylint-py.info
@@ -3,7 +3,7 @@ Info3: <<
 Package: pylint-py%type_pkg[python]
 Type: python (2.7 3.4 3.5 3.6)
 Version: 1.8.4
-Revision: 1
+Revision: 2
 Source: https://pypi.io/packages/source/p/pylint/pylint-%v.tar.gz
 Source-MD5: a69d02563a64400b2c766bef39fece92
 
@@ -14,7 +14,8 @@ Depends: <<
   mccabe-py%type_pkg[python],
   six-py%type_pkg[python],
   (%type_raw[python] = 2.7) backports.functools-lru-cache-py%type_pkg[python],
-  (%type_raw[python] = 2.7) configparser-py%type_pkg[python]
+  (%type_raw[python] = 2.7) configparser-py%type_pkg[python],
+  (%type_raw[python] = 2.7) singledispatch-py%type_pkg[python]
 <<
 BuildDepends: setuptools-tng-py%type_pkg[python], sphinx-py%type_pkg[python]
 


### PR DESCRIPTION
Without this module installed, pylint fails at startup with
```
Traceback (most recent call last):
  File "/sw/bin/pylint", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/sw/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3019, in <module>
    @_call_aside
  File "/sw/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3003, in _call_aside
    f(*args, **kwargs)
  File "/sw/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3032, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/sw/lib/python2.7/site-packages/pkg_resources/__init__.py", line 655, in _build_master
    ws.require(__requires__)
  File "/sw/lib/python2.7/site-packages/pkg_resources/__init__.py", line 963, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/sw/lib/python2.7/site-packages/pkg_resources/__init__.py", line 849, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'singledispatch' distribution was not found and is required by pylint
```