### PR TITLE
m2crypto-pyXX: new version, switch to openssl110

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/m2crypto-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/m2crypto-py.info
@@ -1,22 +1,22 @@
 Info2: <<
 Package: m2crypto-py%type_pkg[python]
-Version: 0.22.5
+Version: 0.30.1
 Revision: 1
 Type: python (2.7)
-Source: http://pypi.python.org/packages/source/M/M2Crypto/M2Crypto-%v.tar.gz
-Source-MD5: f84eb07aa1687f39bc26ee7b1ba5a105
+Source: https://pypi.python.org/packages/source/M/M2Crypto/M2Crypto-%v.tar.gz
+Source-MD5: 7fce3cbf85eb84a669682892b935746b
 
-BuildDepends: swig, distribute-py%type_pkg[python], openssl100-dev
-Depends: python%type_pkg[python], openssl100-shlibs
+BuildDepends: swig, setuptools-tng-py%type_pkg[python], openssl110-dev
+Depends: python%type_pkg[python], openssl110-shlibs
 
 NoSetCPPFlags: True
 CompileScript: <<
-  python%type_raw[python] setup.py build build_ext --openssl=%p/lib -I%p/include
+  python%type_raw[python] setup.py build build_ext --openssl=%p
 <<
 InstallScript: <<
   python%type_raw[python] setup.py install --prefix %p --root %d
 <<
-DocFiles: PKG-INFO README
+DocFiles: CHANGES LICENCE PKG-INFO README.rst
 Description: Python interface to openssl
 DescDetail: <<
 M2Crypto is the most complete Python wrapper for OpenSSL featuring


### PR DESCRIPTION
m2crypto-pyXX: new version, switch to openssl110