### PR TITLE
ghostscript-9.23-1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/text/ghostscript.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/ghostscript.info
@@ -8,7 +8,7 @@ Description: Interpreter for PostScript and PDF
 Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs923/ghostscript-%v.tar.xz
 Source-MD5: c5cd025f17e0d87f812bcdb76a61ba3a
 PatchFile: ghostscript.patch
-PatchFile-MD5: c32a191390b2e024f8b0fb057ad441a0
+PatchFile-MD5: f791cfb2f5641372c3213d0e0d0a8ec6
 Depends: <<
 	fontconfig2-shlibs (>= 2.10.0-1),
 	freetype219-shlibs (>= 2.6-1),
@@ -99,6 +99,11 @@ DescPackaging: <<
 	lib is already passed. Easier than trying to remove the -I or
 	figure out why it's being passed instead of or in addition to
 	the external one.
+
+	Fixes cases where %ld was used instead of %lld.
+
+	Removes a link to an old ghostscript document location. Is
+	expected to be gone in the next upstream version (9.24).
 
 	CMap files are not GPL (see LICENSE file for info)
 <<

--- a/10.9-libcxx/stable/main/finkinfo/text/ghostscript.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/ghostscript.info
@@ -2,18 +2,17 @@ Info2: <<
 Package: ghostscript%type_pkg[-nox]
 # LIBIDN2 FTBFS; see https://bugs.ghostscript.com/show_bug.cgi?id=698774
 Type: -nox (boolean)
-Version: 9.21
+Version: 9.23
 Revision: 1
 Description: Interpreter for PostScript and PDF
-Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs921/ghostscript-%v.tar.xz
-Source-MD5: 631beea7aa1f70f2cdca14e0308b8801
+Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs923/ghostscript-%v.tar.xz
+Source-MD5: c5cd025f17e0d87f812bcdb76a61ba3a
 PatchFile: ghostscript.patch
-PatchFile-MD5: 4d958d6ffa647ef9a856ddc83a9fc345
+PatchFile-MD5: 7b9a5ee5832d0e4663c1c9b6c9eb6c44
 Depends: <<
 	fontconfig2-shlibs (>= 2.10.0-1),
 	freetype219-shlibs (>= 2.6-1),
 	ghostscript-fonts,
-	lcms2-shlibs (>= 2.7-1),
 	libiconv,
 	libidn-shlibs,
 	libjbig2dec-shlibs,
@@ -33,7 +32,6 @@ BuildDepends: <<
 	fink-package-precedence,
 	fontconfig2-dev (>= 2.10.0-1),
 	freetype219 (>= 2.6-1),
-	lcms2 (>= 2.7-1),
 	libiconv-dev,
 	libidn,
 	libjbig2dec-dev,
@@ -87,7 +85,6 @@ CompileScript: <<
 	mv tiff tiff_local
 	mv freetype freetype_local
 	mv jbig2dec jbig2dec_local
-	mv lcms2 lcms2_local
 	./autogen.sh %c
 	make
 	fink-package-precedence --depfile-ext='\.d' .
@@ -108,6 +105,6 @@ DescPackaging: <<
 
 	CMap files are not GPL (see LICENSE file for info)
 <<
-Maintainer: None <fink-devel@lists.sourceforge.net>
+Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 Homepage: http://www.cs.wisc.edu/~ghost/
 <<

--- a/10.9-libcxx/stable/main/finkinfo/text/ghostscript.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/ghostscript.info
@@ -8,7 +8,7 @@ Description: Interpreter for PostScript and PDF
 Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs923/ghostscript-%v.tar.xz
 Source-MD5: c5cd025f17e0d87f812bcdb76a61ba3a
 PatchFile: ghostscript.patch
-PatchFile-MD5: 7b9a5ee5832d0e4663c1c9b6c9eb6c44
+PatchFile-MD5: c32a191390b2e024f8b0fb057ad441a0
 Depends: <<
 	fontconfig2-shlibs (>= 2.10.0-1),
 	freetype219-shlibs (>= 2.6-1),
@@ -43,9 +43,6 @@ BuildDepends: <<
 	(%type_raw[-nox] = .) libxt,
 	pkgconfig,
 	(%type_raw[-nox] = .) x11-dev
-<<
-BuildConflicts: <<
-	lcms
 <<
 Conflicts: <<
 	ghostscript,

