### PR TITLE
Postgresql9x: : update to latest upstream + backport info file changes from pg10

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
@@ -1,8 +1,9 @@
 Info4: <<
-Package: postgresql94
-Version: 9.4.17
+Package: postgresql%type_pkg[postgresql]
+Version: 9.4.18
 Revision: 1
 Epoch: 1
+Type: postgresql 9.4
 Description: PostgreSQL open-source database
 License: BSD
 Maintainer: Wolfgang Fischer <wodev@users.sourceforge.net>
@@ -30,14 +31,12 @@ BuildDepends: <<
 Provides: postgresql-server
 GCC: 4.0
 
-#Source: mirror:postgresql:source/v%v/postgresql-%v.tar.bz2
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 0a08f4078f5e4a54e764f63ad38a6de3
-Source-Checksum: SHA1(706aea600900e5818eaae2ea9ecc008a08da7585)
+Source-MD5: 4032f32af5afb0aa8f78f9a5639c0873
+Source-Checksum: SHA1(ce77a18526dee4ee10a0a14da230de3e9239c751)
 PatchScript: <<
 	#!/bin/sh -ex
-	
-	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|9.4|g' < %{PatchFile} | patch -p1
+	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
 	
 	# If we have fink ExtUtils::ParseXS, it is early in PERL5LIB;
 	# therefore we need the xsubpp program (also part of that
@@ -60,7 +59,7 @@ CompileScript: <<
 	export FLEX=/usr/bin/flex	
 
 	./configure \
-	--prefix='%p/opt/postgresql-9.4' \
+	--prefix='%p/opt/postgresql-%type_raw[postgresql]' \
 	--docdir='%p/share/doc/%N' \
 	--mandir='${prefix}/share/man' \
 	--infodir='${prefix}/share/info' \
@@ -81,7 +80,6 @@ CompileScript: <<
 	--with-libxml \
 	--with-libxslt
 	
-	perl -pi -e 's,-arch x86_64,,g; s,-arch i386,,g; s,-arch ppc,,g' src/Makefile.global
 	make
 	make -C contrib
 <<
@@ -92,29 +90,32 @@ InstallScript: <<
 #!/bin/sh -xe
 
 	# postgresql
-	make -j1 install DESTDIR="%d" BE_DLLLIBS=%p/opt/postgresql-9.4/bin/postgres
-	make -j1 -C contrib install DESTDIR="%d" BE_DLLLIBS=%p/opt/postgresql-9.4/bin/postgres
+	make -j1 install DESTDIR="%d" BE_DLLLIBS=%p/opt/postgresql-%type_raw[postgresql]/bin/postgres
+	make -j1 -C contrib install DESTDIR="%d" BE_DLLLIBS=%p/opt/postgresql-%type_raw[postgresql]/bin/postgres
 
         # remove static lib files
