### PR TITLE
update converatll to latest upstream version

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/convertall.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/convertall.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: convertall
-Version: 0.7.3
+Version: 0.7.5
 Revision: 1
 Type: python (3.4)
 Maintainer: Kevin Horton <khorton02@gmail.com>
@@ -11,7 +11,7 @@ Depends: <<
   qt5-mac-qcocoa-plugin (>=5.7.1-5)
 <<
 Source: http://sourceforge.net/projects/convertall/files/%v/convertall-%v.tar.gz
-Source-MD5: 1d2e012d18f12950add237dc7611331a
+Source-MD5: 1be0f139a3cb7cf04c73d9c8d1edea9f
 SourceDirectory: ConvertAll
 CompileScript: <<
 echo "Nothing to do in compile phase"


### PR DESCRIPTION
built with fink -m rebuild.  tested on macOS 10.13