### PR TITLE
ghostscript-9.24-1: Upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/text/ghostscript.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/ghostscript.info
@@ -2,13 +2,15 @@ Info2: <<
 Package: ghostscript%type_pkg[-nox]
 # LIBIDN2 FTBFS; see https://bugs.ghostscript.com/show_bug.cgi?id=698774
 Type: -nox (boolean)
-Version: 9.23
+Version: 9.24
 Revision: 1
 Description: Interpreter for PostScript and PDF
-Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs923/ghostscript-%v.tar.xz
-Source-MD5: c5cd025f17e0d87f812bcdb76a61ba3a
+Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs924/ghostscript-%v.tar.xz
+Source-MD5: 258c73e4ec0da94c95ea3cbd2968889a
+Source-Checksum: SHA1(46a605c2576f9b11a733f6854845dcb4c24d9e10)
 PatchFile: ghostscript.patch
-PatchFile-MD5: f791cfb2f5641372c3213d0e0d0a8ec6
+PatchFile-MD5: 5e704157968c362f594622ba9f867fb9
+PatchFile-Checksum: SHA1(b54b0a554efbc605cd77578db5a5c7925c45839b)
 Depends: <<
 	fontconfig2-shlibs (>= 2.10.0-1),
 	freetype219-shlibs (>= 2.6-1),
@@ -101,9 +103,6 @@ DescPackaging: <<
 	the external one.
 
 	Fixes cases where %ld was used instead of %lld.
-
-	Removes a link to an old ghostscript document location. Is
-	expected to be gone in the next upstream version (9.24).
 
 	CMap files are not GPL (see LICENSE file for info)
 <<

--- a/10.9-libcxx/stable/main/finkinfo/text/ghostscript.patch
+++ b/10.9-libcxx/stable/main/finkinfo/text/ghostscript.patch
@@ -1,6 +1,6 @@
-diff -Nurd ghostscript-9.23-orig/base/mkromfs.c ghostscript-9.23/base/mkromfs.c
---- ghostscript-9.23-orig/base/mkromfs.c	2018-03-21 09:48:06.000000000 +0100
-+++ ghostscript-9.23/base/mkromfs.c	2018-06-20 16:19:28.829604860 +0200
+diff -Nurd ghostscript-9.24-orig/base/mkromfs.c ghostscript-9.24/base/mkromfs.c
+--- ghostscript-9.24-orig/base/mkromfs.c	2018-09-03 10:50:27.000000000 +0200
++++ ghostscript-9.24/base/mkromfs.c	2018-09-04 12:08:24.836840617 +0200
 @@ -2379,7 +2379,7 @@
      }
      if (!buildtime)
