### PR TITLE
Geos upgrades

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/shapely-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/shapely-py.info
@@ -1,35 +1,40 @@
 Info2: <<
 Package: shapely-py%type_pkg[python]
-Version: 1.5.8
+Version: 1.6.4.post1
 Revision: 1
 Homepage: https://pypi.python.org/pypi/Shapely
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 Type: python (2.7 3.4 3.5)
-Depends: python%type_pkg[python], libgeos3.4.2-shlibs (>= 3.4.2-1)
+Depends: <<
+  libgeos3.6.1-shlibs,
+  numpy-py%type_pkg[python],
+  python%type_pkg[python]
+<<
 
-BuildDepends: setuptools-tng-py%type_pkg[python], libgeos3.4.2
+BuildDepends: setuptools-tng-py%type_pkg[python], libgeos3.6.1
 
 # Unpack Phase.
-Source: http://pypi.python.org/packages/source/S/Shapely/Shapely-%v.tar.gz
-Source-MD5: e9c57f84ce080ec87e60c398536ea5c4
+#Source: http://pypi.python.org/packages/source/S/Shapely/Shapely-%v.tar.gz
+Source: https://files.pythonhosted.org/packages/7d/3c/0f09841db07aabf9cc387662be646f181d07ed196e6f60ce8be5f4a8f0bd/Shapely-%v.tar.gz
+Source-MD5: 00a5c44b3ad33f5c5bef14031393b23a
 
 # FIX: keep working towards a better solution to let ctypes packages find their libs
 PatchScript: <<
   #!/bin/bash -ev
-  perl -pi -e 's|/Library/Frameworks/GEOS.framework/Versions/Current/GEOS|%p/opt/libgeos3.4.2/lib/libgeos_c.1.dylib|g' shapely/geos.py
+  perl -pi -e 's|/Library/Frameworks/GEOS.framework/Versions/Current/GEOS|%p/opt/libgeos3.6.1/lib/libgeos_c.1.dylib|g' shapely/geos.py
 <<
 
-SetCPPFLAGS: -I%p/opt/libgeos3.4.2/include
-SetLDFLAGS: -L%p/opt/libgeos3.4.2/lib
-
 CompileScript: <<
-  python%type_raw[python] setup.py build 
+  #!/bin/bash -ev
+  export GEOS_CONFIG=%p/opt/libgeos3.6.1/bin/geos-config
+  python%type_raw[python] setup.py build
 <<
 
 InstallScript: <<
   #!/bin/bash -ev
+  export GEOS_CONFIG=%p/opt/libgeos3.6.1/bin/geos-config
   python%type_raw[python] setup.py install --root=%d
-  rm -r %i/shapely
+  # rm -r %i/shapely
   # rm %i/shapely/_geos.pxi
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/web/django-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/django-py.info
@@ -1,26 +1,31 @@
 Info2: <<
 Package: django-py%type_pkg[python]
+# 1.11.x is last release series to support python27
 Type: python (2.7 3.4 3.5)
-Version: 1.9.1
+Version: 1.11.13
 Revision: 1
 
 Depends: <<
-  python%type_pkg[python], docutils-py%type_pkg[python]
+  bcrypt-py%type_pkg[python],
+  docutils-py%type_pkg[python],
+  python%type_pkg[python],
+  pytz-py%type_pkg[python]
 <<
 BuildDepends: setuptools-tng-py%type_pkg[python]
 
 #  mysql-python-py%type_pkg[python]
 Recommends: psycopg2-py%type_pkg[python], yaml-py%type_pkg[python]
 
-Source: https://pypi.python.org/packages/source/D/Django/Django-%v.tar.gz
-Source-MD5: 02754aa2d5c9c171dfc3f9422b20e12c
+#Source: https://pypi.python.org/packages/source/D/Django/Django-%v.tar.gz
+Source: https://www.djangoproject.com/m/releases/1.11/Django-%v.tar.gz
+Source-MD5: ebdac613143ebdca911d5cef326fdc53
 
 DocFiles: AUTHORS INSTALL LICENSE README.rst docs
 
 PatchScript: <<
   #!/bin/bash -ev
   perl -pi -e "s|'geos_c'|'libgeos_c.1.dylib'|g" django/contrib/gis/geos/libgeos.py
-  perl -pi -e "s|lib_path = None|lib_path = '%p/opt/libgeos3.4.2/lib/libgeos_c.1.dylib'|g" django/contrib/gis/geos/libgeos.py
+  perl -pi -e "s|lib_path = None|lib_path = '%p/opt/libgeos3.5.0/lib/libgeos_c.1.dylib'|g" django/contrib/gis/geos/libgeos.py
   perl -pi -e "s|lib_path = None|lib_path = '%p/lib/libgdal.1.dylib'|g" django/contrib/gis/gdal/libgdal.py
 <<
 
@@ -44,7 +49,13 @@ SplitOff: <<
   Description: GIS/geo contrib application for django
   # FIX: bring these back when mysql lands in 10.7
   # gdal-mysql-shlibs| gdal-pgsql-mysql-shlibs
-  Depends: libgeos3.4.2-shlibs, django-py%type_pkg[python], gdal-shlibs | gdal-pgsql-shlibs 
+  # See docs/ref/contrib/gis/install/geolibs.txt for
+  # information about supported versions
+  Depends: <<
+    django-py%type_pkg[python],
+    gdal-shlibs | gdal-pgsql-shlibs,
+    libgeos3.5.0-shlibs
+  <<
   Files: <<
     lib/python%type_raw[python]/site-packages/django/contrib/gis
     lib/python%type_raw[python]/site-packages/django/contrib/admin/static/admin/img/gis


### PR DESCRIPTION
New versions of django-pyXX and shapely-pyXX and switch their dependencies from geos3.4 to 3.5 or 3.6.