### PR TITLE
tox-py: update to newer upstream version (3.2.1)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/filelock-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/filelock-py.info
@@ -1,0 +1,33 @@
+Info2: <<
+
+Package: filelock-py%type_pkg[python]
+Version: 3.0.10
+Revision: 1
+License: OSI-Approved
+Type: python (2.7 3.4 3.5 3.6 3.7)
+
+Depends: <<
+  pv-py%type_pkg[python],
+  python%type_pkg[python]
+<<
+BuildDepends: setuptools-tng-py%type_pkg[python]
+
+Source: https://files.pythonhosted.org/packages/source/f/filelock/filelock-%v.tar.gz
+Source-MD5: df0006d2b1ec96473bfc0927de123aa6
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build
+
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
+
+DocFiles: LICENSE.rst README.rst PKG-INFO
+
+InfoTest: <<
+  TestScript: %p/bin/python%type_raw[python] setup.py test || exit 2
+<<
+
+Description: Platform independent file lock
+
+Homepage: https://github.com/benediktschmitt/py-filelock
+Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pv-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pv-py.info
@@ -1,0 +1,37 @@
+Info2: <<
+
+Package: pv-py%type_pkg[python]
+Version: 0.1.3
+Revision: 1
+License: OSI-Approved
+Type: python (2.7 3.4 3.5 3.6 3.7)
+
+Depends: <<
+  webob-py%type_pkg[python],
+  python%type_pkg[python]
+<<
+BuildDepends: setuptools-tng-py%type_pkg[python]
+
+Source: https://files.pythonhosted.org/packages/source/p/pv/pv-%v.tar.gz
+Source-MD5: 733f34c529ec5632db5b3049140cdde9
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build
+
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
+
+DocFiles: PKG-INFO
+
+InfoTest: <<
+#  TestDepends: <<
+#    webob-py%type_pkg[python],
+#    simplejson-py%type_pkg[python]
+#  <<
+#  TestScript: %p/bin/python%type_raw[python] setup.py test || exit 2
+<<
+
+Description: Minimal wsgi framework
+
+Homepage: https://github.com/tetsuo/pv
+Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pv-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pv-py.info
@@ -22,10 +22,7 @@ InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
 DocFiles: PKG-INFO
 
 InfoTest: <<
-#  TestDepends: <<
-#    webob-py%type_pkg[python],
-#    simplejson-py%type_pkg[python]
-#  <<
+#  TestDepends: simplejson-py%type_pkg[python]
 #  TestScript: %p/bin/python%type_raw[python] setup.py test || exit 2
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pv-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pv-py.info
@@ -15,6 +15,11 @@ BuildDepends: setuptools-tng-py%type_pkg[python]
 Source: https://files.pythonhosted.org/packages/source/p/pv/pv-%v.tar.gz
 Source-MD5: 733f34c529ec5632db5b3049140cdde9
 
+PatchScript: <<
+  perl -pi -e 's|except Exception, e|except Exception as e|g' pv/web.py
+  perl -pi -e 's|lambda \(l, s\)|lambda l, s|g' pv/web.py
+<<
+
 CompileScript: %p/bin/python%type_raw[python] setup.py build
 
 InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
@@ -22,8 +27,13 @@ InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
 DocFiles: PKG-INFO
 
 InfoTest: <<
-#  TestDepends: simplejson-py%type_pkg[python]
-#  TestScript: %p/bin/python%type_raw[python] setup.py test || exit 2
+  TestDepends: simplejson-py%type_pkg[python]
+  TestScript: <<
+    #!/bin/sh -ev
+    export PYTHONPATH=%b/build/lib/pv
+# looking for deprecated htmlentitydefs and failing
+#    %p/bin/python%type_raw[python] setup.py test || exit 2
+  <<
 <<
 
 Description: Minimal wsgi framework

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pv-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pv-py.info
@@ -16,8 +16,11 @@ Source: https://files.pythonhosted.org/packages/source/p/pv/pv-%v.tar.gz
 Source-MD5: 733f34c529ec5632db5b3049140cdde9
 
 PatchScript: <<
-  perl -pi -e 's|except Exception, e|except Exception as e|g' pv/web.py
-  perl -pi -e 's|lambda \(l, s\)|lambda l, s|g' pv/web.py
+  #!/bin/sh -ev
+  # Almost nothing in this package conforms with Python 3!
+  if [ %type_pkg[python] -ge 34 ]; then
+    %p/bin/2to3-%type_raw[python] -w pv/__init__.py pv/escape.py pv/web.py pv/wsgi.py pv/template.py
+  fi
 <<
 
 CompileScript: %p/bin/python%type_raw[python] setup.py build
@@ -30,9 +33,8 @@ InfoTest: <<
   TestDepends: simplejson-py%type_pkg[python]
   TestScript: <<
     #!/bin/sh -ev
-    export PYTHONPATH=%b/build/lib/pv
-# looking for deprecated htmlentitydefs and failing
-#    %p/bin/python%type_raw[python] setup.py test || exit 2
+    export PYTHONPATH=%b/build/lib
+    %p/bin/python%type_raw[python] setup.py test || exit 2
   <<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/toml-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/toml-py.info
