### PR TITLE
Version Update for Duplicity

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/utils/duplicity.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/duplicity.info
@@ -1,6 +1,6 @@
 Package: duplicity
-Version: 0.7.14
-Revision: 9
+Version: 0.7.18.1
+Revision: 2
 Description: Encrypted backup using rsync algorithm
 License: GPL
 Homepage: http://duplicity.nongnu.org/
@@ -31,11 +31,11 @@ Depends: <<
 
 # Unpack Phase.
 Source: https://code.launchpad.net/%n/0.7-series/%v/+download/%n-%v.tar.gz
-Source-MD5: dc3b22100c3b5a356f357318c1343673
+Source-MD5: 2d24aa1091d4909281e3f4386aa6b84b
 
 # Patch Phase.
 PatchFile: %n.patch
-PatchFile-MD5: bab7bb98698d5558b2ba9d89647d9bc4
+PatchFile-MD5: 6c3d2a0d7abf7b3c27001ef53429fdd1
 PatchScript: <<
     sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 <<

--- a/10.9-libcxx/stable/main/finkinfo/utils/duplicity.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/duplicity.info
@@ -1,6 +1,6 @@
 Package: duplicity
 Version: 0.7.18.1
-Revision: 2
+Revision: 3
 Description: Encrypted backup using rsync algorithm
 License: GPL
 Homepage: http://duplicity.nongnu.org/
@@ -25,7 +25,7 @@ Depends: <<
 	lftp,
 	ncftp,
 	par2,
-	boto-py27 (>= 2.1.1),
+	boto-py27 (>= 2.7.0),
 	requests-oauthlib-py27
 <<
 
@@ -41,7 +41,7 @@ PatchScript: <<
 <<
 
 # Compile Phase.
-CompileScript: %p/bin/python2.7 setup.py build  --librsync-dir=%p 
+CompileScript: %p/bin/python2.7 setup.py build  --librsync-dir=%p
 
 InfoTest: <<
     TestDepends: <<
@@ -86,13 +86,11 @@ GNU tar format.
 
 DescPackaging:  <<
 The testing phase needs more than the default 256
-maximum files.  Testing phase has 1 failure and 19
-errors when built as nobody.  Has 2 failures and 3
-errors when built as root.  Upstream is working on
+maximum files, it is set to 5120 in the test script.
+Testing phase has 418 tests, 0 failures and 9
+errors when built as nobody.  Upstream is working on
 the testing issue.
 
-Does not support Glacier S3 access until Boto
-updated to at least version 2.7.0
 supports
   ssh parmiko
   ssh pexpect
@@ -100,20 +98,18 @@ supports
   lftp
   ncftp
   onedrive
-  Amazon web services
+  Amazon web services (multi-processing and Glacier)
   Google Cloud Storage
 
-Other backends 
+Other backends
 Backend Requirements:
  * scp/sftp paramiko -- python-paramiko, python-pycryptopp
  * scp/sftp pexpect -- openssh, pexpect
  * lftp -- lftp version 3.7.15 or later
- * ncftp -- ncftp 
+ * ncftp -- ncftp
  * OneDrive -- python-requests & python-requests-oauthlib
- * Azure -- python Azure SDK
- * Boto 2.0 or later for single-processing S3 or GCS access
- * Boto 2.1.1 or later for multi-processing S3 access
- * Boto 2.7.0 or later for Glacier S3 access (not yet)
+ * Azure -- python Azure SDK (not implemented)
+ * Boto 2.7.0 or later for Glacier S3 access
 
 Previously maintained by Murali Vadivelu
 <<

--- a/10.9-libcxx/stable/main/finkinfo/utils/duplicity.patch
+++ b/10.9-libcxx/stable/main/finkinfo/utils/duplicity.patch
@@ -1,123 +1,123 @@
-diff -ruN duplicity-0.7.14-orig/bin/duplicity duplicity-0.7.14/bin/duplicity
---- duplicity-0.7.14-orig/bin/duplicity	2017-09-04 16:48:41.000000000 -0400
-+++ duplicity-0.7.14/bin/duplicity	2017-09-04 16:53:08.000000000 -0400
+diff -ruN duplicity-0.7.18.1-orig/bin/duplicity duplicity-0.7.18.1/bin/duplicity
+--- duplicity-0.7.18.1-orig/bin/duplicity	2018-08-27 21:41:00.000000000 -0400
++++ duplicity-0.7.18.1/bin/duplicity	2018-08-27 21:41:39.000000000 -0400
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python2
 +#!@PREFIX@/bin/python2.7
  # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
  #
  # duplicity -- Encrypted bandwidth efficient backup
