### PR TITLE
zmq-py, libzmq6: update, add py37 variant

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/net/libzmq6-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/libzmq6-shlibs.info
@@ -21,6 +21,10 @@ PatchScript: <<
 perl -pi.bak -e 's|10\.\[012\]\*|10.[012][,.]*|g' configure
 <<
 
+InfoTest: <<
+	TestScript: ulimit -n 1200; make check || exit 2
+<<
+
 DocFiles: AUTHORS COPYING COPYING.LESSER ChangeLog INSTALL NEWS
 
 Shlibs: %p/lib/libzmq.5.dylib 8.0.0 libzmq (>= 4.3.1-1)

--- a/10.9-libcxx/stable/main/finkinfo/net/libzmq6-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/libzmq6-shlibs.info
@@ -3,33 +3,33 @@ Package: libzmq6-shlibs
 #   libzmq2-shlibs: libzmq.1.dylib
 #   libzmq4-shlibs: libzmq.3.dylib
 #   libzmq6-shlibs: libzmq.5.dylib
-Version: 4.1.3
-Revision: 2
+Version: 4.2.5
+Revision: 1
 Description: No config transport layer
 License: LGPL
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 
-Depends: libsodium17-shlibs
-BuildDepends: libsodium17
+Depends: libsodium23-shlibs
+BuildDepends: libsodium23
 GCC: 4.0
 
-Source: http://download.zeromq.org/zeromq-%v.tar.gz
-Source-MD5: d0824317348cfb44b8692e19cc73dc3a
+Source: https://github.com/zeromq/libzmq/releases/download/v%v/zeromq-%v.tar.gz
+Source-MD5: a1c95b34384257e986842f4d006957b8
 
 PatchScript: <<
 # Patch configure to not link like Puma on Yosemite
 perl -pi.bak -e 's|10\.\[012\]\*|10.[012][,.]*|g' configure
 <<
 
-DocFiles: AUTHORS COPYING COPYING.LESSER ChangeLog INSTALL MAINTAINERS NEWS
+DocFiles: AUTHORS COPYING COPYING.LESSER ChangeLog INSTALL NEWS
 
-Shlibs: %p/lib/libzmq.5.dylib 6.0.0 libzmq (>= 4.1.3-1)
+Shlibs: %p/lib/libzmq.5.dylib 7.0.0 libzmq (>= 4.2.5-1)
 
 SplitOff: <<
 	Package: libzmq6
 	Depends: %N (= %v-%r)
 	Conflicts: libzmq2, libzmq4, libzmq6
-	Replaces: libzmq2, libzmq4, libzmq6
+	Replaces:  libzmq2, libzmq4, libzmq6
 	BuildDependsOnly: true
 	Files: <<
 		bin

--- a/10.9-libcxx/stable/main/finkinfo/net/libzmq6-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/libzmq6-shlibs.info
@@ -3,7 +3,7 @@ Package: libzmq6-shlibs
 #   libzmq2-shlibs: libzmq.1.dylib
 #   libzmq4-shlibs: libzmq.3.dylib
 #   libzmq6-shlibs: libzmq.5.dylib
-Version: 4.2.5
+Version: 4.3.1
 Revision: 1
 Description: No config transport layer
 License: LGPL
@@ -14,7 +14,7 @@ BuildDepends: libsodium23
 GCC: 4.0
 
 Source: https://github.com/zeromq/libzmq/releases/download/v%v/zeromq-%v.tar.gz
-Source-MD5: a1c95b34384257e986842f4d006957b8
+Source-MD5: 64cbf3577afdbfda30358bc757a6ac83
 
 PatchScript: <<
 # Patch configure to not link like Puma on Yosemite
@@ -23,7 +23,7 @@ perl -pi.bak -e 's|10\.\[012\]\*|10.[012][,.]*|g' configure
 
 DocFiles: AUTHORS COPYING COPYING.LESSER ChangeLog INSTALL NEWS
 
-Shlibs: %p/lib/libzmq.5.dylib 7.0.0 libzmq (>= 4.2.5-1)
+Shlibs: %p/lib/libzmq.5.dylib 8.0.0 libzmq (>= 4.3.1-1)
 
 SplitOff: <<
 	Package: libzmq6

