### PR TITLE
pypubsub-py: new package

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pypubsub3-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pypubsub3-py.info
@@ -32,7 +32,7 @@ InfoTest: <<
     %p/bin/python%type_raw[python] setup.py test || exit 2
 # this parts needs py2and3-py%type_pkg[python], which we do not have so far.
 #    cd tests
-#    %p/bin/python%type_raw[python] perf.py || exit 2
+#    PYTHONPATH=%b/build/lib %p/bin/python%type_raw[python] -B perf.py || exit 2
   <<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pypubsub3-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pypubsub3-py.info
@@ -1,0 +1,59 @@
+Info2: <<
+
+Package: pypubsub3-py%type_pkg[python]
+Version: 3.3.0
+Revision: 1
+License: BSD
+Type: python (2.7)
+
+Depends: <<
+  python%type_pkg[python],
+  typing-py%type_pkg[python]
+<<
+BuildDepends: setuptools-tng-py%type_pkg[python]
+
+Source: https://github.com/schollii/pypubsub/archive/v%v.tar.gz
+Source-MD5: 474277abd66a4cded984afd37acd8daf
+SourceRename: pypubsub-%v.tar.gz
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build 
+
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
+
+DocFiles: <<
+  src/pubsub/LICENSE_BSD_Simple.txt
+  README.txt
+<<
+
+InfoTest: <<
+  TestDepends: pytest-py%type_pkg[python]
+  TestScript: <<
+    #!/bin/bash -ev
+    %p/bin/python%type_raw[python] setup.py test || exit 2
+# this parts needs py2and3-py%type_pkg[python], which we do not have so far.
+#    cd tests
+#    %p/bin/python%type_raw[python] perf.py || exit 2
+  <<
+<<
+
+Description: Publish - subscribe API
+DescDetail: <<
+PyPubSub provides a publish - subscribe API that facilitates the
+development of event-based / message-based applications.  PyPubSub supports
+sending and receiving messages between objects of an application.  It is
+centered on the notion of a topic; senders publish messages of a given
+topic, and listeners subscribe to messages of a given topic.  The package
+also supports a variety of advanced features that facilitate debugging and
+maintaining pypubsub topics and messages in larger applications.
+<<
+
+DescPort: <<
+  - First test does actually nothing
+  - Second part of test according to Makefile
+  - Version 4 cannot be built with python2.7
+<<
+Homepage: https://github.com/schollii/pypubsub
+Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
+
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pypubsub4-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pypubsub4-py.info
@@ -1,0 +1,60 @@
+Info2: <<
+
+Package: pypubsub4-py%type_pkg[python]
+Version: 4.0.0
+Revision: 1
+License: BSD
+Type: python (3.4 3.5 3.6 3.7)
+
+Depends: <<
+  python%type_pkg[python],
+  (%type_pkg[python] = 27) typing-py%type_pkg[python],
+  (%type_pkg[python] = 34) typing-py%type_pkg[python]
+<<
+BuildDepends: setuptools-tng-py%type_pkg[python]
+
+Source: https://github.com/schollii/pypubsub/archive/v%v.tar.gz
+Source-MD5: c0e5eb651065f684788917c2475791ea
+SourceRename: pypubsub-%v.tar.gz
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build 
+
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
+
+DocFiles: <<
+  src/pubsub/LICENSE_BSD_Simple.txt
+  README.txt
+<<
+
+InfoTest: <<
+  TestDepends: pytest-py%type_pkg[python]
+  TestScript: <<
+    #!/bin/bash -ev
+    %p/bin/python%type_raw[python] setup.py test || exit 2
+    cd tests
+    %p/bin/python%type_raw[python] perf.py || exit 2
+  <<
+<<
+
+Description: Publish - subscribe API
+DescDetail: <<
+PyPubSub provides a publish - subscribe API that facilitates the
+development of event-based / message-based applications.  PyPubSub supports
+sending and receiving messages between objects of an application.  It is
+centered on the notion of a topic; senders publish messages of a given
+topic, and listeners subscribe to messages of a given topic.  The package
+also supports a variety of advanced features that facilitate debugging and
+maintaining pypubsub topics and messages in larger applications.
+<<
+
+DescPort: <<
+  - test only works if package is installed
+  - First test does actually nothing
+  - Second part of test according to Makefile
+  - Does not build with python2.7, you may use version 3.3.0
+<<
+Homepage: https://github.com/schollii/pypubsub
+Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
+
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pypubsub4-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pypubsub4-py.info
@@ -32,7 +32,7 @@ InfoTest: <<
     #!/bin/bash -ev
     %p/bin/python%type_raw[python] setup.py test || exit 2
     cd tests
-    %p/bin/python%type_raw[python] perf.py || exit 2
+    PYTHONPATH=%b/build/lib %p/bin/python%type_raw[python] -B perf.py || exit 2
   <<
 <<
 


### PR DESCRIPTION
Version 4 does not build on python 2.7. Therefore, version 3 for that.