-diff -ruN duplicity-0.7.14-orig/bin/rdiffdir duplicity-0.7.14/bin/rdiffdir
---- duplicity-0.7.14-orig/bin/rdiffdir	2017-09-04 16:48:41.000000000 -0400
-+++ duplicity-0.7.14/bin/rdiffdir	2017-09-04 16:53:08.000000000 -0400
+diff -ruN duplicity-0.7.18.1-orig/bin/rdiffdir duplicity-0.7.18.1/bin/rdiffdir
+--- duplicity-0.7.18.1-orig/bin/rdiffdir	2018-08-27 21:41:00.000000000 -0400
++++ duplicity-0.7.18.1/bin/rdiffdir	2018-08-27 21:41:39.000000000 -0400
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python2
 +#!@PREFIX@/bin/python2.7
  # rdiffdir -- Extend rdiff functionality to directories
- # Version 0.7.14 released August 31, 2017
+ # Version 0.7.18.1 released August 27, 2018
  #
-diff -ruN duplicity-0.7.14-orig/dist/makedist duplicity-0.7.14/dist/makedist
---- duplicity-0.7.14-orig/dist/makedist	2017-09-04 16:48:41.000000000 -0400
-+++ duplicity-0.7.14/dist/makedist	2017-09-04 16:53:08.000000000 -0400
+diff -ruN duplicity-0.7.18.1-orig/dist/makedist duplicity-0.7.18.1/dist/makedist
+--- duplicity-0.7.18.1-orig/dist/makedist	2018-08-27 21:41:00.000000000 -0400
++++ duplicity-0.7.18.1/dist/makedist	2018-08-27 21:41:39.000000000 -0400
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python2
 +#!@PREFIX@/bin/python2.7
  # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
  #
  # Copyright 2002 Ben Escoto <ben@emerose.org>
-diff -ruN duplicity-0.7.14-orig/duplicity/backends/pyrax_identity/hubic.py duplicity-0.7.14/duplicity/backends/pyrax_identity/hubic.py
---- duplicity-0.7.14-orig/duplicity/backends/pyrax_identity/hubic.py	2017-09-04 16:48:41.000000000 -0400
-+++ duplicity-0.7.14/duplicity/backends/pyrax_identity/hubic.py	2017-09-04 16:53:08.000000000 -0400
+diff -ruN duplicity-0.7.18.1-orig/duplicity/backends/pyrax_identity/hubic.py duplicity-0.7.18.1/duplicity/backends/pyrax_identity/hubic.py
+--- duplicity-0.7.18.1-orig/duplicity/backends/pyrax_identity/hubic.py	2018-08-27 21:41:00.000000000 -0400
++++ duplicity-0.7.18.1/duplicity/backends/pyrax_identity/hubic.py	2018-08-27 21:41:39.000000000 -0400
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python
 +#!@PREFIX@/bin/python2.7
  # -*- coding: utf-8 -*-
  # Copyright (c) 2014 Gu1
  # Licensed under the MIT license
-diff -ruN duplicity-0.7.14-orig/duplicity/compilec.py duplicity-0.7.14/duplicity/compilec.py
---- duplicity-0.7.14-orig/duplicity/compilec.py	2017-09-04 16:48:41.000000000 -0400
-+++ duplicity-0.7.14/duplicity/compilec.py	2017-09-04 16:53:08.000000000 -0400
+diff -ruN duplicity-0.7.18.1-orig/duplicity/compilec.py duplicity-0.7.18.1/duplicity/compilec.py
+--- duplicity-0.7.18.1-orig/duplicity/compilec.py	2018-08-27 21:41:00.000000000 -0400
++++ duplicity-0.7.18.1/duplicity/compilec.py	2018-08-27 21:41:39.000000000 -0400
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python2
 +#!@PREFIX@/bin/python2.7
  # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
  #
  # Copyright 2002 Ben Escoto <ben@emerose.org>
