### PR TITLE
invoke-py: update to newer upstream version (1.1.1)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/libyaml.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/libyaml.info
@@ -1,10 +1,10 @@
 Package: libyaml
-Version: 0.1.6
+Version: 0.2.1
 Revision: 1
 Depends: %N-shlibs (= %v-%r)
 BuildDependsOnly: true
 Source: http://pyyaml.org/download/%n/yaml-%v.tar.gz
-Source-MD5: 5fe00cda18ca5daeb43762b80c38e06e
+Source-MD5: 72724b9736923c517e5a8fc6757ef03d
 PatchScript: <<
 	# Patch configure to not link like Puma on Yosemite
 	perl -pi.bak -e 's|10\.\[012\]\*|10.[012][,.]*|g' configure

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/hypothesis-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/hypothesis-py.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info4: <<
 Package: hypothesis-py%type_pkg[python]
-Version: 3.65.1
+Version: 3.69.2
 Revision: 1
 Type: python (2.7 3.4 3.5 3.6 3.7)
 
@@ -11,7 +11,7 @@ License: BSD
 Homepage: https://hypothesis.works/
 
 Source: https://files.pythonhosted.org/packages/source/h/hypothesis/hypothesis-%v.tar.gz
-Source-Checksum: SHA256(eee51b25f923bfff663b37d4cacb7d46d2121c5322926a35e3a2314f1343e250)
+Source-Checksum: SHA256(d9ebdad11ee9a948d218ca7aa237a6ee3a7659f32ed1389010b13f22be2e43a8)
 
 Depends: <<
 	(%type_pkg[python] <= 27) enum34-py%type_pkg[python],

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/invoke-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/invoke-py.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info4: <<
 Package: invoke-py%type_pkg[python]
-Version: 1.0.0
+Version: 1.1.1
 Revision: 1
 Type: python (2.7 3.4 3.5 3.6 3.7)
 
@@ -42,7 +42,7 @@ License: BSD
 Homepage: http://pyinvoke.org/
 
 Source: https://files.pythonhosted.org/packages/source/i/invoke/invoke-%v.tar.gz
-Source-Checksum: SHA256(21274204515dca62206470b088bbcf9d41ffda82b3715b90e01d71b7a4681921)
+Source-Checksum: SHA256(1c2cf54c9b9af973ad9704d8ba81b225117cab612568cacbfb3fc42958cc20a9)
 
 Depends: python%type_pkg[python]
 BuildDepends: fink (>= 0.32), setuptools-tng-py%type_pkg[python]

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/more-itertools-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/more-itertools-py.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info4: <<
 Package: more-itertools-py%type_pkg[python]
-Version: 4.2.0
+Version: 4.3.0
 Revision: 1
 Type: python (2.7 3.4 3.5 3.6 3.7)
 
@@ -17,8 +17,8 @@ License: BSD
 Homepage: https://pypi.org/project/more-itertools/
 
 Source: https://files.pythonhosted.org/packages/source/m/more-itertools/more-itertools-%v.tar.gz
-Source-MD5: 5629c955d17df328ec534989f0649369
-Source-Checksum: SHA256(2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8)
+Source-MD5: 42157ef9b677bdf6d3609ed6eadcbd4a
+Source-Checksum: SHA256(c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e)
 
 Depends: python%type_pkg[python], six-py%type_pkg[python] (>= 1.11.0-1)
 BuildDepends: fink (>= 0.32), setuptools-tng-py%type_pkg[python]

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pluggy-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pluggy-py.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: pluggy-py%type_pkg[python]
-Version: 0.6.0
+Version: 0.7.1
 Revision: 1
 Description: Python plugin and hook mechanism
 License: BSD
@@ -14,7 +14,7 @@ BuildDepends: <<
 	setuptools-tng-py%type_pkg[python]
 <<
 Source: https://files.pythonhosted.org/packages/source/p/pluggy/pluggy-%v.tar.gz
-Source-MD5: ffdde7c3a5ba9a440404570366ffb6d5
+Source-MD5: cd5cc1003143f86dd6e2a865a20f8837
 CompileScript: <<
 	%p/bin/python%type_raw[python] setup.py build
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/yaml-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/yaml-py.info
@@ -1,16 +1,16 @@
 Info2: <<
 Package: yaml-py%type_pkg[python]
-Version: 3.12
+Version: 3.13
 Revision: 1
 Homepage: http://pyyaml.org
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
-Type: python (2.7 3.4 3.5 3.6)
+Type: python (2.7 3.4 3.5 3.6 3.7)
 
 Depends: python%type_pkg[python], libyaml-shlibs
 BuildDepends: setuptools-tng-py%type_pkg[python], libyaml
 
 Source: http://pyyaml.org/download/pyyaml/PyYAML-%v.tar.gz
-Source-MD5: 4c129761b661d181ebf7ff4eb2d79950
+Source-MD5: b78b96636d68ac581c0e2f38158c224f
 
 CompileScript: python%type_raw[python] setup.py build
 


### PR DESCRIPTION
no further change.