### PR TITLE
Numba - JIT LLVM compiler for Python numerical expressions

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/llvmlite-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/llvmlite-py.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info4: <<
 Package: llvmlite-py%type_pkg[python]
-Version: 0.22.0
+Version: 0.24.0
 Revision: 1
 Type: python (2.7 3.5 3.6 3.7)
 
@@ -44,25 +44,24 @@ License: BSD
 Homepage: https://pypi.org/project/llvmlite/
 
 Source: https://pypi.io/packages/source/l/llvmlite/llvmlite-%v.tar.gz
-Source-Checksum: SHA256(a0a875f3d502f41f4a24444aa98fbf076a6bf36e2a0b3b4481b22e1c4a3acdc2)
+Source-Checksum: SHA256(320de4c4a1c105b91629305be069d217f3a9d7fbe32cb22bcfb016361895fc07)
 
-Depends: llvm50-shlibs, python%type_pkg[python], ( %type_pkg[python] <= 33 ) enum34-py%type_pkg[python]
-BuildDepends: fink (>= 0.32), llvm50, llvm50-dev, setuptools-tng-py%type_pkg[python]
+Depends: llvm60-shlibs, python%type_pkg[python], ( %type_pkg[python] <= 33 ) enum34-py%type_pkg[python]
+BuildDepends: fink (>= 0.32), llvm60 (>= 6.0.1), llvm60-dev (>= 6.0.1), setuptools-tng-py%type_pkg[python]
 
-CompileScript: LLVM_CONFIG=%p/opt/llvm-5.0/bin/llvm-config %p/bin/python%type_raw[python] setup.py build
+CompileScript: LLVM_CONFIG=%p/opt/llvm-6.0/bin/llvm-config %p/bin/python%type_raw[python] setup.py build
 
 InstallScript: <<
-	LLVM_CONFIG=%p/opt/llvm-5.0/bin/llvm-config %p/bin/python%type_raw[python] setup.py install --root=%d
+	LLVM_CONFIG=%p/opt/llvm-6.0/bin/llvm-config %p/bin/python%type_raw[python] setup.py install --root=%d
 	install_name_tool -id %p/lib/python%type_raw[python]/site-packages/llvmlite/binding/libllvmlite.dylib %i/lib/python%type_raw[python]/site-packages/llvmlite/binding/libllvmlite.dylib
 <<
 
 InfoTest: <<
-	# 4 sre_parse-related errors with python3.7 (build without --tests or change to exit 1)
-	TestScript: LLVM_CONFIG=%p/opt/llvm-5.0/bin/llvm-config PYTHONPATH=%b %p/bin/python%type_raw[python] runtests.py || exit 2
+	TestScript: LLVM_CONFIG=%p/opt/llvm-6.0/bin/llvm-config PYTHONPATH=%b %p/bin/python%type_raw[python] runtests.py || exit 2
 <<
 
 Shlibs: <<
- 	%p/lib/python%type_raw[python]/site-packages/llvmlite/binding/libllvmlite.dylib 0.0.0 llvmlite (>= 0.22.0-0)
+ 	%p/lib/python%type_raw[python]/site-packages/llvmlite/binding/libllvmlite.dylib 0.0.0 llvmlite (>= 0.24.0-0)
 <<
 
 # ToDo: Sphinx-build docs (not included in 0.22...)

