### PR TITLE
expat1: new version

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/base/expat1.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/expat1.info
@@ -1,5 +1,5 @@
 Package: expat1
-Version: 2.2.5
+Version: 2.2.6
 Revision: 1
 BuildDepends: fink-package-precedence
 Depends: %N-shlibs (= %v-%r)
@@ -7,7 +7,7 @@ Replaces: expat
 Conflicts: expat
 BuildDependsOnly: true
 Source: mirror:sourceforge:expat/expat-%v.tar.bz2
-Source-MD5: 789e297f547980fc9ecc036f9a070d49
+Source-MD5: ca047ae951b40020ac831c28859161b2
 #PatchFile: %n.patch
 #PatchFile-MD5: 
 #PatchScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/base/expat1.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/expat1.info
@@ -14,7 +14,7 @@ Source-MD5: ca047ae951b40020ac831c28859161b2
 #	%{default_script}
 #<<
 # don't autodetect docbook tools, which would trigger doc regeneration
-ConfigureParams: --without-docbook
+ConfigureParams: --without-docbook --disable-static
 SetCFLAGS: -g -O2 -fshort-wchar
 CompileScript: <<
 	%{default_script}


### PR DESCRIPTION
Per https://sourceforge.net/p/fink/mailman/message/36396563/

Should we scrap the static lib? I've left it due to inertia, but .a are generally unused when there is a .dylib (and fully static linking isn't even possible regardless)