### PR TITLE
postgresql updates Aug. 2018

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 10.4
+Version: 10.5
 Revision: 1
 Type: postgresql 10
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 8e8770c289b3e0bdb779b5b171593479
-Source-Checksum: SHA1(56106299525156834f055b421531f05947ba8691)
+Source-MD5: a5fe5fdff2d6c28f65601398be0950df
+Source-Checksum: SHA1(8c7b4406b0ba2987f4170657f89908ad47947429)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.4.18
+Version: 9.4.19
 Revision: 1
 Epoch: 1
 Type: postgresql 9.4
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 4032f32af5afb0aa8f78f9a5639c0873
-Source-Checksum: SHA1(ce77a18526dee4ee10a0a14da230de3e9239c751)
+Source-MD5: c7b24ea742692f33376ee40716f8b3ac
+Source-Checksum: SHA1(7f153fd150a07f7515e7e1aa2e704ce88b13173c)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
@@ -47,7 +47,7 @@ PatchScript: <<
 	fi
 <<
 PatchFile: %n.patch
-PatchFile-MD5: 067b9e49dba8b88330bd928e95c78bc0
+PatchFile-MD5: 76ee3710f431eda1a9c7de2441c60054
 
 SetCPPFLAGS: -DHAVE_OPTRESET -fno-common
 SetLDFLAGS: -F/System/Library/Frameworks

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql94.patch
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql94.patch
@@ -1,7 +1,7 @@
-diff -uNr postgresql-9.4.0/pgsql.sh postgresql-9.4.0-patched/pgsql.sh
---- postgresql-9.4.0/pgsql.sh	1969-12-31 19:00:00.000000000 -0500
-+++ postgresql-9.4.0-patched/pgsql.sh	2015-01-18 11:57:53.000000000 -0500
-@@ -0,0 +1,83 @@
+diff -uNr postgresql-9.4.19/pgsql.sh postgresql-9.4.19_patched/pgsql.sh
+--- postgresql-9.4.19/pgsql.sh	1970-01-01 01:00:00.000000000 +0100
++++ postgresql-9.4.19_patched/pgsql.sh	2018-08-17 16:58:24.000000000 +0200
+@@ -0,0 +1,87 @@
 +#!/bin/sh
 +
 +die () {
@@ -55,6 +55,8 @@ diff -uNr postgresql-9.4.0/pgsql.sh postgresql-9.4.0-patched/pgsql.sh
 +END
 +fi
 +
++pushd /tmp
++
 +if [ ! -d "$DATADIR" ]; then
 +	printf -- "- making postgresql directories: "
 +	sudo mkdir -p "$DATADIR"
@@ -85,31 +87,12 @@ diff -uNr postgresql-9.4.0/pgsql.sh postgresql-9.4.0-patched/pgsql.sh
 +		$PG_COMMAND -D "$DATADIR" -m fast stop
 +		;;
 +esac
-diff -uNr postgresql-9.4.0/src/Makefile.global.in postgresql-9.4.0-patched/src/Makefile.global.in
---- postgresql-9.4.0/src/Makefile.global.in	2014-12-15 20:07:34.000000000 -0500
-+++ postgresql-9.4.0-patched/src/Makefile.global.in	2015-01-18 11:57:53.000000000 -0500
-@@ -208,7 +208,7 @@
- 
- # Compilers
- 
--CPP = @CPP@
-+CPP = $(CC) -E
- CPPFLAGS = @CPPFLAGS@
- 
- ifdef PGXS
-@@ -258,7 +258,7 @@
- ifdef PGXS
-   LDFLAGS = -L$(libdir)
- else
--  LDFLAGS = -L$(top_builddir)/src/port -L$(top_builddir)/src/common
-+  LDFLAGS = -L$(top_builddir)/src/port -L$(top_builddir)/src/common -L$(top_builddir)/src/interfaces/libpq -L$(top_builddir)/src/interfaces/ecpg/ecpglib -L$(top_builddir)/src/interfaces/ecpg/pgtypeslib -L$(top_builddir)/src/interfaces/ecpg/compatlib
- endif
- LDFLAGS += @LDFLAGS@
- 
-diff -uNr postgresql-9.4.0/src/backend/utils/misc/postgresql.conf.sample postgresql-9.4.0-patched/src/backend/utils/misc/postgresql.conf.sample
---- postgresql-9.4.0/src/backend/utils/misc/postgresql.conf.sample	2014-12-15 20:07:34.000000000 -0500
-+++ postgresql-9.4.0-patched/src/backend/utils/misc/postgresql.conf.sample	2015-01-18 11:59:02.000000000 -0500
-@@ -78,7 +78,7 @@
++
++popd
+diff -uNr postgresql-9.4.19/src/backend/utils/misc/postgresql.conf.sample postgresql-9.4.19_patched/src/backend/utils/misc/postgresql.conf.sample
+--- postgresql-9.4.19/src/backend/utils/misc/postgresql.conf.sample	2018-08-06 22:11:24.000000000 +0200
++++ postgresql-9.4.19_patched/src/backend/utils/misc/postgresql.conf.sample	2018-08-17 16:55:00.000000000 +0200
+@@ -76,7 +76,7 @@
  # - Security and Authentication -
  
  #authentication_timeout = 1min		# 1s-600s
@@ -118,46 +101,3 @@ diff -uNr postgresql-9.4.0/src/backend/utils/misc/postgresql.conf.sample postgre
  #ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
  					# (change requires restart)
  #ssl_prefer_server_ciphers = on		# (change requires restart)
-diff -uNr postgresql-9.4.0/src/bin/initdb/initdb.c postgresql-9.4.0-patched/src/bin/initdb/initdb.c
---- postgresql-9.4.0/src/bin/initdb/initdb.c	2014-12-15 20:07:34.000000000 -0500
-+++ postgresql-9.4.0-patched/src/bin/initdb/initdb.c	2015-01-18 12:00:19.000000000 -0500
-@@ -152,7 +152,7 @@
- 
- /* defaults */
- static int	n_connections = 10;
--static int	n_buffers = 50;
-+static int	n_buffers = 20;
- static char *dynamic_shared_memory_type = NULL;
- 
- /*
-diff -uNr postgresql-9.4.0/src/interfaces/ecpg/compatlib/Makefile postgresql-9.4.0-patched/src/interfaces/ecpg/compatlib/Makefile
---- postgresql-9.4.0/src/interfaces/ecpg/compatlib/Makefile	2014-12-15 20:07:34.000000000 -0500
-+++ postgresql-9.4.0-patched/src/interfaces/ecpg/compatlib/Makefile	2015-01-18 11:57:53.000000000 -0500
-@@ -21,6 +21,7 @@
- 	-I$(libpq_srcdir) -I$(top_srcdir)/src/include/utils $(CPPFLAGS)
- override CFLAGS += $(PTHREAD_CFLAGS)
- 
-+LDFLAGS := -L../ecpglib -L../pgtypeslib $(LDFLAGS)
- SHLIB_LINK = -L../ecpglib -lecpg -L../pgtypeslib -lpgtypes $(libpq) \
- 	$(filter -lintl -lm, $(LIBS)) $(PTHREAD_LIBS)
- SHLIB_PREREQS = submake-ecpglib submake-pgtypeslib
-diff -uNr postgresql-9.4.0/src/interfaces/ecpg/ecpglib/Makefile postgresql-9.4.0-patched/src/interfaces/ecpg/ecpglib/Makefile
---- postgresql-9.4.0/src/interfaces/ecpg/ecpglib/Makefile	2014-12-15 20:07:34.000000000 -0500
-+++ postgresql-9.4.0-patched/src/interfaces/ecpg/ecpglib/Makefile	2015-01-18 11:57:53.000000000 -0500
-@@ -33,6 +33,7 @@
- OBJS += thread.o
- endif
- 
-+LDFLAGS := -L../pgtypeslib $(LDFLAGS)
- SHLIB_LINK = -L../pgtypeslib -lpgtypes $(libpq) $(filter -lintl -lm, $(LIBS)) $(PTHREAD_LIBS)
- SHLIB_PREREQS = submake-libpq submake-pgtypeslib
- 
-diff -uNr postgresql-9.4.0/src/makefiles/Makefile.darwin postgresql-9.4.0-patched/src/makefiles/Makefile.darwin
---- postgresql-9.4.0/src/makefiles/Makefile.darwin	2014-12-15 20:07:34.000000000 -0500
-+++ postgresql-9.4.0-patched/src/makefiles/Makefile.darwin	2015-01-18 11:57:53.000000000 -0500
-@@ -10,4 +10,4 @@
- 
- # Rule for building a shared library from a single .o file
- %.so: %.o
--	$(CC) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_SL) -bundle $(BE_DLLLIBS) -o $@ $<
-+	$(CC) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_SL) -bundle $(BE_DLLLIBS) -undefined dynamic_lookup -o $@ $<

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.5.13
+Version: 9.5.14
 Revision: 1
 Epoch: 1
 Type: postgresql 9.5
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 09287b1b863020fd1cf6833b6786896e
-Source-Checksum: SHA1(c1c9885b578224995f3663a17b1c3ab3bb7bef13)
+Source-MD5: 36c51ae03c2cd7606e22b8ba228df304
+Source-Checksum: SHA1(23b29fbf57730c3d0662f5875d5bb8072d9f1074)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.6.9
+Version: 9.6.10
 Revision: 1
 Epoch: 1
 Type: postgresql 9.6
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 60002b3588dfcb02c284332037a372e9
-Source-Checksum: SHA1(086f440fca02044cc1798be22257dc6bcd437381)
+Source-MD5: 9a7f465252c0fbe2212566e3c079e062
+Source-Checksum: SHA1(860ff3e2ce42246f45db1fc4519f972228168242)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1


### PR DESCRIPTION
Update for postgresql packages to latest upstream version

postgresql94 update to 9.4.19
postgresql95 update to 9.5.14
postgresql96 update to 9.6.10
postgresql10 update to 10.5

Update includes security fixes:
CVE-2018-10925  -Memory disclosure and missing authorization in INSERT ... ON CONFLICT DO UPDATE.
CVE-2018-10915 - Certain host connection parameters defeat client-side security defenses