--- a/10.9-libcxx/stable/main/finkinfo/text/ghostscript.patch
+++ b/10.9-libcxx/stable/main/finkinfo/text/ghostscript.patch
@@ -1,7 +1,7 @@
-diff -Nurd ghostscript-9.21.orig/base/mkromfs.c ghostscript-9.21/base/mkromfs.c
---- ghostscript-9.21.orig/base/mkromfs.c	2017-03-16 11:12:02.000000000 +0100
-+++ ghostscript-9.21/base/mkromfs.c	2017-04-09 16:58:14.000000000 +0200
-@@ -2368,7 +2368,7 @@
+diff -Nurd ghostscript-9.23-orig/base/mkromfs.c ghostscript-9.23/base/mkromfs.c
+--- ghostscript-9.23-orig/base/mkromfs.c	2018-03-21 09:48:06.000000000 +0100
++++ ghostscript-9.23/base/mkromfs.c	2018-06-20 16:19:28.829604860 +0200
+@@ -2379,7 +2379,7 @@
      }
      if (!buildtime)
          buildtime = time(NULL);
@@ -10,21 +10,21 @@ diff -Nurd ghostscript-9.21.orig/base/mkromfs.c ghostscript-9.21/base/mkromfs.c
  
      /* process the remaining arguments (options interspersed with paths) */
      for (; atarg < argc; atarg++) {
-diff -Nurd ghostscript-9.21.orig/base/sjpx_openjpeg.c ghostscript-9.21/base/sjpx_openjpeg.c
---- ghostscript-9.21.orig/base/sjpx_openjpeg.c	2017-03-16 11:12:02.000000000 +0100
-+++ ghostscript-9.21/base/sjpx_openjpeg.c	2017-04-09 16:58:43.000000000 +0200
-@@ -24,7 +24,6 @@
- #include "sjpx_openjpeg.h"
+diff -Nurd ghostscript-9.23-orig/base/sjpx_openjpeg.c ghostscript-9.23/base/sjpx_openjpeg.c
+--- ghostscript-9.23-orig/base/sjpx_openjpeg.c	2018-03-21 09:48:06.000000000 +0100
++++ ghostscript-9.23/base/sjpx_openjpeg.c	2018-06-20 16:22:19.026344754 +0200
+@@ -25,7 +25,6 @@
  #include "gxsync.h"
  #include "assert_.h"
+ #if !defined(SHARE_JPX) || (SHARE_JPX == 0)
 -#include "opj_malloc.h"
- 
+ #endif
  /* Some locking to get around the criminal lack of context
   * in the openjpeg library. */
-diff -Nurd ghostscript-9.21.orig/base/stdpre.h ghostscript-9.21/base/stdpre.h
---- ghostscript-9.21.orig/base/stdpre.h	2017-03-16 11:12:02.000000000 +0100
-+++ ghostscript-9.21/base/stdpre.h	2017-04-09 16:58:14.000000000 +0200
-@@ -271,7 +271,9 @@
+diff -Nurd ghostscript-9.23-orig/base/stdpre.h ghostscript-9.23/base/stdpre.h
+--- ghostscript-9.23-orig/base/stdpre.h	2018-03-21 09:48:06.000000000 +0100
++++ ghostscript-9.23/base/stdpre.h	2018-06-20 16:19:28.835196595 +0200
+@@ -290,7 +290,9 @@
   * header file that includes sys/types.h.
   *
   */
@@ -35,9 +35,9 @@ diff -Nurd ghostscript-9.21.orig/base/stdpre.h ghostscript-9.21/base/stdpre.h
  #define uchar uchar_
  #define uint uint_
  #define ushort ushort_
-diff -Nurd ghostscript-9.21.orig/base/unistd_.h ghostscript-9.21/base/unistd_.h
---- ghostscript-9.21.orig/base/unistd_.h	2017-03-16 11:12:02.000000000 +0100
-+++ ghostscript-9.21/base/unistd_.h	2017-04-09 16:58:14.000000000 +0200
+diff -Nurd ghostscript-9.23-orig/base/unistd_.h ghostscript-9.23/base/unistd_.h
+--- ghostscript-9.23-orig/base/unistd_.h	2018-03-21 09:48:06.000000000 +0100
++++ ghostscript-9.23/base/unistd_.h	2018-06-20 16:19:28.837831312 +0200
 @@ -53,7 +53,9 @@
     /* _XOPEN_SOURCE 500 define is needed to get
      * access to pread and pwrite */
@@ -49,33 +49,33 @@ diff -Nurd ghostscript-9.21.orig/base/unistd_.h ghostscript-9.21/base/unistd_.h
  #  include <unistd.h>
  #endif
  
-diff -Nurd ghostscript-9.21.orig/configure ghostscript-9.21/configure
---- ghostscript-9.21.orig/configure	2017-03-16 11:12:44.000000000 +0100
-+++ ghostscript-9.21/configure	2017-04-09 16:58:14.000000000 +0200
-@@ -7228,7 +7228,7 @@
+diff -Nurd ghostscript-9.23-orig/configure ghostscript-9.23/configure
+--- ghostscript-9.23-orig/configure	2018-03-21 09:49:04.000000000 +0100
++++ ghostscript-9.23/configure	2018-06-20 16:19:28.842097512 +0200
+@@ -7252,7 +7252,7 @@
  $as_echo_n "checking for local zlib source... " >&6; }
  # we must define ZLIBDIR regardless because png.mak does a -I$(ZLIBDIR)
  # this seems a harmless default
 -ZLIBDIR=src
 +ZLIBDIR=$oldincludedir
  AUX_SHARED_ZLIB=