@@ -10,9 +10,9 @@ diff -Nurd ghostscript-9.23-orig/base/mkromfs.c ghostscript-9.23/base/mkromfs.c
  
      /* process the remaining arguments (options interspersed with paths) */
      for (; atarg < argc; atarg++) {
-diff -Nurd ghostscript-9.23-orig/base/sjpx_openjpeg.c ghostscript-9.23/base/sjpx_openjpeg.c
---- ghostscript-9.23-orig/base/sjpx_openjpeg.c	2018-03-21 09:48:06.000000000 +0100
-+++ ghostscript-9.23/base/sjpx_openjpeg.c	2018-06-20 16:22:19.026344754 +0200
+diff -Nurd ghostscript-9.24-orig/base/sjpx_openjpeg.c ghostscript-9.24/base/sjpx_openjpeg.c
+--- ghostscript-9.24-orig/base/sjpx_openjpeg.c	2018-09-03 10:50:27.000000000 +0200
++++ ghostscript-9.24/base/sjpx_openjpeg.c	2018-09-04 12:08:24.837951736 +0200
 @@ -25,7 +25,6 @@
  #include "gxsync.h"
  #include "assert_.h"
@@ -21,10 +21,10 @@ diff -Nurd ghostscript-9.23-orig/base/sjpx_openjpeg.c ghostscript-9.23/base/sjpx
  #endif
  /* Some locking to get around the criminal lack of context
   * in the openjpeg library. */
-diff -Nurd ghostscript-9.23-orig/base/stdpre.h ghostscript-9.23/base/stdpre.h
---- ghostscript-9.23-orig/base/stdpre.h	2018-03-21 09:48:06.000000000 +0100
-+++ ghostscript-9.23/base/stdpre.h	2018-06-20 16:19:28.835196595 +0200
-@@ -290,7 +290,9 @@
+diff -Nurd ghostscript-9.24-orig/base/stdpre.h ghostscript-9.24/base/stdpre.h
+--- ghostscript-9.24-orig/base/stdpre.h	2018-09-03 10:50:27.000000000 +0200
++++ ghostscript-9.24/base/stdpre.h	2018-09-04 12:08:24.838871826 +0200
+@@ -301,7 +301,9 @@
   * header file that includes sys/types.h.
   *
   */
@@ -35,9 +35,9 @@ diff -Nurd ghostscript-9.23-orig/base/stdpre.h ghostscript-9.23/base/stdpre.h
  #define uchar uchar_
  #define uint uint_
  #define ushort ushort_
-diff -Nurd ghostscript-9.23-orig/base/unistd_.h ghostscript-9.23/base/unistd_.h
---- ghostscript-9.23-orig/base/unistd_.h	2018-03-21 09:48:06.000000000 +0100
-+++ ghostscript-9.23/base/unistd_.h	2018-06-20 16:19:28.837831312 +0200
+diff -Nurd ghostscript-9.24-orig/base/unistd_.h ghostscript-9.24/base/unistd_.h
+--- ghostscript-9.24-orig/base/unistd_.h	2018-09-03 10:50:27.000000000 +0200
++++ ghostscript-9.24/base/unistd_.h	2018-09-04 12:08:24.841437868 +0200
 @@ -53,7 +53,9 @@
     /* _XOPEN_SOURCE 500 define is needed to get
      * access to pread and pwrite */
@@ -49,21 +49,10 @@ diff -Nurd ghostscript-9.23-orig/base/unistd_.h ghostscript-9.23/base/unistd_.h
  #  include <unistd.h>
  #endif
  
-diff -Nurd ghostscript-9.23-orig/base/unixinst.mak ghostscript-9.23/base/unixinst.mak
---- ghostscript-9.23-orig/base/unixinst.mak	2018-03-21 09:48:06.000000000 +0100
-+++ ghostscript-9.23/base/unixinst.mak	2018-06-21 10:28:15.877174455 +0200
-@@ -165,7 +165,6 @@
- 	$(SH) -c 'for f in $(DOC_PAGES) ;\
- 	do if ( test -f $(PSDOCDIR)/$$f ); then $(INSTALL_DATA) $(PSDOCDIR)/$$f $(DESTDIR)$(docdir); fi;\
- 	done'
--	ln -s $(DESTDIR)$(docdir) $(DESTDIR)$(gsdatadir)/doc
- 
- # install the man pages for each locale
- MAN_LCDIRS=. de
-diff -Nurd ghostscript-9.23-orig/configure ghostscript-9.23/configure
---- ghostscript-9.23-orig/configure	2018-03-21 09:49:04.000000000 +0100
-+++ ghostscript-9.23/configure	2018-06-20 16:19:28.842097512 +0200
-@@ -7252,7 +7252,7 @@
+diff -Nurd ghostscript-9.24-orig/configure ghostscript-9.24/configure
+--- ghostscript-9.24-orig/configure	2018-09-03 10:51:26.000000000 +0200
++++ ghostscript-9.24/configure	2018-09-04 12:08:38.175130690 +0200
+@@ -7295,7 +7295,7 @@
  $as_echo_n "checking for local zlib source... " >&6; }
  # we must define ZLIBDIR regardless because png.mak does a -I$(ZLIBDIR)
  # this seems a harmless default
@@ -72,10 +61,10 @@ diff -Nurd ghostscript-9.23-orig/configure ghostscript-9.23/configure
  AUX_SHARED_ZLIB=
  ZLIBCFLAGS=""
  
-diff -Nurd ghostscript-9.23-orig/configure.ac ghostscript-9.23/configure.ac
---- ghostscript-9.23-orig/configure.ac	2018-03-21 09:48:06.000000000 +0100
-+++ ghostscript-9.23/configure.ac	2018-06-20 16:19:28.844559355 +0200
-@@ -1070,7 +1070,7 @@
+diff -Nurd ghostscript-9.24-orig/configure.ac ghostscript-9.24/configure.ac
+--- ghostscript-9.24-orig/configure.ac	2018-09-03 10:50:27.000000000 +0200
++++ ghostscript-9.24/configure.ac	2018-09-04 12:08:38.176848649 +0200
+@@ -1092,7 +1092,7 @@
  dnl zlib is needed for language level 3, and libpng
  # we must define ZLIBDIR regardless because png.mak does a -I$(ZLIBDIR)
  # this seems a harmless default
@@ -84,9 +73,9 @@ diff -Nurd ghostscript-9.23-orig/configure.ac ghostscript-9.23/configure.ac
  AUX_SHARED_ZLIB=
  ZLIBCFLAGS=""
  
