### PR TITLE
gir2pascal: new package

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/gir2pascal.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/gir2pascal.info
@@ -13,6 +13,8 @@ Source-MD5: 8e7ddef72c408842a60ca0f01207d290
 CompileScript: <<
 #!/bin/sh -ev
   fpc gir2pascal.lpr
+# create license file from text in source code
+  head -n 17 gir2pascal.lpr | tail -n 15 > LICENSE
 <<
 
 # Install Phase:
@@ -21,6 +23,8 @@ InstallScript: <<
   mkdir %i/bin
   install -m 755 gir2pascal %i/bin/
 <<
+
+DocFiles: LICENSE
 
 DescDetail: <<
 Gir2pascal is a program to convert gobject-introspection (*.gir) xml files

--- a/10.9-libcxx/stable/main/finkinfo/devel/gir2pascal.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/gir2pascal.info
@@ -1,0 +1,64 @@
+Package: gir2pascal
+Version: 6570
+Revision: 1
+Description: Gobject-introspection Pascal Codegenerator
+BuildDepends: fpc
+License: GPL
+
+# Unpack Phase:
+Source: mirror:sourceforge:fink/%n-r%v.tar.bz2
+Source-MD5: 8e7ddef72c408842a60ca0f01207d290
+
+# Compile Phase (NOTE: there is no configure):
+CompileScript: <<
+#!/bin/sh -ev
+  fpc gir2pascal.lpr
+<<
+
+# Install Phase:
+InstallScript: <<
+#!/bin/sh -ev
+  mkdir %i/bin
+  install -m 755 gir2pascal %i/bin/
+<<
+
+DescDetail: <<
+Gir2pascal is a program to convert gobject-introspection (*.gir) xml files
+into Pascal files which can be compiled (hopefully) without modification. 
+For more details, see the homepage.
+<<
+
+DescUsage: <<
+Usage: gir2pascal [options] -i filename
+ -h --help                    Show this help message.
+ -i --input                   .gir filename to convert.
+ -o --output-directory        Directory to write the resulting .pas files to. 
+                              If not specified then the current working 
+                              directory is used.
+ -D --dynamic                 Use unit dynlibs and link at runtime
+ -N --no-wrappers             Do not create wrappers for objects.
+ -w --overwrite-files         If the output .pas file(s) already exists then 
+                              overwrite them.
+ -n --no-default              /usr/share/gir-1.0 is not added as a search 
+                              location for needed .gir files.
+ -p --paths                   List of paths seperated by ":" to search for 
+                              needed .gir files.
+ -d --deprecated              Include fields and methods marked as deprecated.
+ -t --test                    Creates a test program per unit to verify struct 
+                              sizes.
+ -P --unit-prefix             Set a prefix to be added to each unitname.
+ -M --max-version             Do not include symbols introduced after 
+                              <max-version>. Can be used multiple times. i.e 
+                              "-M gtk-3.12 -M glib-2.23"
+ -k --keep-deprecated-version Include deprecated symbols that are >= to 
+                              $version. Uses the same format as --max-version.
+                              Has no effect if --deprecated is defined.
+<<
+
+DescPort: <<
+tar ball created from renamed unpacked zip archive from svn repository.
+Command: tar -cj -f gir2pascal-r6570.tar.bz2 gir2pascal-r6570
+<<
+
+Homepage: http://wiki.lazarus.freepascal.org/gir2pascal
+Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>


### PR DESCRIPTION
gir2pascal converts gobject-introspection (*.gir) xml files into Pascal files.