### PR TITLE
redis 4.0.11

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/redis.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/redis.info
@@ -1,5 +1,5 @@
 Package: redis
-Version: 4.0.9
+Version: 4.0.11
 Revision: 1
 Source: http://download.redis.io/releases/%n-%v.tar.gz
 Maintainer: Kevin Bullock <kbullock@ringworld.org>
@@ -8,8 +8,8 @@ License: BSD
 Description: Advanced in-memory NoSQL database
 Depends: passwd-redis (>= 20131111-1), daemonic (>= 20010902-4)
 BuildDepends: fink (>= 0.32)
-Source-MD5: 23e34838590c028e2d5b3037dbbef335
-Source-Checksum: SHA1(8aa33d13c3ff5c4d4d2cc52932340893132c8aec)
+Source-MD5: e62d3793f86a6a0021609c9f905cb960
+Source-Checksum: SHA256(fc53e73ae7586bcdacb4b63875d1ff04f68c5474c1ddeda78f00e5ae2eed1bbb)
 PatchFile: %n.patch
 PatchFile-MD5: a7d0dad232019a86450b91e37d579782
 PatchScript: <<


### PR DESCRIPTION
update to latest upstream version 4.0.11 for the redis package.

The update fixes important security issues related to the Lua scripting engine (CVE-2018-11218
CVE-2018-11219 ):
https://github.com/antirez/redis/issues/5017 
http://antirez.com/news/119

@krbullock please check the package as the package maintainer.