-diff -ruN duplicity-0.7.14-orig/setup.py duplicity-0.7.14/setup.py
---- duplicity-0.7.14-orig/setup.py	2017-09-04 16:48:41.000000000 -0400
-+++ duplicity-0.7.14/setup.py	2017-09-04 16:53:08.000000000 -0400
+diff -ruN duplicity-0.7.18.1-orig/setup.py duplicity-0.7.18.1/setup.py
+--- duplicity-0.7.18.1-orig/setup.py	2018-08-27 21:41:01.000000000 -0400
++++ duplicity-0.7.18.1/setup.py	2018-08-27 21:41:39.000000000 -0400
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python2
 +#!@PREFIX@/bin/python2.7
  # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
  #
  # Copyright 2002 Ben Escoto <ben@emerose.org>
-diff -ruN duplicity-0.7.14-orig/testing/manual/backendtest duplicity-0.7.14/testing/manual/backendtest
---- duplicity-0.7.14-orig/testing/manual/backendtest	2017-09-04 16:48:41.000000000 -0400
-+++ duplicity-0.7.14/testing/manual/backendtest	2017-09-04 16:53:08.000000000 -0400
+diff -ruN duplicity-0.7.18.1-orig/testing/manual/backendtest duplicity-0.7.18.1/testing/manual/backendtest
+--- duplicity-0.7.18.1-orig/testing/manual/backendtest	2018-08-27 21:41:01.000000000 -0400
++++ duplicity-0.7.18.1/testing/manual/backendtest	2018-08-27 21:41:39.000000000 -0400
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python2
 +#!@PREFIX@/bin/python2.7
  # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
  #
  # Copyright 2002 Ben Escoto <ben@emerose.org>
-diff -ruN duplicity-0.7.14-orig/testing/overrides/bin/hsi duplicity-0.7.14/testing/overrides/bin/hsi
---- duplicity-0.7.14-orig/testing/overrides/bin/hsi	2017-09-04 16:48:41.000000000 -0400
-+++ duplicity-0.7.14/testing/overrides/bin/hsi	2017-09-04 16:53:08.000000000 -0400
+diff -ruN duplicity-0.7.18.1-orig/testing/overrides/bin/hsi duplicity-0.7.18.1/testing/overrides/bin/hsi
+--- duplicity-0.7.18.1-orig/testing/overrides/bin/hsi	2018-08-27 21:41:01.000000000 -0400
++++ duplicity-0.7.18.1/testing/overrides/bin/hsi	2018-08-27 21:41:39.000000000 -0400
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python2
 +#!@PREFIX@/bin/python2.7
  
  import subprocess
  import sys
-diff -ruN duplicity-0.7.14-orig/testing/overrides/bin/lftp duplicity-0.7.14/testing/overrides/bin/lftp
---- duplicity-0.7.14-orig/testing/overrides/bin/lftp	2017-09-04 16:48:41.000000000 -0400
-+++ duplicity-0.7.14/testing/overrides/bin/lftp	2017-09-04 16:53:08.000000000 -0400
+diff -ruN duplicity-0.7.18.1-orig/testing/overrides/bin/lftp duplicity-0.7.18.1/testing/overrides/bin/lftp
+--- duplicity-0.7.18.1-orig/testing/overrides/bin/lftp	2018-08-27 21:41:01.000000000 -0400
++++ duplicity-0.7.18.1/testing/overrides/bin/lftp	2018-08-27 21:41:39.000000000 -0400
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python2
 +#!@PREFIX@/bin/python2.7
  
  import os
  import subprocess
-diff -ruN duplicity-0.7.14-orig/testing/overrides/bin/ncftpget duplicity-0.7.14/testing/overrides/bin/ncftpget
---- duplicity-0.7.14-orig/testing/overrides/bin/ncftpget	2017-09-04 16:48:41.000000000 -0400
-+++ duplicity-0.7.14/testing/overrides/bin/ncftpget	2017-09-04 16:53:08.000000000 -0400
+diff -ruN duplicity-0.7.18.1-orig/testing/overrides/bin/ncftpget duplicity-0.7.18.1/testing/overrides/bin/ncftpget
+--- duplicity-0.7.18.1-orig/testing/overrides/bin/ncftpget	2018-08-27 21:41:01.000000000 -0400
++++ duplicity-0.7.18.1/testing/overrides/bin/ncftpget	2018-08-27 21:41:39.000000000 -0400
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python2
 +#!@PREFIX@/bin/python2.7
  
  import subprocess
  import sys
