### PR TITLE
netcdf-cxx4-4.3.0-1: Fix checksum issue

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-cxx4.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-cxx4.info
@@ -27,10 +27,9 @@ Replaces: <<
 	netcdf7
 <<
 
-Source: https://github.com/Unidata/%n/archive/v%v.tar.gz
+Source: ftp://ftp.unidata.ucar.edu/pub/netcdf/%n-%v.tar.gz
 Source-MD5: b4a9783b2b0b98d4e6f36cc19c8d08ef
 Source-Checksum: SHA1(796d71c7aae8bc15e923d5c5b50a54bcc7538f0c)
-SourceRename: %n-%v.tar.gz
 
 PatchScript: perl -pi -e 's/(10\.\[012\])\*/\1\,.\*/' configure
 


### PR DESCRIPTION
Update Source to match the FTP Download site also used for other netCDF packages.

This fixes an issue reported by nieder on 22 May and dmacks on 4 July, i.e. that the checksum did not match the source. That is because the checksum of the tarball put on the netCDF GitHub pages is not identical to that put on the official Download pages.
