### PR TITLE
wget-1.9.5-1: Upstream update (linked to openssl110, not openssl110)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/web/wget.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/wget.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package:  wget%type_pkg[-gnutls]%type_pkg[-idn]
 # OPENSSL110 FTBFS; on hold pending issue #19
-Version: 1.19.2
-Revision: 3
+Version: 1.19.5
+Revision: 1
 Type: -gnutls (boolean), -idn (boolean)
 Description: Automatic web site retriever (SSL)
 Conflicts: <<
@@ -32,7 +32,7 @@ BuildDepends: <<
 	libpcre1,
 	libunistring2,
 	pkgconfig,
-	( %type_raw[-gnutls] = . )		 	openssl100-dev,
+	( %type_raw[-gnutls] = . )		 	openssl110-dev,
 	( %type_raw[-gnutls] = -gnutls )	gnutls28,
 	( %type_raw[-gnutls] = -gnutls )	nettle4a,
 	( %type_raw[-idn] = -idn )			libidn2.0-dev
@@ -44,7 +44,7 @@ Depends: <<
 	libmetalink3-shlibs,
 	libpcre1-shlibs,
 	libunistring2-shlibs,
-	( %type_raw[-gnutls] = . )		 	openssl100-shlibs,
+	( %type_raw[-gnutls] = . )		 	openssl110-shlibs,
 	( %type_raw[-gnutls] = -gnutls )	gnutls28-shlibs,
 	( %type_raw[-gnutls] = -gnutls )	nettle4a-shlibs,
 	( %type_raw[-idn] = -idn ) 			libidn2.0-shlibs
@@ -53,8 +53,8 @@ Provides: gnu-wget
 Suggests: ca-bundle
 
 Source: mirror:gnu:%{ni}/%{ni}-%v.tar.gz
-Source-MD5: caabf9727fa429626316619a6369fffa
-Source-Checksum: SHA1(02f99202df6e540e91bc3764455a27ff9db02167)
+Source-MD5: 2db6f03d655041f82eb64b8c8a1fa7da
+Source-Checksum: SHA1(43b3d09e786df9e8d7aa454095d4ea2d420ae41c)
 
 PatchScript: <<
 #!/bin/sh -ev
@@ -141,16 +141,17 @@ DescPackaging: <<
 
  Now uses gettext8.
 
- Either uses the Fink's openssl100 or GNUTLS, depdending on which variant
+ Either uses the Fink's openssl110 or GNUTLS, depdending on which variant
  is chosen.  Wget's license carries explicit permission to redistribute
  it when using OpenSSL.
 
  Patch for compatibility with texinfo-5.0.
 
+ Previous Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
  Previous revisions by Christoph Pfisterer <chrisp@users.sourceforge.net> 
  and Sylvain Cuaz (zauc@users.sourceforge.net)
 <<
 License: GPL
-Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
+Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 Homepage: http://www.gnu.org/software/wget/wget.html
 <<


### PR DESCRIPTION
As per issue #167 update to version 1.9.5