-diff -ruN duplicity-0.7.14-orig/testing/overrides/bin/ncftpls duplicity-0.7.14/testing/overrides/bin/ncftpls
---- duplicity-0.7.14-orig/testing/overrides/bin/ncftpls	2017-09-04 16:48:41.000000000 -0400
-+++ duplicity-0.7.14/testing/overrides/bin/ncftpls	2017-09-04 16:53:08.000000000 -0400
+diff -ruN duplicity-0.7.18.1-orig/testing/overrides/bin/ncftpls duplicity-0.7.18.1/testing/overrides/bin/ncftpls
+--- duplicity-0.7.18.1-orig/testing/overrides/bin/ncftpls	2018-08-27 21:41:01.000000000 -0400
++++ duplicity-0.7.18.1/testing/overrides/bin/ncftpls	2018-08-27 21:41:39.000000000 -0400
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python2
 +#!@PREFIX@/bin/python2.7
  
  from duplicity.backend import ParsedUrl
  import os
-diff -ruN duplicity-0.7.14-orig/testing/overrides/bin/ncftpput duplicity-0.7.14/testing/overrides/bin/ncftpput
---- duplicity-0.7.14-orig/testing/overrides/bin/ncftpput	2017-09-04 16:48:41.000000000 -0400
-+++ duplicity-0.7.14/testing/overrides/bin/ncftpput	2017-09-04 16:53:08.000000000 -0400
+diff -ruN duplicity-0.7.18.1-orig/testing/overrides/bin/ncftpput duplicity-0.7.18.1/testing/overrides/bin/ncftpput
+--- duplicity-0.7.18.1-orig/testing/overrides/bin/ncftpput	2018-08-27 21:41:01.000000000 -0400
++++ duplicity-0.7.18.1/testing/overrides/bin/ncftpput	2018-08-27 21:41:39.000000000 -0400
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python2
 +#!@PREFIX@/bin/python2.7
  
  import subprocess
  import sys
-diff -ruN duplicity-0.7.14-orig/testing/overrides/bin/tahoe duplicity-0.7.14/testing/overrides/bin/tahoe
---- duplicity-0.7.14-orig/testing/overrides/bin/tahoe	2017-09-04 16:48:41.000000000 -0400
-+++ duplicity-0.7.14/testing/overrides/bin/tahoe	2017-09-04 16:53:08.000000000 -0400
+diff -ruN duplicity-0.7.18.1-orig/testing/overrides/bin/tahoe duplicity-0.7.18.1/testing/overrides/bin/tahoe
+--- duplicity-0.7.18.1-orig/testing/overrides/bin/tahoe	2018-08-27 21:41:01.000000000 -0400
++++ duplicity-0.7.18.1/testing/overrides/bin/tahoe	2018-08-27 21:41:39.000000000 -0400
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python2
 +#!@PREFIX@/bin/python2.7
  
  import subprocess
  import sys
-diff -ruN duplicity-0.7.14-orig/testing/run-tests duplicity-0.7.14/testing/run-tests
---- duplicity-0.7.14-orig/testing/run-tests	2017-09-04 16:48:41.000000000 -0400
-+++ duplicity-0.7.14/testing/run-tests	2017-09-04 16:53:08.000000000 -0400
+diff -ruN duplicity-0.7.18.1-orig/testing/run-tests duplicity-0.7.18.1/testing/run-tests
+--- duplicity-0.7.18.1-orig/testing/run-tests	2018-08-27 21:41:01.000000000 -0400
++++ duplicity-0.7.18.1/testing/run-tests	2018-08-27 21:41:39.000000000 -0400
 @@ -20,4 +20,4 @@
  # along with duplicity; if not, write to the Free Software Foundation,
  # Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA


### PR DESCRIPTION
Updated version, and MD5 hash for latest release with bug patch to duplicity 0.7.18.1 released on 2018-08-27