### PR TITLE
Readline update (upstream patchlevel 5)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/readline6.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/readline6.info
@@ -1,12 +1,12 @@
 Info4: <<
 Package: readline6
+# teeny-version is the upstream patchlevel ("x.y.z" is "x.y" pl "z")
 Version: 6.3.8
 Revision: 2
 Maintainer: Fink Core Group <fink-core@lists.sourceforge.net>
 #
 Depends: %n-shlibs (= %v-%r)
 BuildDepends: <<
-	fink (>= 0.24.12),
 	fink-package-precedence,
 	libncurses5 (>= 5.4-20041023-1006)
 <<
@@ -34,10 +34,10 @@ PatchFile: %{ni}.patch
 PatchFile-MD5: ecbe94481b0fa4f530c0a51887653d67
 PatchScript: <<
 #! /bin/sh -ev
-  for file in ../readline63-* ; do
-    patch -p0 < $file
-  done
-  %{default_script}
+	for file in ../readline63-* ; do
+		patch -p0 < $file
+	done
+	%{default_script}
 <<
 SetCPPFLAGS: -MD
 CompileScript: <<
@@ -51,15 +51,20 @@ DocFiles: NEWS CHANGELOG CHANGES COPYING README USAGE
 InfoDocs: history.info readline.info rluserman.info
 BuildDependsOnly: True
 SplitOff: <<
- Package: %N-shlibs
- Depends: libncurses5-shlibs (>= 5.4-20041023-1006)
- Replaces: %N
- Files: %lib/libhistory.6.3.dylib %lib/libreadline.6.3.dylib %lib/libhistory.6.dylib %lib/libreadline.6.dylib
- Shlibs: <<
-   %p/%lib/libhistory.6.dylib 6.3.0 %n (>= 6.3.3-2)
-   %p/%lib/libreadline.6.dylib 6.3.0 %n (>= 6.3.3-2)
- <<
- DocFiles: NEWS CHANGELOG CHANGES COPYING README USAGE
+	Package: %N-shlibs
+	Depends: libncurses5-shlibs (>= 5.4-20041023-1006)
+	Replaces: %N
+	Files: <<
+		%lib/libhistory.6.dylib
+		%lib/libhistory.6.3.dylib
+		%lib/libreadline.6.dylib
+		%lib/libreadline.6.3.dylib
+	<<
+	Shlibs: <<
+		%p/%lib/libhistory.6.dylib 6.3.0 %n (>= 6.3.3-2)
+		%p/%lib/libreadline.6.dylib 6.3.0 %n (>= 6.3.3-2)
+	<<
+	DocFiles: NEWS CHANGELOG CHANGES COPYING README USAGE
 <<
 #
 Description: Comfortable terminal input library

--- a/10.9-libcxx/stable/main/finkinfo/libs/readline7.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/readline7.info
@@ -1,12 +1,12 @@
 Info4: <<
 Package: readline7
+# teeny-version is the upstream patchlevel ("x.y.z" is "x.y" pl "z")
 Version: 7.0.5
 Revision: 1
 Maintainer: Fink Core Group <fink-core@lists.sourceforge.net>
 #
 Depends: %n-shlibs (= %v-%r)
 BuildDepends: <<
-	fink (>= 0.24.12),
 	fink-package-precedence,
 	libncurses5 (>= 5.4-20041023-1006)
 <<
@@ -45,15 +45,20 @@ DocFiles: NEWS CHANGELOG CHANGES COPYING README USAGE
 InfoDocs: history.info readline.info rluserman.info
 BuildDependsOnly: True
 SplitOff: <<
- Package: %N-shlibs
- Depends: libncurses5-shlibs (>= 5.4-20041023-1006)
- Replaces: %N
- Files: %lib/libhistory.7.0.dylib %lib/libreadline.7.0.dylib %lib/libhistory.7.dylib %lib/libreadline.7.dylib
- Shlibs: <<
-   %p/%lib/libhistory.7.dylib 7.0.0 %n (>= 7.0.0-1)
-   %p/%lib/libreadline.7.dylib 7.0.0 %n (>= 7.0.0-1)
- <<
- DocFiles: NEWS CHANGELOG CHANGES COPYING README USAGE
+	Package: %N-shlibs
+	Depends: libncurses5-shlibs (>= 5.4-20041023-1006)
+	Replaces: %N
+	Files: <<
+		%lib/libhistory.7.dylib
+		%lib/libhistory.7.0.dylib
+		%lib/libreadline.7.dylib
+		%lib/libreadline.7.0.dylib
+	<<
+	Shlibs: <<
+		%p/%lib/libhistory.7.dylib 7.0.0 %n (>= 7.0.0-1)
+		%p/%lib/libreadline.7.dylib 7.0.0 %n (>= 7.0.0-1)
+	<<
+	DocFiles: NEWS CHANGELOG CHANGES COPYING README USAGE
 <<
 #
 Description: Comfortable terminal input library

--- a/10.9-libcxx/stable/main/finkinfo/libs/readline7.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/readline7.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: readline7
-Version: 7.0.3
+Version: 7.0.5
 Revision: 1
 Maintainer: Fink Core Group <fink-core@lists.sourceforge.net>
 #
@@ -16,10 +16,14 @@ Source: mirror:gnu:readline/readline-7.0.tar.gz
 Source2: mirror:gnu:readline/readline-7.0-patches/readline70-001
 Source3: mirror:gnu:readline/readline-7.0-patches/readline70-002
 Source4: mirror:gnu:readline/readline-7.0-patches/readline70-003
+Source5: mirror:gnu:readline/readline-7.0-patches/readline70-004
+Source6: mirror:gnu:readline/readline-7.0-patches/readline70-005
 Source-MD5: 205b03a87fc83dab653b628c59b9fc91
 Source2-MD5: e299384458a4cbefaaac3f30e9cc2bba
 Source3-MD5: f9071a353e2fd52a91d32667b23715d6
 Source4-MD5: 03595464cf0283286a6e07f4f01c4a70
+Source5-MD5: 80e29bef54e2164bf9ecca0c8932cf23
+Source6-MD5: 2146e694e0f1f67b025790879111c6cb
 PatchFile: %{ni}.patch
 PatchFile-MD5: d43bdde26742f49a3dbe735f54d28bdd
 PatchScript: <<


### PR DESCRIPTION
Should we switch to "Version: X.Y.plZ" the next time we jump to a new X or Y to clarify that our "Z" is what upstream calls "patchlevel" rather than a teensy-version? Debian does not even include this specific value in its version or revision (merely increments revision just like any other packaging change).