### PR TITLE
pip-py: Update to newer upstream version (18.0)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/pip-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/pip-py.info
@@ -2,11 +2,11 @@
 Info4: << 
 Package: pip-py%type_pkg[python]
 Type: python (2.7 3.4 3.5 3.6 3.7)
-Version: 10.0.1
+Version: 18.0
 Revision: 1
 
-Source: https://pypi.io/packages/source/p/pip/pip-%v.tar.gz
-Source-Checksum: SHA256(f2bd08e0cd1b06e10218feaf6fef299f473ba706582eb3bd9d52203fdbd7ee68)
+Source: https://files.pythonhosted.org/packages/source/p/pip/pip-%v.tar.gz
+Source-Checksum: SHA256(a0e11645ee37c90b40c46d607070c4fd583e2cd46231b1c06e389c5e814eed76)
 
 Depends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
 BuildDepends: setuptools-tng-py%type_pkg[python]


### PR DESCRIPTION
Source URL updated as well.