### PR TITLE
sync with changes from Mojave and additional fixes

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.14.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.14.info
@@ -1,0 +1,20 @@
+# -*- coding: ascii; tab-width: 4; x-counterpart: extutils-makemaker-pm.info -*-
+Package: extutils-makemaker-pm
+Version: 7.34
+Revision: 1
+Distribution: 10.14
+Depends: system-perl5182, %n5182 (>= %v)
+Type: bundle
+Description: ExtUtils::MakeMaker for /usr/bin/perl
+DescDetail: <<
+	Use BuildDepends:extutils-makemaker-pm for packages that do not
+	otherwise need to be perl-version varianted so that they do
+	not need to be perl-version varianted on account of this build
+	dependency.
+
+	For packages that *are* perl-version varianted, use
+	BuildDepends:extutils-makemaker-pmXXX for the appropriate perlXXX.
+<<
+License: Artistic
+Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
+Homepage: http://search.cpan.org/dist/ExtUtils-MakeMaker/

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm.info
@@ -46,7 +46,7 @@ Source-MD5: 073c0fb4eebf3953de2a1e94fa189bac
 Source-Checksum: SHA256(95f1eb44de480d00b28d031b574ec868f7aeeee199eb5abe5666f6bcbbf68480)
 
 PatchFile: %{ni}.patch
-PatchFile-MD5: 4e690e03f0f654f0922c2261038f1c4e
+PatchFile-MD5: c10cd9bf709b76df975cf23da5c28973 
 PatchScript: <<
 	#!/bin/bash -ev
 	/usr/bin/sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm.patch