-	rm %i/opt/postgresql-9.4/lib/*.a
+	rm %i/opt/postgresql-%type_raw[postgresql]/lib/*.a
 
 	install -d -m 755 %i/share/doc/%N
 	find contrib -name README.\* -exec cp {} %i/share/doc/%N/ \;
 
 	install -d -m 755 %i/bin
-	install -c -m 755 pgsql.sh %i/bin/pgsql.sh-9.4
+	install -c -m 755 pgsql.sh %i/bin/pgsql.sh-%type_raw[postgresql]
 
-	install -d -m 755 %i/var/postgresql-9.4
-	echo "be sure to back up this database before any upgrades!" >> %i/var/postgresql-9.4/README
+	install -d -m 755 %i/var/postgresql-%type_raw[postgresql]
+	echo "be sure to back up this database before any upgrades!" >> %i/var/postgresql-%type_raw[postgresql]/README
 
 	install -d -m 755 %i/var/log
-	ln -sf %p/var/postgresql-9.4/pgsql.log %i/var/log/pgsql-9.4.log
+	ln -sf %p/var/postgresql-%type_raw[postgresql]/pgsql.log %i/var/log/pgsql-%type_raw[postgresql].log
 
-	for file in `ls -1 %i/opt/postgresql-9.4/bin/`; do
-		echo "${file}" >> %i/var/postgresql-9.4/binary.list
+	for file in `ls -1 %i/opt/postgresql-%type_raw[postgresql]/bin/`; do
+		echo "${file}" >> %i/var/postgresql-%type_raw[postgresql]/binary.list
 	done
 
-	cat <<END > %i/var/postgresql-9.4/remove-alternatives.sh
+        # update alternatives priority
+	PRIORITY=`perl -e 'print %type_raw[postgresql] * 10'`
+
+	cat <<END > %i/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh
 #!/bin/sh
 
 for arg in "\$@"; do
@@ -133,20 +134,20 @@ for arg in "\$@"; do
 	esac
 done
 
-update-alternatives --remove "pgsql.sh" "%p/bin/pgsql.sh-9.4"
+update-alternatives --remove "pgsql.sh" "%p/bin/pgsql.sh-%type_raw[postgresql]"
 
-for tuple in %p/opt/postgresql-9.4/bin:binary.list; do
+for tuple in %p/opt/postgresql-%type_raw[postgresql]/bin:binary.list; do
 	TUPLE_PATH=\`echo \$tuple | cut -d: -f1\`
 	TUPLE_FILE=\`echo \$tuple | cut -d: -f2\`
 
-	for file in \`cat %p/var/postgresql-9.4/\${TUPLE_FILE}\`; do
+	for file in \`cat %p/var/postgresql-%type_raw[postgresql]/\${TUPLE_FILE}\`; do
 		update-alternatives --remove "\${file}" "\${TUPLE_PATH}/\${file}"
 	done
 done
 
 END
 
-	cat <<END > %i/var/postgresql-9.4/update-alternatives.sh
+	cat <<END > %i/var/postgresql-%type_raw[postgresql]/update-alternatives.sh
 #!/bin/sh
 
 FORCE=0
@@ -157,13 +158,13 @@ for arg in "\$@"; do
 			echo "usage: \$0 [-h] [-f]"
 			echo ""
 			echo "  -h, --help          this help"
-#			echo "  -f, --force         force this version of PostgreSQL, even if there is a newer one"
+			echo "  -f, --force         force this version of PostgreSQL, even if there is a newer one"
 			echo ""
 			exit 0;
 			;;
-#		-f|--f|--fo|--for|--forc|--force)
-#			FORCE=1
-#			;;
+		-f|--f|--fo|--for|--forc|--force)
+			FORCE=1
+			;;
 		*)
 			echo "\$0: unknown argument '\$arg'"
 			exit 1;
@@ -171,29 +172,35 @@ for arg in "\$@"; do
 	esac
 done
 
-update-alternatives --install "%p/bin/pgsql.sh" "pgsql.sh" "%p/bin/pgsql.sh-9.4" 94
+update-alternatives --install "%p/bin/pgsql.sh" "pgsql.sh" "%p/bin/pgsql.sh-%type_raw[postgresql]" $PRIORITY
+if [ "\$FORCE" == "1" ]; then
+    update-alternatives --set "pgsql.sh" "%p/bin/pgsql.sh-%type_raw[postgresql]" 
+fi
 
 for tuple in bin:binary.list; do
 	TUPLE_PATH=\`echo \$tuple | cut -d: -f1\`
 	TUPLE_FILE=\`echo \$tuple | cut -d: -f2\`
 
-	for file in \`cat %p/var/postgresql-9.4/\${TUPLE_FILE}\`; do
-		if [ -e "%p/opt/postgresql-9.4/\${TUPLE_PATH}/\${file}" ]; then
-			#echo update-alternatives --install "%p/\${TUPLE_PATH}/\${file}" "\${file}" "%p/opt/postgresql-9.4/\${TUPLE_PATH}/\${file}" 94
-			update-alternatives --install "%p/\${TUPLE_PATH}/\${file}" "\${file}" "%p/opt/postgresql-9.4/\${TUPLE_PATH}/\${file}" 94
+	for file in \`cat %p/var/postgresql-%type_raw[postgresql]/\${TUPLE_FILE}\`; do
+		if [ -e "%p/opt/postgresql-%type_raw[postgresql]/\${TUPLE_PATH}/\${file}" ]; then
+			update-alternatives --install "%p/\${TUPLE_PATH}/\${file}" "\${file}" "%p/opt/postgresql-%type_raw[postgresql]/\${TUPLE_PATH}/\${file}" $PRIORITY
+			if [ "\$FORCE" == "1" ]; then
+    			    update-alternatives --set "\${file}" "%p/opt/postgresql-%type_raw[postgresql]/\${TUPLE_PATH}/\${file}"
+			fi
 		fi
 	done
 done
 
 END
 
-	chmod 755 %i/var/postgresql-9.4/*.sh
+	chmod 755 %i/var/postgresql-%type_raw[postgresql]/*.sh
+	perl -pi -e 's,^%d,,' %i/bin/pg_config*
 <<
 DocFiles: COPYRIGHT HISTORY INSTALL README
 SplitOff: <<
 	Package: %N-dev
 	Description: PostgreSQL development headers and libraries
-	Depends: %N (>= 1:%v-%r)
+	Depends: %N (>= %v-%r)
 	# Even though the files are all buried to prevent filename
 	# collisions and require special -I/-L to make them visible,
 	# update-alternatives exposes them (and therefore maybe *other
@@ -217,12 +224,12 @@ SplitOff: <<
 	<<
 	BuildDependsOnly: true
 	Files: <<
-		opt/postgresql-9.4/bin/pg_config*
-		opt/postgresql-9.4/include
-		opt/postgresql-9.4/lib/libecpg_compat.dylib
-		opt/postgresql-9.4/lib/libecpg.dylib
-		opt/postgresql-9.4/lib/libpgtypes.dylib
-		opt/postgresql-9.4/lib/libpq.dylib
+		opt/postgresql-%type_raw[postgresql]/bin/pg_config*
+		opt/postgresql-%type_raw[postgresql]/include
+		opt/postgresql-%type_raw[postgresql]/lib/libecpg_compat.dylib
+		opt/postgresql-%type_raw[postgresql]/lib/libecpg.dylib
+		opt/postgresql-%type_raw[postgresql]/lib/libpgtypes.dylib
+		opt/postgresql-%type_raw[postgresql]/lib/libpq.dylib
 	<<
 	PreInstScript: <<
 PG_ID=`id -u postgres 2>/dev/null || true`
@@ -233,98 +240,49 @@ if [ -z "$PG_ID" ]; then
 	exit 1
 fi
 	<<
-	PostInstScript: [ -x %p/var/postgresql-9.4/update-alternatives.sh ] && %p/var/postgresql-9.4/update-alternatives.sh
-	PreRmScript: if [ "$1" != "upgrade" ]; then [ -x %p/var/postgresql-9.4/remove-alternatives.sh ] && %p/var/postgresql-9.4/remove-alternatives.sh; fi
+	PostInstScript: [ -x %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh
+	PreRmScript: if [ "$1" != "upgrade" ]; then [ -x %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh; fi
 <<
 SplitOff2: <<
 	Package: %N-shlibs
 	Description: PostgreSQL shared libraries
 	Depends: openssl110-shlibs
 	Files: <<
-		opt/postgresql-9.4/lib/lib*.*.dylib
-		var/postgresql-9.4/*.sh
-		var/postgresql-9.4/*.list
+		opt/postgresql-%type_raw[postgresql]/lib/lib*.*.dylib
+		var/postgresql-%type_raw[postgresql]/*.sh
+		var/postgresql-%type_raw[postgresql]/*.list
 	<<
 	Shlibs: <<
-		%p/opt/postgresql-9.4/lib/libecpg.6.dylib        6.0.0 postgresql94-shlibs (>= 9.4.0-1)
-		%p/opt/postgresql-9.4/lib/libecpg_compat.3.dylib 3.0.0 postgresql94-shlibs (>= 9.4.0-1)
-		%p/opt/postgresql-9.4/lib/libpgtypes.3.dylib     3.0.0 postgresql94-shlibs (>= 9.4.0-1)
-		%p/opt/postgresql-9.4/lib/libpq.5.dylib          5.0.0 postgresql94-shlibs (>= 9.4.0-1)
+		%p/opt/postgresql-%type_raw[postgresql]/lib/libecpg.6.dylib        6.0.0 postgresql%type_pkg[postgresql]-shlibs (>= 9.4.0-1)
+		%p/opt/postgresql-%type_raw[postgresql]/lib/libecpg_compat.3.dylib 3.0.0 postgresql%type_pkg[postgresql]-shlibs (>= 9.4.0-1)
+		%p/opt/postgresql-%type_raw[postgresql]/lib/libpgtypes.3.dylib     3.0.0 postgresql%type_pkg[postgresql]-shlibs (>= 9.4.0-1)
+		%p/opt/postgresql-%type_raw[postgresql]/lib/libpq.5.dylib          5.0.0 postgresql%type_pkg[postgresql]-shlibs (>= 9.4.0-1)
 	<<
-	PostInstScript: [ -x %p/var/postgresql-9.4/update-alternatives.sh ] && %p/var/postgresql-9.4/update-alternatives.sh
-	PreRmScript: if [ "$1" != "upgrade" ]; then [ -x %p/var/postgresql-9.4/remove-alternatives.sh ] && %p/var/postgresql-9.4/remove-alternatives.sh; fi
+	PostInstScript: [ -x %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh
+	PreRmScript: if [ "$1" != "upgrade" ]; then [ -x %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh; fi
 <<
 
 PreInstScript: <<
-PG_ID=`id -u postgres 2>/dev/null || true`
-if [ -z "$PG_ID" ]; then
+   PG_ID=`id -u postgres 2>/dev/null || true`
+   if [ -z "$PG_ID" ]; then
 	echo "Whoa there!  You must have a postgres user to install this package."
 	echo "Please do a 'fink reinstall passwd-postgres' and make sure you hit"
 	echo "'y' when it asks if you want to update your users."
 	exit 1
-fi
+   fi
 <<
 PostInstScript: <<
-INSTALL_PHASE="$1"
-
-[ -x %p/var/postgresql-9.4/update-alternatives.sh ] && %p/var/postgresql-9.4/update-alternatives.sh
-
-# remove the old "pgsql" entries from netinfo; the username was switched to
-# "postgres" but the old ones hang around because of the way niload works
-niutil -destroy . /users/pgsql  >/dev/null 2>&1 || true
-niutil -destroy . /groups/pgsql >/dev/null 2>&1 || true
-
-die () {
-	echo "failed"
-	echo ""
-	echo "*** bailing because an error ocurred:"
-	echo ""
-	echo "$*"
-	exit 1
-}
-
-# update daemonic init script if necessary
-daemonic install %N >/dev/null 2>&1 || :
-
-# get a nice port to run on
-while true; do
-	PGPORT=$RANDOM;
-	if [ "$PGPORT" -gt 10000 ] && [ "$PGPORT" -lt 20000 ]; then
-		break
-	fi
-done
-export PGPORT
-echo "- starting PostgreSQL on port $PGPORT"
-if %p/bin/pgsql.sh-9.4 start >/tmp/pgstart-9.4.log 2>&1; then
-
-	sleep 5
-
-	ERROR=0
-	# install the plpgsql language if possible
-	printf -- "- attempting to install the plpgsql language in the template1 database... "
-
-	%p/bin/pgsql.sh-9.4 stop >/dev/null 2>&1 || echo "WARNING: unable to stop postgresql: run 'PGPORT=$PGPORT sudo %p/bin/pgsql.sh-9.4 stop' to try again"
-
-else
-
-	cat <<END
-WARNING: unable to start postgresql on an alternate port, not installing plpgsql!
-
-	If you wish to install it manually, run:
-
-		sudo %p/bin/pgsql.sh-9.4 start
-		sudo -u postgres %p/opt/postgresql-9.4/bin/createlang plpgsql template1
-	
-END
-
-fi
+   INSTALL_PHASE="$1"
+   [ -x %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh
+   # update daemonic init script if necessary
+   daemonic install %N >/dev/null 2>&1 || :
 <<
 PreRmScript: <<
-# clean up
-if [ $1 != "upgrade" ]; then
-	[ -x %p/var/postgresql-9.4/remove-alternatives.sh ] && %p/var/postgresql-9.4/remove-alternatives.sh
+   # clean up
+   if [ $1 != "upgrade" ]; then
+	[ -x %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh
 	daemonic remove %N >/dev/null 2>&1 || :
-fi
+   fi
 <<
 DaemonicFile: <<
 <service>
@@ -332,7 +290,7 @@ DaemonicFile: <<
 <message> PostgreSQL database server</message>
 
 <daemon name="%N">
-	<executable background="no">%p/bin/pgsql.sh-9.4</executable>
+	<executable background="no">%p/bin/pgsql.sh-%type_raw[postgresql]</executable>
 	<parameters>start</parameters>
 </daemon>
 
@@ -355,16 +313,15 @@ password, and then run the command as the postgres user.
 
 For example, to create a new database, you would run:
 
-  sudo -u postgres %p/opt/postgresql-9.4/bin/createdb mydb
+  sudo -u postgres %p/opt/postgresql-%type_raw[postgresql]/bin/createdb mydb
 <<
 DescPackaging: <<
 When run from the startup script, logs output to 
-<prefix>/var/postgresql-9.4/pgsql.log
+<prefix>/var/postgresql-%type_raw[postgresql]/pgsql.log
 <<
 DescPort: <<
 Rearranged a lot of the PostgreSQL build to be more "correct" on
-Darwin, including making proper dylibs (instead of bundles, which
-ended up creating static binaries).
+Darwin.
 <<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
@@ -200,7 +200,7 @@ DocFiles: COPYRIGHT HISTORY INSTALL README
 SplitOff: <<
 	Package: %N-dev
 	Description: PostgreSQL development headers and libraries
-	Depends: %N (>= %v-%r)
+	Depends: %N (>= 1:%v-%r)
 	# Even though the files are all buried to prevent filename
 	# collisions and require special -I/-L to make them visible,
 	# update-alternatives exposes them (and therefore maybe *other

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
@@ -1,8 +1,9 @@
 Info4: <<
-Package: postgresql95
-Version: 9.5.12
+Package: postgresql%type_pkg[postgresql]
+Version: 9.5.13
 Revision: 1
 Epoch: 1
+Type: postgresql 9.5
 Description: PostgreSQL open-source database
 License: BSD
 Maintainer: Wolfgang Fischer <wodev@users.sourceforge.net>
@@ -31,12 +32,11 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 184b8704d1e22764e4ea250d74dfde2f
-Source-Checksum: SHA1(5c135e82e6056735dd94c66c24e3822b629769b7)
+Source-MD5: 09287b1b863020fd1cf6833b6786896e
+Source-Checksum: SHA1(c1c9885b578224995f3663a17b1c3ab3bb7bef13)
 PatchScript: <<
 	#!/bin/sh -ex
-	
-	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|9.5|g' < %{PatchFile} | patch -p1
+	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
 	
 	# If we have fink ExtUtils::ParseXS, it is early in PERL5LIB;
 	# therefore we need the xsubpp program (also part of that
@@ -59,7 +59,7 @@ CompileScript: <<
 	export FLEX=/usr/bin/flex	
 
 	./configure \
-	--prefix='%p/opt/postgresql-9.5' \
+	--prefix='%p/opt/postgresql-%type_raw[postgresql]' \
 	--docdir='%p/share/doc/%N' \
 	--mandir='${prefix}/share/man' \
 	--infodir='${prefix}/share/info' \
@@ -90,29 +90,32 @@ InstallScript: <<
 #!/bin/sh -xe
 
 	# postgresql
-	make -j1 install DESTDIR="%d" BE_DLLLIBS=%p/opt/postgresql-9.5/bin/postgres
-	make -j1 -C contrib install DESTDIR="%d" BE_DLLLIBS=%p/opt/postgresql-9.5/bin/postgres
+	make -j1 install DESTDIR="%d" BE_DLLLIBS=%p/opt/postgresql-%type_raw[postgresql]/bin/postgres
+	make -j1 -C contrib install DESTDIR="%d" BE_DLLLIBS=%p/opt/postgresql-%type_raw[postgresql]/bin/postgres
 
         # remove static lib files
-	rm %i/opt/postgresql-9.5/lib/*.a
+	rm %i/opt/postgresql-%type_raw[postgresql]/lib/*.a
 
 	install -d -m 755 %i/share/doc/%N
 	find contrib -name README.\* -exec cp {} %i/share/doc/%N/ \;
 
 	install -d -m 755 %i/bin
-	install -c -m 755 pgsql.sh %i/bin/pgsql.sh-9.5
+	install -c -m 755 pgsql.sh %i/bin/pgsql.sh-%type_raw[postgresql]
 
-	install -d -m 755 %i/var/postgresql-9.5
-	echo "be sure to back up this database before any upgrades!" >> %i/var/postgresql-9.5/README
+	install -d -m 755 %i/var/postgresql-%type_raw[postgresql]
+	echo "be sure to back up this database before any upgrades!" >> %i/var/postgresql-%type_raw[postgresql]/README
 
 	install -d -m 755 %i/var/log
-	ln -sf %p/var/postgresql-9.5/pgsql.log %i/var/log/pgsql-9.5.log
+	ln -sf %p/var/postgresql-%type_raw[postgresql]/pgsql.log %i/var/log/pgsql-%type_raw[postgresql].log
 
-	for file in `ls -1 %i/opt/postgresql-9.5/bin/`; do
-		echo "${file}" >> %i/var/postgresql-9.5/binary.list
+	for file in `ls -1 %i/opt/postgresql-%type_raw[postgresql]/bin/`; do
+		echo "${file}" >> %i/var/postgresql-%type_raw[postgresql]/binary.list
 	done
 
-	cat <<END > %i/var/postgresql-9.5/remove-alternatives.sh
+        # update alternatives priority
+	PRIORITY=`perl -e 'print %type_raw[postgresql] * 10'`
+
+	cat <<END > %i/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh
 #!/bin/sh
 
 for arg in "\$@"; do
@@ -131,20 +134,20 @@ for arg in "\$@"; do
 	esac
 done
 
-update-alternatives --remove "pgsql.sh" "%p/bin/pgsql.sh-9.5"
+update-alternatives --remove "pgsql.sh" "%p/bin/pgsql.sh-%type_raw[postgresql]"
 
-for tuple in %p/opt/postgresql-9.5/bin:binary.list; do
+for tuple in %p/opt/postgresql-%type_raw[postgresql]/bin:binary.list; do
 	TUPLE_PATH=\`echo \$tuple | cut -d: -f1\`
 	TUPLE_FILE=\`echo \$tuple | cut -d: -f2\`
 
-	for file in \`cat %p/var/postgresql-9.5/\${TUPLE_FILE}\`; do
+	for file in \`cat %p/var/postgresql-%type_raw[postgresql]/\${TUPLE_FILE}\`; do
 		update-alternatives --remove "\${file}" "\${TUPLE_PATH}/\${file}"
 	done
 done
 
 END
 
-	cat <<END > %i/var/postgresql-9.5/update-alternatives.sh
+	cat <<END > %i/var/postgresql-%type_raw[postgresql]/update-alternatives.sh
 #!/bin/sh
 
 FORCE=0
@@ -155,13 +158,13 @@ for arg in "\$@"; do
 			echo "usage: \$0 [-h] [-f]"
 			echo ""
 			echo "  -h, --help          this help"
-#			echo "  -f, --force         force this version of PostgreSQL, even if there is a newer one"
+			echo "  -f, --force         force this version of PostgreSQL, even if there is a newer one"
 			echo ""
 			exit 0;
 			;;
-#		-f|--f|--fo|--for|--forc|--force)
-#			FORCE=1
-#			;;
+		-f|--f|--fo|--for|--forc|--force)
+			FORCE=1
+			;;
 		*)
 			echo "\$0: unknown argument '\$arg'"
 			exit 1;
@@ -169,30 +172,35 @@ for arg in "\$@"; do
 	esac
 done
 
-update-alternatives --install "%p/bin/pgsql.sh" "pgsql.sh" "%p/bin/pgsql.sh-9.5" 95
+update-alternatives --install "%p/bin/pgsql.sh" "pgsql.sh" "%p/bin/pgsql.sh-%type_raw[postgresql]" $PRIORITY
+if [ "\$FORCE" == "1" ]; then
+    update-alternatives --set "pgsql.sh" "%p/bin/pgsql.sh-%type_raw[postgresql]" 
+fi
 
 for tuple in bin:binary.list; do
 	TUPLE_PATH=\`echo \$tuple | cut -d: -f1\`
 	TUPLE_FILE=\`echo \$tuple | cut -d: -f2\`
 
-	for file in \`cat %p/var/postgresql-9.5/\${TUPLE_FILE}\`; do
-		if [ -e "%p/opt/postgresql-9.5/\${TUPLE_PATH}/\${file}" ]; then
-			#echo update-alternatives --install "%p/\${TUPLE_PATH}/\${file}" "\${file}" "%p/opt/postgresql-9.5/\${TUPLE_PATH}/\${file}" 95
-			update-alternatives --install "%p/\${TUPLE_PATH}/\${file}" "\${file}" "%p/opt/postgresql-9.5/\${TUPLE_PATH}/\${file}" 95
+	for file in \`cat %p/var/postgresql-%type_raw[postgresql]/\${TUPLE_FILE}\`; do
+		if [ -e "%p/opt/postgresql-%type_raw[postgresql]/\${TUPLE_PATH}/\${file}" ]; then
+			update-alternatives --install "%p/\${TUPLE_PATH}/\${file}" "\${file}" "%p/opt/postgresql-%type_raw[postgresql]/\${TUPLE_PATH}/\${file}" $PRIORITY
+			if [ "\$FORCE" == "1" ]; then
+    			    update-alternatives --set "\${file}" "%p/opt/postgresql-%type_raw[postgresql]/\${TUPLE_PATH}/\${file}"
+			fi
 		fi
 	done
 done
 
 END
 
-	chmod 755 %i/var/postgresql-9.5/*.sh
+	chmod 755 %i/var/postgresql-%type_raw[postgresql]/*.sh
 	perl -pi -e 's,^%d,,' %i/bin/pg_config*
 <<
 DocFiles: COPYRIGHT HISTORY INSTALL README
 SplitOff: <<
 	Package: %N-dev
 	Description: PostgreSQL development headers and libraries
-	Depends: %N (>= 1:%v-%r)
+	Depends: %N (>= %v-%r)
 	# Even though the files are all buried to prevent filename
 	# collisions and require special -I/-L to make them visible,
 	# update-alternatives exposes them (and therefore maybe *other
@@ -216,12 +224,12 @@ SplitOff: <<
 	<<
 	BuildDependsOnly: true
 	Files: <<
-		opt/postgresql-9.5/bin/pg_config*
-		opt/postgresql-9.5/include
-		opt/postgresql-9.5/lib/libecpg_compat.dylib
-		opt/postgresql-9.5/lib/libecpg.dylib
-		opt/postgresql-9.5/lib/libpgtypes.dylib
-		opt/postgresql-9.5/lib/libpq.dylib
+		opt/postgresql-%type_raw[postgresql]/bin/pg_config*
+		opt/postgresql-%type_raw[postgresql]/include
+		opt/postgresql-%type_raw[postgresql]/lib/libecpg_compat.dylib
+		opt/postgresql-%type_raw[postgresql]/lib/libecpg.dylib
+		opt/postgresql-%type_raw[postgresql]/lib/libpgtypes.dylib
+		opt/postgresql-%type_raw[postgresql]/lib/libpq.dylib
 	<<
 	PreInstScript: <<
 PG_ID=`id -u postgres 2>/dev/null || true`
@@ -232,98 +240,49 @@ if [ -z "$PG_ID" ]; then
 	exit 1
 fi
 	<<
-	PostInstScript: [ -x %p/var/postgresql-9.5/update-alternatives.sh ] && %p/var/postgresql-9.5/update-alternatives.sh
-	PreRmScript: if [ "$1" != "upgrade" ]; then [ -x %p/var/postgresql-9.5/remove-alternatives.sh ] && %p/var/postgresql-9.5/remove-alternatives.sh; fi
+	PostInstScript: [ -x %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh
+	PreRmScript: if [ "$1" != "upgrade" ]; then [ -x %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh; fi
 <<
 SplitOff2: <<
 	Package: %N-shlibs
 	Description: PostgreSQL shared libraries
 	Depends: openssl110-shlibs
 	Files: <<
-		opt/postgresql-9.5/lib/lib*.*.dylib
-		var/postgresql-9.5/*.sh
-		var/postgresql-9.5/*.list
+		opt/postgresql-%type_raw[postgresql]/lib/lib*.*.dylib
+		var/postgresql-%type_raw[postgresql]/*.sh
+		var/postgresql-%type_raw[postgresql]/*.list
 	<<
 	Shlibs: <<
-		%p/opt/postgresql-9.5/lib/libecpg.6.dylib        6.0.0 postgresql95-shlibs (>= 9.5.0-1)
-		%p/opt/postgresql-9.5/lib/libecpg_compat.3.dylib 3.0.0 postgresql95-shlibs (>= 9.5.0-1)
-		%p/opt/postgresql-9.5/lib/libpgtypes.3.dylib     3.0.0 postgresql95-shlibs (>= 9.5.0-1)
-		%p/opt/postgresql-9.5/lib/libpq.5.dylib          5.0.0 postgresql95-shlibs (>= 9.5.0-1)
+		%p/opt/postgresql-%type_raw[postgresql]/lib/libecpg.6.dylib        6.0.0 postgresql%type_pkg[postgresql]-shlibs (>= 9.5.0-1)
+		%p/opt/postgresql-%type_raw[postgresql]/lib/libecpg_compat.3.dylib 3.0.0 postgresql%type_pkg[postgresql]-shlibs (>= 9.5.0-1)
+		%p/opt/postgresql-%type_raw[postgresql]/lib/libpgtypes.3.dylib     3.0.0 postgresql%type_pkg[postgresql]-shlibs (>= 9.5.0-1)
+		%p/opt/postgresql-%type_raw[postgresql]/lib/libpq.5.dylib          5.0.0 postgresql%type_pkg[postgresql]-shlibs (>= 9.5.0-1)
 	<<
-	PostInstScript: [ -x %p/var/postgresql-9.5/update-alternatives.sh ] && %p/var/postgresql-9.5/update-alternatives.sh
-	PreRmScript: if [ "$1" != "upgrade" ]; then [ -x %p/var/postgresql-9.5/remove-alternatives.sh ] && %p/var/postgresql-9.5/remove-alternatives.sh; fi
+	PostInstScript: [ -x %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh
+	PreRmScript: if [ "$1" != "upgrade" ]; then [ -x %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh; fi
 <<
 
 PreInstScript: <<
-PG_ID=`id -u postgres 2>/dev/null || true`
-if [ -z "$PG_ID" ]; then
+   PG_ID=`id -u postgres 2>/dev/null || true`
+   if [ -z "$PG_ID" ]; then
 	echo "Whoa there!  You must have a postgres user to install this package."
 	echo "Please do a 'fink reinstall passwd-postgres' and make sure you hit"
 	echo "'y' when it asks if you want to update your users."
 	exit 1
-fi
+   fi
 <<
 PostInstScript: <<
-INSTALL_PHASE="$1"
-
-[ -x %p/var/postgresql-9.5/update-alternatives.sh ] && %p/var/postgresql-9.5/update-alternatives.sh
-
-# remove the old "pgsql" entries from netinfo; the username was switched to
-# "postgres" but the old ones hang around because of the way niload works
-niutil -destroy . /users/pgsql  >/dev/null 2>&1 || true
-niutil -destroy . /groups/pgsql >/dev/null 2>&1 || true
-
-die () {
-	echo "failed"
-	echo ""
-	echo "*** bailing because an error ocurred:"
-	echo ""
-	echo "$*"
-	exit 1
-}
-
-# update daemonic init script if necessary
-daemonic install %N >/dev/null 2>&1 || :
-
-# get a nice port to run on
-while true; do
-	PGPORT=$RANDOM;
-	if [ "$PGPORT" -gt 10000 ] && [ "$PGPORT" -lt 20000 ]; then
-		break
-	fi
-done
-export PGPORT
-echo "- starting PostgreSQL on port $PGPORT"
-if %p/bin/pgsql.sh-9.5 start >/tmp/pgstart-9.5.log 2>&1; then
-
-	sleep 5
-
-	ERROR=0
-	# install the plpgsql language if possible
-	printf -- "- attempting to install the plpgsql language in the template1 database... "
-
-	%p/bin/pgsql.sh-9.5 stop >/dev/null 2>&1 || echo "WARNING: unable to stop postgresql: run 'PGPORT=$PGPORT sudo %p/bin/pgsql.sh-9.5 stop' to try again"
-
-else
-
-	cat <<END
-WARNING: unable to start postgresql on an alternate port, not installing plpgsql!
-
-	If you wish to install it manually, run:
-
-		sudo %p/bin/pgsql.sh-9.5 start
-		sudo -u postgres %p/opt/postgresql-9.5/bin/createlang plpgsql template1
-	
-END
-
-fi
+   INSTALL_PHASE="$1"
+   [ -x %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh
+   # update daemonic init script if necessary
+   daemonic install %N >/dev/null 2>&1 || :
 <<
 PreRmScript: <<
-# clean up
-if [ $1 != "upgrade" ]; then
-	[ -x %p/var/postgresql-9.5/remove-alternatives.sh ] && %p/var/postgresql-9.5/remove-alternatives.sh
+   # clean up
+   if [ $1 != "upgrade" ]; then
+	[ -x %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh
 	daemonic remove %N >/dev/null 2>&1 || :
-fi
+   fi
 <<
 DaemonicFile: <<
 <service>
@@ -331,7 +290,7 @@ DaemonicFile: <<
 <message> PostgreSQL database server</message>
 
 <daemon name="%N">
-	<executable background="no">%p/bin/pgsql.sh-9.5</executable>
+	<executable background="no">%p/bin/pgsql.sh-%type_raw[postgresql]</executable>
 	<parameters>start</parameters>
 </daemon>
 
@@ -354,16 +313,15 @@ password, and then run the command as the postgres user.
 
 For example, to create a new database, you would run:
 
-  sudo -u postgres %p/opt/postgresql-9.5/bin/createdb mydb
+  sudo -u postgres %p/opt/postgresql-%type_raw[postgresql]/bin/createdb mydb
 <<
 DescPackaging: <<
 When run from the startup script, logs output to 
-<prefix>/var/postgresql-9.5/pgsql.log
+<prefix>/var/postgresql-%type_raw[postgresql]/pgsql.log
 <<
 DescPort: <<
 Rearranged a lot of the PostgreSQL build to be more "correct" on
-Darwin, including making proper dylibs (instead of bundles, which
-ended up creating static binaries).
+Darwin.
 <<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
@@ -200,7 +200,7 @@ DocFiles: COPYRIGHT HISTORY INSTALL README
 SplitOff: <<
 	Package: %N-dev
 	Description: PostgreSQL development headers and libraries
-	Depends: %N (>= %v-%r)
+	Depends: %N (>= 1:%v-%r)
 	# Even though the files are all buried to prevent filename
 	# collisions and require special -I/-L to make them visible,
 	# update-alternatives exposes them (and therefore maybe *other

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
@@ -200,7 +200,7 @@ DocFiles: COPYRIGHT HISTORY INSTALL README
 SplitOff: <<
 	Package: %N-dev
 	Description: PostgreSQL development headers and libraries
-	Depends: %N (>= %v-%r)
+	Depends: %N (>= 1:%v-%r)
 	# Even though the files are all buried to prevent filename
 	# collisions and require special -I/-L to make them visible,
 	# update-alternatives exposes them (and therefore maybe *other

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
@@ -1,8 +1,9 @@
 Info4: <<
-Package: postgresql96
-Version: 9.6.8
+Package: postgresql%type_pkg[postgresql]
+Version: 9.6.9
 Revision: 1
 Epoch: 1
+Type: postgresql 9.6
 Description: PostgreSQL open-source database
 License: BSD
 Maintainer: Wolfgang Fischer <wodev@users.sourceforge.net>
@@ -31,12 +32,11 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 4c907252d166eabe2fc2b5cc3f034583
-Source-Checksum: SHA1(8e610dd8dbaab69982d12324971b0c6b5225142f)
+Source-MD5: 60002b3588dfcb02c284332037a372e9
+Source-Checksum: SHA1(086f440fca02044cc1798be22257dc6bcd437381)
 PatchScript: <<
 	#!/bin/sh -ex
-	
-	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|9.6|g' < %{PatchFile} | patch -p1
+	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
 	
 	# If we have fink ExtUtils::ParseXS, it is early in PERL5LIB;
 	# therefore we need the xsubpp program (also part of that
@@ -59,7 +59,7 @@ CompileScript: <<
 	export FLEX=/usr/bin/flex	
 
 	./configure \
-	--prefix='%p/opt/postgresql-9.6' \
+	--prefix='%p/opt/postgresql-%type_raw[postgresql]' \
 	--docdir='%p/share/doc/%N' \
 	--mandir='${prefix}/share/man' \
 	--infodir='${prefix}/share/info' \
@@ -90,29 +90,32 @@ InstallScript: <<
 #!/bin/sh -xe
 
 	# postgresql
-	make -j1 install DESTDIR="%d" BE_DLLLIBS=%p/opt/postgresql-9.6/bin/postgres
-	make -j1 -C contrib install DESTDIR="%d" BE_DLLLIBS=%p/opt/postgresql-9.6/bin/postgres
+	make -j1 install DESTDIR="%d" BE_DLLLIBS=%p/opt/postgresql-%type_raw[postgresql]/bin/postgres
+	make -j1 -C contrib install DESTDIR="%d" BE_DLLLIBS=%p/opt/postgresql-%type_raw[postgresql]/bin/postgres
 
         # remove static lib files
-	rm %i/opt/postgresql-9.6/lib/*.a
+	rm %i/opt/postgresql-%type_raw[postgresql]/lib/*.a
 
 	install -d -m 755 %i/share/doc/%N
 	find contrib -name README.\* -exec cp {} %i/share/doc/%N/ \;
 
 	install -d -m 755 %i/bin
-	install -c -m 755 pgsql.sh %i/bin/pgsql.sh-9.6
+	install -c -m 755 pgsql.sh %i/bin/pgsql.sh-%type_raw[postgresql]
 
-	install -d -m 755 %i/var/postgresql-9.6
-	echo "be sure to back up this database before any upgrades!" >> %i/var/postgresql-9.6/README
+	install -d -m 755 %i/var/postgresql-%type_raw[postgresql]
+	echo "be sure to back up this database before any upgrades!" >> %i/var/postgresql-%type_raw[postgresql]/README
 
 	install -d -m 755 %i/var/log
-	ln -sf %p/var/postgresql-9.6/pgsql.log %i/var/log/pgsql-9.6.log
+	ln -sf %p/var/postgresql-%type_raw[postgresql]/pgsql.log %i/var/log/pgsql-%type_raw[postgresql].log
 
-	for file in `ls -1 %i/opt/postgresql-9.6/bin/`; do
-		echo "${file}" >> %i/var/postgresql-9.6/binary.list
+	for file in `ls -1 %i/opt/postgresql-%type_raw[postgresql]/bin/`; do
+		echo "${file}" >> %i/var/postgresql-%type_raw[postgresql]/binary.list
 	done
 
-	cat <<END > %i/var/postgresql-9.6/remove-alternatives.sh
+        # update alternatives priority
+	PRIORITY=`perl -e 'print %type_raw[postgresql] * 10'`
+
+	cat <<END > %i/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh
 #!/bin/sh
 
 for arg in "\$@"; do
@@ -131,20 +134,20 @@ for arg in "\$@"; do
 	esac
 done
 
-update-alternatives --remove "pgsql.sh" "%p/bin/pgsql.sh-9.6"
+update-alternatives --remove "pgsql.sh" "%p/bin/pgsql.sh-%type_raw[postgresql]"
 
-for tuple in %p/opt/postgresql-9.6/bin:binary.list; do
+for tuple in %p/opt/postgresql-%type_raw[postgresql]/bin:binary.list; do
 	TUPLE_PATH=\`echo \$tuple | cut -d: -f1\`
 	TUPLE_FILE=\`echo \$tuple | cut -d: -f2\`
 
-	for file in \`cat %p/var/postgresql-9.6/\${TUPLE_FILE}\`; do
+	for file in \`cat %p/var/postgresql-%type_raw[postgresql]/\${TUPLE_FILE}\`; do
 		update-alternatives --remove "\${file}" "\${TUPLE_PATH}/\${file}"
 	done
 done
 
 END
 
-	cat <<END > %i/var/postgresql-9.6/update-alternatives.sh
+	cat <<END > %i/var/postgresql-%type_raw[postgresql]/update-alternatives.sh
 #!/bin/sh
 
 FORCE=0
@@ -155,13 +158,13 @@ for arg in "\$@"; do
 			echo "usage: \$0 [-h] [-f]"
 			echo ""
 			echo "  -h, --help          this help"
-#			echo "  -f, --force         force this version of PostgreSQL, even if there is a newer one"
+			echo "  -f, --force         force this version of PostgreSQL, even if there is a newer one"
 			echo ""
 			exit 0;
 			;;
-#		-f|--f|--fo|--for|--forc|--force)
-#			FORCE=1
-#			;;
+		-f|--f|--fo|--for|--forc|--force)
+			FORCE=1
+			;;
 		*)
 			echo "\$0: unknown argument '\$arg'"
 			exit 1;
@@ -169,30 +172,35 @@ for arg in "\$@"; do
 	esac
 done
 
-update-alternatives --install "%p/bin/pgsql.sh" "pgsql.sh" "%p/bin/pgsql.sh-9.6" 96
+update-alternatives --install "%p/bin/pgsql.sh" "pgsql.sh" "%p/bin/pgsql.sh-%type_raw[postgresql]" $PRIORITY
+if [ "\$FORCE" == "1" ]; then
+    update-alternatives --set "pgsql.sh" "%p/bin/pgsql.sh-%type_raw[postgresql]" 
+fi
 
 for tuple in bin:binary.list; do
 	TUPLE_PATH=\`echo \$tuple | cut -d: -f1\`
 	TUPLE_FILE=\`echo \$tuple | cut -d: -f2\`
 
-	for file in \`cat %p/var/postgresql-9.6/\${TUPLE_FILE}\`; do
-		if [ -e "%p/opt/postgresql-9.6/\${TUPLE_PATH}/\${file}" ]; then
-			#echo update-alternatives --install "%p/\${TUPLE_PATH}/\${file}" "\${file}" "%p/opt/postgresql-9.6/\${TUPLE_PATH}/\${file}" 96
-			update-alternatives --install "%p/\${TUPLE_PATH}/\${file}" "\${file}" "%p/opt/postgresql-9.6/\${TUPLE_PATH}/\${file}" 96
+	for file in \`cat %p/var/postgresql-%type_raw[postgresql]/\${TUPLE_FILE}\`; do
+		if [ -e "%p/opt/postgresql-%type_raw[postgresql]/\${TUPLE_PATH}/\${file}" ]; then
+			update-alternatives --install "%p/\${TUPLE_PATH}/\${file}" "\${file}" "%p/opt/postgresql-%type_raw[postgresql]/\${TUPLE_PATH}/\${file}" $PRIORITY
+			if [ "\$FORCE" == "1" ]; then
+    			    update-alternatives --set "\${file}" "%p/opt/postgresql-%type_raw[postgresql]/\${TUPLE_PATH}/\${file}"
+			fi
 		fi
 	done
 done
 
 END
 
-	chmod 755 %i/var/postgresql-9.6/*.sh
+	chmod 755 %i/var/postgresql-%type_raw[postgresql]/*.sh
 	perl -pi -e 's,^%d,,' %i/bin/pg_config*
 <<
 DocFiles: COPYRIGHT HISTORY INSTALL README
 SplitOff: <<
 	Package: %N-dev
 	Description: PostgreSQL development headers and libraries
-	Depends: %N (>= 1:%v-%r)
+	Depends: %N (>= %v-%r)
 	# Even though the files are all buried to prevent filename
 	# collisions and require special -I/-L to make them visible,
 	# update-alternatives exposes them (and therefore maybe *other
@@ -216,12 +224,12 @@ SplitOff: <<
 	<<
 	BuildDependsOnly: true
 	Files: <<
-		opt/postgresql-9.6/bin/pg_config*
-		opt/postgresql-9.6/include
-		opt/postgresql-9.6/lib/libecpg_compat.dylib
-		opt/postgresql-9.6/lib/libecpg.dylib
-		opt/postgresql-9.6/lib/libpgtypes.dylib
-		opt/postgresql-9.6/lib/libpq.dylib
+		opt/postgresql-%type_raw[postgresql]/bin/pg_config*
+		opt/postgresql-%type_raw[postgresql]/include
+		opt/postgresql-%type_raw[postgresql]/lib/libecpg_compat.dylib
+		opt/postgresql-%type_raw[postgresql]/lib/libecpg.dylib
+		opt/postgresql-%type_raw[postgresql]/lib/libpgtypes.dylib
+		opt/postgresql-%type_raw[postgresql]/lib/libpq.dylib
 	<<
 	PreInstScript: <<
 PG_ID=`id -u postgres 2>/dev/null || true`
@@ -232,98 +240,49 @@ if [ -z "$PG_ID" ]; then
 	exit 1
 fi
 	<<
-	PostInstScript: [ -x %p/var/postgresql-9.6/update-alternatives.sh ] && %p/var/postgresql-9.6/update-alternatives.sh
-	PreRmScript: if [ "$1" != "upgrade" ]; then [ -x %p/var/postgresql-9.6/remove-alternatives.sh ] && %p/var/postgresql-9.6/remove-alternatives.sh; fi
+	PostInstScript: [ -x %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh
+	PreRmScript: if [ "$1" != "upgrade" ]; then [ -x %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh; fi
 <<
 SplitOff2: <<
 	Package: %N-shlibs
 	Description: PostgreSQL shared libraries
 	Depends: openssl110-shlibs
 	Files: <<
-		opt/postgresql-9.6/lib/lib*.*.dylib
-		var/postgresql-9.6/*.sh
-		var/postgresql-9.6/*.list
+		opt/postgresql-%type_raw[postgresql]/lib/lib*.*.dylib
+		var/postgresql-%type_raw[postgresql]/*.sh
+		var/postgresql-%type_raw[postgresql]/*.list
 	<<
 	Shlibs: <<
-		%p/opt/postgresql-9.6/lib/libecpg.6.dylib        6.0.0 postgresql96-shlibs (>= 9.6.0-1)
-		%p/opt/postgresql-9.6/lib/libecpg_compat.3.dylib 3.0.0 postgresql96-shlibs (>= 9.6.0-1)
-		%p/opt/postgresql-9.6/lib/libpgtypes.3.dylib     3.0.0 postgresql96-shlibs (>= 9.6.0-1)
-		%p/opt/postgresql-9.6/lib/libpq.5.dylib          5.0.0 postgresql96-shlibs (>= 9.6.0-1)
+		%p/opt/postgresql-%type_raw[postgresql]/lib/libecpg.6.dylib        6.0.0 postgresql%type_pkg[postgresql]-shlibs (>= 9.6.0-1)
+		%p/opt/postgresql-%type_raw[postgresql]/lib/libecpg_compat.3.dylib 3.0.0 postgresql%type_pkg[postgresql]-shlibs (>= 9.6.0-1)
+		%p/opt/postgresql-%type_raw[postgresql]/lib/libpgtypes.3.dylib     3.0.0 postgresql%type_pkg[postgresql]-shlibs (>= 9.6.0-1)
+		%p/opt/postgresql-%type_raw[postgresql]/lib/libpq.5.dylib          5.0.0 postgresql%type_pkg[postgresql]-shlibs (>= 9.6.0-1)
 	<<
-	PostInstScript: [ -x %p/var/postgresql-9.6/update-alternatives.sh ] && %p/var/postgresql-9.6/update-alternatives.sh
-	PreRmScript: if [ "$1" != "upgrade" ]; then [ -x %p/var/postgresql-9.6/remove-alternatives.sh ] && %p/var/postgresql-9.6/remove-alternatives.sh; fi
+	PostInstScript: [ -x %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh
+	PreRmScript: if [ "$1" != "upgrade" ]; then [ -x %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh; fi
 <<
 
 PreInstScript: <<
-PG_ID=`id -u postgres 2>/dev/null || true`
-if [ -z "$PG_ID" ]; then
+   PG_ID=`id -u postgres 2>/dev/null || true`
+   if [ -z "$PG_ID" ]; then
 	echo "Whoa there!  You must have a postgres user to install this package."
 	echo "Please do a 'fink reinstall passwd-postgres' and make sure you hit"
 	echo "'y' when it asks if you want to update your users."
 	exit 1
-fi
+   fi
 <<
 PostInstScript: <<
-INSTALL_PHASE="$1"
-
-[ -x %p/var/postgresql-9.6/update-alternatives.sh ] && %p/var/postgresql-9.6/update-alternatives.sh
-
-# remove the old "pgsql" entries from netinfo; the username was switched to
-# "postgres" but the old ones hang around because of the way niload works
-niutil -destroy . /users/pgsql  >/dev/null 2>&1 || true
-niutil -destroy . /groups/pgsql >/dev/null 2>&1 || true
-
-die () {
-	echo "failed"
-	echo ""
-	echo "*** bailing because an error ocurred:"
-	echo ""
-	echo "$*"
-	exit 1
-}
-
-# update daemonic init script if necessary
-daemonic install %N >/dev/null 2>&1 || :
-
-# get a nice port to run on
-while true; do
-	PGPORT=$RANDOM;
-	if [ "$PGPORT" -gt 10000 ] && [ "$PGPORT" -lt 20000 ]; then
-		break
-	fi
-done
-export PGPORT
-echo "- starting PostgreSQL on port $PGPORT"
-if %p/bin/pgsql.sh-9.6 start >/tmp/pgstart-9.6.log 2>&1; then
-
-	sleep 5
-
-	ERROR=0
-	# install the plpgsql language if possible
-	printf -- "- attempting to install the plpgsql language in the template1 database... "
-
-	%p/bin/pgsql.sh-9.6 stop >/dev/null 2>&1 || echo "WARNING: unable to stop postgresql: run 'PGPORT=$PGPORT sudo %p/bin/pgsql.sh-9.6 stop' to try again"
-
-else
-
-	cat <<END
-WARNING: unable to start postgresql on an alternate port, not installing plpgsql!
-
-	If you wish to install it manually, run:
-
-		sudo %p/bin/pgsql.sh-9.6 start
-		sudo -u postgres %p/opt/postgresql-9.6/bin/createlang plpgsql template1
-	
-END
-
-fi
+   INSTALL_PHASE="$1"
+   [ -x %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/update-alternatives.sh
+   # update daemonic init script if necessary
+   daemonic install %N >/dev/null 2>&1 || :
 <<
 PreRmScript: <<
-# clean up
-if [ $1 != "upgrade" ]; then
-	[ -x %p/var/postgresql-9.6/remove-alternatives.sh ] && %p/var/postgresql-9.6/remove-alternatives.sh
+   # clean up
+   if [ $1 != "upgrade" ]; then
+	[ -x %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh ] && %p/var/postgresql-%type_raw[postgresql]/remove-alternatives.sh
 	daemonic remove %N >/dev/null 2>&1 || :
-fi
+   fi
 <<
 DaemonicFile: <<
 <service>
@@ -331,7 +290,7 @@ DaemonicFile: <<
 <message> PostgreSQL database server</message>
 
 <daemon name="%N">
-	<executable background="no">%p/bin/pgsql.sh-9.6</executable>
+	<executable background="no">%p/bin/pgsql.sh-%type_raw[postgresql]</executable>
 	<parameters>start</parameters>
 </daemon>
 
@@ -354,16 +313,15 @@ password, and then run the command as the postgres user.
 
 For example, to create a new database, you would run:
 
-  sudo -u postgres %p/opt/postgresql-9.6/bin/createdb mydb
+  sudo -u postgres %p/opt/postgresql-%type_raw[postgresql]/bin/createdb mydb
 <<
 DescPackaging: <<
 When run from the startup script, logs output to 
-<prefix>/var/postgresql-9.6/pgsql.log
+<prefix>/var/postgresql-%type_raw[postgresql]/pgsql.log
 <<
 DescPort: <<
 Rearranged a lot of the PostgreSQL build to be more "correct" on
-Darwin, including making proper dylibs (instead of bundles, which
-ended up creating static binaries).
+Darwin.
 <<
 <<
 


### PR DESCRIPTION
the PR updates the pg 9.x packages to the latest upstream version
postgresql94: Update to 9.4.18 
postgresql96: Update to 9.5.13 
postgresql96: Update to 9.6.9 

and the latest info file changes from pg10 (using a variant to minimize diffs among the version).

All versions testet with fink -m build.