--- a/10.9-libcxx/stable/main/finkinfo/sci/llvmlite-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/llvmlite-py.info
@@ -1,0 +1,71 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info4: <<
+Package: llvmlite-py%type_pkg[python]
+Version: 0.22.0
+Revision: 1
+Type: python (2.7 3.5 3.6 3.7)
+
+Description: LLVM-Python binding for writing JIT compilers
+DescDetail: <<
+The old llvmpy binding exposes a lot of LLVM APIs but the mapping of C++-style
+memory management to Python is error prone. Numba and many JIT compilers do not
+need a full LLVM API. Only the IR builder, optimizer, and JIT compiler APIs are
+necessary.
+
+llvmlite is a project originally tailored for Numba's needs, using the
+following approach:
+- A small C wrapper around the parts of the LLVM C++ API we need that are not
+  already exposed by the LLVM C API.
+- A ctypes Python wrapper around the C API.
+- A pure Python implementation of the subset of the LLVM IR builder that we
+  need for Numba.
+
+Key Benefits
+- The IR builder is pure Python code and decoupled from LLVM's frequently-
+  changing C++ APIs.
+- Materializing a LLVM module calls LLVM's IR parser which provides better
+  error messages than step-by-step IR building through the C++ API (no more
+  segfaults or process aborts).
+- Most of llvmlite uses the LLVM C API which is small but very stable
+  (low maintenance when changing LLVM version).
+- The binding is not a Python C-extension, but a plain DLL accessed using
+  ctypes (no need to wrestle with Python's compiler requirements and C++ 11
+  compatibility).
+- The Python binding layer has sane memory management.
+- llvmlite is quite faster than llvmpy thanks to a much simpler architecture
+  (the Numba test suite is twice faster than it was).
+
+llvmpy Compatibility Layer
+- The llvmlite.llvmpy namespace provides a minimal llvmpy compatibility layer.
+<<
+DescPackaging: Last version to work with LLVM 5.0; python3.7 not officially supported yet
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+License: BSD
+Homepage: https://pypi.org/project/llvmlite/
+
+Source: https://pypi.io/packages/source/l/llvmlite/llvmlite-%v.tar.gz
+Source-Checksum: SHA256(a0a875f3d502f41f4a24444aa98fbf076a6bf36e2a0b3b4481b22e1c4a3acdc2)
+
+Depends: llvm50-shlibs, python%type_pkg[python], ( %type_pkg[python] <= 33 ) enum34-py%type_pkg[python]
+BuildDepends: fink (>= 0.32), llvm50, llvm50-dev, setuptools-tng-py%type_pkg[python]
+
+CompileScript: LLVM_CONFIG=%p/opt/llvm-5.0/bin/llvm-config %p/bin/python%type_raw[python] setup.py build
+
+InstallScript: <<
+	LLVM_CONFIG=%p/opt/llvm-5.0/bin/llvm-config %p/bin/python%type_raw[python] setup.py install --root=%d
+	install_name_tool -id %p/lib/python%type_raw[python]/site-packages/llvmlite/binding/libllvmlite.dylib %i/lib/python%type_raw[python]/site-packages/llvmlite/binding/libllvmlite.dylib
+<<
+
+InfoTest: <<
+	# 4 sre_parse-related errors with python3.7 (build without --tests or change to exit 1)
+	TestScript: LLVM_CONFIG=%p/opt/llvm-5.0/bin/llvm-config PYTHONPATH=%b %p/bin/python%type_raw[python] runtests.py || exit 2
+<<
+
+Shlibs: <<
+ 	%p/lib/python%type_raw[python]/site-packages/llvmlite/binding/libllvmlite.dylib 0.0.0 llvmlite (>= 0.22.0-0)
+<<
+
+# ToDo: Sphinx-build docs (not included in 0.22...)
+DocFiles: LICENSE PKG-INFO README.rst examples
+# Info4
+<<

--- a/10.9-libcxx/stable/main/finkinfo/sci/numba-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/numba-py.info
@@ -1,9 +1,9 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info4: <<
 Package: numba-py%type_pkg[python]
-Version: 0.37.0
+Version: 0.39.0
 Revision: 1
-Type: python (2.7 3.5 3.6)
+Type: python (2.7 3.5 3.6 3.7)
 
 Description: Compiler for Python array/numerical functions
 DescDetail: <<
@@ -26,17 +26,20 @@ License: BSD
 Homepage: https://pypi.org/project/numba/
 
 Source: https://pypi.io/packages/source/n/numba/numba-%v.tar.gz
-Source-Checksum: SHA256(c62121b2d384d8b4d244ef26c1cf8bb5cb819278a80b893bf41918ad6d391258)
+Source-Checksum: SHA256(07749d1ddac8c4c0ce8b22bf3dec52ef2fd4922174c71447126807f5f8dc2bae)
 
 Depends: <<
 	python%type_pkg[python],
 	argparse-py%type_pkg[python],
-	llvmlite-py%type_pkg[python],
+	llvmlite-py%type_pkg[python] (>= 0.24.0),
 	numpy-py%type_pkg[python],
 	( %type_pkg[python] <= 30 ) funcsigs-py%type_pkg[python],
 	( %type_pkg[python] <= 30 ) singledispatch-py%type_pkg[python]
 <<
 BuildDepends: fink (>= 0.32), setuptools-tng-py%type_pkg[python]
+
+# For pretty_annotate module (code highlighting):
+Recommends: jinja2-py%type_pkg[python], pygments-py%type_pkg[python]
 
 CompileScript:  SHELL=/bin/sh %p/bin/python%type_raw[python] setup.py build_ext --inplace
 
@@ -56,18 +59,17 @@ PostInstScript: <<
 	echo "updated by the update-alternatives utility. If you install multiple flavours"
 	echo "of the numba package the symlinks will point to the higher flavour by default."
 
-	#%p/bin/python%type_raw[python] -O %p/lib/python%type_raw[python]/compileall.py -q %p/lib/python%type_raw[python]/site-packages/numba
 <<
 
 PreRmScript:<<
 	if [ $1 != "upgrade" ]; then
 		update-alternatives --remove numba %p/bin/numba-py%type_pkg[python]
 	fi
-	#/usr/bin/find %p/lib/python%type_raw[python]/site-packages/numba -name '*.pyo' -delete
 <<
 
 InfoTest: <<
-	# 1 Failure in test_array_debug_opt_stats()
+	# Requires packages currently without py37 versions for 2-3 tests
+	TestDepends: ( %type_pkg[python] <= 36 ) jinja2-py%type_pkg[python], ( %type_pkg[python] <= 36 ) pygments-py%type_pkg[python]
 	TestScript: <<
 		perl -pi.bak -e 's|(cmd = ..)(python)(.. .-)|${1}%p/bin/python%type_raw[python]${3}|;' numba/tests/test_runtests.py
 		SHELL=/bin/sh %p/bin/python%type_raw[python] runtests.py || exit 1
