### PR TITLE
ghostscript-9.25-1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/text/ghostscript.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/ghostscript.info
@@ -2,15 +2,15 @@ Info2: <<
 Package: ghostscript%type_pkg[-nox]
 # LIBIDN2 FTBFS; see https://bugs.ghostscript.com/show_bug.cgi?id=698774
 Type: -nox (boolean)
-Version: 9.24
+Version: 9.25
 Revision: 1
 Description: Interpreter for PostScript and PDF
-Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs924/ghostscript-%v.tar.xz
-Source-MD5: 258c73e4ec0da94c95ea3cbd2968889a
-Source-Checksum: SHA1(46a605c2576f9b11a733f6854845dcb4c24d9e10)
+Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs925/ghostscript-%v.tar.xz
+Source-MD5: d5ac3f3d76cf82a549bafdf86d58395b
+Source-Checksum: SHA1(9d8ddff3382113bf4a1640368350e05652c93613)
 PatchFile: ghostscript.patch
-PatchFile-MD5: 5e704157968c362f594622ba9f867fb9
-PatchFile-Checksum: SHA1(b54b0a554efbc605cd77578db5a5c7925c45839b)
+PatchFile-MD5: 441e9a28c4bf84b5056bf60e588ab4b1
+PatchFile-Checksum: SHA1(87448b72d2741c747ced99cc46c2faa070823935)
 Depends: <<
 	fontconfig2-shlibs (>= 2.10.0-1),
 	freetype219-shlibs (>= 2.6-1),

--- a/10.9-libcxx/stable/main/finkinfo/text/ghostscript.patch
+++ b/10.9-libcxx/stable/main/finkinfo/text/ghostscript.patch
@@ -1,7 +1,7 @@
-diff -Nurd ghostscript-9.24-orig/base/mkromfs.c ghostscript-9.24/base/mkromfs.c
---- ghostscript-9.24-orig/base/mkromfs.c	2018-09-03 10:50:27.000000000 +0200
-+++ ghostscript-9.24/base/mkromfs.c	2018-09-04 12:08:24.836840617 +0200
-@@ -2379,7 +2379,7 @@
+diff -Nurd ghostscript-9.25-orig/base/mkromfs.c ghostscript-9.25/base/mkromfs.c
+--- ghostscript-9.25-orig/base/mkromfs.c	2018-09-13 12:02:01.000000000 +0200
++++ ghostscript-9.25/base/mkromfs.c	2018-10-09 13:15:21.809953158 +0200
+@@ -2390,7 +2390,7 @@
      }
      if (!buildtime)
          buildtime = time(NULL);
