### PR TITLE
libsodium: update to new upstream version (1.0.16)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/libsodium13.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/libsodium13.info
@@ -2,7 +2,7 @@
 Info4: <<
 Package: libsodium13
 Version: 1.0.5
-Revision: 1
+Revision: 2
 Description: Portable NaCl-based crypto library
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Homepage: https://github.com/jedisct1/libsodium
@@ -26,8 +26,8 @@ Source-MD5: 69f0c5975d9f4b8e136616df34a43ff5
 Depends: %N-shlibs (= %v-%r)
 BuildDepends: fink (>= 0.26.2)
 BuildDependsOnly: True
-Conflicts: libsodium4, libsodium10, libsodium13, libsodium17
-Replaces: libsodium4, libsodium10, libsodium13, libsodium17
+Conflicts: libsodium4, libsodium10, libsodium13, libsodium17, libsodium23
+Replaces: libsodium4, libsodium10, libsodium13, libsodium17, libsodium23
 
 NoSetCPPFLAGS: True
 NoSetLDFLAGS: True

--- a/10.9-libcxx/stable/main/finkinfo/crypto/libsodium23.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/libsodium23.info
@@ -1,8 +1,8 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info4: <<
-Package: libsodium17
-Version: 1.0.6
-Revision: 2
+Package: libsodium23
+Version: 1.0.16
+Revision: 1
 Description: Portable NaCl-based crypto library
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Homepage: https://github.com/jedisct1/libsodium
@@ -21,7 +21,7 @@ DescPackaging: <<
 <<
 
 Source: http://download.libsodium.org/libsodium/releases/libsodium-%v.tar.gz
-Source-MD5: 03e8e96cef9d18473aafef7d474a6e88
+Source-MD5: 37b18839e57e7a62834231395c8e962b
 
 Depends: %N-shlibs (= %v-%r)
 BuildDepends: fink (>= 0.26.2)
@@ -47,8 +47,8 @@ DocFiles: AUTHORS ChangeLog LICENSE README* THANKS
 SplitOff: <<
 	Package: %N-shlibs
 	
-	Files: lib/libsodium.17.dylib
-	Shlibs: %p/lib/libsodium.17.dylib 18.0.0 %n (>= 1.0.6-1)
+	Files: lib/libsodium.23.dylib
+	Shlibs: %p/lib/libsodium.23.dylib 25.0.0 %n (>= 1.0.16-1)
 	DocFiles: AUTHORS ChangeLog LICENSE README* THANKS
 <<
 <<


### PR DESCRIPTION
includes conflicts and replaces with older versions.