+ ZLIBCFLAGS=""
  
- if test -d $srcdir/zlib; then
-diff -Nurd ghostscript-9.21.orig/configure.ac ghostscript-9.21/configure.ac
---- ghostscript-9.21.orig/configure.ac	2017-03-16 11:12:02.000000000 +0100
-+++ ghostscript-9.21/configure.ac	2017-04-09 16:58:14.000000000 +0200
-@@ -1065,7 +1065,7 @@
+diff -Nurd ghostscript-9.23-orig/configure.ac ghostscript-9.23/configure.ac
+--- ghostscript-9.23-orig/configure.ac	2018-03-21 09:48:06.000000000 +0100
++++ ghostscript-9.23/configure.ac	2018-06-20 16:19:28.844559355 +0200
+@@ -1070,7 +1070,7 @@
  dnl zlib is needed for language level 3, and libpng
  # we must define ZLIBDIR regardless because png.mak does a -I$(ZLIBDIR)
  # this seems a harmless default
 -ZLIBDIR=src
 +ZLIBDIR=$oldincludedir
  AUX_SHARED_ZLIB=
+ ZLIBCFLAGS=""
  
- if test -d $srcdir/zlib; then
-diff -Nurd ghostscript-9.21.orig/contrib/gdevhl12.c ghostscript-9.21/contrib/gdevhl12.c
---- ghostscript-9.21.orig/contrib/gdevhl12.c	2017-03-16 11:12:02.000000000 +0100
-+++ ghostscript-9.21/contrib/gdevhl12.c	2017-04-09 16:58:14.000000000 +0200
+diff -Nurd ghostscript-9.23-orig/contrib/gdevhl12.c ghostscript-9.23/contrib/gdevhl12.c
+--- ghostscript-9.23-orig/contrib/gdevhl12.c	2018-03-21 09:48:06.000000000 +0100
++++ ghostscript-9.23/contrib/gdevhl12.c	2018-06-20 16:19:28.846529241 +0200
 @@ -481,7 +481,7 @@
          break;
      }
@@ -85,9 +85,9 @@ diff -Nurd ghostscript-9.21.orig/contrib/gdevhl12.c ghostscript-9.21/contrib/gde
          put_be16(prn_stream, s->out_count * sizeof(u16) + 7);
          put_be16(prn_stream, s->xl * 16);
          put_be16(prn_stream, band + ytop);
-diff -Nurd ghostscript-9.21.orig/contrib/japanese/gdevp201.c ghostscript-9.21/contrib/japanese/gdevp201.c
---- ghostscript-9.21.orig/contrib/japanese/gdevp201.c	2017-03-16 11:12:02.000000000 +0100
-+++ ghostscript-9.21/contrib/japanese/gdevp201.c	2017-04-09 16:58:14.000000000 +0200
+diff -Nurd ghostscript-9.23-orig/contrib/japanese/gdevp201.c ghostscript-9.23/contrib/japanese/gdevp201.c
+--- ghostscript-9.23-orig/contrib/japanese/gdevp201.c	2018-03-21 09:48:06.000000000 +0100
++++ ghostscript-9.23/contrib/japanese/gdevp201.c	2018-06-20 16:19:28.847504138 +0200
 @@ -242,7 +242,7 @@
                  out_beg -= (out_beg - out) % bytes_per_column;
  
@@ -97,9 +97,9 @@ diff -Nurd ghostscript-9.21.orig/contrib/japanese/gdevp201.c ghostscript-9.21/co
                          (out_beg - out) / bytes_per_column);
  
                  /* Dot graphics */
-diff -Nurd ghostscript-9.21.orig/devices/gdevlp8k.c ghostscript-9.21/devices/gdevlp8k.c
---- ghostscript-9.21.orig/devices/gdevlp8k.c	2017-03-16 11:12:02.000000000 +0100
-+++ ghostscript-9.21/devices/gdevlp8k.c	2017-04-09 16:58:14.000000000 +0200
+diff -Nurd ghostscript-9.23-orig/devices/gdevlp8k.c ghostscript-9.23/devices/gdevlp8k.c
+--- ghostscript-9.23-orig/devices/gdevlp8k.c	2018-03-21 09:48:06.000000000 +0100
++++ ghostscript-9.23/devices/gdevlp8k.c	2018-06-20 16:19:28.848587475 +0200
 @@ -360,9 +360,9 @@
          fprintf(prn_stream,"%d",lnum-60);
          fwrite("Y\035",1,2,prn_stream);
