### PR TITLE
sqlalchemy-py: update to newer upstream version (1.2.12) + py37 variant

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/sqlalchemy-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/sqlalchemy-py.info
@@ -2,12 +2,12 @@ Info2: <<
 GCC: 4.0
 
 Package: sqlalchemy-py%type_pkg[python]
-Version: 1.0.19
+Version: 1.2.12
 Revision: 1
-Source: https://pypi.io/packages/source/S/SQLAlchemy/SQLAlchemy-%v.tar.gz
-Source-MD5: a5bf07ace8630e929b68f47c6a163f08
+Source: https://files.pythonhosted.org/packages/source/S/SQLAlchemy/SQLAlchemy-%v.tar.gz
+Source-MD5: 3baca105a1e49798d6bc99eb2738cb3b
 
-Type: python (2.7 3.4 3.5 3.6)
+Type: python (2.7 3.4 3.5 3.6 3.7)
 Depends: python%type_pkg[python]
 BuildDepends: setuptools-tng-py%type_pkg[python]
 # Recommends: psycopg2 MySQLdb pg8000 pymysql pyodbc
@@ -15,12 +15,14 @@ BuildDepends: setuptools-tng-py%type_pkg[python]
 CompileScript: true
 InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d --single-version-externally-managed
 
-DocFiles: CHANGES LICENSE PKG-INFO
+DocFiles: AUTHORS CHANGES LICENSE PKG-INFO README.rst README.unittests.rst
 License: OSI-Approved
 Homepage: http://www.sqlalchemy.org/
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 
 # Still some weird failures that don't impact running it.
+# 1.2.12 Update: 'setup.py test' still fails.
+# 'tox -e py**-sqlite' succeeds.
 #InfoTest: <<
 #  TestDepends: <<
 #  	nose-py%type_pkg[python],


### PR DESCRIPTION
Details:
- Update version, server host and MD5
- add py37 variant
- add doc files
- add note about tests