### PR TITLE
Gcrypt updates

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/gnupg2.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/gnupg2.info
@@ -1,27 +1,27 @@
 Package: gnupg2
-Version: 2.2.1
-Revision: 2
+Version: 2.2.8
+Revision: 1
 Description: Gnu privacy guard - A Free PGP replacement
 License: GPL/OpenSSL
 BuildDepends: <<
-  texinfo (>= 4.1-3), libgettext8-dev, libiconv-dev, bzip2-dev, libusb,
-  openldap24-dev, readline6, libgpg-error (>= 1.24-1), libgcrypt20 (>= 1.7.0-1),
-  libassuan2 (>= 2.4.3-1), libksba8 (>= 1.3.4-1), libcurl4, libssh2.1,
-  npth (>= 1.2-1), openssl100-dev, sqlite3-dev, adns-1.4-dev,
+  texinfo (>= 4.1-3), libgettext8-dev, libiconv-dev, bzip2-dev,
+  openldap24-dev, readline7, libgpg-error (>= 1.24-1), libgcrypt20 (>= 1.7.0-1),
+  libassuan2 (>= 2.5.0-1), libksba8 (>= 1.3.4-1), libcurl4, libssh2.1,
+  npth (>= 1.2-1), sqlite3-dev, adns-1.4-dev,
   ntbtls (>= 0.1.0-1), libusb1, pkgconfig, fink-package-precedence
 <<
 Depends: <<
-  bzip2-shlibs, libgettext8-shlibs, libiconv, libusb-shlibs,
-  openldap24-shlibs, readline6-shlibs, libgpg-error-shlibs (>= 1.24-1),
+  bzip2-shlibs, libgettext8-shlibs, libiconv,
+  openldap24-shlibs, readline7-shlibs, libgpg-error-shlibs (>= 1.24-1),
   libgcrypt20-shlibs (>= 1.7.0-1), libksba8-shlibs (>= 1.2.0-1),
-  libassuan2-shlibs, libcurl4-shlibs, npth-shlibs (>= 1.2-1),
-  openssl100-shlibs, sqlite3-shlibs, adns-1.4-shlibs,
+  libassuan2-shlibs (>= 2.5.0-1), libcurl4-shlibs, npth-shlibs (>= 1.2-1),
+  sqlite3-shlibs, adns-1.4-shlibs,
   ntbtls-shlibs (>= 0.1.0-1), libusb1-shlibs
 <<
 Conflicts: gpg-agent (<= 1.9.20-1), gnupg-unified
 Replaces: gpg-agent (<= 1.9.20-1)
 Source: ftp://ftp.gnupg.org/gcrypt/gnupg/gnupg-%v.tar.bz2
-Source-MD5: f781efae8756f6cf5d500aad8e4b33e2
+Source-MD5: 0db6d8ec569e260435a7d2bfb2ecfe5c
 Source2: mirror:sourceforge:fink/gnupg-docs-20021001.tar.gz
 Source2-MD5: 5e34b5be84adc6a898e164b99fce45d8
 Source2ExtractDir: gnupg-%v

--- a/10.9-libcxx/stable/main/finkinfo/crypto/libassuan2.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/libassuan2.info
@@ -1,13 +1,13 @@
 Package: libassuan2
-Version: 2.4.3
+Version: 2.5.1
 Revision: 1
-BuildDepends: libgpg-error (>= 1.8-1)
+BuildDepends: libgpg-error (>= 1.17-1)
 Depends: %n-shlibs (= %v-%r)
 BuildDependsOnly: True
 Conflicts: libassuan
 Replaces: libassuan
 Source: ftp://ftp.gnupg.org/gcrypt/libassuan/libassuan-%v.tar.bz2
-Source-MD5: 8e01a7c72d3e5d154481230668e6eb5a
+Source-MD5: 4354b7ae296894f232ada226a062d7d7
 ConfigureParams: --mandir=%p/share/man --infodir=%p/share/info --disable-dependency-tracking
 
 PatchScript: <<
@@ -33,8 +33,8 @@ InfoDocs: assuan.info
 
 SplitOff: <<
   Package: %N-shlibs