--- a/10.9-libcxx/stable/main/finkinfo/net/zmq-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/zmq-py.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: zmq-py%type_pkg[python]
-Version: 17.1.3
+Version: 18.0.1
 Revision: 1
 Type: python (2.7 3.4 3.5 3.6 3.7)
 Description: ZeroMQ networking (0MQ)
@@ -8,11 +8,11 @@ License: OSI-Approved
 HomePage: https://pypi.org/project/pyzmq/
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 
-Depends: python%type_pkg[python], libzmq6-shlibs (>= 4.2.5-1)
-BuildDepends: python%type_pkg[python], libzmq6 (>= 4.2.5-1)
+Depends: python%type_pkg[python], libzmq6-shlibs (>= 4.3.1-1)
+BuildDepends: python%type_pkg[python], libzmq6 (>= 4.3.1-1)
 
 Source: https://files.pythonhosted.org/packages/source/p/pyzmq/pyzmq-%v.tar.gz
-Source-MD5: a87075f4a9c2729bfdbe907f96cc6c29
+Source-Checksum: SHA256(8b319805f6f7c907b101c864c3ca6cefc9db8ce0791356f180b1b644c7347e4c)
 Source2: https://github.com/minrk/pyzmq-py3k-examples/archive/master.zip
 Source2-MD5: ef467d0c5d13964006581eb7535b268b
 

--- a/10.9-libcxx/stable/main/finkinfo/net/zmq-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/zmq-py.info
@@ -4,8 +4,8 @@ Version: 17.1.2
 Revision: 1
 Type: python (2.7 3.4 3.5 3.6 3.7)
 Description: ZeroMQ networking (0MQ)
-License: LGPL
-HomePage: http://pypi.python.org/pypi/pyzmq/
+License: OSI-Approved
+HomePage: https://pypi.org/project/pyzmq/
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 
 Depends: python%type_pkg[python], libzmq6-shlibs
@@ -13,11 +13,23 @@ BuildDepends: python%type_pkg[python], libzmq6
 
 Source: https://files.pythonhosted.org/packages/source/p/pyzmq/pyzmq-%v.tar.gz
 Source-MD5: 6f5d77cb5ec1617ce9b6e5ad7c6174fb
+#Source2: https://github.com/minrk/pyzmq-py3k-examples/archive/master.zip
+#Source-MD5: ef467d0c5d13964006581eb7535b268b
 
 CompileScript: <<
   python%type_raw[python] setup.py configure --zmq=%p
 <<
 InstallScript: python%type_raw[python] setup.py install --root=%d
+# 11-24 test failures; exclude tracker test potentially hanging under 2.7
+InfoTest: <<
+  TestDepends: pytest-py%type_pkg[python]
+  TestScript: <<
+    PYTHONPATH=%b/build/lib %p/bin/pytest-%type_raw[python]  -vk 'not test_tracker' zmq/tests || exit 1
+  <<
+<<
+
+# Python3 examples are kept separately on https://github.com/minrk/pyzmq-py3k-examples - should
+# we nonetheless include the Python2 versions or get the appropriate ones from Source2?
 DocFiles: README.md COPYING.LESSER COPYING.BSD
 # FIX: build the docs with sphinx
 

--- a/10.9-libcxx/stable/main/finkinfo/net/zmq-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/zmq-py.info
@@ -8,8 +8,8 @@ License: OSI-Approved
 HomePage: https://pypi.org/project/pyzmq/
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 
-Depends: python%type_pkg[python], libzmq6-shlibs
-BuildDepends: python%type_pkg[python], libzmq6
+Depends: python%type_pkg[python], libzmq6-shlibs (>= 4.2.5-1)
+BuildDepends: python%type_pkg[python], libzmq6 (>= 4.2.5-1)
 
 Source: https://files.pythonhosted.org/packages/source/p/pyzmq/pyzmq-%v.tar.gz
 Source-MD5: a87075f4a9c2729bfdbe907f96cc6c29

