### PR TITLE
pipdeptree-py: new package

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pipdeptree-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pipdeptree-py.info
@@ -1,0 +1,52 @@
+Info2: <<
+
+Package: pipdeptree-py%type_pkg[python]
+Version: 0.13.0
+Revision: 1
+License: OSI-Approved
+Type: python (2.7 3.4 3.5 3.6 3.7)
+
+Depends: pip-py%type_pkg[python]
+BuildDepends: setuptools-tng-py%type_pkg[python]
+
+Source: https://files.pythonhosted.org/packages/source/p/pipdeptree/pipdeptree-%v.tar.gz
+Source-MD5: 1cbdbd185f3e09106930549bbef0a9a1
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build
+InstallScript: <<
+  #!/bin/sh -ev
+  %p/bin/python%type_raw[python] setup.py install --root=%d
+  # rename binary to version specific one
+  mv %i/bin/pipdeptree %i/bin/pipdeptree%type_raw[python]
+<<
+
+DocFiles: LICENSE PKG-INFO README.rst
+
+InfoTest: <<
+  TestScript: %p/bin/python%type_raw[python] setup.py test || exit 2
+<<
+
+Description: Utility to show dependency tree of packages
+
+DescDetail: <<
+pipdeptree is a command line utility for displaying the installed python
+packages in form of a dependency tree.  It works for packages installed
+globally on a machine as well as in a virtualenv.  Since pip freeze shows
+all dependencies as a flat list, finding out which are the top level
+packages and which packages do they depend on requires some effort.  It can
+also be tedious to resolve conflicting dependencies because pip doesn't yet
+have true dependency resolution (more on this later).  This utility tries
+to solve this problem.
+<<
+
+DescPort: <<
+There are 2 packages python wrappers of graphviz, namely pygraphviz and
+graphviz.  graphviz is needed here.  As long as it is not present, graphviz
+output fails with:
+graphviz is not available, but necessary for the output option. Please install it.
+<<
+
+Homepage: https://github.com/naiquevin/pipdeptree
+Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
+# Info2
+<<


### PR DESCRIPTION
pipdeptree is a utility to show dependency trees of packages.