@@ -10,9 +10,9 @@ diff -Nurd ghostscript-9.24-orig/base/mkromfs.c ghostscript-9.24/base/mkromfs.c
  
      /* process the remaining arguments (options interspersed with paths) */
      for (; atarg < argc; atarg++) {
-diff -Nurd ghostscript-9.24-orig/base/sjpx_openjpeg.c ghostscript-9.24/base/sjpx_openjpeg.c
---- ghostscript-9.24-orig/base/sjpx_openjpeg.c	2018-09-03 10:50:27.000000000 +0200
-+++ ghostscript-9.24/base/sjpx_openjpeg.c	2018-09-04 12:08:24.837951736 +0200
+diff -Nurd ghostscript-9.25-orig/base/sjpx_openjpeg.c ghostscript-9.25/base/sjpx_openjpeg.c
+--- ghostscript-9.25-orig/base/sjpx_openjpeg.c	2018-09-13 12:02:01.000000000 +0200
++++ ghostscript-9.25/base/sjpx_openjpeg.c	2018-10-09 13:15:21.811800231 +0200
 @@ -25,7 +25,6 @@
  #include "gxsync.h"
  #include "assert_.h"
@@ -21,9 +21,9 @@ diff -Nurd ghostscript-9.24-orig/base/sjpx_openjpeg.c ghostscript-9.24/base/sjpx
  #endif
  /* Some locking to get around the criminal lack of context
   * in the openjpeg library. */
-diff -Nurd ghostscript-9.24-orig/base/stdpre.h ghostscript-9.24/base/stdpre.h
---- ghostscript-9.24-orig/base/stdpre.h	2018-09-03 10:50:27.000000000 +0200
-+++ ghostscript-9.24/base/stdpre.h	2018-09-04 12:08:24.838871826 +0200
+diff -Nurd ghostscript-9.25-orig/base/stdpre.h ghostscript-9.25/base/stdpre.h
+--- ghostscript-9.25-orig/base/stdpre.h	2018-09-13 12:02:01.000000000 +0200
++++ ghostscript-9.25/base/stdpre.h	2018-10-09 13:15:21.812590681 +0200
 @@ -301,7 +301,9 @@
   * header file that includes sys/types.h.
   *
@@ -35,9 +35,9 @@ diff -Nurd ghostscript-9.24-orig/base/stdpre.h ghostscript-9.24/base/stdpre.h
  #define uchar uchar_
  #define uint uint_
  #define ushort ushort_
-diff -Nurd ghostscript-9.24-orig/base/unistd_.h ghostscript-9.24/base/unistd_.h
---- ghostscript-9.24-orig/base/unistd_.h	2018-09-03 10:50:27.000000000 +0200
-+++ ghostscript-9.24/base/unistd_.h	2018-09-04 12:08:24.841437868 +0200
+diff -Nurd ghostscript-9.25-orig/base/unistd_.h ghostscript-9.25/base/unistd_.h
+--- ghostscript-9.25-orig/base/unistd_.h	2018-09-13 12:02:01.000000000 +0200
++++ ghostscript-9.25/base/unistd_.h	2018-10-09 13:15:21.813285404 +0200
 @@ -53,7 +53,9 @@
     /* _XOPEN_SOURCE 500 define is needed to get
      * access to pread and pwrite */
@@ -49,9 +49,9 @@ diff -Nurd ghostscript-9.24-orig/base/unistd_.h ghostscript-9.24/base/unistd_.h
  #  include <unistd.h>
  #endif
  
-diff -Nurd ghostscript-9.24-orig/configure ghostscript-9.24/configure
---- ghostscript-9.24-orig/configure	2018-09-03 10:51:26.000000000 +0200
-+++ ghostscript-9.24/configure	2018-09-04 12:08:38.175130690 +0200
+diff -Nurd ghostscript-9.25-orig/configure ghostscript-9.25/configure
+--- ghostscript-9.25-orig/configure	2018-09-13 12:02:46.000000000 +0200
++++ ghostscript-9.25/configure	2018-10-09 13:15:21.816811327 +0200
 @@ -7295,7 +7295,7 @@
  $as_echo_n "checking for local zlib source... " >&6; }
  # we must define ZLIBDIR regardless because png.mak does a -I$(ZLIBDIR)
@@ -61,9 +61,9 @@ diff -Nurd ghostscript-9.24-orig/configure ghostscript-9.24/configure
  AUX_SHARED_ZLIB=
  ZLIBCFLAGS=""
  
-diff -Nurd ghostscript-9.24-orig/configure.ac ghostscript-9.24/configure.ac
---- ghostscript-9.24-orig/configure.ac	2018-09-03 10:50:27.000000000 +0200
-+++ ghostscript-9.24/configure.ac	2018-09-04 12:08:38.176848649 +0200
+diff -Nurd ghostscript-9.25-orig/configure.ac ghostscript-9.25/configure.ac
+--- ghostscript-9.25-orig/configure.ac	2018-09-13 12:02:01.000000000 +0200
++++ ghostscript-9.25/configure.ac	2018-10-09 13:15:21.818774091 +0200
 @@ -1092,7 +1092,7 @@
  dnl zlib is needed for language level 3, and libpng
  # we must define ZLIBDIR regardless because png.mak does a -I$(ZLIBDIR)
@@ -73,9 +73,9 @@ diff -Nurd ghostscript-9.24-orig/configure.ac ghostscript-9.24/configure.ac
  AUX_SHARED_ZLIB=
  ZLIBCFLAGS=""
  
