### PR TITLE
libspatialindex cleanup

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex2-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex2-shlibs.info
@@ -1,11 +1,10 @@
 Info2: <<
 
-Package: libspatialindex2
-BuildDependsOnly: True
+Package: libspatialindex2-shlibs
 
 Version: 1.7.1
 Revision: 4
-Description: Headers for Spatial Index
+Description: Libraries for Spatial Index
 License: BSD
 Homepage: http://libspatialindex.github.com
 Maintainer: BABA Yoshihiko <babayoshihiko@mac.com>
@@ -30,10 +29,7 @@ The purpose of this library is to provide:
 <<
 
 # Dependencies.
-Depends: %n-shlibs (= %v-%r)
 BuildDepends: fink-package-precedence
-Conflicts: libspatialindex3, libspatialindex4
-Replaces: libspatialindex3, libspatialindex4
 
 # Unpack Phase.
 Source: http://download.osgeo.org/libspatialindex/spatialindex-src-%v.tar.gz
@@ -48,20 +44,38 @@ PatchScript: <<
 GCC: 4.0
 CompileScript: <<
   %{default_script}
-  fink-package-precedence --prohibit-bdep=%n .
+  fink-package-precedence --prohibit-bdep=libspatialindex2 .
 <<
 InstallScript: <<
 #!/bin/bash -ev
   make install DESTDIR=%d
 <<
 
+Shlibs: <<
+  %p/lib/libspatialindex.2.dylib     3.0.0 %n (>= 1.7.1-1)
+  %p/lib/libspatialindex_c.2.dylib   3.0.0 %n (>= 1.7.1-1)
+<<
+
 SplitOff: <<
