### PR TITLE
readline7: scrap static lib; switch to '.plX' versioning (PR#178)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/readline7.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/readline7.info
@@ -1,6 +1,7 @@
 Info4: <<
 Package: readline7
-# teeny-version is the upstream patchlevel ("x.y.z" is "x.y" pl "z")
+# Upstream releases official patches to their major.minor version
+# We use "X.Y.plZ" for upstream "X.Y patchlevel Z"
 Version: 7.0.pl5
 Revision: 2
 Maintainer: Fink Core Group <fink-core@lists.sourceforge.net>

--- a/10.9-libcxx/stable/main/finkinfo/libs/readline7.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/readline7.info
@@ -1,8 +1,8 @@
 Info4: <<
 Package: readline7
 # teeny-version is the upstream patchlevel ("x.y.z" is "x.y" pl "z")
-Version: 7.0.5
-Revision: 1
+Version: 7.0.pl5
+Revision: 2
 Maintainer: Fink Core Group <fink-core@lists.sourceforge.net>
 #
 Depends: %n-shlibs (= %v-%r)
@@ -34,6 +34,7 @@ PatchScript: <<
 	%{default_script}
 <<
 SetCPPFLAGS: -MD
+ConfigureParams: --disable-static
 CompileScript: <<
 #! /bin/sh -ev
 	./configure %c


### PR DESCRIPTION
I rebuilt all rdeps on readline7 (except intermediate libversions where I only built the earliest and latest) and there were no differences in detection. Saved a minute of build time, and hey, what good are static libs anyway (esp. noting that this is the active release series, so prone to changes). I used this rebuild as an opportunity to switch to ```Version: X.Y.plZ``` for upstream X.Y upstream patchlevel Z, as discussed in PR #178 