### PR TITLE
Fix ddd build on Xcode9

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/ddd.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/ddd.info
@@ -1,6 +1,6 @@
 Package: ddd
 Version: 3.3.12
-Revision: 8
+Revision: 9
 GCC: 4.0
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 BuildDepends: fink-package-precedence, libxt-flat, openmotif4, libelf, libncurses5 (>= 5.4-20041023-1006)
@@ -8,7 +8,7 @@ Depends: libxt-flat-shlibs, openmotif4-shlibs, libncurses5-shlibs (>= 5.4-200410
 Source: mirror:gnu:%n/%n-%v.tar.gz
 Source-MD5: c50396db7bac3862a6d2555b3b22c34e
 PatchFile: %n.patch
-PatchFile-MD5: 911063fe1c1976e7f72cc5365d07df77
+PatchFile-MD5: 1a80a325225de24f5e407d5be56111e8
 PatchScript: <<
  %{default_script}
  # patch *ancient* darwin-ignorant autoconf
@@ -44,6 +44,10 @@ all executables while building, and only rename "ddd.exe" back to "ddd"
 when building the final deb file.
 
 Needs flat-namespace libXt for compatibility with openmotif4
+
+Upstream fix for Xcode9
+Unknown type name 'a_class'
+https://savannah.gnu.org/bugs/?52175
 <<
 Homepage: http://www.gnu.org/software/ddd/
 License: GPL

--- a/10.9-libcxx/stable/main/finkinfo/devel/ddd.patch
+++ b/10.9-libcxx/stable/main/finkinfo/devel/ddd.patch
@@ -1,6 +1,6 @@
-diff -ru ddd-3.3.12/configure ddd-3.3.12-patched/configure
---- ddd-3.3.12/configure	2009-02-11 18:25:52.000000000 +0100
-+++ ddd-3.3.12-patched/configure	2009-10-22 23:44:00.000000000 +0200
+diff -ru ddd-3.3.12-orig/configure ddd-3.3.12/configure
+--- ddd-3.3.12-orig/configure	2009-02-11 11:25:52.000000000 -0600
++++ ddd-3.3.12/configure	2018-08-12 06:13:12.000000000 -0500
 @@ -4275,7 +4275,7 @@
  rm -f conftest$ac_cv_exeext
  { echo "$as_me:$LINENO: result: $ac_cv_exeext" >&5
@@ -10,9 +10,22 @@ diff -ru ddd-3.3.12/configure ddd-3.3.12-patched/configure
  rm -f conftest.$ac_ext
  EXEEXT=$ac_cv_exeext
  ac_exeext=$EXEEXT
-diff -ru ddd-3.3.12/ddd/Makefile.in ddd-3.3.12-patched/ddd/Makefile.in
---- ddd-3.3.12/ddd/Makefile.in	2009-02-11 18:25:55.000000000 +0100
-+++ ddd-3.3.12-patched/ddd/Makefile.in	2009-10-22 23:41:51.000000000 +0200
+Only in ddd-3.3.12/ddd: .LabelH.C.un~
+diff -ru ddd-3.3.12-orig/ddd/LabelH.C ddd-3.3.12/ddd/LabelH.C
+--- ddd-3.3.12-orig/ddd/LabelH.C	2009-02-11 11:25:07.000000000 -0600
++++ ddd-3.3.12/ddd/LabelH.C	2018-08-12 06:14:01.000000000 -0500
+@@ -30,6 +30,8 @@
+  *  cwikla@wolfram.com
+ */
+ 
++#include <stddef.h>
++
+ #define new a_new		// Motif 1.1 wants this
+ #define class a_class
+ extern "C" {
+diff -ru ddd-3.3.12-orig/ddd/Makefile.in ddd-3.3.12/ddd/Makefile.in
+--- ddd-3.3.12-orig/ddd/Makefile.in	2009-02-11 11:25:55.000000000 -0600
++++ ddd-3.3.12/ddd/Makefile.in	2018-08-12 06:13:12.000000000 -0500
 @@ -2693,7 +2693,7 @@
  
  $(srcdir)/ddd.info.txt.gz.C: $(srcdir)/ddd.info.txt.gz
@@ -40,9 +53,9 @@ diff -ru ddd-3.3.12/ddd/Makefile.in ddd-3.3.12-patched/ddd/Makefile.in
  
  show.$(OBJEXT): COPYING.gz.C NEWS.gz.C ddd.info.txt.gz.C
  
-diff -ru ddd-3.3.12/ddd/VSLDefList.C ddd-3.3.12-patched/ddd/VSLDefList.C
---- ddd-3.3.12/ddd/VSLDefList.C	2009-02-11 18:25:07.000000000 +0100
-+++ ddd-3.3.12-patched/ddd/VSLDefList.C	2013-12-07 22:30:31.000000000 +0100
+diff -ru ddd-3.3.12-orig/ddd/VSLDefList.C ddd-3.3.12/ddd/VSLDefList.C
+--- ddd-3.3.12-orig/ddd/VSLDefList.C	2009-02-11 11:25:07.000000000 -0600
++++ ddd-3.3.12/ddd/VSLDefList.C	2018-08-12 06:13:12.000000000 -0500
 @@ -60,7 +60,7 @@
      {
  	std::ostringstream s;
@@ -52,9 +65,9 @@ diff -ru ddd-3.3.12/ddd/VSLDefList.C ddd-3.3.12-patched/ddd/VSLDefList.C
      }
  
      return d ? d->eval(arg) : 0;
-diff -ru ddd-3.3.12/ddd/strclass.h ddd-3.3.12-patched/ddd/strclass.h
---- ddd-3.3.12/ddd/strclass.h	2014-04-26 13:11:06.000000000 -0400
-+++ ddd-3.3.12-patched/ddd/strclass.h	2014-04-26 13:35:52.000000000 -0400
+diff -ru ddd-3.3.12-orig/ddd/strclass.h ddd-3.3.12/ddd/strclass.h
+--- ddd-3.3.12-orig/ddd/strclass.h	2009-02-11 11:25:06.000000000 -0600
++++ ddd-3.3.12/ddd/strclass.h	2018-08-12 06:13:12.000000000 -0500
 @@ -543,6 +543,9 @@
      bool OK() const; 
  };
@@ -77,7 +90,8 @@ diff -ru ddd-3.3.12/ddd/strclass.h ddd-3.3.12-patched/ddd/strclass.h
      friend string replicate(char c, int n);
      friend string replicate(const string& y, int n);
      friend string join(const string *src, int n, const string& sep);
-@@ -865,7 +868,7 @@
+@@ -864,8 +867,8 @@
+     friend std::istream& operator>>(std::istream& s, string& x);
  
      friend int readline(std::istream& s, string& x, 
 -			char terminator = '\n',


### PR DESCRIPTION
ddd fails to build on Xcode9 with unknown type name a_class.
This is the upstream submission to fix it.