### PR TITLE
unrar: Update to new upstream version (5.6.5)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/utils/unrar.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/unrar.info
@@ -1,19 +1,18 @@
 Package: unrar
-Version: 5.6.4
+Version: 5.6.5
 Revision: 1
 Description: RAR archive decoder
 BuildDepends: fink-package-precedence
 License: Restrictive/Distributable
 
 Source: http://www.rarlab.com/rar/%nsrc-%v.tar.gz
-Source-MD5: 43ef1b92b6d266730e5a631d07477ab2
+Source-MD5: ef013fc6a31cf8bb9943e2f88f3dc70d
 SourceDirectory: unrar
 
 GCC: 4.0
 
 CompileScript: <<
-  make -f makefile LDFLAGS='' \
-  CPPFLAGS='-Wno-dangling-else -Wno-logical-op-parentheses -Wno-switch -Wno-parentheses'
+  make -f makefile
   fink-package-precedence --no-headers .
 <<
 
@@ -25,19 +24,17 @@ Installscript: <<
 DocFiles: *.txt
 
 DescDetail: <<
-Useful for decoding RAR archives, commonly found on USENET
-newsgroups. Source is "not be used to develop a RAR (WinRAR) 
-compatible archiver."
+Useful for decoding RAR archives, commonly found on USENET newsgroups.
+Source is "not be used to develop a RAR (WinRAR) compatible archiver."
 <<
 
 DescUsage: Type "unrar" for usage notes.
 
 DescPackaging: <<
-Restrictive license that source is "not be used to 
-develop a RAR (WinRAR) compatible archiver."
-CPPFLAGS switch off warnings, which upstream developer considers harmless.
-This removes distracting clutter.
-LDFLAGS='' removes warning about -pthreads arguments for linker
+Restrictive license that source is "not be used to develop a RAR (WinRAR)
+compatible archiver."
+Previous CPPFLAGS and LDFLAGS to remove warnings and other clutter are no
+longer required.
 <<
 
 Homepage: http://www.rarlab.com/


### PR DESCRIPTION
Removal of some FLAGS. Their effect is now taken care of by upstream and they are no longer required.