-diff -Nurd ghostscript-9.23-orig/contrib/gdevhl12.c ghostscript-9.23/contrib/gdevhl12.c
---- ghostscript-9.23-orig/contrib/gdevhl12.c	2018-03-21 09:48:06.000000000 +0100
-+++ ghostscript-9.23/contrib/gdevhl12.c	2018-06-20 16:19:28.846529241 +0200
+diff -Nurd ghostscript-9.24-orig/contrib/gdevhl12.c ghostscript-9.24/contrib/gdevhl12.c
+--- ghostscript-9.24-orig/contrib/gdevhl12.c	2018-09-03 10:50:27.000000000 +0200
++++ ghostscript-9.24/contrib/gdevhl12.c	2018-09-04 12:08:38.178013818 +0200
 @@ -481,7 +481,7 @@
          break;
      }
@@ -96,9 +85,9 @@ diff -Nurd ghostscript-9.23-orig/contrib/gdevhl12.c ghostscript-9.23/contrib/gde
          put_be16(prn_stream, s->out_count * sizeof(u16) + 7);
          put_be16(prn_stream, s->xl * 16);
          put_be16(prn_stream, band + ytop);
-diff -Nurd ghostscript-9.23-orig/contrib/japanese/gdevp201.c ghostscript-9.23/contrib/japanese/gdevp201.c
---- ghostscript-9.23-orig/contrib/japanese/gdevp201.c	2018-03-21 09:48:06.000000000 +0100
-+++ ghostscript-9.23/contrib/japanese/gdevp201.c	2018-06-20 16:19:28.847504138 +0200
+diff -Nurd ghostscript-9.24-orig/contrib/japanese/gdevp201.c ghostscript-9.24/contrib/japanese/gdevp201.c
+--- ghostscript-9.24-orig/contrib/japanese/gdevp201.c	2018-09-03 10:50:27.000000000 +0200
++++ ghostscript-9.24/contrib/japanese/gdevp201.c	2018-09-04 12:08:38.178879227 +0200
 @@ -242,7 +242,7 @@
                  out_beg -= (out_beg - out) % bytes_per_column;
  
@@ -108,9 +97,9 @@ diff -Nurd ghostscript-9.23-orig/contrib/japanese/gdevp201.c ghostscript-9.23/co
                          (out_beg - out) / bytes_per_column);
  
                  /* Dot graphics */
-diff -Nurd ghostscript-9.23-orig/devices/gdevlp8k.c ghostscript-9.23/devices/gdevlp8k.c
---- ghostscript-9.23-orig/devices/gdevlp8k.c	2018-03-21 09:48:06.000000000 +0100
-+++ ghostscript-9.23/devices/gdevlp8k.c	2018-06-20 16:19:28.848587475 +0200
+diff -Nurd ghostscript-9.24-orig/devices/gdevlp8k.c ghostscript-9.24/devices/gdevlp8k.c
+--- ghostscript-9.24-orig/devices/gdevlp8k.c	2018-09-03 10:50:27.000000000 +0200
++++ ghostscript-9.24/devices/gdevlp8k.c	2018-09-04 12:08:38.179700860 +0200
 @@ -360,9 +360,9 @@
          fprintf(prn_stream,"%d",lnum-60);
          fwrite("Y\035",1,2,prn_stream);
@@ -123,9 +112,9 @@ diff -Nurd ghostscript-9.23-orig/devices/gdevlp8k.c ghostscript-9.23/devices/gde
          fwrite("1;0bi{I",1,7,prn_stream);
          fwrite(out,1,(outp - out),prn_stream);
  
-diff -Nurd ghostscript-9.23-orig/devices/gdevpng.c ghostscript-9.23/devices/gdevpng.c
---- ghostscript-9.23-orig/devices/gdevpng.c	2018-03-21 09:48:06.000000000 +0100
-+++ ghostscript-9.23/devices/gdevpng.c	2018-06-20 16:19:28.849981010 +0200
+diff -Nurd ghostscript-9.24-orig/devices/gdevpng.c ghostscript-9.24/devices/gdevpng.c
+--- ghostscript-9.24-orig/devices/gdevpng.c	2018-09-03 10:50:27.000000000 +0200
++++ ghostscript-9.24/devices/gdevpng.c	2018-09-04 12:08:38.180703470 +0200
 @@ -724,6 +724,7 @@
  
  #if PNG_LIBPNG_VER_MINOR < 5


### PR DESCRIPTION
This also got rid of one of our patches, the one on the link to an old documentation location. This is now fixed upstream, as expected and discussed during Pull Request #188.