### PR TITLE
wheel & setuptools-tng: update to upstream

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py.info
@@ -1,11 +1,11 @@
 Info2: << 
 Package: setuptools-tng-py%type_pkg[python]
 Type: python (2.7 3.4 3.5 3.6 3.7)
-Version: 39.2.0
+Version: 40.2.0
 Revision: 1
 #Source: https://pypi.python.org/packages/b0/04/d7aac18d0d8b1b9bd9b88af02af8090e72653753bced3226f9903cabb991/setuptools-%v.zip
-Source: https://pypi.io/packages/source/s/setuptools/setuptools-%v.zip
-Source-MD5: dd4e3fa83a21bf7bf9c51026dc8a4e59
+Source: https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-%v.zip
+Source-MD5: 592efabea3a65d8e97a025ed52f69b12
 
 BuildDepends: fink (>=0.32)
 Depends: python%type_pkg[python]

--- a/10.9-libcxx/stable/main/finkinfo/languages/wheel-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/wheel-py.info
@@ -1,14 +1,14 @@
 Info2: << 
 Package: wheel-py%type_pkg[python]
-Type: python (2.7 3.4 3.5 3.6)
-Version: 0.29.0
+Type: python (2.7 3.4 3.5 3.6 3.7)
+Version: 0.31.1
 Revision: 1
-Source: https://pypi.python.org/packages/source/w/wheel/wheel-%v.tar.gz
-Source-MD5: 555a67e4507cedee23a0deb9651e452f
+Source: https://files.pythonhosted.org/packages/source/w/wheel/wheel-%v.tar.gz
+Source-MD5: 0ac15797d94ca759702b1d52425850c4
 
 Depends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
 
-DocFiles: README.txt
+DocFiles: LICENSE.txt PKG-INFO README.rst
 CompileScript: true
 InstallScript: <<
   #!/bin/bash -ev


### PR DESCRIPTION
In addition:
- change source to files.pythonhosted.org
- add py37 variant of wheel
- update docfiles of wheel