### PR TITLE
bcrypt-py: new upstream release 3.1.4

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bcrypt-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bcrypt-py.info
@@ -1,12 +1,17 @@
 Info2: <<
 Package: bcrypt-py%type_pkg[python]
-Version: 3.1.3
+Version: 3.1.4
 Revision: 1
 Type: python (2.7 3.4 3.5 3.6)
-Source: https://pypi.python.org/packages/58/e9/6d7f1d883d8c5876470b5d187d72c04f2a9954d61e71e7eb5d2ea2a50442/bcrypt-%v.tar.gz
-Source-MD5: 20da8b40790caad99c4086dba533154b
+Source: https://files.pythonhosted.org/packages/source/b/bcrypt/bcrypt-%v.tar.gz
+Source-MD5: 8408abc974446e64862a9742104e97b6
+BuildDepends: <<
+  setuptools-tng-py%type_pkg[python]
+<<
 Depends: <<
-  python%type_pkg[python]
+  python%type_pkg[python],
+  cffi-py%type_pkg[python],
+  six-py%type_pkg[python]
 <<
 
 CompileScript: <<


### PR DESCRIPTION
Add builddep on setuptools-tng-py, and deps on cffi-py and six-py