### PR TITLE
discount 2.2.3a to solve clang build failures

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/text/discount.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/discount.info
@@ -1,13 +1,20 @@
 Package: discount
-Version: 2.1.3
+Version: 2.2.3a
 Revision: 1
 Description: Markdown compiler in C
 License: BSD
 Maintainer: Steve Huff <hakamadare@users.sourceforge.net>
 Source:  http://www.pell.portland.or.us/~orc/Code/%n/%n-%v.tar.bz2
-Source-MD5: a1a4eade44f8141e38f2be7f2ed56c98
+Source-MD5: f0d34d232b81b2fa8e5a2f2281d3f1e7
 TarFilesRename: configure.sh:configure
-ConfigureParams: --mandir=%p/share/man --enable-all-features --with-dl=both --with-fenced-code --with-github-tags --with-id-anchor
+ConfigureParams: <<
+	--mandir=%p/share/man \
+	--enable-all-features \
+	--with-dl=both \
+	--with-fenced-code \
+	--with-github-tags \
+	--with-id-anchor
+<<
 InfoTest: <<
  TestScript: make test || exit 2
 <<


### PR DESCRIPTION
Fixes #135