### PR TITLE
Additional updates and py36/py37 variants for pythonmods

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libnewt0-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libnewt0-shlibs.info
@@ -1,6 +1,6 @@
 Package: libnewt0-shlibs
-Version: 0.52.19
-Revision: 1.3
+Version: 0.52.20
+Revision: 1
 ###
 BuildDepends: <<
 	fink (>= 0.32),
@@ -13,6 +13,8 @@ BuildDepends: <<
 	tcltk-dev,
 	python27,
 	python35,
+	python36,
+	python37,
 	autoconf2.6,
 	automake1.15-core,
 	docbook-utils
@@ -27,10 +29,10 @@ Recommends: <<
 <<
 ###
 Source: mirror:debian:pool/main/n/newt/newt_%v.orig.tar.xz
-Source-Checksum: SHA1(5f1ed2c12fa08596c8c4c9fa8aece4c5a86e7423)
+Source-Checksum: SHA1(a0a3989bf639d54377f6b5fad66489e99b38ebe5)
 SourceDirectory: newt-%v
-Source2: mirror:debian:pool/main/n/newt/newt_%v-1.debian.tar.xz
-Source2-Checksum: SHA1(36c1167c03fc8aef798522143ec9c5772b0e2f6d)
+Source2: mirror:debian:pool/main/n/newt/newt_%v-5.debian.tar.xz
+Source2-Checksum: SHA1(3d21ecdd7ac2fd710ae7bc1022192899a23e3226)
 Source2ExtractDir: newt-%v
 ###
 PatchScript: <<
@@ -77,7 +79,7 @@ perl -pi -e 's,\$\(WHIPTCLLIB\)\.\$\(SOEXT\),\$\(WHIPTCLLIB\)\.so,g' Makefile.in
 perl -pi -e 's,Tcl_setResult,Tcl_SetResult,g' whiptcl.c
 
 perl -pi -e 's,LIBTCL = .TCL_LIB_FLAG.,LIBTCL = -ltcl,g' Makefile.in
-perl -pi -e 's,PYTHONVERS = .*,PYTHONVERS = python2.7 python3.5,g' Makefile.in
+perl -pi -e 's,PYTHONVERS = .*,PYTHONVERS = python2.7 python3.5 python3.6 python3.7,g' Makefile.in
 # fink doesn't have python-dbg packages
 perl -pi -e 's,PYTHONDBG := .*,PYTHONDBG :=,g' Makefile.in
 
@@ -106,6 +108,9 @@ ConfigureParams: <<
 --with-colorsfile=%p/etc/newt/palette \
 ac_cv_c_tclconfig=%p/lib
 <<
+# passing python versions as configure option does not seem to work yet. See:
+# https://pagure.io/newt/issue/3
+#--with-python="python2.7 python3.5 python3.6" \
 ###
 CompileScript: <<
 cp %p/share/automake-1.15/install-sh ./install-sh
@@ -122,8 +127,7 @@ fink-package-precedence --prohibit-bdep=libnewt-dev --depfile-ext='\.depend' .
 InstallScript: <<
 make install DESTDIR=%d
 
-find %i/python2.7 -name '*.o' | xargs rm -f
-find %i/python3.5 -name '*.o' | xargs rm -f
+find %i/python{2.7,3.5,3.6,3.7} -name '*.o' | xargs rm -f
 
 install -d -m 755 %i/etc/newt
 install -m 644 %b/debian/palette.original %i/etc/newt/
@@ -230,10 +234,9 @@ install -m0755 popcorn.py %i/share/doc/%n/examples/
 		lib/python2.7
 	<<
 	DocFiles: CHANGES debian/copyright
-	Description: NEWT module for Python
+	Description: NEWT module for Python2
 	DescDetail: <<
-This module allows you to built a text UI for your Python scripts
-using newt.
+This module allows you to built a text UI for your Python scripts using newt.
 	<<
 <<
 SplitOff4: <<
@@ -247,13 +250,44 @@ SplitOff4: <<
 		lib/python3.5
 	<<
 	DocFiles: CHANGES debian/copyright