@@ -1,0 +1,33 @@
+Info2: <<
+
+Package: toml-py%type_pkg[python]
+Version: 0.9.6
+Revision: 1
+License: OSI-Approved
+Type: python (2.7 3.4 3.5 3.6 3.7)
+
+Depends: python%type_pkg[python]
+BuildDepends: setuptools-tng-py%type_pkg[python]
+
+Source: https://files.pythonhosted.org/packages/source/t/toml/toml-%v.tar.gz
+Source-MD5: efbe91ac7bec4e2ff23dd7d69cd7bb97
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build
+
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
+
+DocFiles: PKG-INFO
+
+InfoTest: <<
+  TestScript: %p/bin/python%type_raw[python] setup.py test || exit 2
+<<
+
+Description: Library for parsing and creating TOML
+DescDetail: <<
+Python Library for Tom's Obvious, Minimal Language
+<<
+
+Homepage: https://github.com/uiri/toml
+Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
@@ -46,19 +46,6 @@ DocFiles: CODE_OF_CONDUCT.md CONTRIBUTING.rst CONTRIBUTORS docs HOWTORELEASE.rst
 # but at least make sure they are running the correct script variants.
 PatchScript: <<
     sed 's|PY_PKG|%type_pkg[python]|g;s|PY_RAW|%type_raw[python]|g;s|FINK_BINDIR|%p/bin|g;' %{PatchFile} | patch -p1
-
-# remove non ascii characters
-    perl -pi -e 's|Andrys..k|Andrysik|g;'                           docs/changelog.rst
-    perl -pi -e 's|Andr.. Caron|Andre Caron|g;'                     docs/changelog.rst
-    perl -pi -e 's|Bartolom.. S..nchez|Bartolome Sanchez|g;'        docs/changelog.rst
-    perl -pi -e 's|Bern..t G..bor|Bernat Gabor|g;'                  docs/changelog.rst
-    perl -pi -e 's|Pawe.. Adamczak|Pawel Adamczak|g;'               docs/changelog.rst
-    perl -pi -e 's|Jorgen Sch..fer|Jorgen Schaefer|g;'              docs/changelog.rst
-    perl -pi -e 's|it hit the masses .*\n|it hits the masses.\n|g;' docs/changelog.rst
-    perl -pi -e 's|Alex Gr..nholm|Alex Groenholm|g;'                docs/changelog.rst
-
-    perl -pi -e 's/... .2. py27 . py36/ [2] py27 | py36/g;' docs/example/basic.rst
-    perl -pi -e 's/... OK /  OK /g;'                        docs/example/basic.rst
 <<
 
 CompileScript: <<
@@ -86,7 +73,9 @@ InfoTest: <<
         mv build/bin/tox-quickstart build/bin/tox-quickstart-py%type_pkg[python]
         chmod -R go+rX build tox*
         PATH=%b/build/bin:$PATH
-        export PYTHONPATH=%b
+        export PYTHONPATH=%b/build/lib
+        # fix non-ASCII characters in docs/changelog.rst and docs/example/basic.rst
+        export LANG=en_US.UTF-8
         # Locally installed scripts run correctly if tested separately, but when testing
         # all at once, fail with a DistributionNotFound - go figure...
         # Set DEB_SKIP_TOX_TESTS to disable them entirely [marked `skipif()`]

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
@@ -80,7 +80,8 @@ InfoTest: <<
         # all at once, fail with a DistributionNotFound - go figure...
         # Set DEB_SKIP_TOX_TESTS to disable them entirely [marked `skipif()`]
         %p/bin/pytest-%type_raw[python] tests -k '_script' || exit 2
-        %p/bin/pytest-%type_raw[python] tests -k 'not _script' || exit 2
+        # skip test in tests/unit/test_z_cmdline.py with "and not test_test_usedevelop"
+        %p/bin/pytest-%type_raw[python] tests -k 'not _script and not test_test_usedevelop' || exit 2
     <<
     TestSuiteSize: medium
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
@@ -3,7 +3,7 @@ Info4: <<
 
 Package: tox-py%type_pkg[python]
 Version: 3.2.1
-Revision: 1
+Revision: 2
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 License: BSD
 Type: python (2.7 3.4 3.5 3.6 3.7)
@@ -13,8 +13,9 @@ Source-MD5: 9842594289bea32be520efe7e1b09d4e
 PatchFile: %{ni}.patch
 PatchFile-MD5: 4bc15e712f008ce6c49ac3446f38040a
 
-Depends: python%type_pkg[python]-shlibs
+Depends: python%type_pkg[python]-shlibs, pluggy-py%type_pkg[python], py-py%type_pkg[python], six-py%type_pkg[python], virtualenv-py%type_pkg[python]
 BuildDepends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
+Suggests: pytest-py%type_pkg[python]
 
 Description: Testing in virtualenvs
 
@@ -43,7 +44,10 @@ PatchScript: <<
     perl -pi -e 's|(python)(3.7)(.-[cm])|%p/bin/${1}%type_raw[python]${3}|g;' tox.ini
     perl -pi -e 's|(python)(.setup.py)|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
     perl -pi -e 's|(python)(.{toxinidir})|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
-    perl -pi -e 's|(coverage)(\ [ecrx])|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
+    perl -pi -e 's|(coverage)(.erase)|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
+    perl -pi -e 's|(coverage)(.combine)|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
+    perl -pi -e 's|(coverage)(.report)|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
+    perl -pi -e 's|(coverage)(.xml)|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
     perl -pi -e 's|(sphinx-build)(.-[d])|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
 <<
 
@@ -55,10 +59,8 @@ InfoTest: <<
     TestDepends: <<
         atomicwrites-py%type_pkg[python], 
         pathlib2-py%type_pkg[python],
-        pluggy-py%type_pkg[python],
         pytest-mock-py%type_pkg[python],
-        scandir-py%type_pkg[python],
-        virtualenv-py%type_pkg[python]
+        scandir-py%type_pkg[python]
     <<
     TestScript: <<
         #!/bin/bash -ev

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
@@ -2,18 +2,25 @@
 Info4: <<
 
 Package: tox-py%type_pkg[python]
-Version: 3.3.0
-Revision: 2
+Version: 3.7.0
+Revision: 1
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 License: BSD
 Type: python (2.7 3.4 3.5 3.6 3.7)
