### PR TITLE
sip-py: update to upstream; add py37 variant

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
@@ -6,7 +6,7 @@ Type: python (2.7 3.4 3.5 3.6 3.7)
 Version: 5.11.2
 Revision: 3
 Source: mirror:sourceforge:pyqt/PyQt5/PyQt-%v/PyQt5_gpl-%v.tar.gz
-Source-MD5: be36c2abaffc9daa8b993f1ca982968f
+Source-MD5: 78837d77c42a2f177da771df6584ee91
 Source-Checksum: SHA256(7caa581155c3433716b7e6aba71fe1378cd7d92f4155c266d60e5cffb64e9603)
 
 PatchScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
@@ -2,12 +2,12 @@
 Info3: <<
 
 Package: pyqt5-mac-py%type_pkg[python]
-Type: python (2.7 3.4 3.5 3.6)
-Version: 5.10.1
+Type: python (2.7 3.4 3.5 3.6 3.7)
+Version: 5.11.2
 Revision: 3
 Source: mirror:sourceforge:pyqt/PyQt5/PyQt-%v/PyQt5_gpl-%v.tar.gz
 Source-MD5: be36c2abaffc9daa8b993f1ca982968f
-Source-Checksum: SHA256(9932e971e825ece4ea08f84ad95017837fa8f3f29c6b0496985fa1093661e9ef)
+Source-Checksum: SHA256(7caa581155c3433716b7e6aba71fe1378cd7d92f4155c266d60e5cffb64e9603)
 
 PatchScript: <<
 	perl -pi -e 's,exe = \"python.*,exe = \"%p/bin/python\",g' configure.py
@@ -50,7 +50,7 @@ Depends: <<
   qt5-mac-qtwidgets-shlibs (>= 5.6.0-1),
   qt5-mac-qtxml-shlibs (>= 5.6.0-1),
   qt5-mac-qtxmlpatterns-shlibs (>= 5.6.0-1),
-  sip-py%type_pkg[python] (>= 4.19.8-2)
+  sip-py%type_pkg[python] (>= 4.19.12-1)
 <<
 BuildDepends:<<
 #  ( %type_pkg[python] <= 27 ) dbus1.3-dev,
@@ -73,7 +73,7 @@ BuildDepends:<<
   qt5-mac-qtwebkit (>= 5.6.0-1),
   qt5-mac-qtwebsockets (>= 5.6.0-1),
   qt5-mac-qtxmlpatterns (>= 5.6.0-1),
-  sip-py%type_pkg[python]-bin (>= 4.19.8-2)
+  sip-py%type_pkg[python]-bin (>= 4.19.12-1)
 <<
 
 UseMaxBuildJobs: true

--- a/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
@@ -2,7 +2,7 @@
 Info3: <<
 
 Package: pyqt5-mac-py%type_pkg[python]
-Type: python (2.7 3.4 3.5 3.6 3.7)
+Type: python (2.7 3.4 3.5 3.6)
 Version: 5.11.2
 Revision: 3
 Source: mirror:sourceforge:pyqt/PyQt5/PyQt-%v/PyQt5_gpl-%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
@@ -4,7 +4,7 @@ Info3: <<
 Package: pyqt5-mac-py%type_pkg[python]
 Type: python (2.7 3.4 3.5 3.6)
 Version: 5.11.2
-Revision: 3
+Revision: 1
 Source: mirror:sourceforge:pyqt/PyQt5/PyQt-%v/PyQt5_gpl-%v.tar.gz
 Source-MD5: 78837d77c42a2f177da771df6584ee91
 Source-Checksum: SHA256(7caa581155c3433716b7e6aba71fe1378cd7d92f4155c266d60e5cffb64e9603)

--- a/10.9-libcxx/stable/main/finkinfo/languages/sip-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/sip-py.info
@@ -2,13 +2,13 @@
 Info2: <<
 
 Package: sip-py%type_pkg[python]
-Version: 4.19.8
-Revision: 2
-Type: python (2.7 3.4 3.5 3.6)
+Version: 4.19.12
+Revision: 1
+Type: python (2.7 3.4 3.5 3.6 3.7)
 
 Source: mirror:sourceforge:pyqt/sip/sip-%v/sip-%v.tar.gz
-Source-MD5: 0625fb20347d4ff1b5da551539be0727
-Source-Checksum: SHA256(7eaf7a2ea7d4d38a56dd6d2506574464bddf7cf284c960801679942377c297bc)
+Source-MD5: e28b0790dfe4962ce6bbd7c4772f40c9
+Source-Checksum: SHA256(24617fc31b983df075500ecac0e99d2fb48bf63ba82d4a17518659e571923822)
 
 GCC: 4.0
 Depends: python%type_pkg[python]