-diff -Nurd ghostscript-9.24-orig/contrib/gdevhl12.c ghostscript-9.24/contrib/gdevhl12.c
---- ghostscript-9.24-orig/contrib/gdevhl12.c	2018-09-03 10:50:27.000000000 +0200
-+++ ghostscript-9.24/contrib/gdevhl12.c	2018-09-04 12:08:38.178013818 +0200
+diff -Nurd ghostscript-9.25-orig/contrib/gdevhl12.c ghostscript-9.25/contrib/gdevhl12.c
+--- ghostscript-9.25-orig/contrib/gdevhl12.c	2018-09-13 12:02:01.000000000 +0200
++++ ghostscript-9.25/contrib/gdevhl12.c	2018-10-09 13:15:21.819872902 +0200
 @@ -481,7 +481,7 @@
          break;
      }
@@ -85,9 +85,9 @@ diff -Nurd ghostscript-9.24-orig/contrib/gdevhl12.c ghostscript-9.24/contrib/gde
          put_be16(prn_stream, s->out_count * sizeof(u16) + 7);
          put_be16(prn_stream, s->xl * 16);
          put_be16(prn_stream, band + ytop);
-diff -Nurd ghostscript-9.24-orig/contrib/japanese/gdevp201.c ghostscript-9.24/contrib/japanese/gdevp201.c
---- ghostscript-9.24-orig/contrib/japanese/gdevp201.c	2018-09-03 10:50:27.000000000 +0200
-+++ ghostscript-9.24/contrib/japanese/gdevp201.c	2018-09-04 12:08:38.178879227 +0200
+diff -Nurd ghostscript-9.25-orig/contrib/japanese/gdevp201.c ghostscript-9.25/contrib/japanese/gdevp201.c
+--- ghostscript-9.25-orig/contrib/japanese/gdevp201.c	2018-09-13 12:02:01.000000000 +0200
++++ ghostscript-9.25/contrib/japanese/gdevp201.c	2018-10-09 13:15:21.820638228 +0200
 @@ -242,7 +242,7 @@
                  out_beg -= (out_beg - out) % bytes_per_column;
  
@@ -97,9 +97,9 @@ diff -Nurd ghostscript-9.24-orig/contrib/japanese/gdevp201.c ghostscript-9.24/co
                          (out_beg - out) / bytes_per_column);
  
                  /* Dot graphics */
-diff -Nurd ghostscript-9.24-orig/devices/gdevlp8k.c ghostscript-9.24/devices/gdevlp8k.c
---- ghostscript-9.24-orig/devices/gdevlp8k.c	2018-09-03 10:50:27.000000000 +0200
-+++ ghostscript-9.24/devices/gdevlp8k.c	2018-09-04 12:08:38.179700860 +0200
+diff -Nurd ghostscript-9.25-orig/devices/gdevlp8k.c ghostscript-9.25/devices/gdevlp8k.c
+--- ghostscript-9.25-orig/devices/gdevlp8k.c	2018-09-13 12:02:01.000000000 +0200
++++ ghostscript-9.25/devices/gdevlp8k.c	2018-10-09 13:15:21.821377933 +0200
 @@ -360,9 +360,9 @@
          fprintf(prn_stream,"%d",lnum-60);
          fwrite("Y\035",1,2,prn_stream);
@@ -112,9 +112,9 @@ diff -Nurd ghostscript-9.24-orig/devices/gdevlp8k.c ghostscript-9.24/devices/gde
          fwrite("1;0bi{I",1,7,prn_stream);
          fwrite(out,1,(outp - out),prn_stream);
  
-diff -Nurd ghostscript-9.24-orig/devices/gdevpng.c ghostscript-9.24/devices/gdevpng.c
---- ghostscript-9.24-orig/devices/gdevpng.c	2018-09-03 10:50:27.000000000 +0200
-+++ ghostscript-9.24/devices/gdevpng.c	2018-09-04 12:08:38.180703470 +0200
+diff -Nurd ghostscript-9.25-orig/devices/gdevpng.c ghostscript-9.25/devices/gdevpng.c
+--- ghostscript-9.25-orig/devices/gdevpng.c	2018-09-13 12:02:01.000000000 +0200
++++ ghostscript-9.25/devices/gdevpng.c	2018-10-09 13:15:21.822416384 +0200
 @@ -724,6 +724,7 @@
  
  #if PNG_LIBPNG_VER_MINOR < 5


### PR DESCRIPTION
This is the update for ghostscript from 9.24 to 9.25.
Built and test on 10.14 with "fink -m build"