-Homepage: http://pypi.python.org/pypi/tox/
+Homepage: https://pypi.org/project/tox/
 Source: https://files.pythonhosted.org/packages/source/t/tox/tox-%v.tar.gz
-Source-MD5: 1d7d9cd0284332dfbadbb203abcf7ecf
+Source-MD5: a759c0bc964c2f3002d5a39212be6886
 PatchFile: %{ni}.patch
-PatchFile-MD5: d05bb72d552c7f6053177e7d2e4d3240
+PatchFile-MD5: d5c35dca76b54a9a2f73d726a2eecc48
 
-Depends: python%type_pkg[python]-shlibs, pluggy-py%type_pkg[python], py-py%type_pkg[python], six-py%type_pkg[python], virtualenv-py%type_pkg[python]
+Depends: <<
+	python%type_pkg[python]-shlibs,
+	filelock-py%type_pkg[python],
+	pluggy-py%type_pkg[python],
+	py-py%type_pkg[python],
+	six-py%type_pkg[python],
+	virtualenv-py%type_pkg[python]
+<<
 BuildDepends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
 Suggests: pytest-py%type_pkg[python]
 
@@ -33,22 +40,25 @@ tox aims to automate and standardize testing in Python. It is part of a larger
 vision of easing the packaging, testing and release process of Python software.
 <<
 
-DocFiles: README.rst CHANGELOG.rst HOWTORELEASE.rst CONTRIBUTING.rst CONTRIBUTORS PKG-INFO LICENSE doc
+DocFiles: CODE_OF_CONDUCT.md CONTRIBUTING.rst CONTRIBUTORS docs HOWTORELEASE.rst LICENSE PKG-INFO README.md
 
 # Tests should not be run against the installed version and are not included in the package after installation,
 # but at least make sure they are running the correct script variants.
 PatchScript: <<
-    sed 's|PY_PKG|%type_pkg[python]|g;s|PY_RAW|%type_raw[python]|g;' %{PatchFile} | patch -p1
-    perl -pi -e 's|(basepython = python)(3.7)|${1}%type_raw[python]|g;' tox.ini
-    perl -pi -e 's|(python)(.-[cm])|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
-    perl -pi -e 's|(python)(3.7)(.-[cm])|%p/bin/${1}%type_raw[python]${3}|g;' tox.ini
-    perl -pi -e 's|(python)(.setup.py)|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
-    perl -pi -e 's|(python)(.{toxinidir})|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
-    perl -pi -e 's|(coverage)(.erase)|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
-    perl -pi -e 's|(coverage)(.combine)|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
-    perl -pi -e 's|(coverage)(.report)|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
-    perl -pi -e 's|(coverage)(.xml)|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
-    perl -pi -e 's|(sphinx-build)(.-[d])|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
+    sed 's|PY_PKG|%type_pkg[python]|g;s|PY_RAW|%type_raw[python]|g;s|FINK_BINDIR|%p/bin|g;' %{PatchFile} | patch -p1
+
+# remove non ascii characters
+    perl -pi -e 's|Andrys..k|Andrysik|g;'                           docs/changelog.rst
+    perl -pi -e 's|Andr.. Caron|Andre Caron|g;'                     docs/changelog.rst
+    perl -pi -e 's|Bartolom.. S..nchez|Bartolome Sanchez|g;'        docs/changelog.rst
+    perl -pi -e 's|Bern..t G..bor|Bernat Gabor|g;'                  docs/changelog.rst
+    perl -pi -e 's|Pawe.. Adamczak|Pawel Adamczak|g;'               docs/changelog.rst
+    perl -pi -e 's|Jorgen Sch..fer|Jorgen Schaefer|g;'              docs/changelog.rst
+    perl -pi -e 's|it hit the masses .*\n|it hits the masses.\n|g;' docs/changelog.rst
+    perl -pi -e 's|Alex Gr..nholm|Alex Groenholm|g;'                docs/changelog.rst
+
+    perl -pi -e 's/... .2. py27 . py36/ [2] py27 | py36/g;' docs/example/basic.rst
+    perl -pi -e 's/... OK /  OK /g;'                        docs/example/basic.rst
 <<
 
 CompileScript: <<
@@ -57,8 +67,11 @@ CompileScript: <<
 
 InfoTest: <<
     TestDepends: <<
-        atomicwrites-py%type_pkg[python], 
+        atomicwrites-py%type_pkg[python],
+        coverage-py%type_pkg[python],
+        freezegun-py%type_pkg[python],
         pathlib2-py%type_pkg[python],
+        pip-py%type_pkg[python],
         pytest-mock-py%type_pkg[python],
         scandir-py%type_pkg[python],
         toml-py%type_pkg[python]

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
@@ -2,16 +2,16 @@
 Info4: <<
 
 Package: tox-py%type_pkg[python]
-Version: 3.2.1
+Version: 3.3.0
 Revision: 2
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 License: BSD
 Type: python (2.7 3.4 3.5 3.6 3.7)
 Homepage: http://pypi.python.org/pypi/tox/
 Source: https://files.pythonhosted.org/packages/source/t/tox/tox-%v.tar.gz
-Source-MD5: 9842594289bea32be520efe7e1b09d4e
+Source-MD5: 1d7d9cd0284332dfbadbb203abcf7ecf
 PatchFile: %{ni}.patch
-PatchFile-MD5: 4bc15e712f008ce6c49ac3446f38040a
+PatchFile-MD5: d05bb72d552c7f6053177e7d2e4d3240
 
 Depends: python%type_pkg[python]-shlibs, pluggy-py%type_pkg[python], py-py%type_pkg[python], six-py%type_pkg[python], virtualenv-py%type_pkg[python]
 BuildDepends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