@@ -112,10 +112,10 @@ diff -Nurd ghostscript-9.21.orig/devices/gdevlp8k.c ghostscript-9.21/devices/gde
          fwrite("1;0bi{I",1,7,prn_stream);
          fwrite(out,1,(outp - out),prn_stream);
  
-diff -Nurd ghostscript-9.21.orig/devices/gdevpng.c ghostscript-9.21/devices/gdevpng.c
---- ghostscript-9.21.orig/devices/gdevpng.c	2017-03-16 11:12:02.000000000 +0100
-+++ ghostscript-9.21/devices/gdevpng.c	2017-04-09 16:58:14.000000000 +0200
-@@ -711,6 +711,7 @@
+diff -Nurd ghostscript-9.23-orig/devices/gdevpng.c ghostscript-9.23/devices/gdevpng.c
+--- ghostscript-9.23-orig/devices/gdevpng.c	2018-03-21 09:48:06.000000000 +0100
++++ ghostscript-9.23/devices/gdevpng.c	2018-06-20 16:19:28.849981010 +0200
+@@ -724,6 +724,7 @@
  
  #if PNG_LIBPNG_VER_MINOR < 5
  
@@ -123,7 +123,7 @@ diff -Nurd ghostscript-9.21.orig/devices/gdevpng.c ghostscript-9.21/devices/gdev
  /*
   * Patch around a static reference to a never-used procedure.
   * This could be avoided if we were willing to edit pngconf.h to
-@@ -731,6 +732,7 @@
+@@ -744,6 +745,7 @@
  }
  #endif
  #endif

--- a/10.9-libcxx/stable/main/finkinfo/text/ghostscript.patch
+++ b/10.9-libcxx/stable/main/finkinfo/text/ghostscript.patch
@@ -49,6 +49,18 @@ diff -Nurd ghostscript-9.23-orig/base/unistd_.h ghostscript-9.23/base/unistd_.h
  #  include <unistd.h>
  #endif
  
+diff -Nurd ghostscript-9.23-orig/base/unixinst.mak ghostscript-9.23/base/unixinst.mak
+--- ghostscript-9.23-orig/base/unixinst.mak	2018-03-21 09:48:06.000000000 +0100
++++ ghostscript-9.23/base/unixinst.mak	2018-06-21 10:28:15.877174455 +0200
+@@ -165,7 +165,7 @@
+ 	$(SH) -c 'for f in $(DOC_PAGES) ;\
+ 	do if ( test -f $(PSDOCDIR)/$$f ); then $(INSTALL_DATA) $(PSDOCDIR)/$$f $(DESTDIR)$(docdir); fi;\
+ 	done'
+-	ln -s $(DESTDIR)$(docdir) $(DESTDIR)$(gsdatadir)/doc
++	ln -s $(docdir) $(DESTDIR)$(gsdatadir)/doc
+ 
+ # install the man pages for each locale
+ MAN_LCDIRS=. de
 diff -Nurd ghostscript-9.23-orig/configure ghostscript-9.23/configure
 --- ghostscript-9.23-orig/configure	2018-03-21 09:49:04.000000000 +0100
 +++ ghostscript-9.23/configure	2018-06-20 16:19:28.842097512 +0200

--- a/10.9-libcxx/stable/main/finkinfo/text/ghostscript.patch
+++ b/10.9-libcxx/stable/main/finkinfo/text/ghostscript.patch
@@ -52,12 +52,11 @@ diff -Nurd ghostscript-9.23-orig/base/unistd_.h ghostscript-9.23/base/unistd_.h
 diff -Nurd ghostscript-9.23-orig/base/unixinst.mak ghostscript-9.23/base/unixinst.mak
 --- ghostscript-9.23-orig/base/unixinst.mak	2018-03-21 09:48:06.000000000 +0100
 +++ ghostscript-9.23/base/unixinst.mak	2018-06-21 10:28:15.877174455 +0200
-@@ -165,7 +165,7 @@
+@@ -165,7 +165,6 @@
  	$(SH) -c 'for f in $(DOC_PAGES) ;\
  	do if ( test -f $(PSDOCDIR)/$$f ); then $(INSTALL_DATA) $(PSDOCDIR)/$$f $(DESTDIR)$(docdir); fi;\
  	done'
 -	ln -s $(DESTDIR)$(docdir) $(DESTDIR)$(gsdatadir)/doc
-+	ln -s $(docdir) $(DESTDIR)$(gsdatadir)/doc
  
  # install the man pages for each locale
  MAN_LCDIRS=. de


### PR DESCRIPTION
This is an update for the ghostscript, from upstream version 9.21 to 9.23.
This removes the dependency on libcms2.
Maintainer switched from "none" to myself.