-  Package: %N-shlibs
-  Description: Libraries for Spatial Index
-  Files: lib/*.2.dylib
-  Shlibs: <<
-    %p/lib/libspatialindex.2.dylib     3.0.0 %n (>= 1.7.1-1)
-    %p/lib/libspatialindex_c.2.dylib   3.0.0 %n (>= 1.7.1-1)
+  Package: libspatialindex2
+  Description: Headers for Spatial Index
+  Depends: %N (= %v-%r)
+  Conflicts: <<
+    libspatialindex3,
+    libspatialindex4
+  <<
+  Replaces: <<
+    libspatialindex3,
+    libspatialindex4
+  <<
+  BuildDependsOnly: True
+  Files: <<
+    include
+    lib/libspatialindex.{a,dylib,la}
+    lib/libspatialindex.2.0.0.dylib
+    lib/libspatialindex_c.{a,dylib,la}
+    lib/libspatialindex_c.2.0.0.dylib
+    lib/pkgconfig
   <<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex2-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex2-shlibs.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: libspatialindex2-shlibs
 
 Version: 1.7.1
-Revision: 6
+Revision: 7
 Description: Libraries for Spatial Index
 License: BSD
 Homepage: http://libspatialindex.github.com
@@ -29,7 +29,8 @@ The purpose of this library is to provide:
 <<
 
 # Dependencies.
-Replaces: libspatialindex2 (<< 1.7.1-5)
+Conflicts: libspatialindex2 (<< 1.7.1-7)
+Replaces: libspatialindex2 (<< 1.7.1-7)
 BuildDepends: fink-package-precedence
 
 # Unpack Phase.
@@ -51,32 +52,15 @@ CompileScript: <<
 InstallScript: <<
 #!/bin/bash -ev
   make install DESTDIR=%d
+  rm -rf %i/include
+  rm -rf %i/lib/libspatialindex.{dylib,la}
+  rm -rf %i/lib/libspatialindex_c.{dylib,la}
+  rm -rf %i/lib/pkgconfig
 <<
 
 Shlibs: <<
   %p/lib/libspatialindex.2.dylib     3.0.0 %n (>= 1.7.1-1)
   %p/lib/libspatialindex_c.2.dylib   3.0.0 %n (>= 1.7.1-1)
-<<
-
-SplitOff: <<
-  Package: libspatialindex2
-  Description: Headers for Spatial Index
-  Depends: %N (= %v-%r)
-  Conflicts: <<
-    libspatialindex3,
-    libspatialindex4
-  <<
-  Replaces: <<
-    libspatialindex3,
-    libspatialindex4
-  <<
-  BuildDependsOnly: True
-  Files: <<
-    include
-    lib/libspatialindex.{dylib,la}
-    lib/libspatialindex_c.{dylib,la}
-    lib/pkgconfig
-  <<
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex2-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex2-shlibs.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: libspatialindex2-shlibs
 
 Version: 1.7.1
-Revision: 7
+Revision: 8
 Description: Libraries for Spatial Index
 License: BSD
 Homepage: http://libspatialindex.github.com
@@ -57,6 +57,7 @@ InstallScript: <<
   rm -rf %i/lib/libspatialindex_c.{dylib,la}
   rm -rf %i/lib/pkgconfig
 <<
+DocFiles: AUTHORS ChangeLog COPYING README
 
 Shlibs: <<
   %p/lib/libspatialindex.2.dylib     3.0.0 %n (>= 1.7.1-1)

--- a/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex2-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex2-shlibs.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: libspatialindex2-shlibs
 
 Version: 1.7.1
-Revision: 5
+Revision: 6
 Description: Libraries for Spatial Index
 License: BSD
 Homepage: http://libspatialindex.github.com
@@ -43,6 +43,7 @@ PatchScript: <<
 
 # Compile Phase.
 GCC: 4.0
+ConfigureParams: --disable-static
 CompileScript: <<
   %{default_script}
   fink-package-precedence --prohibit-bdep=libspatialindex2 .
@@ -72,8 +73,8 @@ SplitOff: <<
   BuildDependsOnly: True
   Files: <<
     include
-    lib/libspatialindex.{a,dylib,la}
-    lib/libspatialindex_c.{a,dylib,la}
+    lib/libspatialindex.{dylib,la}
+    lib/libspatialindex_c.{dylib,la}
     lib/pkgconfig
   <<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex2-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex2-shlibs.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: libspatialindex2-shlibs
 
 Version: 1.7.1
-Revision: 4
+Revision: 5
 Description: Libraries for Spatial Index
 License: BSD
 Homepage: http://libspatialindex.github.com
@@ -29,6 +29,7 @@ The purpose of this library is to provide:
 <<
 
 # Dependencies.
+Replaces: libspatialindex2 (<< 1.7.1-5)
 BuildDepends: fink-package-precedence
 
 # Unpack Phase.
@@ -72,9 +73,7 @@ SplitOff: <<
   Files: <<
     include
     lib/libspatialindex.{a,dylib,la}
-    lib/libspatialindex.2.0.0.dylib
     lib/libspatialindex_c.{a,dylib,la}
-    lib/libspatialindex_c.2.0.0.dylib
     lib/pkgconfig
   <<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex3-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex3-shlibs.info
@@ -1,11 +1,10 @@
 Info2: <<
 
-Package: libspatialindex3
-BuildDependsOnly: True
+Package: libspatialindex3-shlibs
 
 Version: 1.8.0
 Revision: 4
-Description: Headers for Spatial Index
+Description: Libraries for Spatial Index
 License: BSD
 Homepage: http://libspatialindex.github.com
 Maintainer: BABA Yoshihiko <babayoshihiko@mac.com>
@@ -30,10 +29,7 @@ The purpose of this library is to provide:
 <<
 
 # Dependencies.
-Depends: %n-shlibs (= %v-%r)
 BuildDepends: fink-package-precedence
-Conflicts: libspatialindex2, libspatialindex4
-Replaces: libspatialindex2, libspatialindex4
 
 # Unpack Phase.
 Source: http://download.osgeo.org/libspatialindex/spatialindex-src-%v.tar.gz
@@ -48,20 +44,36 @@ PatchScript: <<
 GCC: 4.0
 CompileScript: <<
   %{default_script}
-  fink-package-precedence --prohibit-bdep=%n .
+  fink-package-precedence --prohibit-bdep=libspatialindex3 .
 <<
 InstallScript: <<
 #!/bin/bash -ev
   make install DESTDIR=%d
 <<
 
+Shlibs: <<
+  %p/lib/libspatialindex.3.dylib     4.0.0 %n (>= 1.8.0-1)
+  %p/lib/libspatialindex_c.3.dylib   4.0.0 %n (>= 1.8.0-1)
+<<
+
 SplitOff: <<
-  Package: %N-shlibs
-  Description: Libraries for Spatial Index
-  Files: lib/*.3.dylib
-  Shlibs: <<
-    %p/lib/libspatialindex.3.dylib     4.0.0 %n (>= 1.8.0-1)
-    %p/lib/libspatialindex_c.3.dylib   4.0.0 %n (>= 1.8.0-1)
+  Package: libspatialindex3
+  Description: Headers for Spatial Index
+  Depends: %N (= %v-%r)
+  Conflicts: <<
+    libspatialindex2,
+    libspatialindex4
+  <<
+  Replaces: <<
+    libspatialindex2,
+    libspatialindex4
+  <<
+  BuildDependsOnly: True
+  Files: <<
+    include
+    lib/libspatialindex.{a,dylib,la}
+    lib/libspatialindex_c.{a,dylib,la}
+    lib/pkgconfig
   <<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex3-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex3-shlibs.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: libspatialindex3-shlibs
 
 Version: 1.8.0
-Revision: 4
+Revision: 5
 Description: Libraries for Spatial Index
 License: BSD
 Homepage: http://libspatialindex.github.com
@@ -42,6 +42,7 @@ PatchScript: <<
 
 # Compile Phase.
 GCC: 4.0
+ConfigureParams: --disable-static
 CompileScript: <<
   %{default_script}
   fink-package-precedence --prohibit-bdep=libspatialindex3 .
@@ -71,8 +72,8 @@ SplitOff: <<
   BuildDependsOnly: True
   Files: <<
     include
-    lib/libspatialindex.{a,dylib,la}
-    lib/libspatialindex_c.{a,dylib,la}
+    lib/libspatialindex.{dylib,la}
+    lib/libspatialindex_c.{dylib,la}
     lib/pkgconfig
   <<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex3-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex3-shlibs.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: libspatialindex3-shlibs
 
 Version: 1.8.0
-Revision: 6
+Revision: 7
 Description: Libraries for Spatial Index
 License: BSD
 Homepage: http://libspatialindex.github.com
@@ -57,6 +57,7 @@ InstallScript: <<
   rm -rf %i/lib/libspatialindex_c.{dylib,la}
   rm -rf %i/lib/pkgconfig
 <<
+DocFiles: AUTHORS ChangeLog COPYING README
 
 Shlibs: <<
   %p/lib/libspatialindex.3.dylib     4.0.0 %n (>= 1.8.0-1)

--- a/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex3-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex3-shlibs.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: libspatialindex3-shlibs
 
 Version: 1.8.0
-Revision: 5
+Revision: 6
 Description: Libraries for Spatial Index
 License: BSD
 Homepage: http://libspatialindex.github.com
@@ -29,6 +29,8 @@ The purpose of this library is to provide:
 <<
 
 # Dependencies.
+Conflicts: libspatialindex3 (<< 1.8.0-6)
+Replaces: libspatialindex3 (<< 1.8.0-6)
 BuildDepends: fink-package-precedence
 
 # Unpack Phase.
@@ -50,32 +52,15 @@ CompileScript: <<
 InstallScript: <<
 #!/bin/bash -ev
   make install DESTDIR=%d
+  rm -rf %i/include
+  rm -rf %i/lib/libspatialindex.{dylib,la}
+  rm -rf %i/lib/libspatialindex_c.{dylib,la}
+  rm -rf %i/lib/pkgconfig
 <<
 
 Shlibs: <<
   %p/lib/libspatialindex.3.dylib     4.0.0 %n (>= 1.8.0-1)
   %p/lib/libspatialindex_c.3.dylib   4.0.0 %n (>= 1.8.0-1)
-<<
-
-SplitOff: <<
-  Package: libspatialindex3
-  Description: Headers for Spatial Index
-  Depends: %N (= %v-%r)
-  Conflicts: <<
-    libspatialindex2,
-    libspatialindex4
-  <<
-  Replaces: <<
-    libspatialindex2,
-    libspatialindex4
-  <<
-  BuildDependsOnly: True
-  Files: <<
-    include
-    lib/libspatialindex.{dylib,la}
-    lib/libspatialindex_c.{dylib,la}
-    lib/pkgconfig
-  <<
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex4-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex4-shlibs.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: libspatialindex4-shlibs
 
 Version: 1.8.5
-Revision: 3
+Revision: 4
 Description: Libraries for Spatial Index
 License: BSD
 Homepage: http://libspatialindex.github.com
@@ -46,6 +46,7 @@ InstallScript: <<
 #!/bin/bash -ev
   make install DESTDIR=%d
 <<
+DocFiles: AUTHORS ChangeLog COPYING README
 
 Shlibs: <<
   %p/lib/libspatialindex.4.dylib     5.0.0 %n (>= 1.8.5-1)
@@ -71,6 +72,7 @@ SplitOff: <<
     lib/libspatialindex_c.{dylib,la}
     lib/pkgconfig
   <<
-<<
+  DocFiles: AUTHORS ChangeLog COPYING README
+  <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex4-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex4-shlibs.info
@@ -3,7 +3,7 @@ Info2: <<
 Package: libspatialindex4-shlibs
 
 Version: 1.8.5
-Revision: 2
+Revision: 3
 Description: Libraries for Spatial Index
 License: BSD
 Homepage: http://libspatialindex.github.com
@@ -37,6 +37,7 @@ Source-MD5: 3303c47fd85aa17e64ef52ebec212762
 
 # Compile Phase.
 GCC: 4.0
+ConfigureParams: --disable-static
 CompileScript: <<
   %{default_script}
   fink-package-precedence --prohibit-bdep=libspatialindex4 .
@@ -66,8 +67,8 @@ SplitOff: <<
   BuildDependsOnly: True
   Files: <<
     include
-    lib/libspatialindex.{a,dylib,la}
-    lib/libspatialindex_c.{a,dylib,la}
+    lib/libspatialindex.{dylib,la}
+    lib/libspatialindex_c.{dylib,la}
     lib/pkgconfig
   <<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex4-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libspatialindex4-shlibs.info
@@ -1,11 +1,10 @@
 Info2: <<
 
-Package: libspatialindex4
-BuildDependsOnly: True
+Package: libspatialindex4-shlibs
 
 Version: 1.8.5
 Revision: 2
-Description: Headers for Spatial Index
+Description: Libraries for Spatial Index
 License: BSD
 Homepage: http://libspatialindex.github.com
 Maintainer: BABA Yoshihiko <babayoshihiko@mac.com>
@@ -30,10 +29,7 @@ The purpose of this library is to provide:
 <<
 
 # Dependencies.
-Depends: %n-shlibs (= %v-%r)
 BuildDepends: fink-package-precedence
-Conflicts: libspatialindex2, libspatialindex3
-Replaces: libspatialindex2, libspatialindex3
 
 # Unpack Phase.
 Source: http://download.osgeo.org/libspatialindex/spatialindex-src-%v.tar.bz2
@@ -43,20 +39,36 @@ Source-MD5: 3303c47fd85aa17e64ef52ebec212762
 GCC: 4.0
 CompileScript: <<
   %{default_script}
-  fink-package-precedence --prohibit-bdep=%n .
+  fink-package-precedence --prohibit-bdep=libspatialindex4 .
 <<
 InstallScript: <<
 #!/bin/bash -ev
   make install DESTDIR=%d
 <<
 
+Shlibs: <<
+  %p/lib/libspatialindex.4.dylib     5.0.0 %n (>= 1.8.5-1)
+  %p/lib/libspatialindex_c.4.dylib   5.0.0 %n (>= 1.8.5-1)
+<<
+
 SplitOff: <<
-  Package: %N-shlibs
-  Description: Libraries for Spatial Index
-  Files: lib/*.4.dylib
-  Shlibs: <<
-    %p/lib/libspatialindex.4.dylib     5.0.0 %n (>= 1.8.5-1)
-    %p/lib/libspatialindex_c.4.dylib   5.0.0 %n (>= 1.8.5-1)
+  Package: libspatialindex4
+  Description: Headers for Spatial Index
+  Depends: %N (= %v-%r)
+  Conflicts: <<
+    libspatialindex2,
+    libspatialindex3
+  <<
+  Replaces: <<
+    libspatialindex2,
+    libspatialindex3
+  <<
+  BuildDependsOnly: True
+  Files: <<
+    include
+    lib/libspatialindex.{a,dylib,la}
+    lib/libspatialindex_c.{a,dylib,la}
+    lib/pkgconfig
   <<
 <<
 


### PR DESCRIPTION
Scrap the BDO packages of unused old libversions (retain -shlibs per policy), turn off static libs, and misc packaging cleanups.

@babayoshihiko, these are yours.