@@ -1,7 +1,67 @@
-diff -ru ExtUtils-MakeMaker-6.68.orig/lib/ExtUtils/MakeMaker.pm ExtUtils-MakeMaker-6.68/lib/ExtUtils/MakeMaker.pm
---- ExtUtils-MakeMaker-6.68.orig/lib/ExtUtils/MakeMaker.pm	2013-06-14 18:26:40.000000000 -0400
-+++ ExtUtils-MakeMaker-6.68/lib/ExtUtils/MakeMaker.pm	2013-07-06 22:55:48.000000000 -0400
-@@ -209,8 +209,8 @@
+diff -uNr ExtUtils-MakeMaker-7.34.orig/lib/ExtUtils/MM_Unix.pm ExtUtils-MakeMaker-7.34/lib/ExtUtils/MM_Unix.pm
+--- ExtUtils-MakeMaker-7.34.orig/lib/ExtUtils/MM_Unix.pm	2018-03-19 06:21:54.000000000 -0400
++++ ExtUtils-MakeMaker-7.34/lib/ExtUtils/MM_Unix.pm	2018-09-06 20:52:25.000000000 -0400
+@@ -130,7 +130,7 @@
+     my(@m);
+ 
+     my $command = '$(CCCMD)';
+-    my $flags   = '$(CCCDLFLAGS) "-I$(PERL_INC)" $(PASTHRU_DEFINE) $(DEFINE)';
++    my $flags   = '$(CCCDLFLAGS) -iwithsysroot "$(PERL_INC)" $(PASTHRU_DEFINE) $(DEFINE)';
+ 
+     if (my $cpp = $Config{cpprun}) {
+         my $cpp_cmd = $self->const_cccmd;
+@@ -461,10 +461,16 @@
+ MAN3PODS = ".$self->wraplist(sort keys %{$self->{MAN3PODS}})."
+ ";
+ 
++if ($self->{'PERL_INC'} =~ /^\/System\/Library\/Perl\//) {
++    push @m, q{
++SDKROOT := $(shell xcrun --show-sdk-path)
++PERL_SYSROOT = $(SDKROOT)
++};
++}
+ 
+     push @m, q{
+ # Where is the Config information that we are using/depend on
+-CONFIGDEP = $(PERL_ARCHLIBDEP)$(DFSEP)Config.pm $(PERL_INCDEP)$(DFSEP)config.h
++CONFIGDEP = $(PERL_ARCHLIBDEP)$(DFSEP)Config.pm $(PERL_SYSROOT)$(PERL_INCDEP)$(DFSEP)config.h
+ } if -e $self->catfile( $self->{PERL_INC}, 'config.h' );
+ 
+ 
+@@ -1034,9 +1040,9 @@
+         # platforms.  We peek at lddlflags to see if we need -Wl,-R
+         # or -R to add paths to the run-time library search path.
+         if ($Config{'lddlflags'} =~ /-Wl,-R/) {
+-            $libs .= ' "-L$(PERL_INC)" "-Wl,-R$(INSTALLARCHLIB)/CORE" "-Wl,-R$(PERL_ARCHLIB)/CORE" -lperl';
++            $libs .= ' "-L$(PERL_SYSROOT)$(PERL_INC)" "-Wl,-R$(INSTALLARCHLIB)/CORE" "-Wl,-R$(PERL_ARCHLIB)/CORE" -lperl';
+         } elsif ($Config{'lddlflags'} =~ /-R/) {
+-            $libs .= ' "-L$(PERL_INC)" "-R$(INSTALLARCHLIB)/CORE" "-R$(PERL_ARCHLIB)/CORE" -lperl';
++            $libs .= ' "-L$(PERL_SYSROOT)$(PERL_INC)" "-R$(INSTALLARCHLIB)/CORE" "-R$(PERL_ARCHLIB)/CORE" -lperl';
+         } elsif ( $Is{Android} ) {
+             # The Android linker will not recognize symbols from
+             # libperl unless the module explicitly depends on it.
+@@ -3963,7 +3969,7 @@
+ .xs$(OBJ_EXT) :
+ 	$(XSUBPPRUN) $(XSPROTOARG) $(XSUBPPARGS) $*.xs > $*.xsc
+ 	$(MV) $*.xsc $*.c
+-	$(CCCMD) $(CCCDLFLAGS) "-I$(PERL_INC)" $(PASTHRU_DEFINE) $(DEFINE) $*.c %s
++	$(CCCMD) $(CCCDLFLAGS) -iwithsysroot "$(PERL_INC)" $(PASTHRU_DEFINE) $(DEFINE) $*.c %s
+ EOF
+     if ($self->{XSMULTI}) {
+ 	for my $ext ($self->_xs_list_basenames) {
+@@ -3983,7 +3989,7 @@
+ %1$s$(OBJ_EXT): %1$s.xs
+ 	$(XSUBPPRUN) $(XSPROTOARG) $(XSUBPPARGS) $*.xs > $*.xsc
+ 	$(MV) $*.xsc $*.c
+-	%2$s $(CCCDLFLAGS) "-I$(PERL_INC)" $(PASTHRU_DEFINE) %4$s $*.c %3$s
++	%2$s $(CCCDLFLAGS) -iwithsysroot "$(PERL_INC)" $(PASTHRU_DEFINE) %4$s $*.c %3$s
+ EOF
+ 	}
+     }
+diff -uNr ExtUtils-MakeMaker-7.34.orig/lib/ExtUtils/MakeMaker.pm ExtUtils-MakeMaker-7.34/lib/ExtUtils/MakeMaker.pm
+--- ExtUtils-MakeMaker-7.34.orig/lib/ExtUtils/MakeMaker.pm	2018-03-19 06:21:54.000000000 -0400
++++ ExtUtils-MakeMaker-7.34/lib/ExtUtils/MakeMaker.pm	2018-09-06 20:50:24.000000000 -0400
+@@ -233,8 +233,8 @@
  
  sub eval_in_subdirs {
      my($self) = @_;
@@ -12,7 +72,7 @@ diff -ru ExtUtils-MakeMaker-6.68.orig/lib/ExtUtils/MakeMaker.pm ExtUtils-MakeMak
  
      local @INC = map eval {abs_path($_) if -e} || $_, @INC;
      push @INC, '.';     # '.' has to always be at the end of @INC
-@@ -363,6 +363,11 @@
+@@ -404,6 +404,11 @@
          $Recognized_Att_Keys{$item} = 1;
      }
      foreach my $item (@Get_from_Config) {


### PR DESCRIPTION
The additional changes to the extutils-makemaker-pm.patch port the changes made to the system ExtUtils-MakeMaker-6.66 to cope with the removal of the SDK from / as well as similar changes for the new xs section in 7.34 not present in 6.66. Tested with 'fink -m' on 10.14 without the fall back header package installed.