### PR TITLE
psycopg2-py: update to 2.7.4; add python36 variant; switch pg94->pg10

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/psycopg2-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/psycopg2-py.info
@@ -1,50 +1,55 @@
 Info2: <<
 
 Package: psycopg2-py%type_pkg[python]
-Version: 2.5.2
-Revision: 3
+Version: 2.7.4
+Revision: 1
 Description: PostgreSQL database adapter for Python
 License: LGPL
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
-Type: python (2.7 3.4 3.5)
+Type: python (2.7 3.4 3.5 3.6), postgresql (10)
 
-BuildDepends: python%type_pkg[python],  postgresql94-dev (>= 1:0-0)
-Depends: python%type_pkg[python], postgresql94-shlibs 
+BuildDepends: <<
+	python%type_pkg[python],
+	postgresql%type_pkg[postgresql]-dev
+<<
+Depends: <<
+	python%type_pkg[python],
+	postgresql%type_pkg[postgresql]-shlibs 
+<<
+Recommends: postgresql%type_pkg[postgresql], postgis96
 
-Recommends: postgresql94, postgis94
-
-Source-MD5: 53d81793fbab8fee6e732a0425d50047
-Source: http://pypi.python.org/packages/source/p/psycopg2/psycopg2-%v.tar.gz
-
+Source-MD5: 70fc57072e084565a42689d416cf2c5c
+Source-Checksum: SHA256(8bf51191d60f6987482ef0cfe8511bbf4877a5aa7f313d7b488b53189cf26209)
+Source: https://pypi.python.org/packages/source/p/psycopg2/psycopg2-%v.tar.gz
+PatchFile: psycopg2-py.patch
+PatchFile-MD5: 885401f4498e87ae9e8f2b8c6708bed4
+PatchScript: <<
+        patch -p1 < %{PatchFile}
+ <<
 CompileScript: <<
   #!/bin/bash -ev
-  if [ "%type_pkg[python]" -ge "31" ]; then
-    2to3-%type_raw[python] --write --no-diffs .
-  fi
-
   %p/bin/python%type_raw[python] setup.py build
 <<
 
 # Test Phase:
-# Must create role "nobody" or "root" in the database.
-# Also note this can only be run after psycopg2
-# is installed.  Need more magic to run it before.
-# As of September 30, 2006 results are:
-#   Ran 35 tests in 2.196s
-#   FAILED (failures=2, errors=1)
-#   Maintainer Notified.
+# Must create role "fink-bld" in the database.
+# As of May 26, 2018 results are:
+# with max_prepared_transactions = 10 in postgresql.conf 
+# Ran 664 tests in O57.996s
+# OK (skipped=34)
+# phase test: passed
 
 InfoTest: <<
     TestScript: <<
-    	PYTHONPATH=`pwd`/`ls -d build/lib*` %p/bin/python%type_raw[python] tests/test_psycopg2_dbapi20.py || exit 2
+       PYTHONPATH=`pwd`/`ls -d build/lib*` %p/bin/python%type_raw[python] -c "from psycopg2 import tests; tests.unittest.main(defaultTest='tests.test_suite')" --verbose || exit 2
     <<
 <<
 
 #Install Phase:
-DocFiles: AUTHORS INSTALL README NEWS LICENSE
+DocFiles: AUTHORS INSTALL README.rst NEWS LICENSE
 InstallScript: <<
-	rm -f build/lib*/psycopg2/*.pyc
-	%p/bin/python%type_raw[python] setup.py install --prefix=%p --root=%d
+        find . \( -name \*.pyc -or -name __pycache__ \) -exec rm -rf {} +
+	%p/bin/python%type_raw[python] -B setup.py install --prefix=%p --root=%d
 <<
 
 
@@ -69,8 +74,12 @@ DescPackaging: <<
 In order for the -m maintainer tests to work, you need to
 run these two commands first:
 
-  createdb psycopg2_test
-  createuser root
+  sudo -u postgres createuser fink-bld
+  sudo -u postgres createdb psycopg2_test --owner=fink-bld
+
+To aktivate the "Two-Phase Commit" tests, you need to
+set the property "max_prepared_transactions = 10" 
+in postgresql.conf.
 
 No need for python-mx date module.  Now uses built in datetime.
 <<

--- a/10.9-libcxx/stable/main/finkinfo/database/psycopg2-py.patch
+++ b/10.9-libcxx/stable/main/finkinfo/database/psycopg2-py.patch
@@ -1,0 +1,24 @@
+From ef64493b8913e4069c4422ad14da6de405c445f6 Mon Sep 17 00:00:00 2001
+From: Jon Dufresne <jon.dufresne@gmail.com>
+Date: Sun, 3 Dec 2017 18:47:19 -0800
+Subject: [PATCH] Fix use of "async" in test_cursor.py
+
+"async" will be a keyword starting with Python 3.7. On Python 3.6, use
+of "async" causes a deprecation warning. Use the alias "async_" instead.
+---
+ tests/test_cursor.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/test_cursor.py b/tests/test_cursor.py
+index e896ef94..5c94f422 100755
+--- a/tests/test_cursor.py
++++ b/tests/test_cursor.py
+@@ -553,7 +553,7 @@ def test_external_close_async(self):
+         # Issue #443 is in the async code too. Since the fix is duplicated,
+         # so is the test.
+         control_conn = self.conn
+-        connect_func = lambda: self.connect(async=True)
++        connect_func = lambda: self.connect(async_=True)
+         wait_func = psycopg2.extras.wait_select
+         self._test_external_close(control_conn, connect_func, wait_func)
+ 


### PR DESCRIPTION
psycopg2-py update:
- update to latest upstream 2.7.4
- add python 3.6 variant + additional patch for python 3.6 tests
- switch Postgres 9.4 to 10

Package testet "fink -m build" and with python 2.7, 3.4, 3.5 and 3.6 and postgresql server 10
For the -m maintainer tests to work, you need to run these two commands first:

sudo -u postgres createuser fink-bld
sudo -u postgres createdb psycopg2_test --owner=fink-bld

@schwehr please check and approve the psycopg2-py update, thanks.
 