### PR TITLE
gevent-py fix; libuv1 update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libuv1.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libuv1.info
@@ -1,6 +1,6 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Package: libuv1
-Version: 1.8.0
+Version: 1.23.1
 Revision: 1
 Description: Library for asynchronous I/O
 DescDetail: <<
@@ -12,13 +12,14 @@ Homepage: http://libuv.org
 License: BSD
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 
-Source: http://dist.libuv.org/dist/v1.8.0/libuv-v1.8.0.tar.gz
-Source-MD5: f4229c4360625e973ae933cb92e1faf7
+Source: http://dist.libuv.org/dist/v%v/libuv-v%v.tar.gz
+Source-MD5: 7e710afbc675d05b6a27903aa4589b96
 
 Depends: %n-shlibs (= %v-%r)
 BuildDepends: <<
 	autoconf2.6,
 	automake1.15-core,
+	fink-package-precedence,
 	libtool2
 <<
 BuildDependsOnly: true
@@ -30,6 +31,7 @@ ConfigureParams: <<
 CompileScript: <<
 	ACLOCAL=aclocal-1.15 AUTOMAKE=automake-1.15 ./autogen.sh
 	%{default_script}
+	fink-package-precedence --prohibit-bdep=%n .
 <<
 
 # Tests need network access. Also 2 failures with build-as-nobody but not with

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/gevent-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/gevent-py.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: gevent-py%type_pkg[python]
 Version: 1.3.6
-Revision: 2
+Revision: 3
 Type: python (2.7 3.4 3.5 3.6 3.7)
 Description: Coroutine-based network library
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
@@ -17,21 +17,27 @@ Depends: <<
 	greenlet-py%type_pkg[python] (>= 0.4.14-1),
 	libcares2-shlibs,
 	libev4-shlibs,
-	libuv1-shlibs (>= 1.23.1-1),
 	python%type_pkg[python]
 <<
 BuildDepends: <<
+	fink-package-precedence,
+	flag-sort,
 	libcares2,
 	libev4,
-	libuv1 (>= 1.23.1-1),
 	setuptools-tng-py%type_pkg[python]
 <<
 
+SetCC: flag-sort gcc
+SetCPPFLAGS: -MD
 CompileScript: <<
 	#!/bin/sh -ev
 	export LIBEV_EMBED=false
 	export CARES_EMBED=false
+	# setup.py calls configure, so we can use autoconf env vars to
+	# propagate into certain python extension-builder functions
 	%p/bin/python%type_raw[python] setup.py build
+	fink-package-precedence .
+	fink-package-precedence --depfile-ext='\.d' --no-l .
 <<
 
 # Tests require network access.

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/gevent-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/gevent-py.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: gevent-py%type_pkg[python]
 Version: 1.3.6
-Revision: 1
+Revision: 2
 Type: python (2.7 3.4 3.5 3.6 3.7)
 Description: Coroutine-based network library
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
@@ -17,12 +17,13 @@ Depends: <<
 	greenlet-py%type_pkg[python] (>= 0.4.14-1),
 	libcares2-shlibs,
 	libev4-shlibs,
+	libuv1-shlibs (>= 1.23.1-1),
 	python%type_pkg[python]
 <<
 BuildDepends: <<
-	fink (>= 0.24.12),
 	libcares2,
 	libev4,
+	libuv1 (>= 1.23.1-1),
 	setuptools-tng-py%type_pkg[python]
 <<
 


### PR DESCRIPTION
gevent-pyXX FTBFS for me (same as on bindist) where I have libuv1-1.8.0-1 installed with errors related to unknown API in libuv1, but gevent-pyXX has no dependencies on libuv1. Looks like it autodetects, and if so actually needs a newer version. Pushing libuv1 to its latest version allows gevent-pyXX to build against it, so I set versioned dependencies accordingly.

I did not investigate what version first added the needed API to be able to set a slightly looser dependency (but since fink has no intermediate versions, who cares). I also did not investigate whether there is a way to disable libuv detection.