-	Description: NEWT module for Python3
+	Description: NEWT module for Python3.5
 	DescDetail: <<
-This module allows you to built a text UI for your Python3 scripts
-using newt.
+This module allows you to built a text UI for your Python3 scripts using newt.
 	<<
 <<
 SplitOff5: <<
+	Package: newt-py36
+	Depends: <<
+		%N (= %v-%r),
+		slang2-shlibs,
+		python36
+	<<
+	Files: <<
+		lib/python3.6
+	<<
+	DocFiles: CHANGES debian/copyright
+	Description: NEWT module for Python3.6
+	DescDetail: <<
+This module allows you to built a text UI for your Python3 scripts using newt.
+	<<
+<<
+SplitOff6: <<
+	Package: newt-py37
+	Depends: <<
+		%N (= %v-%r),
+		slang2-shlibs,
+		python37
+	<<
+	Files: <<
+		lib/python3.7
+	<<
+	DocFiles: CHANGES debian/copyright
+	Description: NEWT module for Python3.7
+	DescDetail: <<
+This module allows you to built a text UI for your Python3 scripts using newt.
+	<<
+<<
+SplitOff7: <<
 	Package: whiptail
 	Depends: <<
 		%N (= %v-%r),
@@ -293,7 +327,7 @@ from shell scripts. This allows a developer of a script to interact with
 the user in a much friendlier manner.
 	<<
 <<
-SplitOff6: <<
+SplitOff8: <<
 	Package: libnewt-pic
 	Recommends: <<
 		libnewt-dev (= %v-%r)

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pysvn-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pysvn-py.info
@@ -1,9 +1,9 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: pysvn-py%type_pkg[python]
-Version: 1.9.0
+Version: 1.9.6
 Revision: 1
-Type: python (2.7 3.4 3.5 3.6)
+Type: python (2.7 3.4 3.5 3.6 3.7)
 
 Description: Python SVN Extension
 DescDetail: <<
@@ -19,8 +19,8 @@ Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 License: BSD
 Homepage: http://pysvn.tigris.org/
 
-Source: http://tigris.org/files/documents/1233/49509/pysvn-%v.tar.gz
-Source-MD5: 3c4678c352b63322f76abdad96761116
+Source: http://tigris.org/files/documents/1233/49617/pysvn-%v.tar.gz
+Source-MD5: e3243d13ba7e3c926924db5ad80dbdbd
 
 Depends: <<
 	libapr.0-shlibs (>= 1.5.2-1),
@@ -31,29 +31,39 @@ BuildDepends: <<
 	fink (>= 0.24.12),
 	libapr.0-dev (>= 1.5.2-1),
 	libaprutil.0-dev (>= 1.5.4-1),
-	svn (>= 1.9.0-1),
+	svn (>= 1.9.3-1),
 	svn19-dev
 <<
 
 UseMaxBuildJobs: false
 
 GCC: 4.0
+# Fix for Python 3.7 build from
+# https://salsa.debian.org/python-team/modules/pycxx/blob/5b108078352342315f6d10a76418a28b4b244f4b/debian/patches/fix-constness-of-__Py_PackageContext.patch
+PatchScript: <<
+	perl -pi -e 's/(char..__Py_PackageContext)/const $1/;' Import/pycxx-7.0.3/CXX/Python*/IndirectPythonInterface.hxx
+	perl -pi -e 's/(char..__Py_PackageContext)/const $1/;' Import/pycxx-7.0.3/Src/IndirectPythonInterface.cxx
+<<
+
 CompileScript: <<
 	#!/bin/bash -ev
+	PYCXXDIR="%b/$(ls -d Import/pycxx-*)"
 	cd Source
 	%p/bin/python%type_raw[python] setup.py configure \
 		--distro-dir=%p \
 		--apr-inc-dir="`%p/bin/apr-1-config --includedir`" \
 		--apr-lib-dir=%p/lib \
-		--apu-inc-dir="`%p/bin/apu-1-config --includedir`"
+		--apu-inc-dir="`%p/bin/apu-1-config --includedir`" \
+		--pycxx-dir=$PYCXXDIR
 	
 	pythonlibs=`%p/bin/python%type_raw[python]-config --ldflags`
 	perl -pi -e "s|%p/Python|${pythonlibs}|" Makefile
 	make
 <<
 