--- a/10.9-libcxx/stable/main/finkinfo/net/zmq-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/zmq-py.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: zmq-py%type_pkg[python]
-Version: 17.1.2
+Version: 17.1.3
 Revision: 1
 Type: python (2.7 3.4 3.5 3.6 3.7)
 Description: ZeroMQ networking (0MQ)
@@ -12,9 +12,9 @@ Depends: python%type_pkg[python], libzmq6-shlibs
 BuildDepends: python%type_pkg[python], libzmq6
 
 Source: https://files.pythonhosted.org/packages/source/p/pyzmq/pyzmq-%v.tar.gz
-Source-MD5: 6f5d77cb5ec1617ce9b6e5ad7c6174fb
-#Source2: https://github.com/minrk/pyzmq-py3k-examples/archive/master.zip
-#Source-MD5: ef467d0c5d13964006581eb7535b268b
+Source-MD5: a87075f4a9c2729bfdbe907f96cc6c29
+Source2: https://github.com/minrk/pyzmq-py3k-examples/archive/master.zip
+Source2-MD5: ef467d0c5d13964006581eb7535b268b
 
 CompileScript: <<
   python%type_raw[python] setup.py configure --zmq=%p
@@ -24,6 +24,10 @@ InstallScript: python%type_raw[python] setup.py install --root=%d
 InfoTest: <<
   TestDepends: pytest-py%type_pkg[python]
   TestScript: <<
+    #!/bin/sh -ev
+    if [ %type_pkg[python] -gt 30 ]; then
+      cp -R ../pyzmq-py3k-examples-master/* examples/
+    fi
     PYTHONPATH=%b/build/lib %p/bin/pytest-%type_raw[python]  -vk 'not test_tracker' zmq/tests || exit 1
   <<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/net/zmq-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/zmq-py.info
@@ -17,10 +17,9 @@ Source2: https://github.com/minrk/pyzmq-py3k-examples/archive/master.zip
 Source2-MD5: ef467d0c5d13964006581eb7535b268b
 
 CompileScript: <<
-  python%type_raw[python] setup.py configure --zmq=%p
+  %p/bin/python%type_raw[python] setup.py build_ext --inplace --zmq=%p
 <<
-InstallScript: python%type_raw[python] setup.py install --root=%d
-# 11-24 test failures; exclude tracker test potentially hanging under 2.7
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
 InfoTest: <<
   TestDepends: pytest-py%type_pkg[python]
   TestScript: <<
@@ -28,7 +27,7 @@ InfoTest: <<
     if [ %type_pkg[python] -gt 30 ]; then
       cp -R ../pyzmq-py3k-examples-master/* examples/
     fi
-    PYTHONPATH=%b/build/lib %p/bin/pytest-%type_raw[python]  -vk 'not test_tracker' zmq/tests || exit 1
+    %p/bin/python%type_raw[python] setup.py test --zmq=%p || exit 2
   <<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/net/zmq-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/zmq-py.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: zmq-py%type_pkg[python]
-Version: 15.0.0
-Revision: 2
-Type: python (2.7 3.4 3.5 3.6)
+Version: 17.1.2
+Revision: 1
+Type: python (2.7 3.4 3.5 3.6 3.7)
 Description: ZeroMQ networking (0MQ)
 License: LGPL
 HomePage: http://pypi.python.org/pypi/pyzmq/
@@ -11,8 +11,8 @@ Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 Depends: python%type_pkg[python], libzmq6-shlibs
 BuildDepends: python%type_pkg[python], libzmq6
 
-Source: http://pypi.python.org/packages/source/p/pyzmq/pyzmq-%v.tar.gz
-Source-MD5: a4e357fe3574fc64a959e7a8e5373b9f
+Source: https://files.pythonhosted.org/packages/source/p/pyzmq/pyzmq-%v.tar.gz
+Source-MD5: 6f5d77cb5ec1617ce9b6e5ad7c6174fb
 
 CompileScript: <<
   python%type_raw[python] setup.py configure --zmq=%p


### PR DESCRIPTION
the new version needs libsodium23, which is in its own update branch.

zmq-py: update source URL.