### PR TITLE
numexpr-py: update; add py37 variant

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/numexpr-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/numexpr-py.info
@@ -1,23 +1,31 @@
 Info2: <<
 Package: numexpr-py%type_pkg[python]
-Version: 2.6.4
-Revision: 2
+Version: 2.6.8
+Revision: 1
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
-Type: python (2.7 3.4 3.5 3.6)
+Type: python (2.7 3.4 3.5 3.6 3.7)
 Depends: <<
 	python%type_pkg[python],
 	numpy-py%type_pkg[python] (>= 1.14.5-2)
 <<
 BuildDepends: fink (>= 0.24.12)
-Source: https://pypi.python.org/packages/74/58/466cfe707a78e6c11725c7be9cee71042bd902fe175bd67429dba655bbd9/numexpr-%v.tar.gz
-Source-MD5: 3898ff5187e6d4c31b0c0f7f677d21d8
+Source: https://files.pythonhosted.org/packages/source/n/numexpr/numexpr-%v.tar.gz
+Source-MD5: 8148ba96476e2c367292789bc2a90d85
 
 GCC: 4.0
 CompileScript: <<
- %p/bin/python%type_raw[python] setup.py build
+ SHELL=/bin/sh %p/bin/python%type_raw[python] setup.py build
 <<
 InstallScript: <<
+ #!/bin/bash -ev
  %p/bin/python%type_raw[python] setup.py install --root %d
+
+# delete offending files *.pyc
+ if [ %type_pkg[python] -eq 27 ]; then
+  rm %i/lib/python%type_raw[python]/site-packages/numexpr/*.pyc
+ else
+  rm %i/lib/python%type_raw[python]/site-packages/numexpr/__pycache__/*.pyc
+ fi
 <<
 InfoTest: <<
  TestScript: <<
@@ -30,7 +38,7 @@ InfoTest: <<
  TestSuiteSize: small
 <<
 
-DocFiles: README.rst LICENSE.txt
+DocFiles: ANNOUNCE.rst AUTHORS.txt LICENSE.txt README.rst RELEASE_NOTES.rst
 Description: Fast array evaluation for NumPy
 DescDetail: <<
 Numexpr is a fast numerical expression evaluator for NumPy.  With it,


### PR DESCRIPTION
- update to 2.6.8
- add py37 variant
- fix source URL
- fix shell trouble
- delete offending *.pyc files (-B did not prevent building them)
- add doc files