@@ -60,7 +60,8 @@ InfoTest: <<
         atomicwrites-py%type_pkg[python], 
         pathlib2-py%type_pkg[python],
         pytest-mock-py%type_pkg[python],
-        scandir-py%type_pkg[python]
+        scandir-py%type_pkg[python],
+        toml-py%type_pkg[python]
     <<
     TestScript: <<
         #!/bin/bash -ev

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
@@ -2,19 +2,19 @@
 Info4: <<
 
 Package: tox-py%type_pkg[python]
-Version: 3.0.0
+Version: 3.2.1
 Revision: 1
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 License: BSD
 Type: python (2.7 3.4 3.5 3.6 3.7)
 Homepage: http://pypi.python.org/pypi/tox/
 Source: https://files.pythonhosted.org/packages/source/t/tox/tox-%v.tar.gz
-Source-MD5: 5dfc0bc3865a7a06186d7e0766015a80
+Source-MD5: 9842594289bea32be520efe7e1b09d4e
 PatchFile: %{ni}.patch
-PatchFile-MD5: a3372c83f50d93b2f00a2de60697d419
+PatchFile-MD5: 4bc15e712f008ce6c49ac3446f38040a
 
-Depends: python%type_pkg[python]-shlibs, pytest-py%type_pkg[python], virtualenv-py%type_pkg[python], pluggy-py%type_pkg[python]
-BuildDepends: python%type_pkg[python], setuptools-scm-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
+Depends: python%type_pkg[python]-shlibs
+BuildDepends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
 
 Description: Testing in virtualenvs
 
@@ -32,15 +32,18 @@ tox aims to automate and standardize testing in Python. It is part of a larger
 vision of easing the packaging, testing and release process of Python software.
 <<
 
-DocFiles: README.rst CHANGELOG.rst HOWTORELEASE.rst CONTRIBUTING.rst CONTRIBUTORS PKG-INFO doc
+DocFiles: README.rst CHANGELOG.rst HOWTORELEASE.rst CONTRIBUTING.rst CONTRIBUTORS PKG-INFO LICENSE doc
 
 # Tests should not be run against the installed version and are not included in the package after installation,
 # but at least make sure they are running the correct script variants.
 PatchScript: <<
     sed 's|PY_PKG|%type_pkg[python]|g;s|PY_RAW|%type_raw[python]|g;' %{PatchFile} | patch -p1
-    perl -pi -e 's|(basepython = python)(3.6)|${1}%type_raw[python]|g;' tox.ini
+    perl -pi -e 's|(basepython = python)(3.7)|${1}%type_raw[python]|g;' tox.ini
     perl -pi -e 's|(python)(.-[cm])|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
-    perl -pi -e 's|(python)(3.6)(.-[cm])|%p/bin/${1}%type_raw[python]${3}|g;' tox.ini
+    perl -pi -e 's|(python)(3.7)(.-[cm])|%p/bin/${1}%type_raw[python]${3}|g;' tox.ini
+    perl -pi -e 's|(python)(.setup.py)|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
+    perl -pi -e 's|(python)(.{toxinidir})|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
+    perl -pi -e 's|(coverage)(\ [ecrx])|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
     perl -pi -e 's|(sphinx-build)(.-[d])|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
 <<
 
@@ -49,7 +52,14 @@ CompileScript: <<
 <<
 
 InfoTest: <<
-    TestDepends: pytest-mock-py%type_pkg[python]
+    TestDepends: <<
+        atomicwrites-py%type_pkg[python], 
+        pathlib2-py%type_pkg[python],
+        pluggy-py%type_pkg[python],
+        pytest-mock-py%type_pkg[python],
+        scandir-py%type_pkg[python],
+        virtualenv-py%type_pkg[python]
+    <<
     TestScript: <<
         #!/bin/bash -ev
         # Create tox/tox-quickstart scripts locally and add pkg_resources info

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
@@ -11,7 +11,7 @@ Homepage: https://pypi.org/project/tox/
 Source: https://files.pythonhosted.org/packages/source/t/tox/tox-%v.tar.gz
 Source-MD5: a759c0bc964c2f3002d5a39212be6886
 PatchFile: %{ni}.patch
-PatchFile-MD5: d5c35dca76b54a9a2f73d726a2eecc48
+PatchFile-MD5: 9c0009ed0ca3a29ce100d67b43dc2839
 
 Depends: <<
 	python%type_pkg[python]-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.patch
@@ -1,38 +1,198 @@
 diff --git a/tox.ini b/tox.ini
 --- a/tox.ini	2018-02-22 12:08:28.000000000 +0100
 +++ b/tox.ini	2018-05-16 22:15:56.000000000 +0200
-@@ -20,7 +20,8 @@
+@@ -21,36 +21,37 @@
+ passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE PYTEST_ADDOPTS
  deps =
  extras = testing
