### PR TITLE
Fix hash segment in Shlibs entries (ghc pkgs)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/hscolour.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/hscolour.info
@@ -1,6 +1,6 @@
 Package: hscolour
 Version: 1.23
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/%n-%v/%n-%v.tar.gz
 Source-MD5: db7d455e29429c2038595ac1d33f1865
 SourceDirectory: %n-%v
@@ -19,6 +19,10 @@ runghc Setup.hs unregister --gen-script
 <<
 InstallScript: <<
 runghc Setup.hs copy --destdir=%d
+<<
+
+Shlibs: <<
+  @rpath/libHShscolour-1.23-D9eX1LEa8SaE1RFFjW0myg-ghc7.10.3.dylib 0.0.0 %n (>= 1.23-1)
 <<
 
 DocFiles: LICENCE-GPL data/rgb24-example-.hscolour register.sh unregister.sh

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-aeson.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-aeson.info
@@ -1,6 +1,6 @@
 Package: ghc-aeson
 Version: 0.10.0.0
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/aeson-%v/aeson-%v.tar.gz
 Source-MD5: a7f29ab57d21f7aa5d2889b2b386b2a1
 SourceDirectory: aeson-%v
@@ -20,7 +20,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSaeson-0.10.0.0-0jTqLysUaUV48FrZWcfgKI-ghc7.10.3.dylib 0.0.0 %n (>= 0.10.0.0-1)
+  @rpath/libHSaeson-0.10.0.0-1vbNSxTuNC3L3MYwmRrXj9-ghc7.10.3.dylib 0.0.0 %n (>= 0.10.0.0-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-attoparsec.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-attoparsec.info
@@ -1,6 +1,6 @@
 Package: ghc-attoparsec
 Version: 0.13.0.1
-Revision: 2
+Revision: 3
 Source: http://hackage.haskell.org/package/attoparsec-%v/attoparsec-%v.tar.gz
 Source-MD5: b1ac8cbeb9bdd55b1c26bec48cf76fa3
 SourceDirectory: attoparsec-%v
@@ -12,7 +12,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSattoparsec-0.13.0.1-2FdFrGI1H7BFYxoTdLHZV5-ghc7.10.3.dylib 0.0.0 %n (>= 0.13.0.1-1)
+  @rpath/libHSattoparsec-0.13.0.1-9xFmhb7ffquGhbZS7wthPh-ghc7.10.3.dylib 0.0.0 %n (>= 0.13.0.1-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-blaze-builder.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-blaze-builder.info
@@ -1,6 +1,6 @@
 Package: ghc-blaze-builder
 Version: 0.4.0.1
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/blaze-builder-%v/blaze-builder-%v.tar.gz
 Source-MD5: 97fd54eb400f8f7170ec57f8b1e3e6af
 SourceDirectory: blaze-builder-%v
@@ -11,7 +11,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSblaze-builder-0.4.0.1-7D6Na2HAomq3FxaKuJX0DE-ghc7.10.3.dylib 0.0.0 %n (>= 0.4.0.1-1)
+  @rpath/libHSblaze-builder-0.4.0.1-HecOjmY0iuOKsSwNiH2ZTc-ghc7.10.3.dylib 0.0.0 %n (>= 0.4.0.1-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-blaze-html.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-blaze-html.info
@@ -1,6 +1,6 @@
 Package: ghc-blaze-html
 Version: 0.8.1.1
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/blaze-html-%v/blaze-html-%v.tar.gz
 Source-MD5: 7c6d84943b552f100cab9b14db6de52c
 SourceDirectory: blaze-html-%v
@@ -13,7 +13,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSblaze-html-0.8.1.1-FByOTVlJXmvFitqrcOmNok-ghc7.10.3.dylib 0.0.0 %n (>= 0.8.1.1-1)
+  @rpath/libHSblaze-html-0.8.1.1-8C4ffLEWe3XH2Iiu1QtOQC-ghc7.10.3.dylib 0.0.0 %n (>= 0.8.1.1-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-blaze-markup.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-blaze-markup.info
@@ -1,6 +1,6 @@
 Package: ghc-blaze-markup
 Version: 0.7.0.3
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/blaze-markup-%v/blaze-markup-%v.tar.gz
 Source-MD5: a1edfcab1893df6cdd244d3f97ca4de5
 SourceDirectory: blaze-markup-%v
@@ -12,7 +12,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSblaze-markup-0.7.0.3-KHuH8QXnlq29LQ51QRCHo0-ghc7.10.3.dylib 0.0.0 %n (>= 0.7.0.3-1)
+  @rpath/libHSblaze-markup-0.7.0.3-Crk3OwRatygHUl6yiIchmw-ghc7.10.3.dylib 0.0.0 %n (>= 0.7.0.3-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-case-insensitive.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-case-insensitive.info
@@ -1,6 +1,6 @@
 Package: ghc-case-insensitive
 Version: 1.2.0.5
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/case-insensitive-%v/case-insensitive-%v.tar.gz
 Source-MD5: e1473703da830478f5bf37100d7a72a7
 SourceDirectory: case-insensitive-%v
@@ -12,7 +12,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHScase-insensitive-1.2.0.5-FEOKgbOKlTVG5A7KrFIMjj-ghc7.10.3.dylib 0.0.0 %n (>= 1.2.0.5-1)
+  @rpath/libHScase-insensitive-1.2.0.5-4kv9YgLSANyC5Zk58ScJzJ-ghc7.10.3.dylib 0.0.0 %n (>= 1.2.0.5-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-cgi.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-cgi.info
@@ -1,6 +1,6 @@
 Package: ghc-cgi
 Version: 3001.2.2.2
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/packages/archive/cgi/%v/cgi-%v.tar.gz
 Source-MD5: d911725daf6f3b764bab6e9bf246533e
 SourceDirectory: cgi-%v
@@ -19,7 +19,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHScgi-3001.2.2.2-CEOwOunYNPs8KwnXyLMnk8-ghc7.10.3.dylib 0.0.0 %n (>= 3001.2.2.2-1)
+  @rpath/libHScgi-3001.2.2.2-DgGiEB6S9ISEbCxv367lVY-ghc7.10.3.dylib 0.0.0 %n (>= 3001.2.2.2-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-cmark.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-cmark.info
@@ -1,6 +1,6 @@
 Package: ghc-cmark
 Version: 0.5.0
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/cmark-%v/cmark-%v.tar.gz
 Source-MD5: 74a8a7911f29c56283e77e31d5ee622f
 SourceDirectory: cmark-%v
@@ -11,7 +11,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHScmark-0.5.0-5B4hp1poKRZJiy57C4hGAe-ghc7.10.3.dylib 0.0.0 %n (>= 0.5.0-1)
+  @rpath/libHScmark-0.5.0-16JicXMgq4WALLnGJXGy5z-ghc7.10.3.dylib 0.0.0 %n (>= 0.5.0-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-cookie.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-cookie.info
@@ -1,6 +1,6 @@
 Package: ghc-cookie
 Version: 0.4.1.6
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/cookie-%v/cookie-%v.tar.gz
 Source-MD5: 0ecc47492d973e99af56f14a4e2b304a
 SourceDirectory: cookie-%v
@@ -14,7 +14,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHScookie-0.4.1.6-AVkwk5YrJib95NkYf2NW6E-ghc7.10.3.dylib 0.0.0 %n (>= 0.4.1.6-1)
+  @rpath/libHScookie-0.4.1.6-ERCOcQyQSqi4gKWLWHTnex-ghc7.10.3.dylib 0.0.0 %n (>= 0.4.1.6-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-gluraw.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-gluraw.info
@@ -1,6 +1,6 @@
 Package: ghc-gluraw
 Version: 1.5.0.2
-Revision: 2
+Revision: 3
 Source: http://hackage.haskell.org/package/GLURaw-%v/GLURaw-%v.tar.gz
 Source-MD5: fbdce8d10e28d28784cd2c6ab7e2e42a
 SourceDirectory: GLURaw-%v
@@ -11,7 +11,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSGLURaw-1.5.0.2-HKg5yV42ax8JhJDvs5LZLD-ghc7.10.3.dylib 0.0.0 %n (>= 1.5.0.2-1)
+  @rpath/libHSGLURaw-1.5.0.2-B1fiYHW4xUrHZxqzxesy9e-ghc7.10.3.dylib 0.0.0 %n (>= 1.5.0.2-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-glut.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-glut.info
@@ -1,6 +1,6 @@
 Package: ghc-glut
 Version: 2.7.0.3
-Revision: 2
+Revision: 3
 Source: http://hackage.haskell.org/package/GLUT-%v/GLUT-%v.tar.gz
 Source-MD5: 3dfd7c3fdf67d53b847e6268bb4e3179
 SourceDirectory: GLUT-%v
@@ -13,7 +13,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSGLUT-2.7.0.3-Kv7Q3BwQOc17wH4zrRoE6V-ghc7.10.3.dylib 0.0.0 %n (>= 2.7.0.3-1)
+  @rpath/libHSGLUT-2.7.0.3-CaXDG5xdmTh2r2xhcfOwEe-ghc7.10.3.dylib 0.0.0 %n (>= 2.7.0.3-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-hashable.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-hashable.info
@@ -1,6 +1,6 @@
 Package: ghc-hashable
 Version: 1.2.3.3
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/hashable-%v/hashable-%v.tar.gz
 Source-MD5: f8f0630f5f715b5693682895cd57cc46
 SourceDirectory: hashable-%v
@@ -11,7 +11,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHShashable-1.2.3.3-ESoMujpGY6DK6X3JJiQzUF-ghc7.10.3.dylib 0.0.0 %n (>= 1.2.3.3-1)
+  @rpath/libHShashable-1.2.3.3-FkEumS1nUjW7dyTC5et8fK-ghc7.10.3.dylib 0.0.0 %n (>= 1.2.3.3-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-hexpat.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-hexpat.info
@@ -1,6 +1,6 @@
 Package: ghc-hexpat
 Version: 0.20.9
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/hexpat-%v/hexpat-%v.tar.gz
 Source-MD5: 2a618ff6c6033f2c0f4f7e0fef3127e3
 SourceDirectory: hexpat-%v
@@ -27,7 +27,7 @@ runghc Setup.lhs unregister --gen-script
 InstallScript: runghc Setup.lhs copy --destdir=%d
 
 Shlibs: <<
-  @rpath/libHShexpat-0.20.9-6AFjapvZoYTBbTPC4Y5dpD-ghc7.10.3.dylib 0.0.0 %n (>= 0.20.9-1)
+  @rpath/libHShexpat-0.20.9-DywMzFItO2QGQc37pW3arv-ghc7.10.3.dylib 0.0.0 %n (>= 0.20.9-1)
 <<
 
 DocFiles: LICENSE register.sh unregister.sh

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-highlighting-kate.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-highlighting-kate.info
@@ -1,6 +1,6 @@
 Package: ghc-highlighting-kate
 Version: 0.6.1
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/highlighting-kate-%v/highlighting-kate-%v.tar.gz
 Source-MD5: 51871d2bf5bd285785a34eb7abb373ac
 SourceDirectory: highlighting-kate-%v
@@ -29,7 +29,7 @@ runghc Setup.lhs unregister --gen-script
 InstallScript: runghc Setup.lhs copy --destdir=%d
 
 Shlibs: <<
-  @rpath/libHShighlighting-kate-0.6.1-1IJvlLeKjEtHxuqIJ3cenS-ghc7.10.3.dylib 0.0.0 %n (>= 0.6.1-1)
+  @rpath/libHShighlighting-kate-0.6.1-ELOTVjm5anM35kXkXIUMii-ghc7.10.3.dylib 0.0.0 %n (>= 0.6.1-1)
 <<
 
 DocFiles: changelog LICENSE README.md register.sh unregister.sh

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-http-client.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-http-client.info
@@ -1,6 +1,6 @@
 Package: ghc-http-client
 Version: 0.4.26.1
-Revision: 2
+Revision: 3
 Source: http://hackage.haskell.org/package/http-client-%v/http-client-%v.tar.gz
 Source-MD5: 7eb2a2d4b102d53b0bb7d4e3c3b0c37e
 SourceDirectory: http-client-%v
@@ -23,7 +23,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHShttp-client-0.4.26.1-Ackqya2DefJ60Vr8Q5H7RC-ghc7.10.3.dylib 0.0.0 %n (>= 0.4.26.1-1)
+  @rpath/libHShttp-client-0.4.26.1-LyU6z1G1iK17BOqE7hKGwQ-ghc7.10.3.dylib 0.0.0 %n (>= 0.4.26.1-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-http-types.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-http-types.info
@@ -1,6 +1,6 @@
 Package: ghc-http-types
 Version: 0.9
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/http-types-%v/http-types-%v.tar.gz
 Source-MD5: 3569c6e2712e62590fbf4a20dcf8d4f3
 SourceDirectory: http-types-%v
@@ -13,7 +13,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHShttp-types-0.9-H1s3cnF29L23AO2IhgYYY5-ghc7.10.3.dylib 0.0.0 %n (>= 0.9-1)
+  @rpath/libHShttp-types-0.9-8bDbjSj2OOuIXwBJNpXouU-ghc7.10.3.dylib 0.0.0 %n (>= 0.9-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-http.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-http.info
@@ -1,6 +1,6 @@
 Package: ghc-http
 Version: 4000.2.20
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/HTTP-%v/HTTP-%v.tar.gz
 Source-MD5: e2d682a564203d90c3fa040dd885afd1
 SourceDirectory: HTTP-%v
@@ -15,7 +15,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSHTTP-4000.2.20-ALmDkzntV1f2dHTcPW5ASO-ghc7.10.3.dylib 0.0.0 %n (>= 4000.2.20-1)
+  @rpath/libHSHTTP-4000.2.20-2zIGkywGkNy77Nr6akFzjk-ghc7.10.3.dylib 0.0.0 %n (>= 4000.2.20-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-json.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-json.info
@@ -1,6 +1,6 @@
 Package: ghc-json
 Version: 0.9.1
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/packages/archive/json/%v/json-%v.tar.gz
 Source-MD5: 39f878c351120c7d8bd1d634eee26cbb
 SourceDirectory: json-%v
@@ -28,7 +28,7 @@ runghc Setup.hs unregister --gen-script
 InstallScript: runghc Setup.hs copy --destdir=%d
 
 Shlibs: <<
-  @rpath/libHSjson-0.9.1-IkZU9srCCQn4hVMcX3zozq-ghc7.10.3.dylib 0.0.0 %n (>= 0.9.1-1)
+  @rpath/libHSjson-0.9.1-31I5dTSYUmA7x7iS3XxMQs-ghc7.10.3.dylib 0.0.0 %n (>= 0.9.1-1)
 <<
 
 DocFiles: CHANGES LICENSE register.sh unregister.sh

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-mime-types.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-mime-types.info
@@ -1,6 +1,6 @@
 Package: ghc-mime-types
 Version: 0.1.0.6
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/mime-types-%v/mime-types-%v.tar.gz
 Source-MD5: 9345d93023bd2f234ab153d324febec6
 SourceDirectory: mime-types-%v
@@ -11,7 +11,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSmime-types-0.1.0.6-Bv5iVyvGywb9mLIQp8TuPZ-ghc7.10.3.dylib 0.0.0 %n (>= 0.1.0.6-1)
+  @rpath/libHSmime-types-0.1.0.6-AMqBBvUScP8DLd7aUKnMRr-ghc7.10.3.dylib 0.0.0 %n (>= 0.1.0.6-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-multipart.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-multipart.info
@@ -1,6 +1,6 @@
 Package: ghc-multipart
 Version: 0.1.2
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/multipart-%v/multipart-%v.tar.gz
 Source-MD5: 375aa366fb2aca34a264d41df1292a87
 SourceDirectory: multipart-%v
@@ -11,7 +11,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSmultipart-0.1.2-4csgZUuxmBs4PNQel4VaJ8-ghc7.10.3.dylib 0.0.0 %n (>= 0.1.2-1)
+  @rpath/libHSmultipart-0.1.2-2VfmXWv5vid4FSQSoUHisp-ghc7.10.3.dylib 0.0.0 %n (>= 0.1.2-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-network-uri.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-network-uri.info
@@ -1,6 +1,6 @@
 Package: ghc-network-uri
 Version: 2.6.0.3
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/network-uri-%v/network-uri-%v.tar.gz
 Source-MD5: 1370aa94bb60da253616e23c4a849277
 SourceDirectory: network-uri-%v
@@ -11,7 +11,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSnetwork-uri-2.6.0.3-CxVdIrhuTmgL7JRJWSeTsJ-ghc7.10.3.dylib 0.0.0 %n (>= 2.6.0.3-1)
+  @rpath/libHSnetwork-uri-2.6.0.3-HW4nM5NubOz68JmePVDdXJ-ghc7.10.3.dylib 0.0.0 %n (>= 2.6.0.3-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-opengl.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-opengl.info
@@ -1,6 +1,6 @@
 Package: ghc-opengl
 Version: 2.13.1.0
-Revision: 2
+Revision: 3
 Source: http://hackage.haskell.org/package/OpenGL-%v/OpenGL-%v.tar.gz
 Source-MD5: bffa9417503abc9c35c7f89bf457d1d0
 SourceDirectory: OpenGL-%v
@@ -15,7 +15,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSOpenGL-2.13.1.0-KgUsTIidviz1sd46ePUF8F-ghc7.10.3.dylib 0.0.0 %n (>= 2.13.1.0-1)
+  @rpath/libHSOpenGL-2.13.1.0-BylKaZHn1O1KqxehksiNNK-ghc7.10.3.dylib 0.0.0 %n (>= 2.13.1.0-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-openglraw.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-openglraw.info
@@ -1,6 +1,6 @@
 Package: ghc-openglraw
 Version: 2.6.0.0
-Revision: 2
+Revision: 3
 Source: http://hackage.haskell.org/package/OpenGLRaw-%v/OpenGLRaw-%v.tar.gz
 Source-MD5: 8ec51d50d249f2707e90c49d37c4632c
 SourceDirectory: OpenGLRaw-%v
@@ -12,7 +12,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSOpenGLRaw-2.6.0.0-5DWNXIV76Ge27Xsvw88LSo-ghc7.10.3.dylib 0.0.0 %n (>= 2.6.0.0-1)
+  @rpath/libHSOpenGLRaw-2.6.0.0-1O7rZx8l4eIB8ErTGCseBl-ghc7.10.3.dylib 0.0.0 %n (>= 2.6.0.0-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-pandoc-types.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-pandoc-types.info
@@ -1,6 +1,6 @@
 Package: ghc-pandoc-types
 Version: 1.16.0.1
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/pandoc-types-%v/pandoc-types-%v.tar.gz
 Source-MD5: 5b47b08dafe5fd2a58c08306d6e95570
 SourceDirectory: pandoc-types-%v
@@ -13,7 +13,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSpandoc-types-1.16.0.1-74oa29svRUX59KUxELUHsx-ghc7.10.3.dylib 0.0.0 %n (>= 1.16.0.1-1)
+  @rpath/libHSpandoc-types-1.16.0.1-GnZZZI5sEKH048KEfpOWys-ghc7.10.3.dylib 0.0.0 %n (>= 1.16.0.1-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-parsec.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-parsec.info
@@ -1,6 +1,6 @@
 Package: ghc-parsec
 Version: 3.1.9
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/parsec-%v/parsec-%v.tar.gz
 Source-MD5: 6ec46302afa68518bac5f1117b6349f5
 SourceDirectory: parsec-%v
@@ -12,7 +12,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSparsec-3.1.9-8bOz3HeEMD67ZDdQubQs32-ghc7.10.3.dylib 0.0.0 %n (>= 3.1.9-1)
+  @rpath/libHSparsec-3.1.9-4dvUsebrwbbKRqOOIGwc2Q-ghc7.10.3.dylib 0.0.0 %n (>= 3.1.9-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-scientific.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-scientific.info
@@ -1,6 +1,6 @@
 Package: ghc-scientific
 Version: 0.3.3.8
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/scientific-%v/scientific-%v.tar.gz
 Source-MD5: a202d9ab282b36e1e4288e4cd8536699
 SourceDirectory: scientific-%v
@@ -12,7 +12,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSscientific-0.3.3.8-41jKKjOL3MC1wNr2vTak8T-ghc7.10.3.dylib 0.0.0 %n (>= 0.3.3.8-1)
+  @rpath/libHSscientific-0.3.3.8-0lnEGtxOJc8ENw4sPj9E5N-ghc7.10.3.dylib 0.0.0 %n (>= 0.3.3.8-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-semigroups.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-semigroups.info
@@ -1,6 +1,6 @@
 Package: ghc-semigroups
 Version: 0.18.0.1
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/semigroups-%v/semigroups-%v.tar.gz
 Source-MD5: f4a3636d007be86d63d5b0d623e2b32a
 SourceDirectory: semigroups-%v
@@ -29,7 +29,7 @@ runghc Setup.lhs unregister --gen-script
 InstallScript: runghc Setup.lhs copy --destdir=%d
 
 Shlibs: <<
-  @rpath/libHSsemigroups-0.18.0.1-Aqd4yn1xt1QFfo71blqpRJ-ghc7.10.3.dylib 0.0.0 %n (>= 0.18.0.1-1)
+  @rpath/libHSsemigroups-0.18.0.1-ArDWEcHdGhPJGQsl0SkyVI-ghc7.10.3.dylib 0.0.0 %n (>= 0.18.0.1-1)
 <<
 
 DocFiles: LICENSE README.markdown CHANGELOG.markdown register.sh unregister.sh

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-streaming-commons.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-streaming-commons.info
@@ -1,6 +1,6 @@
 Package: ghc-streaming-commons
 Version: 0.1.15
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/streaming-commons-%v/streaming-commons-%v.tar.gz
 Source-MD5: 558487295c7e9f9ce608e4e7113e122d
 SourceDirectory: streaming-commons-%v
@@ -16,7 +16,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHSstreaming-commons-0.1.15-6WuovqzOrCkKbDzC9tlkaN-ghc7.10.3.dylib 0.0.0 %n (>= 0.1.15-1)
+  @rpath/libHSstreaming-commons-0.1.15-JH7hQuC0s2UKqcWGoejY0m-ghc7.10.3.dylib 0.0.0 %n (>= 0.1.15-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-tagsoup.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-tagsoup.info
@@ -1,6 +1,6 @@
 Package: ghc-tagsoup
 Version: 0.13.6
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/packages/archive/tagsoup/%v/tagsoup-%v.tar.gz
 Source-MD5: 777a59fc4ef175c74f0c907e093f4b9e
 SourceDirectory: tagsoup-%v
@@ -26,7 +26,7 @@ runghc Setup.hs unregister --gen-script
 InstallScript: runghc Setup.hs copy --destdir=%d
 
 Shlibs: <<
-  @rpath/libHStagsoup-0.13.6-8Zn3OOvBTR39FQJyBtSnpF-ghc7.10.3.dylib 0.0.0 %n (>= 0.13.6-1)
+  @rpath/libHStagsoup-0.13.6-JU4GsYe9Jz80ZroMiTGrj3-ghc7.10.3.dylib 0.0.0 %n (>= 0.13.6-1)
 <<
 
 DocFiles: LICENSE README.md CHANGES.txt register.sh unregister.sh

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-texmath.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-texmath.info
@@ -1,6 +1,6 @@
 Package: ghc-texmath
 Version: 0.8.4.1
-Revision: 2
+Revision: 3
 Source: http://hackage.haskell.org/package/texmath-%v/texmath-%v.tar.gz
 Source-MD5: 716a85c4de94ec69b30812487e7d0a51
 SourceDirectory: texmath-%v
@@ -34,7 +34,7 @@ runghc Setup.lhs unregister --gen-script
 InstallScript: runghc Setup.lhs copy --destdir=%d
 
 Shlibs: <<
-  @rpath/libHStexmath-0.8.4.1-DWqCRKCh7aA95Hd2JJ7kQU-ghc7.10.3.dylib 0.0.0 %n (>= 0.8.4.1-2)
+  @rpath/libHStexmath-0.8.4.1-KffxDKPzjUR1Bo1MJC4F2h-ghc7.10.3.dylib 0.0.0 %n (>= 0.8.4.1-2)
 <<
 
 DocFiles: LICENSE README.markdown register.sh unregister.sh

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-text.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-text.info
@@ -1,6 +1,6 @@
 Package: ghc-text
 Version: 1.2.1.3
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/text-%v/text-%v.tar.gz
 Source-MD5: cda1b7c5322b46b2e5fdab92e2e21dd7
 SourceDirectory: text-%v
@@ -10,7 +10,7 @@ Depends: <<
 <<
 
 Shlibs: <<
-  @rpath/libHStext-1.2.1.3-FGvB6qqz81tFju4pBPAqne-ghc7.10.3.dylib 0.0.0 %n (>= 1.2.1.3-1)
+  @rpath/libHStext-1.2.1.3-7QorKQIfitG2nP1YuDsTt9-ghc7.10.3.dylib 0.0.0 %n (>= 1.2.1.3-1)
 <<
 
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-unordered-containers.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-unordered-containers.info
@@ -1,6 +1,6 @@
 Package: ghc-unordered-containers
 Version: 0.2.5.1
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/unordered-containers-%v/unordered-containers-%v.tar.gz
 Source-MD5: c330100ca1d5e6b3cb8242d0bde706f9
 SourceDirectory: unordered-containers-%v
@@ -25,7 +25,7 @@ runghc Setup.hs unregister --gen-script
 InstallScript: runghc Setup.hs copy --destdir=%d
 
 Shlibs: <<
-  @rpath/libHSunordered-containers-0.2.5.1-A6bVq0vdIMX7egYGM1u3oi-ghc7.10.3.dylib 0.0.0 %n (>= 0.2.5.1-1)
+  @rpath/libHSunordered-containers-0.2.5.1-JtKV6WfXjx8F2wrKz4sShb-ghc7.10.3.dylib 0.0.0 %n (>= 0.2.5.1-1)
 <<
 
 DocFiles: LICENSE register.sh unregister.sh

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-void.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-void.info
@@ -1,6 +1,6 @@
 Package: ghc-void
 Version: 0.7.1
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/void-%v/void-%v.tar.gz
 Source-MD5: 42609d17158aff2686fe37424e2673f6
 SourceDirectory: void-%v
@@ -26,7 +26,7 @@ runghc Setup.lhs unregister --gen-script
 InstallScript: runghc Setup.lhs copy --destdir=%d
 
 Shlibs: <<
-  @rpath/libHSvoid-0.7.1-CstzUewYaoGFRT9dESbXI1-ghc7.10.3.dylib 0.0.0 %n (>= 0.7.1-1)
+  @rpath/libHSvoid-0.7.1-7KFDrhuqZRt1yuLiPSqyI6-ghc7.10.3.dylib 0.0.0 %n (>= 0.7.1-1)
 <<
 
 DocFiles: CHANGELOG.markdown LICENSE README.markdown register.sh unregister.sh

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-xml.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-xml.info
@@ -1,6 +1,6 @@
 Package: ghc-xml
 Version: 1.3.14
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/packages/archive/xml/%v/xml-%v.tar.gz
 Source-MD5: bc3d37dca61f52e4d3f547b07beb76c8
 SourceDirectory: xml-%v
@@ -25,7 +25,7 @@ runghc Setup.hs unregister --gen-script
 InstallScript: runghc Setup.hs copy --destdir=%d
 
 Shlibs: <<
-  @rpath/libHSxml-1.3.14-1sTtIUDIWM0757EvcEwWw5-ghc7.10.3.dylib 0.0.0 %n (>= 1.3.14-1)
+  @rpath/libHSxml-1.3.14-3N2umqOyFFQFu7JgiwirKd-ghc7.10.3.dylib 0.0.0 %n (>= 1.3.14-1)
 <<
 
 DocFiles: LICENSE register.sh unregister.sh

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-yaml.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-yaml.info
@@ -1,6 +1,6 @@
 Package: ghc-yaml
 Version: 0.8.15.2
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/yaml-%v/yaml-%v.tar.gz
 Source-MD5: 286c8b0b91b50c50c0871811c839f4c6
 SourceDirectory: yaml-%v
@@ -33,7 +33,7 @@ runghc Setup.lhs unregister --gen-script
 InstallScript: runghc Setup.lhs copy --destdir=%d
 
 Shlibs: <<
-  @rpath/libHSyaml-0.8.15.2-LKEjxyOhba2Eti6luLTBa6-ghc7.10.3.dylib 0.0.0 %n (>= 0.8.15.2-1)
+  @rpath/libHSyaml-0.8.15.2-GDcKBgDE1nzEoGdw0lDYxJ-ghc7.10.3.dylib 0.0.0 %n (>= 0.8.15.2-1)
 <<
 
 DocFiles: LICENSE register.sh unregister.sh

--- a/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-zip-archive.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/ghc/ghc-zip-archive.info
@@ -1,6 +1,6 @@
 Package: ghc-zip-archive
 Version: 0.2.3.7
-Revision: 1
+Revision: 2
 Source: http://hackage.haskell.org/package/zip-archive-%v/zip-archive-%v.tar.gz
 Source-MD5: d1a00d760cae3613bff2b306f54bfc3d
 SourceDirectory: zip-archive-%v
@@ -30,7 +30,7 @@ runghc Setup.lhs unregister --gen-script
 InstallScript: runghc Setup.lhs copy --destdir=%d
 
 Shlibs: <<
-  @rpath/libHSzip-archive-0.2.3.7-KudaoWomyEmG8ZYQI3G6Ul-ghc7.10.3.dylib 0.0.0 %n (>= 0.2.3.7-1)
+  @rpath/libHSzip-archive-0.2.3.7-1FtrANyjwjn0ncxf6heRjz-ghc7.10.3.dylib 0.0.0 %n (>= 0.2.3.7-1)
 <<
 
 DocFiles: LICENSE register.sh unregister.sh

--- a/10.9-libcxx/stable/main/finkinfo/text/pandoc.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/pandoc.info
@@ -1,6 +1,6 @@
 Package: pandoc
 Version: 1.16.0.2
-Revision: 1
+Revision: 3
 Source: http://hackage.haskell.org/package/%n-%v/%n-%v.tar.gz
 Source-MD5: e8497a0db52756339db5ce96e9e5fe7e
 SourceDirectory: %n-%v
@@ -59,7 +59,7 @@ runghc Setup.hs copy --destdir=%d
 <<
 
 Shlibs: <<
-  @rpath/libHSpandoc-1.16.0.2-GHuLbII2dHR8cKZPwKqTPs-ghc7.10.3.dylib 0.0.0 %n (>= 1.16.0.2-1)
+  @rpath/libHSpandoc-1.16.0.2-EQcIEKDzAVR0uSl2ztp8WG-ghc7.10.3.dylib 0.0.0 %n (>= 1.16.0.2-1)
 <<
 
 DocFiles: BUGS COPYING COPYRIGHT README changelog


### PR DESCRIPTION
Many of the haskell mods have invalid Shlibs entries since it seems that the dylibs have a hash segment in the file name that changes with every release.
This updates the Shlibs entries for all the failing haskell mods so that the packages can be built in maintainer mode.
Taken from the old tracker: https://sourceforge.net/p/fink/package-submissions/4697/