### PR TITLE
isync: new version; openssl update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/net/isync.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/isync.info
@@ -1,16 +1,16 @@
 Package: isync
-Version: 1.2.1
-Revision: 2
+Version: 1.3.0
+Revision: 1
 Description: Synchronize maildir with IMAP4
 License: GPL/OpenSSL
 BuildDepends: <<
-  cyrus-sasl2-dev, db53-aes, fink-package-precedence, openssl100-dev
+  cyrus-sasl2-dev, db53-aes, fink-package-precedence, openssl110-dev, pkgconfig
 <<
 Depends: <<
-  cyrus-sasl2-shlibs, db53-aes-shlibs, openssl100-shlibs
+  cyrus-sasl2-shlibs, db53-aes-shlibs, openssl110-shlibs
 <<
 Source: mirror:sourceforge:%n/%n-%v.tar.gz
-Source-MD5: 7ba1a07c7b487a3ab5fef54d0071f1dd
+Source-MD5: f64e8723ebbb081bc15510586bfa1f8f
 DocFiles: AUTHORS COPYING ChangeLog NEWS README TODO
 
 SetCPPFLAGS: -I%p/include/db5


### PR DESCRIPTION
New version clears a few compiler warnings vs old, and switching openssl100->openssl110 clears a few more without adding any.