@@ -16,7 +16,7 @@ BuildDepends: fink-buildenv-modules (>= 0.1.3-1), fink (>= 0.24.12-1)
 BuildDependsOnly: false
 
 PatchFile: %{ni}.patch
-PatchFile-MD5: 68d92fd3f6e074a958a4d2c6cdbf88ec
+PatchFile-MD5: d53f5e4456cca0104bdd5a5c7d0dfa99
 
 UseMaxBuildJobs: true
 CompileScript: <<
@@ -43,10 +43,10 @@ SplitOff: <<
 	Package: %N-bin
 	Depends: sip-py%type_pkg[python]
 	Conflicts: <<
-		sip-py27-bin, sip-py34-bin, sip-py35-bin, sip-py36-bin
+		sip-py27-bin, sip-py34-bin, sip-py35-bin, sip-py36-bin, sip-py37-bin
 	<<
 	Replaces: <<
-		sip-py27-bin, sip-py34-bin, sip-py35-bin, sip-py36-bin
+		sip-py27-bin, sip-py34-bin, sip-py35-bin, sip-py36-bin, sip-py37-bin
 	<<
 	Files: bin
 	DocFiles: LICENSE* NEWS README

--- a/10.9-libcxx/stable/main/finkinfo/languages/sip-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/sip-py.info
@@ -23,6 +23,7 @@ CompileScript: <<
 	#!/bin/sh -ev
 	. %p/sbin/fink-buildenv-helper.sh
  	%p/bin/python%type_raw[python] configure.py \
+		--sip-module=PyQt5.sip \
 		-p macx-g++ \
 		-v %p/share/sip-py%type_pkg[python] \
 		INCDIR_OPENGL=$X11_INCLUDE_DIR \

--- a/10.9-libcxx/stable/main/finkinfo/languages/sip-py.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/sip-py.patch
@@ -1,7 +1,7 @@
 diff -ru sip-4.15.5.orig/configure.py sip-4.15.5/configure.py
 --- sip-4.15.5.orig/configure.py	2014-03-14 10:09:34.000000000 -0400
 +++ sip-4.15.5/configure.py	2014-04-04 10:51:23.000000000 -0400
-@@ -216,7 +216,7 @@
+@@ -247,7 +247,7 @@
      else:
          lib_dir = sysconfig.get_python_lib(plat_specific=1, standard_lib=1)
  
@@ -13,7 +13,7 @@ diff -ru sip-4.15.5.orig/configure.py sip-4.15.5/configure.py
 diff -ru sip-4.15.5.orig/siputils.py sip-4.15.5/siputils.py
 --- sip-4.15.5.orig/siputils.py	2014-02-21 05:31:35.000000000 -0500
 +++ sip-4.15.5/siputils.py	2014-04-04 10:52:12.000000000 -0400
-@@ -1306,7 +1306,7 @@
+@@ -1316,7 +1316,7 @@
          if self.generator == "UNIX":
              dst = "$(DESTDIR)" + dst
  
@@ -22,7 +22,7 @@ diff -ru sip-4.15.5.orig/siputils.py sip-4.15.5/siputils.py
  
          if self.generator == "UNIX":
              mfile.write("|| ")
-@@ -1388,14 +1388,7 @@
+@@ -1398,14 +1398,7 @@
          mfile.write("\n" + target + ":\n")
  
          for d in self._subdirs:
@@ -38,7 +38,7 @@ diff -ru sip-4.15.5.orig/siputils.py sip-4.15.5/siputils.py
  
  
  class PythonModuleMakefile(Makefile):
-@@ -1541,10 +1534,7 @@
+@@ -1551,10 +1544,7 @@
              # can handle extension modules that are bundles or dynamic
              # libraries, but python.org versions need bundles (unless built
              # with DYNLOADFILE=dynload_shlib.o).
@@ -50,7 +50,7 @@ diff -ru sip-4.15.5.orig/siputils.py sip-4.15.5/siputils.py
  
              if not lflags_plugin:
                  lflags_plugin = self.optional_list("LFLAGS_SHLIB")
-@@ -1553,7 +1543,7 @@
+@@ -1563,7 +1553,7 @@
  
          self.LFLAGS.extend(self.optional_list(lflags_console))
  


### PR DESCRIPTION
In addition: line numbers in patch files adjusted.