- changedir = {toxinidir}/tests
--commands = pytest {posargs:--cov="{envsitepackagesdir}/tox" --cov-config="{toxinidir}/tox.ini"  --timeout=180 . -n {env:PYTEST_XDIST_PROC_NR:auto} --junitxml={toxworkdir}/test-results.{envname}.xml}
-+commands = pytest-PY_RAW {posargs:--cov="{envsitepackagesdir}/tox" --cov-config="{toxinidir}/tox.ini"  --timeout=180 . -n {env:PYTEST_XDIST_PROC_NR:auto} --junitxml={toxworkdir}/test-results.{envname}.xml}
+-commands = pytest {posargs:\
++commands = FINK_BINDIR/pytest-PY_RAW {posargs:\
+            --cov="{envsitepackagesdir}/tox" \
+            --cov-config="{toxinidir}/tox.ini"  \
+            --timeout=180 \
+            -n={env:PYTEST_XDIST_PROC_NR:auto} \
+            --junitxml={env:JUNIT_XML_FILE:{toxworkdir}/.test.{envname}.xml} \
+            . }
 +whitelist_externals: pytest-PY_RAW
  
  [testenv:docs]
- description = invoke sphinx-build to build the HTML docs and check that all links are valid
+ description = invoke sphinx-build to build the HTML docs
+-basepython = python3.7
++basepython = pythonPY_RAW
+ extras = docs
+-commands = sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
+-           python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
++commands = FINK_BINDIR/sphinx-buildPY_RAW -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
++           FINK_BINDIR/pythonPY_RAW -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
+ 
+ [testenv:package_description]
+ description = check that the long description is valid
+-basepython = python3.7
++basepython = FINK_BINDIR/pythonPY_RAW
+ deps = twine >= 1.12.1
+        # TODO installing readme-renderer[md] should not be necessary
+        readme-renderer[md] >= 24.0
+        pip >= 18.0.0
+ skip_install = true
+ extras =
+-commands = pip wheel -w {envtmpdir}/build --no-deps .
++commands = FINK_BINDIR/pipPY_RAW wheel -w {envtmpdir}/build --no-deps .
+            twine check {envtmpdir}/build/*
+ 
+ [testenv:fix_lint]
+ description = format the code base to adhere to our styles, and complain about what we cannot do automatically
+-basepython = python3.7
++basepython = FINK_BINDIR/pythonPY_RAW
+ passenv = {[testenv]passenv}
+           HOMEPATH
+           # without PROGRAMDATA cloning using git for Windows will fail with an
+@@ -60,7 +61,7 @@
+ deps = pre-commit == 1.10.3
+ skip_install = True
+ commands = pre-commit run --all-files --show-diff-on-failure
+-           python -c 'import pathlib; print("hint: run \{\} install to add checks as pre-commit hook".format(pathlib.Path(r"{envdir}") / "bin" / "pre-commit"))'
++           FINK_BINDIR/pythonPY_RAW -c 'import pathlib; print("hint: run \{\} install to add checks as pre-commit hook".format(pathlib.Path(r"{envdir}") / "bin" / "pre-commit"))'
+ 
+ 
+ [testenv:coverage]
+@@ -73,12 +74,12 @@
+ passenv = {[testenv]passenv}
+           DIFF_AGAINST
+ setenv = COVERAGE_FILE={toxworkdir}/.coverage
+-commands = coverage erase
+-           coverage combine
+-           coverage report -m
+-           coverage xml -o {toxworkdir}/coverage.xml
+-           coverage html -d {toxworkdir}/htmlcov
+-           diff-cover --compare-branch {env:DIFF_AGAINST:origin/master} {toxworkdir}/coverage.xml
++commands = FINK_BINDIR/coveragePY_RAW erase
++           FINK_BINDIR/coveragePY_RAW combine
++           FINK_BINDIR/coveragePY_RAW report -m
++           FINK_BINDIR/coveragePY_RAW xml -o {toxworkdir}/coverage.xml
++           FINK_BINDIR/coveragePY_RAW html -d {toxworkdir}/htmlcov
++           diff-cover --compare-branch {env:DIFF_AGAINST:origin/master} {toxworkdir}/FINK_BINDIR/coveragePY_RAW.xml
+ depends = py27, py34, py35, py36, py37, pypy, pypy3
+ parallel_show_output = True
+ 
+@@ -89,15 +90,15 @@
+ setenv = COVERAGE_FILE={toxworkdir}/.coverage
+ deps = coveralls[yaml]>= 1.5.1, <2
+ skip_install = True
+-commands = coveralls --rcfile=tox.ini -v
++commands = FINK_BINDIR/coverallsPY_RAW --rcfile=tox.ini -v
+ 
+ [testenv:exit_code]
+ # to see how the InvocationError is displayed, use
+ # PYTHONPATH=.:$PYTHONPATH python3 -m tox -e exit_code
+-basepython = python3.7
++basepython = FINK_BINDIR/pythonPY_RAW
+ description = commands with several exit codes
+ skip_install = True
+-commands = python3.7 -c "import sys; sys.exit(139)"
++commands = FINK_BINDIR/pythonPY_RAW -c "import sys; sys.exit(139)"
+ 
+ [testenv:X]
+ description = print the positional arguments passed in with echo
+@@ -150,23 +151,23 @@
+ 
+ [testenv:release]
+ description = do a release, required posarg of the version number
+-basepython = python3.7
++basepython = FINK_BINDIR/pythonPY_RAW
+ passenv = *
+ deps = gitpython >= 2.1.10
+        towncrier >= 18.5.0
+        packaging  >= 17.1
+-commands = python {toxinidir}/tasks/release.py --version {posargs}
++commands = FINK_BINDIR/pythonPY_RAW {toxinidir}/tasks/release.py --version {posargs}
+ 
+ [testenv:notify]
+ description = notify people about the release of the library
+-basepython = python3.7
++basepython = FINK_BINDIR/pythonPY_RAW
+ skip_install = true
+ passenv = *
+ deps = gitpython >= 2.1.10
+        packaging  >= 17.1
+        google-api-python-client >= 1.7.3
+        oauth2client >= 4.1.2
+-commands = python {toxinidir}/tasks/notify.py
++commands = FINK_BINDIR/pythonPY_RAW {toxinidir}/tasks/notify.py
+ 
+ [testenv:dev]
+ description = dev environment with all deps at {envdir}
+@@ -176,4 +177,4 @@
+        {[testenv:notify]deps}
+ usedevelop = True
+-commands = python -m pip list --format=columns
+-           python -c "print('{envpython}')"
++commands = FINK_BINDIR/pythonPY_RAW -m pip list --format=columns
++           FINK_BINDIR/pythonPY_RAW -c "print('{envpython}')"
+diff -Naur a/tests/unit/test_config.py b/tests/unit/test_config.py
+--- a/tests/unit/config/test_config.py	2018-10-09 12:10:01.000000000 +0200
++++ b/tests/unit/config/test_config.py	2019-01-06 19:50:42.195315677 +0100
+@@ -988,7 +988,7 @@
+         config = newconfig(
+             """
+             [testenv]
+-            basepython=python
++            basepython=FINK_BINDIR/pythonPY_RAW
+         """
+         )
+         assert len(config.envconfigs) == 1
+@@ -1874,14 +1874,14 @@
+             config = newconfig(
+                 """
+                 [testenv]
+-                basepython=python3
++                basepython=FINK_BINDIR/pythonPY_RAW
+                 [testenv:py27]
+-                commands = python --version
++                commands = FINK_BINDIR/pythonPY_RAW --version
+             """
+             )
+         assert len(config.envconfigs) == 1
+         envconfig = config.envconfigs["py27"]
+-        assert envconfig.basepython == "python3"
++        assert envconfig.basepython == "FINK_BINDIR/pythonPY_RAW"
+ 
+     def test_default_factors_conflict_lying_name(
+         self, newconfig, capsys, tmpdir, recwarn, monkeypatch
+@@ -1915,7 +1915,7 @@
+                 [tox]
+                 ignore_basepython_conflict=True
+                 [testenv]
+-                basepython=python3
++                basepython=FINK_BINDIR/pythonPY_RAW
+                 [testenv:py27]
+-                commands = python --version
++                commands = FINK_BINDIR/pythonPY_RAW --version
+             """
 diff --git a/tests/test_z_cmdline.py b/tests/test_z_cmdline.py
 --- a/tests/unit/test_z_cmdline.py	2018-03-24 11:05:06.000000000 +0100
 +++ b/tests/unit/test_z_cmdline.py	2018-05-16 22:07:44.000000000 +0200
-@@ -447,7 +447,7 @@
+@@ -429,7 +429,7 @@
              changedir=tests
-             commands= pytest --basetemp={envtmpdir} \
+-            commands= pytest --basetemp={envtmpdir} \
++            commands= FINK_BINDIR/pytest-PY_RAW --basetemp={envtmpdir} \
                                --junitxml=junit-{envname}.xml
 -            deps=pytest
 +            sitepackages=True
          """,
          },
      )
-@@ -565,7 +565,7 @@
+@@ -549,8 +549,7 @@
              changedir=tests
              commands=
-                 pytest --basetemp={envtmpdir} --junitxml=junit-{envname}.xml []
--            deps=pytest
+-                pytest --basetemp={envtmpdir} --junitxml=junit-{envname}.xml []
+-            deps=pytest"""
+-            + """
++                FINK_BINDIR/pytest-PY_RAW --basetemp={envtmpdir} --junitxml=junit-{envname}.xml []
 +            sitepackages=True
-         """,
-         },
-     )
-@@ -852,15 +852,17 @@
+             skipsdist={}
+         """.format(
+                 skipsdist
+@@ -891,15 +890,17 @@
      )
  
  
@@ -40,7 +200,7 @@ diff --git a/tests/test_z_cmdline.py b/tests/test_z_cmdline.py
  def test_tox_console_script(initproj):
      initproj("help", filedefs={"tox.ini": ""})
 -    result = subprocess.check_call(["tox", "--help"])
-+    result = subprocess.check_call(["tox-pyPY_PKG", "--help"])
++    result = subprocess.check_call(["FINK_BINDIR/tox-pyPY_PKG", "--help"])
      assert result == 0
  
  
@@ -48,7 +208,7 @@ diff --git a/tests/test_z_cmdline.py b/tests/test_z_cmdline.py
  def test_tox_quickstart_script(initproj):
      initproj("help", filedefs={"tox.ini": ""})
 -    result = subprocess.check_call(["tox-quickstart", "--help"])
-+    result = subprocess.check_call(["tox-quickstart-pyPY_PKG", "--help"])
++    result = subprocess.check_call(["FINK_BINDIR/tox-quickstart-pyPY_PKG", "--help"])
      assert result == 0
  
  

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.patch
@@ -158,7 +158,7 @@ diff -Naur a/tests/unit/test_config.py b/tests/unit/test_config.py
  
      def test_default_factors_conflict_lying_name(
          self, newconfig, capsys, tmpdir, recwarn, monkeypatch
-@@ -1915,7 +1915,7 @@
+@@ -1915,9 +1915,9 @@
                  [tox]
                  ignore_basepython_conflict=True
                  [testenv]
@@ -168,10 +168,14 @@ diff -Naur a/tests/unit/test_config.py b/tests/unit/test_config.py
 -                commands = python --version
 +                commands = FINK_BINDIR/pythonPY_RAW --version
              """
+             )
+         assert len(config.envconfigs) == 1
 diff --git a/tests/test_z_cmdline.py b/tests/test_z_cmdline.py
 --- a/tests/unit/test_z_cmdline.py	2018-03-24 11:05:06.000000000 +0100
 +++ b/tests/unit/test_z_cmdline.py	2018-05-16 22:07:44.000000000 +0200
-@@ -429,7 +429,7 @@
+@@ -427,9 +427,9 @@
+             "tox.ini": """
+             [testenv]
              changedir=tests
 -            commands= pytest --basetemp={envtmpdir} \
 +            commands= FINK_BINDIR/pytest-PY_RAW --basetemp={envtmpdir} \
@@ -181,7 +185,8 @@ diff --git a/tests/test_z_cmdline.py b/tests/test_z_cmdline.py
          """,
          },
      )
-@@ -549,8 +549,7 @@
+@@ -548,9 +548,8 @@
+             usedevelop=True
              changedir=tests
              commands=
 -                pytest --basetemp={envtmpdir} --junitxml=junit-{envname}.xml []

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.patch
@@ -1,52 +1,54 @@
 diff --git a/tox.ini b/tox.ini
 --- a/tox.ini	2018-02-22 12:08:28.000000000 +0100
 +++ b/tox.ini	2018-05-16 22:15:56.000000000 +0200
-@@ -15,7 +15,8 @@
- setenv = COVERAGE_FILE={toxworkdir}/.coverage.{envname}
- passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE TOXENV CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_* CODECOV_*
+@@ -20,7 +20,8 @@
+ deps =
  extras = testing
--commands = pytest {posargs:--cov-config="{toxinidir}/tox.ini" --cov="{envsitepackagesdir}/tox" --timeout=180 tests}
-+commands = pytest-PY_RAW {posargs:--cov-config="{toxinidir}/tox.ini" --cov="{envsitepackagesdir}/tox" --timeout=180 tests}
+ changedir = {toxinidir}/tests
+-commands = pytest {posargs:--cov="{envsitepackagesdir}/tox" --cov-config="{toxinidir}/tox.ini"  --timeout=180 . -n {env:PYTEST_XDIST_PROC_NR:auto} --junitxml={toxworkdir}/test-results.{envname}.xml }
++commands = pytest-PY_RAW {posargs:--cov="{envsitepackagesdir}/tox" --cov-config="{toxinidir}/tox.ini"  --timeout=180 . -n {env:PYTEST_XDIST_PROC_NR:auto} --junitxml={toxworkdir}/test-results.{envname}.xml }
 +whitelist_externals: pytest-PY_RAW
  
  [testenv:docs]
- description = invoke sphinx-build to build the HTML docs, check that URIs are valid
+ description = invoke sphinx-build to build the HTML docs and check that all links are valid
 diff --git a/tests/test_z_cmdline.py b/tests/test_z_cmdline.py
 --- a/tests/test_z_cmdline.py	2018-03-24 11:05:06.000000000 +0100
 +++ b/tests/test_z_cmdline.py	2018-05-16 22:07:44.000000000 +0200
-@@ -492,7 +492,7 @@
+@@ -494,7 +494,7 @@
              changedir=tests
              commands= pytest --basetemp={envtmpdir} \
                                --junitxml=junit-{envname}.xml
 -            deps=pytest
 +            sitepackages=True
-         '''
-     })
- 
-@@ -586,7 +586,7 @@
+         """,
+         },
+     )
+@@ -612,7 +612,7 @@
              changedir=tests
              commands=
                  pytest --basetemp={envtmpdir} --junitxml=junit-{envname}.xml []
 -            deps=pytest
 +            sitepackages=True
-         '''
-     })
-     result = cmd("-v")
-@@ -892,13 +892,15 @@
-                                " Environment variables are missing or defined recursively.\n")
+         """,
+         },
+     )
+@@ -985,15 +985,17 @@
+     )
  
  
 +@pytest.mark.skipif(os.environ.get('DEB_SKIP_TOX_TESTS'), reason='Use DEP-8')
- def test_tox_console_script():
--    result = subprocess.check_call(['tox', '--help'])
-+    result = subprocess.check_call(['tox-pyPY_PKG', '--help'])
+ def test_tox_console_script(initproj):
+     initproj("help", filedefs={"tox.ini": ""})
+-    result = subprocess.check_call(["tox", "--help"])
++    result = subprocess.check_call(["tox-pyPY_PKG", "--help"])
      assert result == 0
  
  
 +@pytest.mark.skipif(os.environ.get('DEB_SKIP_TOX_TESTS'), reason='Use DEP-8')
- def test_tox_quickstart_script():
--    result = subprocess.check_call(['tox-quickstart', '--help'])
-+    result = subprocess.check_call(['tox-quickstart-pyPY_PKG', '--help'])
+ def test_tox_quickstart_script(initproj):
+     initproj("help", filedefs={"tox.ini": ""})
+-    result = subprocess.check_call(["tox-quickstart", "--help"])
++    result = subprocess.check_call(["tox-quickstart-pyPY_PKG", "--help"])
      assert result == 0
  
  

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.patch
@@ -5,16 +5,16 @@ diff --git a/tox.ini b/tox.ini
  deps =
  extras = testing
  changedir = {toxinidir}/tests
--commands = pytest {posargs:--cov="{envsitepackagesdir}/tox" --cov-config="{toxinidir}/tox.ini"  --timeout=180 . -n {env:PYTEST_XDIST_PROC_NR:auto} --junitxml={toxworkdir}/test-results.{envname}.xml }
-+commands = pytest-PY_RAW {posargs:--cov="{envsitepackagesdir}/tox" --cov-config="{toxinidir}/tox.ini"  --timeout=180 . -n {env:PYTEST_XDIST_PROC_NR:auto} --junitxml={toxworkdir}/test-results.{envname}.xml }
+-commands = pytest {posargs:--cov="{envsitepackagesdir}/tox" --cov-config="{toxinidir}/tox.ini"  --timeout=180 . -n {env:PYTEST_XDIST_PROC_NR:auto} --junitxml={toxworkdir}/test-results.{envname}.xml}
++commands = pytest-PY_RAW {posargs:--cov="{envsitepackagesdir}/tox" --cov-config="{toxinidir}/tox.ini"  --timeout=180 . -n {env:PYTEST_XDIST_PROC_NR:auto} --junitxml={toxworkdir}/test-results.{envname}.xml}
 +whitelist_externals: pytest-PY_RAW
  
  [testenv:docs]
  description = invoke sphinx-build to build the HTML docs and check that all links are valid
 diff --git a/tests/test_z_cmdline.py b/tests/test_z_cmdline.py
---- a/tests/test_z_cmdline.py	2018-03-24 11:05:06.000000000 +0100
-+++ b/tests/test_z_cmdline.py	2018-05-16 22:07:44.000000000 +0200
-@@ -494,7 +494,7 @@
+--- a/tests/unit/test_z_cmdline.py	2018-03-24 11:05:06.000000000 +0100
++++ b/tests/unit/test_z_cmdline.py	2018-05-16 22:07:44.000000000 +0200
+@@ -447,7 +447,7 @@
              changedir=tests
              commands= pytest --basetemp={envtmpdir} \
                                --junitxml=junit-{envname}.xml
@@ -23,7 +23,7 @@ diff --git a/tests/test_z_cmdline.py b/tests/test_z_cmdline.py
          """,
          },
      )
-@@ -612,7 +612,7 @@
+@@ -565,7 +565,7 @@
              changedir=tests
              commands=
                  pytest --basetemp={envtmpdir} --junitxml=junit-{envname}.xml []
@@ -32,7 +32,7 @@ diff --git a/tests/test_z_cmdline.py b/tests/test_z_cmdline.py
          """,
          },
      )
-@@ -985,15 +985,17 @@
+@@ -852,15 +852,17 @@
      )
  
  

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/webob-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/webob-py.info
@@ -1,7 +1,7 @@
 Info2: <<
 
 Package: webob-py%type_pkg[python]
-Version: 1.4.1
+Version: 1.8.5
 Revision: 1
 License: OSI-Approved
 Type: python (2.7 3.4 3.5 3.6 3.7)
@@ -10,46 +10,13 @@ Depends: python%type_pkg[python]
 BuildDepends: setuptools-tng-py%type_pkg[python]
 
 Source: https://files.pythonhosted.org/packages/source/W/WebOb/WebOb-%v.tar.gz
-Source-MD5: a5c6e8ba5431756e6a5d5ec56047ec94
-
-Patchscript: <<
-#!/bin/sh -ev
-# add missing LICENSE file, a copy from the git repository
-cat >LICENSE <<EOFFILE
-The MIT License
-
-Copyright 2013-2018 William Pearson
-Copyright 2015-2016 Julien Enselme
-Copyright 2016 Google Inc.
-Copyright 2017 Samuel Vasko
-Copyright 2017 Nate Prewitt
-Copyright 2017 Jack Evans
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-EOFFILE
-<<
+Source-MD5: 1761f416e8cf53f6fb674149cc223bd1
 
 CompileScript: %p/bin/python%type_raw[python] setup.py build
 
 InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
 
-DocFiles: LICENSE PKG-INFO
+DocFiles: docs/license.txt *.txt *.rst
 
 InfoTest: <<
   TestScript: %p/bin/python%type_raw[python] setup.py test || exit 2
@@ -57,7 +24,7 @@ InfoTest: <<
 
 Description: WSGI request and response object
 
-Homepage: https://github.com/uiri/toml
+Homepage: https://webob.org
 Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
 # Info2
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/webob-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/webob-py.info
@@ -1,0 +1,63 @@
+Info2: <<
+
+Package: webob-py%type_pkg[python]
+Version: 1.4.1
+Revision: 1
+License: OSI-Approved
+Type: python (2.7 3.4 3.5 3.6 3.7)
+
+Depends: python%type_pkg[python]
+BuildDepends: setuptools-tng-py%type_pkg[python]
+
+Source: https://files.pythonhosted.org/packages/source/W/WebOb/WebOb-%v.tar.gz
+Source-MD5: a5c6e8ba5431756e6a5d5ec56047ec94
+
+Patchscript: <<
+#!/bin/sh -ev
+# add missing LICENSE file, a copy from the git repository
+cat >LICENSE <<EOFFILE
+The MIT License
+
+Copyright 2013-2018 William Pearson
+Copyright 2015-2016 Julien Enselme
+Copyright 2016 Google Inc.
+Copyright 2017 Samuel Vasko
+Copyright 2017 Nate Prewitt
+Copyright 2017 Jack Evans
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+EOFFILE
+<<
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build
+
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
+
+DocFiles: LICENSE PKG-INFO
+
+InfoTest: <<
+  TestScript: %p/bin/python%type_raw[python] setup.py test || exit 2
+<<
+
+Description: WSGI request and response object
+
+Homepage: https://github.com/uiri/toml
+Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/webob-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/webob-py.info
@@ -19,7 +19,11 @@ InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
 DocFiles: docs/license.txt *.txt *.rst
 
 InfoTest: <<
-  TestScript: %p/bin/python%type_raw[python] setup.py test || exit 2
+  TestDepends: pytest-py%type_pkg[python]
+  TestScript: <<
+    PYTHONPATH=%b/build/lib %p/bin/pytest-%type_raw[python] tests/test*.py || exit 2
+    find build -name "*.pyc" -delete
+  <<    
 <<
 
 Description: WSGI request and response object


### PR DESCRIPTION
Changes:
- patches in Patchfile adjusted
- moved some dependencies to TestDepends. I saw no reason for Depends: pytest-py and BuildDepends: setuptools-scm-py. So, I removed them. But, is that ok?
- Added LICENSE to Docfiles:
- Corrected/added the version patches for tox.ini

One problem is that the test do not succeed as long as tox is not yet installed. No idea, how to fix that.
