### PR TITLE
libspatialite7: changed dependency from libgeos3.5.0 to libgeos3.6.1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/libspatialite7.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/libspatialite7.info
@@ -1,7 +1,7 @@
 Info3: <<
 Package: libspatialite7
 Version: 4.3.0
-Revision: 2
+Revision: 3
 Description: GIS extensions and tools to SQLite
 License: OSI-Approved
 Homepage: http://www.gaia-gis.it/spatialite/
@@ -33,7 +33,7 @@ BuildDepends: <<
   fink-package-precedence,
   libxml2, libiconv-dev,
   sqlite3-dev,
-  libproj9, libgeos3.5.0,
+  libproj9, libgeos3.6.1,
   libfreexl1-dev (>=1.0.2-1)
 <<
 BuildDependsOnly: True
@@ -43,11 +43,11 @@ BuildDependsOnly: True
 Source: http://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-%v.tar.gz
 Source-MD5: 59ec162d3e4db2d247945e3a943f64bc
 
-SetCPPFLAGS: -Os -I%p/opt/libgeos3.5.0/include
+SetCPPFLAGS: -Os -I%p/opt/libgeos3.6.1/include
 SetLDFLAGS: -lcharset
 ConfigureParams: <<
 	--target=macosx \
-	--with-geosconfig=%p/opt/libgeos3.5.0/bin/geos-config \
+	--with-geosconfig=%p/opt/libgeos3.6.1/bin/geos-config \
 	--enable-dependency-tracking
 <<
 
@@ -81,7 +81,7 @@ SplitOff: <<
     libiconv,
     sqlite3-shlibs,
     libproj9-shlibs,
-    libgeos3.5.0-shlibs,
+    libgeos3.6.1-shlibs,
     libfreexl1-shlibs (>=1.0.2-1)
   <<  
   Files: <<


### PR DESCRIPTION
This is to avoid that gdal2 links to both libgeos3.6.1 (by itself) and the libgeos3.5.1 (though libspatiallte7)