### PR TITLE
pytz-py: Upstream update.

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pytz-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pytz-py.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: pytz-py%type_pkg[python]
-Version: 2014.2
+Version: 2018.5
 Revision: 1
 Type: python (2.7 3.4 3.5 3.6)
 
@@ -8,8 +8,8 @@ BuildDepends: setuptools-tng-py%type_pkg[python]
 Depends: python%type_pkg[python]
 Replaces: matplotlib-py%type_pkg[python] (<< 0.91.3-24)
 
-Source: http://pypi.python.org/packages/source/p/pytz/pytz-%v.tar.bz2
-Source-MD5: 00247633f88029c69ace3b359e25cef3
+Source: https://files.pythonhosted.org/packages/source/p/pytz/pytz-%v.tar.gz
+Source-MD5: 45409cbfa3927bdd2f3ee914dd5b1060
 
 CompileScript: %p/bin/python%type_raw[python] setup.py build
 InfoTest: <<
@@ -22,7 +22,7 @@ InfoTest: <<
 InstallScript: <<
 	%p/bin/python%type_raw[python] setup.py install --root=%d
 <<
-DocFiles: CHANGES.txt LICENSE.txt README.txt
+DocFiles: LICENSE.txt README.txt
 
 Description: World timezone definitions database
 License: BSD


### PR DESCRIPTION
Update to newer upstream version (2018.5). Adding py37 variant gives fails in tests, which do not look like a big problem, but i could not fix them.
Log:
```
...
FAIL: pytz/tests/../../README.txt
Doctest: README.txt
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/sw/lib/python3.7/doctest.py", line 2198, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for README.txt
  File "pytz/tests/../../README.txt", line 0

----------------------------------------------------------------------
File "pytz/tests/../../README.txt", line 183, in README.txt
Failed example:
    tz.utcoffset(normal, is_dst=True)
Expected:
    datetime.timedelta(-1, 77400)
Got:
    datetime.timedelta(days=-1, seconds=77400)
...
```

dmacks edited: formatting of log