-  Depends: libgpg-error-shlibs (>= 1.8-1)
-  Shlibs: %p/lib/libassuan.0.dylib 8.0.0 %n (>= 2.4.3-1)
+  Depends: libgpg-error-shlibs (>= 1.17-1)
+  Shlibs: %p/lib/libassuan.0.dylib 9.0.0 %n (>= 2.5.1-1)
   Files: lib/libassuan.0.dylib
   DocFiles: COPYING
 <<

--- a/10.9-libcxx/stable/main/finkinfo/crypto/libgpg-error.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/libgpg-error.info
@@ -1,8 +1,8 @@
 Package: libgpg-error
-Version: 1.27
+Version: 1.31
 Revision: 1
 Source: ftp://ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-%v.tar.bz2
-Source-MD5: 5217ef3e76a7275a2a3b569a12ddc989
+Source-MD5: 5cc6df0fea27832e9cdbafc60f51561b
 Depends: %N-shlibs (= %v-%r)
 Replaces: %N-dev
 Conflicts: %N-dev
@@ -23,7 +23,7 @@ SplitOff: <<
   Files: lib/libgpg-error.0*.dylib
   DocFiles: COPYING README
   Shlibs: <<
-    %p/lib/libgpg-error.0.dylib 23.0.0 %n (>= 1.27-1)
+    %p/lib/libgpg-error.0.dylib 25.0.0 %n (>= 1.31-1)
   <<
 <<
 DocFiles: AUTHORS COPYING COPYING.LIB ChangeLog NEWS README 

--- a/10.9-libcxx/stable/main/finkinfo/crypto/libgpgme11-1.9-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/libgpgme11-1.9-shlibs.info
@@ -1,21 +1,22 @@
 Package: libgpgme11-1.9-shlibs
-Version: 1.9.0
+Version: 1.11.1
 Revision: 1
 Description: Application access library for GnuPG
 License: GPL
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
 Depends: <<
 	gnupg2,
-	libgpg-error-shlibs (>= 1.17)
+	libassuan2-shlibs (>= 2.4.3),
+	libgpg-error-shlibs (>= 1.31)
 <<
 BuildDepends: <<
 	fink-package-precedence,
-	libassuan2 (>= 2.0.2),
-	libgpg-error (>= 1.17),
+	libassuan2 (>= 2.4.3),
+	libgpg-error (>= 1.31),
 	gnupg2
 <<
 Source: ftp://ftp.gnupg.org/gcrypt/gpgme/gpgme-%v.tar.bz2
-Source-MD5: 1e00bb8ef04d1d05d5a0f19e143854c3
+Source-MD5: 129c46fb85a7ffa41e43345e48aee884
 PatchScript: <<
 	# Patch configure to not link like Puma on Yosemite
 	perl -pi.bak -e 's|10\.\[012\]\*|10.[012][,.]*|g' configure
@@ -50,12 +51,16 @@ InstallScript: <<
 	ln -s %p/lib/gpgme-1.9.0/libgpgme.la %i/lib/libgpgme.la
 <<
 Shlibs: <<
-	%p/lib/gpgme-1.9.0/libgpgme.11.dylib 30.0.0 %n (>= 1.9.0-1)
+	%p/lib/gpgme-1.9.0/libgpgme.11.dylib 32.0.0 %n (>= 1.11.1-1)
 <<
 SplitOff: <<
 	Package: libgpgme11-1.9-dev
 	Description: Developement files for libgpgme
-	Depends: libgpgme11-1.9-shlibs (= %v-%r)
+	Depends: <<
+		libgpgme11-1.9-shlibs (= %v-%r),
+		libassuan2-shlibs (>= 2.4.3),
+		libgpg-error-shlibs (>= 1.31)
+	<<
 	Replaces: gpgme11, libgpgme11, libgpgme11-1.9-dev
 	Conflicts: gpgme11, libgpgme11, libgpgme11-1.9-dev
 	BuildDependsOnly: true


### PR DESCRIPTION
Updates to gcrypt libraries and programs. Ironically, this first started with an update to libgcrypt20, but version 1.8.3 hangs during the tests, so I didn't update it. All others tested on 10.11.