-#Some tests fails when run as root but pass with --build-as-nobody.
-InfoTest: TestScript: cd Tests && make || exit 2
+# Tests involve comparison of diagnostic output with reference logs -
+#  make sure to use the same language!
+InfoTest: TestScript: cd Tests && make LANG=en_US.UTF-8 || exit 2
 
 InstallScript: <<
 	#!/bin/bash -ev
@@ -76,4 +86,5 @@ InstallScript: <<
 <<
 
 DocFiles: LICENSE.txt Docs/*.{html,js} Examples/Client/*.py
+# Info2
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/uncertainties-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/uncertainties-py.info
@@ -1,29 +1,36 @@
 Info2: <<
 Package: uncertainties-py%type_pkg[python]
-Version: 2.4.8.1
+Version: 3.0.2
 Revision: 1
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
-Type: python (2.7 3.4 3.5 3.6)
+Type: python (2.7 3.4 3.5 3.6 3.7)
 Description: Transparent calculations with uncertainties
 Depends: python%type_pkg[python], numpy-py%type_pkg[python] (>= 1.9.0), setuptools-tng-py%type_pkg[python]
-BuildDepends: fink (>= 0.24.12)
+BuildDepends: fink (>= 0.32)
 Source: https://pypi.io/packages/source/u/uncertainties/uncertainties-%v.tar.gz
-Source-MD5: 1faf2f9f54e077d81b1de649984bc3a1
+Source-Checksum: SHA256(91db922d54dff6094b4ea0d6e058f713a992cdf42e3ebaf73278e1893bfa2942)
 
 CompileScript: <<
- %p/bin/python%type_raw[python] setup.py build
+    %p/bin/python%type_raw[python] setup.py build
 <<
 
 InstallScript: <<
- %p/bin/python%type_raw[python] setup.py install --root %d
+    %p/bin/python%type_raw[python] setup.py install --root %d
 <<
 
 InfoTest: <<
- TestDepends: nose-py%type_pkg[python], coverage-py%type_pkg[python]
- TestScript: <<
-  %p/bin/nosetests-%type_raw[python] --no-byte-compile --with-coverage build
- <<
- TestSuiteSize: small
+    TestDepends: nose-py%type_pkg[python], coverage-py%type_pkg[python]
+    TestScript: <<
+        #!/bin/bash -ev
+        # coverage of test_uncertainties.py is broken (segfaults) under Python 3.7
+        if [ %type_pkg[python] -le 36 ] ; then
+            %p/bin/nosetests-%type_raw[python] --no-byte-compile --with-coverage build || exit 2
+        else
+            %p/bin/nosetests-%type_raw[python] --no-byte-compile --with-coverage build/lib/uncertainties/{lib1to2,unumpy,test_umath.py} || exit 2
+            %p/bin/nosetests-%type_raw[python] --no-byte-compile -v build/lib/uncertainties/test_uncertainties.py || exit 2
+        fi
+    <<
+    TestSuiteSize: small
 <<
 
 DocFiles: README.rst LICENSE.txt doc/[i-u]*.rst
@@ -36,9 +43,10 @@ The module can also yield the derivatives of any expression.
 Integration with NumPy is provided by replacements of many NumPy functions
 and the possibility to create NumPy arrays from uncertainty objects.
 <<
-License: OSI-Approved
+License: BSD
 Homepage: http://pythonhosted.org/uncertainties/
 DescPort: <<
-No doc build yet; will require Sphinx dependency
+    No doc build yet; will require Sphinx dependency
 <<
+# Info2
 <<


### PR DESCRIPTION
In the update #140 a single (non-deprecated) package was left without a `py36` variant, `newt-py`, which is added here together with its `py37` counterpart. Unfortunately this is still part of the monolithic `libnewt0` build, so required two additional `SplitOff`s. Should this rather be restricted to a single Python3 variant?
The `pysvn` update to the latest upstream resolves a conflict `1.9.0` had with our current `svn-1.10`.
`uncertainties` update thrown in on request.