@@ -75,7 +77,7 @@ InfoTest: <<
 	TestSuiteSize: huge
 <<
 
-# ToDo: Sphinx-build docs (not included in 0.22...)
+# ToDo: Sphinx-build docs
 DocFiles: LICENSE PKG-INFO README.rst examples docs/source
 # Info4
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/numba-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/numba-py.info
@@ -1,0 +1,81 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info4: <<
+Package: numba-py%type_pkg[python]
+Version: 0.37.0
+Revision: 1
+Type: python (2.7 3.5 3.6)
+
+Description: Compiler for Python array/numerical functions
+DescDetail: <<
+Numba is an Open Source NumPy-aware optimizing compiler for Python sponsored by
+Anaconda, Inc. It uses the remarkable LLVM compiler infrastructure to compile
+Python syntax to machine code.
+It is aware of NumPy arrays as typed memory regions and so can speed-up code
+using NumPy arrays. Other, less well-typed code will be translated to Python
+C-API calls effectively removing the "interpreter" but not removing the dynamic
+indirection.
+Numba is also not a tracing JIT. It compiles your code before it gets run
+either using run-time type information or type information you provide in
+the decorator.
+Numba is a mechanism for producing machine code from Python syntax and typed
+data structures such as those that exist in NumPy.
+<<
+DescPackaging: Last version to work with LLVM 5.0
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+License: BSD
+Homepage: https://pypi.org/project/numba/
+
+Source: https://pypi.io/packages/source/n/numba/numba-%v.tar.gz
+Source-Checksum: SHA256(c62121b2d384d8b4d244ef26c1cf8bb5cb819278a80b893bf41918ad6d391258)
+
+Depends: <<
+	python%type_pkg[python],
+	argparse-py%type_pkg[python],
+	llvmlite-py%type_pkg[python],
+	numpy-py%type_pkg[python],
+	( %type_pkg[python] <= 30 ) funcsigs-py%type_pkg[python],
+	( %type_pkg[python] <= 30 ) singledispatch-py%type_pkg[python]
+<<
+BuildDepends: fink (>= 0.32), setuptools-tng-py%type_pkg[python]
+
+CompileScript:  SHELL=/bin/sh %p/bin/python%type_raw[python] setup.py build_ext --inplace
+
+InstallScript: <<
+	perl -pi -e 's|( =) (\d+e\+\d //) (\d+)|$1 round($2 $3)|;' examples/vectorize/*polynomial.py
+	%p/bin/python%type_raw[python] setup.py install --root=%d
+	mv %i/bin/numba %i/bin/numba-py%type_pkg[python]
+	mv %i/bin/pycc %i/bin/pycc-py%type_pkg[python]
+	#/usr/bin/find %i/lib/python%type_raw[python]/site-packages/numba -name '*.pyc' -delete
+<<
+
+PostInstScript: <<
+	update-alternatives --install %p/bin/numba numba %p/bin/numba-py%type_pkg[python] %type_pkg[python] --slave %p/bin/pycc pycc %p/bin/pycc-py%type_pkg[python]
+
+	echo ""
+	echo "The scripts 'numba', 'pycc', installed in %p/bin/ are symlinks automatically" 
+	echo "updated by the update-alternatives utility. If you install multiple flavours"
+	echo "of the numba package the symlinks will point to the higher flavour by default."
+
+	#%p/bin/python%type_raw[python] -O %p/lib/python%type_raw[python]/compileall.py -q %p/lib/python%type_raw[python]/site-packages/numba
+<<
+
+PreRmScript:<<
+	if [ $1 != "upgrade" ]; then
+		update-alternatives --remove numba %p/bin/numba-py%type_pkg[python]
+	fi
+	#/usr/bin/find %p/lib/python%type_raw[python]/site-packages/numba -name '*.pyo' -delete
+<<
+
+InfoTest: <<
+	# 1 Failure in test_array_debug_opt_stats()
+	TestScript: <<
+		perl -pi.bak -e 's|(cmd = ..)(python)(.. .-)|${1}%p/bin/python%type_raw[python]${3}|;' numba/tests/test_runtests.py
+		SHELL=/bin/sh %p/bin/python%type_raw[python] runtests.py || exit 1
+	<<
+	TestSuiteSize: huge
+<<
+
+# ToDo: Sphinx-build docs (not included in 0.22...)
+DocFiles: LICENSE PKG-INFO README.rst examples docs/source
+# Info4
+<<


### PR DESCRIPTION
Numba provides automated automated compilation (kind of cythonising switched on by a simple decorator) for numerical code in Python, achieving potential 10-100 times further speedups over plain numpy operations plus OMP parallelisation. It is based on the llvmlite Python binding for LLVM.

Note that the first two commits bring versions `llvmlite-0.22` and `numba-0.37`, the last ones working with LLVM 5.0. The most recent versions in a6bb90d require an update of the `llvm60` package from #96 to 6.0.1.