### PR TITLE
New upstream setuptools 39.2.0 and add py37 variant

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py.info
@@ -1,11 +1,11 @@
 Info2: << 
 Package: setuptools-tng-py%type_pkg[python]
-Type: python (2.7 3.4 3.5 3.6)
-Version: 32.3.0
+Type: python (2.7 3.4 3.5 3.6 3.7)
+Version: 39.2.0
 Revision: 1
-Source: https://pypi.python.org/packages/b0/04/d7aac18d0d8b1b9bd9b88af02af8090e72653753bced3226f9903cabb991/setuptools-%v.zip
-# Source: https://pypi.io/packages/source/s/setuptools/setuptools-%v.tar.gz
-Source-MD5: f72378b7152ad33d8a33a44d673f5794
+#Source: https://pypi.python.org/packages/b0/04/d7aac18d0d8b1b9bd9b88af02af8090e72653753bced3226f9903cabb991/setuptools-%v.zip
+Source: https://pypi.io/packages/source/s/setuptools/setuptools-%v.zip
+Source-MD5: dd4e3fa83a21bf7bf9c51026dc8a4e59
 
 BuildDepends: fink (>=0.32)
 Depends: python%type_pkg[python]
@@ -25,6 +25,7 @@ HomePage: https://pypi.python.org/pypi/setuptools
 
 # Does not pass on macosx with /tmp really being /private/tmp
 # http://bugs.python.org/setuptools/issue125
+# Tests also need pytest which introduces a circular dep.
 #InfoTest: <<
 #    TestScript: <<
 #      %p/bin/python%type_raw[python] setup.py test  || exit 2


### PR DESCRIPTION
I just added python 3.7 and virtually every pymod will need this before they can be updated.