### PR TITLE
grib-api-1.27.0-1 (and grib-api-fortran-1.27.0-1)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/grib-api-fortran.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/grib-api-fortran.info
@@ -15,17 +15,15 @@ PatchFile-MD5: 0448a7a625b66581baab7cc3e5834e71
 
 SourceDirectory: grib_api-%v-Source
 BuildDependsOnly: true
-BuildDepends: libopenjpeg1, libpng16, gcc%type_pkg[gcc]-compiler, grib-api (>= %v-0)
-Depends: libopenjpeg1-shlibs, libpng16-shlibs, grib-api-shlibs (>= %v-0), grib-api-fortran-shlibs (>= %v-%r), gcc%type_pkg[gcc]-shlibs
-SetLDFLAGS: -L%p/lib/libopenjpeg
-SetCPPFLAGS: -I%p/include/openjpeg-1.5
+BuildDepends: libjasper.1, libpng16, gcc%type_pkg[gcc]-compiler, grib-api (>= %v-0)
+Depends: libjasper.1-shlibs, libpng16-shlibs, grib-api-shlibs (>= %v-0), grib-api-fortran-shlibs (>= %v-%r), gcc%type_pkg[gcc]-shlibs
 UseMaxBuildJobs: false
 
 Conflicts: eccodes-fortran
 Replaces: eccodes-fortran
 
 PatchScript: sed -e 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
-ConfigureParams: --prefix=%p --with-png-support --with-openjpeg=%p --enable-fortran FC=%p/bin/gfortran-fsf-%type_raw[gcc]
+ConfigureParams: --prefix=%p --with-png-support --with-jasper=%p --enable-fortran FC=%p/bin/gfortran-fsf-%type_raw[gcc]
 CompileScript: <<
 	./configure %c
 	(cd fortran ; make)

--- a/10.9-libcxx/stable/main/finkinfo/sci/grib-api-fortran.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/grib-api-fortran.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: grib-api-fortran
-Version: 1.23.1
-Revision: 2
+Version: 1.27.0
+Revision: 1
 Type: gcc (7)
 Description: ECMWF GRIB API, Fortran headers
 Homepage: https://software.ecmwf.int/wiki/display/GRIB/Home
@@ -10,7 +10,7 @@ Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Source: https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-%v-Source.tar.gz
 PatchFile: grib-api.patch
-Source-MD5: 21f938b5ce1b6bf814a166e3b9cf1c98
+Source-MD5: b18cacc99909462cc81fb6cd4f0c300f
 PatchFile-MD5: 0448a7a625b66581baab7cc3e5834e71
 
 SourceDirectory: grib_api-%v-Source

--- a/10.9-libcxx/stable/main/finkinfo/sci/grib-api.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/grib-api.info
@@ -1,5 +1,5 @@
 Package: grib-api
-Version: 1.26.1
+Version: 1.27.0
 Revision: 1
 Description: ECMWF GRIB API
 Homepage: https://software.ecmwf.int/wiki/display/GRIB/Home
@@ -8,7 +8,7 @@ Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Source: https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-%v-Source.tar.gz
 PatchFile: %n.patch
-Source-MD5: ebe892c026f482460af85221df50f3a1
+Source-MD5: b18cacc99909462cc81fb6cd4f0c300f
 PatchFile-MD5: 0448a7a625b66581baab7cc3e5834e71
 
 SourceDirectory: grib_api-%v-Source

--- a/10.9-libcxx/stable/main/finkinfo/sci/grib-api.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/grib-api.info
@@ -13,11 +13,10 @@ PatchFile-MD5: 0448a7a625b66581baab7cc3e5834e71
 
 SourceDirectory: grib_api-%v-Source
 BuildDependsOnly: true
-BuildDepends: libopenjp2.7, libpng16, fink-package-precedence
-Depends: libopenjp2.7-shlibs, libpng16-shlibs, %N-shlibs
+BuildDepends: libjasper.1, libpng16, fink-package-precedence
+Depends: libjasper.1-shlibs, libpng16-shlibs, %N-shlibs
 Conflicts: eccodes
 Replaces: eccodes
-SetCPPFLAGS: -I%p/include/openjpeg-2.1
 UseMaxBuildJobs: false
 
 PatchScript: sed -e 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1


### PR DESCRIPTION
This is a simple upstream update from 1.26.1 to 1.27.0.
(I missed that update on grib-api-fortran though so that jumps one version).
Built and tested with "fink -m build"

Note 1:
This does not need the complicated install_name_tool stuff as in eccodes (see PR #231)
This is because GRIB-API is not built with cmake.

Note 2:
I removed the old packages first to be sure the test was done with the just built executables (before installing in %p)