### PR TITLE
Sphinx-py: update to newer upstream version (1.8.1)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinx-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinx-py.info
@@ -8,8 +8,10 @@ Type: python (2.7 3.4 3.5 3.6 3.7)
 BuildDepends: tetex-base, babel-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
 Depends: <<
   python%type_pkg[python],
+  alabaster-py%type_pkg[python],
   babel-py%type_pkg[python],
   docutils-py%type_pkg[python] (>= 0.11-1),
+  imagesize-py%type_pkg[python],
   jinja2-py%type_pkg[python] (>= 2.1-1),
   packaging-py%type_pkg[python],
   pygments-py%type_pkg[python] (>= 0.8-1),
@@ -23,31 +25,17 @@ Depends: <<
 
 Source: https://files.pythonhosted.org/packages/source/S/Sphinx/Sphinx-%v.tar.gz
 Source-MD5: 4395cfbcb89a41a952c0b58c1de6e817
-Source2: https://files.pythonhosted.org/packages/source/a/alabaster/alabaster-0.7.9.tar.gz
-Source2-MD5: b29646a8bbe7aa52830375b7d17b5d7a
-Source3: https://files.pythonhosted.org/packages/source/i/imagesize/imagesize-0.7.1.tar.gz
-Source3-MD5: 976148283286a6ba5f69b0f81aef8052
-Source4: https://files.pythonhosted.org/packages/source/s/sphinx_rtd_theme/sphinx_rtd_theme-0.1.9.tar.gz
-Source4-MD5: 86a25c8d47147c872e42dc84cc66f97b
+Source2: https://files.pythonhosted.org/packages/source/s/sphinx_rtd_theme/sphinx_rtd_theme-0.1.9.tar.gz
+Source2-MD5: 86a25c8d47147c872e42dc84cc66f97b
 CompileScript: <<
- %p/bin/python%type_raw[python] setup.py build
- cd ../alabaster-0.7.9
- %p/bin/python%type_raw[python] setup.py build
- cd ../imagesize-0.7.1
  %p/bin/python%type_raw[python] setup.py build
  cd ../sphinx_rtd_theme-0.1.9
  %p/bin/python%type_raw[python] setup.py build
 <<
 InstallScript: <<
  #!/bin/bash -ev
-  pushd ../alabaster-0.7.9
-  %p/bin/python%type_raw[python] setup.py install --root %d
-  pushd ../imagesize-0.7.1
-  %p/bin/python%type_raw[python] setup.py install --root %d
   pushd ../sphinx_rtd_theme-0.1.9
   %p/bin/python%type_raw[python] setup.py install --root %d
-  popd
-  popd
   popd
   %p/bin/python%type_raw[python] setup.py install --root %d
   mkdir -p %i/share/doc/sphinx-py%type_pkg[python]
@@ -79,9 +67,9 @@ InfoTest: <<
     TestScript: <<
         #!/bin/bash -ev
         %p/bin/python%type_raw[python] setup.py build
-        export PYTHONPATH=%b/build/lib:%b/../alabaster-0.7.9:%b/../imagesize-0.7.1:%b/../sphinx_rtd_theme-0.1.9
+        export PYTHONPATH=%b/build/lib:%b/../sphinx_rtd_theme-0.1.9
         PYTHON="%p/bin/python%type_raw[python] -B" make test 2>&1 | tee test.log
-        find build ../alabaster-0.7.9 ../imagesize-0.7.1 ../sphinx_rtd_theme-0.1.9 -name "*.pyc" -exec rm {} \;
+        find build ../sphinx_rtd_theme-0.1.9 -name "*.pyc" -exec rm {} \;
         exit $(( $(grep -c FAIL: test.log)/4+$(grep -c ERROR: test.log) ))
     <<
     TestSuiteSize: small
@@ -101,8 +89,8 @@ To initialize your documentation setup in a new project, run
 (cf. %p/share/doc/sphinx-py%type_pkg[python]/doc/invocation.rst).
 <<
 DescPort: <<
-Alabaster, imagesize and sphinx_rtd themes included with package as they
-are required for the test suite.
+Sphinx_rtd themes included with package as it 
+is required for the test suite.
 Had to remove source directory before "make doc" because it would get
 in the way with python3.x
 With 1.3.4 all tests passing under python2.7, 1 str/bytes-related failure

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinx-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinx-py.info
@@ -1,14 +1,28 @@
 Info2: <<
 
 Package: sphinx-py%type_pkg[python]
-Version: 1.4.8
+Version: 1.8.1
 Revision: 1
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
-Type: python (2.7 3.4 3.5 3.6)
+Type: python (2.7 3.4 3.5 3.6 3.7)
 BuildDepends: tetex-base, babel-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
-Depends: python%type_pkg[python], jinja2-py%type_pkg[python] (>= 2.1-1), pygments-py%type_pkg[python] (>= 0.8-1), docutils-py%type_pkg[python] (>= 0.11-1), snowballstemmer-py%type_pkg[python] (>= 1.1-1), setuptools-tng-py%type_pkg[python], pytz-py%type_pkg[python], babel-py%type_pkg[python]
+Depends: <<
+  python%type_pkg[python],
+  babel-py%type_pkg[python],
+  docutils-py%type_pkg[python] (>= 0.11-1),
+  jinja2-py%type_pkg[python] (>= 2.1-1),
+  packaging-py%type_pkg[python],
+  pygments-py%type_pkg[python] (>= 0.8-1),
+  pytz-py%type_pkg[python],
+  requests-py%type_pkg[python],
+  setuptools-tng-py%type_pkg[python],
+  six-py%type_pkg[python],
+  snowballstemmer-py%type_pkg[python] (>= 1.1-1),
+  sphinxcontrib-websupport-py%type_pkg[python]
+<<
+
 Source: https://files.pythonhosted.org/packages/source/S/Sphinx/Sphinx-%v.tar.gz
-Source-MD5: 5ec718a4855917e149498bba91b74e67
+Source-MD5: 4395cfbcb89a41a952c0b58c1de6e817
 Source2: https://files.pythonhosted.org/packages/source/a/alabaster/alabaster-0.7.9.tar.gz
 Source2-MD5: b29646a8bbe7aa52830375b7d17b5d7a
 Source3: https://files.pythonhosted.org/packages/source/i/imagesize/imagesize-0.7.1.tar.gz
@@ -50,7 +64,18 @@ PreRmScript: <<
  update-alternatives --remove sphinx-build %p/bin/sphinx-build%type_raw[python]
 <<
 InfoTest: <<
-    TestDepends: nose-py%type_pkg[python]
+    TestDepends: <<
+		atomicwrites-py%type_pkg[python],
+		html5lib-py%type_pkg[python],
+		mock-py%type_pkg[python],
+		nose-py%type_pkg[python],
+		pathlib2-py%type_pkg[python],
+		pluggy-py%type_pkg[python],
+		pytest-py%type_pkg[python],
+		(%type_pkg[python] = 27) typing-py%type_pkg[python],
+		(%type_pkg[python] = 34) typing-py%type_pkg[python],
+		scandir-py%type_pkg[python]
+	<<
     TestScript: <<
         #!/bin/bash -ev
         %p/bin/python%type_raw[python] setup.py build

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinx-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinx-py.info
@@ -1,11 +1,14 @@
 Info2: <<
 
 Package: sphinx-py%type_pkg[python]
-Version: 1.8.1
+Version: 1.8.3
 Revision: 1
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 Type: python (2.7 3.4 3.5 3.6 3.7)
-BuildDepends: tetex-base, babel-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
+BuildDepends: <<
+  setuptools-tng-py%type_pkg[python],
+  tetex-base
+<<
 Depends: <<
   python%type_pkg[python],
   alabaster-py%type_pkg[python],
@@ -17,24 +20,26 @@ Depends: <<
   pygments-py%type_pkg[python] (>= 0.8-1),
   pytz-py%type_pkg[python],
   requests-py%type_pkg[python],
-  setuptools-tng-py%type_pkg[python],
   six-py%type_pkg[python],
   snowballstemmer-py%type_pkg[python] (>= 1.1-1),
   sphinxcontrib-websupport-py%type_pkg[python]
 <<
 
 Source: https://files.pythonhosted.org/packages/source/S/Sphinx/Sphinx-%v.tar.gz
-Source-MD5: 4395cfbcb89a41a952c0b58c1de6e817
-Source2: https://files.pythonhosted.org/packages/source/s/sphinx_rtd_theme/sphinx_rtd_theme-0.1.9.tar.gz
-Source2-MD5: 86a25c8d47147c872e42dc84cc66f97b
+Source-MD5: b74f45df555833a3df904d3ecaf6fcd4
+Source2: https://files.pythonhosted.org/packages/source/s/sphinx_rtd_theme/sphinx_rtd_theme-0.4.2.tar.gz
+Source2-MD5: 524ba614e60bf214b621bc259f283ccd
+PatchScript: <<
+	perl -pi -e 's|\@\$\(PYTHON\) -m pytest|%p/bin/pytest-%type_raw[python]|g' Makefile
+<<
 CompileScript: <<
  %p/bin/python%type_raw[python] setup.py build
- cd ../sphinx_rtd_theme-0.1.9
+ cd ../sphinx_rtd_theme-0.4.2
  %p/bin/python%type_raw[python] setup.py build
 <<
 InstallScript: <<
  #!/bin/bash -ev
-  pushd ../sphinx_rtd_theme-0.1.9
+  pushd ../sphinx_rtd_theme-0.4.2
   %p/bin/python%type_raw[python] setup.py install --root %d
   popd
   %p/bin/python%type_raw[python] setup.py install --root %d
@@ -46,7 +51,10 @@ InstallScript: <<
   mv %i/bin/sphinx-apidoc %i/bin/sphinx-apidoc%type_raw[python]
 <<
 PostInstScript: <<
- update-alternatives --install %p/bin/sphinx-build sphinx-build %p/bin/sphinx-build%type_raw[python] %type_pkg[python] --slave %p/bin/sphinx-quickstart sphinx-quickstart %p/bin/sphinx-quickstart%type_raw[python] --slave %p/bin/sphinx-autogen sphinx-autogen %p/bin/sphinx-autogen%type_raw[python] --slave %p/bin/sphinx-apidoc sphinx-apidoc %p/bin/sphinx-apidoc%type_raw[python]
+  update-alternatives --install %p/bin/sphinx-build sphinx-build %p/bin/sphinx-build%type_raw[python] %type_pkg[python] \
+    --slave %p/bin/sphinx-quickstart sphinx-quickstart %p/bin/sphinx-quickstart%type_raw[python] \
+    --slave %p/bin/sphinx-autogen sphinx-autogen %p/bin/sphinx-autogen%type_raw[python] \
+    --slave %p/bin/sphinx-apidoc sphinx-apidoc %p/bin/sphinx-apidoc%type_raw[python]
 <<
 PreRmScript: <<
  update-alternatives --remove sphinx-build %p/bin/sphinx-build%type_raw[python]
@@ -66,10 +74,10 @@ InfoTest: <<
 	<<
     TestScript: <<
         #!/bin/bash -ev
+        export LANG=en_US.UTF-8
         %p/bin/python%type_raw[python] setup.py build
-        export PYTHONPATH=%b/build/lib:%b/../sphinx_rtd_theme-0.1.9
-        PYTHON="%p/bin/python%type_raw[python] -B" make test 2>&1 | tee test.log
-        find build ../sphinx_rtd_theme-0.1.9 -name "*.pyc" -exec rm {} \;
+        PYTHONPATH=%b/build/lib:%b/../sphinx_rtd_theme-0.4.2:%p/lib/python%type_raw[python]/site-packages/sphinxcontrib:$PYTHONPATH %p/bin/pytest-%type_raw[python] -v 2>&1 | tee test.log || exit 2
+        find build ../sphinx_rtd_theme-0.4.2 -name "*.pyc" -exec rm {} \;
         exit $(( $(grep -c FAIL: test.log)/4+$(grep -c ERROR: test.log) ))
     <<
     TestSuiteSize: small
@@ -93,9 +101,8 @@ Sphinx_rtd themes included with package as it
 is required for the test suite.
 Had to remove source directory before "make doc" because it would get
 in the way with python3.x
-With 1.3.4 all tests passing under python2.7, 1 str/bytes-related failure
-for the -py3* versions. 6 additional failures with all variants in 1.4.4,
-but there are also more tests in total.
+
+`make test` runs '$PYTHON -m pytest', but that's somehow not importing sphinxcontrib_websupport, so we run the pytest command directly instead.
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinxcontrib-websupport-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinxcontrib-websupport-py.info
@@ -1,0 +1,43 @@
+Info2: <<
+
+Package: sphinxcontrib-websupport-py%type_pkg[python]
+Version: 1.1.0
+Revision: 1
+License: OSI-Approved
+Type: python (2.7 3.4 3.5 3.6 3.7)
+
+Depends: python%type_pkg[python]
+BuildDepends: setuptools-tng-py%type_pkg[python]
+
+Source: https://files.pythonhosted.org/packages/source/s/sphinxcontrib-websupport/sphinxcontrib-websupport-%v.tar.gz
+Source-MD5: ca6435e7b4eb9408df4f54972361e9d3
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build
+
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
+
+DocFiles: CHANGES LICENSE PKG-INFO README.rst
+
+InfoTest: <<
+  TestDepends: <<
+    mock-py%type_pkg[python],
+    pytest-py%type_pkg[python],
+    sqlalchemy-py%type_pkg[python],
+    tox-py%type_pkg[python],
+    whoosh-py%type_pkg[python],
+    (%type_pkg[python]  = 27) xapian22-py%type_pkg[python],
+    (%type_pkg[python] >= 34) xapian30-py%type_pkg[python]
+  <<
+  TestScript: %p/bin/python%type_raw[python] setup.py test || exit 2
+  # The test above does nothing, as does nosetests.  The following trials
+  # also fail and i have no clue how to fix it.
+  # - %p/bin/python%type_raw[python] -m pytest
+  # - tox
+<<
+
+Description: Sphinx documentation for web applications
+
+Homepage: http://www.sphinx-doc.org
+Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinxcontrib-websupport-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinxcontrib-websupport-py.info
@@ -12,6 +12,10 @@ BuildDepends: setuptools-tng-py%type_pkg[python]
 Source: https://files.pythonhosted.org/packages/source/s/sphinxcontrib-websupport/sphinxcontrib-websupport-%v.tar.gz
 Source-MD5: ca6435e7b4eb9408df4f54972361e9d3
 
+PatchFile: %{Ni}.patch
+PatchFile-MD5: 41244ce9987e3306cb263474098329e4
+PatchScript: sed -e 's|@FINK_PREFIX@|%p|g' -e 's|@FINK_BUILDDIR@|%b|g' <  %{PatchFile} | patch -p1
+
 CompileScript: %p/bin/python%type_raw[python] setup.py build
 
 InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
@@ -19,25 +23,51 @@ InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
 DocFiles: CHANGES LICENSE PKG-INFO README.rst
 
 InfoTest: <<
+  # Needs sphinx and xapianXX-py to run tests (circular dependency)
+  #  sphinx-py%type_pkg[python] (>= 1.8.2),
+  #  (%type_pkg[python]  = 27) xapian22-py%type_pkg[python],
+  #  (%type_pkg[python] >= 34) xapian30-py%type_pkg[python]
   TestDepends: <<
     mock-py%type_pkg[python],
     pytest-py%type_pkg[python],
+    six-py%type_pkg[python],
     sqlalchemy-py%type_pkg[python],
-    tox-py%type_pkg[python],
-    whoosh-py%type_pkg[python],
-    (%type_pkg[python]  = 27) xapian22-py%type_pkg[python],
-    (%type_pkg[python] >= 34) xapian30-py%type_pkg[python]
+    whoosh-py%type_pkg[python]
   <<
-  TestScript: %p/bin/python%type_raw[python] setup.py test || exit 2
-  # The test above does nothing, as does nosetests.  The following trials
-  # also fail and i have no clue how to fix it.
-  # - %p/bin/python%type_raw[python] -m pytest
-  # - tox
+  TestScript: <<
+    #!/bin/sh -ev
+    # check for presence of sphinx-build and %v >= 1.8.2
+    export SPHINX_VERSION=`%p/bin/sphinx-build%type_raw[python] --version 2>&1`
+    if [ ! -x %p/bin/sphinx-build%type_raw[python] ] ; then
+      echo '\nNot running tests because sphinx-py%type_pkg[python] is not installed.\n'
+      exit 0;
+    else
+      # sphinx-build must be >= 1.8.2
+      # sphinx-1.4 and sphinx-1.8 output --version differently.
+      if dpkg --compare-versions ${SPHINX_VERSION: -5} lt 1.8.2 1>/dev/null; then
+        echo '\nSphinx-%type_pkg[python] version less than 1.8.2. Not running tests.\n'
+        exit 0
+      fi
+    fi
+    # check for presence of xapian bindings
+    if [ ! -x %p/lib/python%type_raw[python]/site-packages/xapian/_xapian.cpython-%type_pkg[python]m-darwin.so ] && [ ! -x %p/lib/python%type_raw[python]/site-packages/xapian/_xapian.so ]; then
+      echo '\nNot running tests because xapian-py bindings are not installed.\n'
+      exit 0;
+    fi
+    # only run tests if sphinx (>=1.8.2) and xapianNN-pyXX are present.
+    #%p/bin/tox-py%type_pkg[python] -e py%type_pkg[python] || exit 2
+    %p/bin/python%type_raw[python] -m pytest tests/ -v || exit 2
+  <<
 <<
 
 Description: Sphinx documentation for web applications
-
+DescPort: <<
+	PatchFile is upstream commits after v1.1.0.
+<<
 Homepage: http://www.sphinx-doc.org
 Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
 # Info2
+#		export PYTHONPATH=%b/build/lib
+#		%p/bin/tox-py%type_pkg[python] || exit 2
+
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinxcontrib-websupport-py.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinxcontrib-websupport-py.patch
@@ -1,0 +1,330 @@
+diff -ruN sphinxcontrib-websupport-1.1.0-orig/.travis.yml sphinxcontrib-websupport/.travis.yml
+--- sphinxcontrib-websupport-1.1.0-orig/.travis.yml	1969-12-31 18:00:00.000000000 -0600
++++ sphinxcontrib-websupport/.travis.yml	2019-01-02 05:26:34.000000000 -0600
+@@ -0,0 +1,20 @@
++language: python
++sudo: false
++cache: pip
++python:
++  - "3.6"
++  - "3.5"
++  - "3.4"
++  - "2.7"
++env:
++  global:
++    - TEST='-v --durations 25'
++    - PYTHONFAULTHANDLER=x
++    - PYTHONWARNINGS=all
++install:
++  - pip install -U pip tox flake8
++  - pip install .
++  - pip install -r test-reqs.txt
++script:
++  - flake8
++  - python -m pytest tests/
+diff -ruN sphinxcontrib-websupport-1.1.0-orig/setup.py sphinxcontrib-websupport/setup.py
+--- sphinxcontrib-websupport-1.1.0-orig/setup.py	2018-06-03 02:45:04.000000000 -0500
++++ sphinxcontrib-websupport/setup.py	2019-01-02 05:26:34.000000000 -0600
+@@ -32,7 +32,7 @@
+     name='sphinxcontrib-websupport',
+     version=get_version(),
+     url='http://sphinx-doc.org/',
+-    download_url='https://pypi.python.org/pypi/sphinxcontrib-websupport',
++    download_url='https://pypi.org/project/sphinxcontrib-websupport/',
+     license='BSD',
+     author='Georg Brandl',
+     author_email='georg@python.org',
+diff -ruN sphinxcontrib-websupport-1.1.0-orig/sphinxcontrib/websupport/core.py sphinxcontrib-websupport/sphinxcontrib/websupport/core.py
+--- sphinxcontrib-websupport-1.1.0-orig/sphinxcontrib/websupport/core.py	2018-06-03 02:16:57.000000000 -0500
++++ sphinxcontrib-websupport/sphinxcontrib/websupport/core.py	2019-01-02 05:26:34.000000000 -0600
+@@ -18,6 +18,7 @@
+ from docutils.core import publish_parts
+ 
+ from sphinx.locale import _
++from sphinx.util.docutils import docutils_namespace
+ from sphinx.util.osutil import ensuredir
+ from sphinx.util.jsonimpl import dumps as dump_json
+ from sphinx.util.pycompat import htmlescape
+@@ -126,16 +127,17 @@
+         if not self.srcdir:
+             raise RuntimeError('No srcdir associated with WebSupport object')
+ 
+-        from sphinx.application import Sphinx
+-        app = Sphinx(self.srcdir, self.srcdir, self.outdir, self.doctreedir,
+-                     self.buildername, self.confoverrides, status=self.status,
+-                     warning=self.warning)
+-        app.builder.set_webinfo(self.staticdir, self.staticroot,  # type: ignore
+-                                self.search, self.storage)
+-
+-        self.storage.pre_build()
+-        app.build()
+-        self.storage.post_build()
++        with docutils_namespace():
++            from sphinx.application import Sphinx
++            app = Sphinx(self.srcdir, self.srcdir, self.outdir, self.doctreedir,
++                         self.buildername, self.confoverrides, status=self.status,
++                         warning=self.warning)
++            app.builder.set_webinfo(self.staticdir, self.staticroot,  # type: ignore
++                                    self.search, self.storage)
++
++            self.storage.pre_build()
++            app.build()
++            self.storage.post_build()
+ 
+     def get_globalcontext(self):
+         """Load and return the "global context" pickle."""
+diff -ruN sphinxcontrib-websupport-1.1.0-orig/sphinxcontrib/websupport/storage/sqlalchemystorage.py sphinxcontrib-websupport/sphinxcontrib/websupport/storage/sqlalchemystorage.py
+--- sphinxcontrib-websupport-1.1.0-orig/sphinxcontrib/websupport/storage/sqlalchemystorage.py	2018-06-03 02:16:57.000000000 -0500
++++ sphinxcontrib-websupport/sphinxcontrib/websupport/storage/sqlalchemystorage.py	2019-01-02 05:26:34.000000000 -0600
+@@ -42,9 +42,7 @@
+         self.build_session = Session()
+ 
+     def has_node(self, id):
+-        session = Session()
+-        node = session.query(Node).filter(Node.id == id).first()
+-        session.close()
++        node = self.build_session.query(Node).filter(Node.id == id).first()
+         return bool(node)
+ 
+     def add_node(self, id, document, source):
+diff -ruN sphinxcontrib-websupport-1.1.0-orig/sphinxcontrib_websupport.egg-info/PKG-INFO sphinxcontrib-websupport/sphinxcontrib_websupport.egg-info/PKG-INFO
+--- sphinxcontrib-websupport-1.1.0-orig/sphinxcontrib_websupport.egg-info/PKG-INFO	2018-06-03 09:09:23.000000000 -0500
++++ sphinxcontrib-websupport/sphinxcontrib_websupport.egg-info/PKG-INFO	2019-01-02 05:27:49.000000000 -0600
+@@ -1,12 +1,12 @@
+ Metadata-Version: 2.1
+ Name: sphinxcontrib-websupport
+-Version: 1.1.0
++Version: 1.1.0
+ Summary: Sphinx API for Web Apps
+ Home-page: http://sphinx-doc.org/
+ Author: Georg Brandl
+ Author-email: georg@python.org
+ License: BSD
+-Download-URL: https://pypi.python.org/pypi/sphinxcontrib-websupport
++Download-URL: https://pypi.org/project/sphinxcontrib-websupport/
+ Description: 
+         sphinxcontrib-websupport provides a Python API to easily integrate Sphinx
+         documentation into your Web application.
+diff -ruN sphinxcontrib-websupport-1.1.0-orig/sphinxcontrib_websupport.egg-info/SOURCES.txt sphinxcontrib-websupport/sphinxcontrib_websupport.egg-info/SOURCES.txt
+--- sphinxcontrib-websupport-1.1.0-orig/sphinxcontrib_websupport.egg-info/SOURCES.txt	2018-06-03 09:09:24.000000000 -0500
++++ sphinxcontrib-websupport/sphinxcontrib_websupport.egg-info/SOURCES.txt	2019-01-02 05:27:49.000000000 -0600
+@@ -1,9 +1,11 @@
+ CHANGES
+ LICENSE
+ MANIFEST.in
+ README.rst
++checklist.rst
+ setup.cfg
+ setup.py
++test-reqs.txt
+ tox.ini
+ sphinxcontrib/__init__.py
+ sphinxcontrib/websupport/__init__.py
+@@ -33,7 +37,6 @@
+ tests/test_websupport.py
+ tests/util.py
+ tests/root/Makefile
+-tests/root/autodoc.txt
+ tests/root/autodoc_fodder.py
+ tests/root/autodoc_missing_imports.py
+ tests/root/bom.po
+@@ -57,7 +60,6 @@
+ tests/root/math.txt
+ tests/root/metadata.add
+ tests/root/objects.txt
+-tests/root/otherext.foo
+ tests/root/parsermod.py
+ tests/root/quotes.inc
+ tests/root/rimg.png
+diff -ruN sphinxcontrib-websupport-1.1.0-orig/test-reqs.txt sphinxcontrib-websupport/test-reqs.txt
+--- sphinxcontrib-websupport-1.1.0-orig/test-reqs.txt	1969-12-31 18:00:00.000000000 -0600
++++ sphinxcontrib-websupport/test-reqs.txt	2019-01-02 05:26:34.000000000 -0600
+@@ -0,0 +1,6 @@
++six
++pytest>=4.0
++sqlalchemy
++whoosh
++mock
++Sphinx>=1.7
+diff -ruN sphinxcontrib-websupport-1.1.0-orig/tests/root/autodoc.txt sphinxcontrib-websupport/tests/root/autodoc.txt
+--- sphinxcontrib-websupport-1.1.0-orig/tests/root/autodoc.txt	2018-06-03 02:16:57.000000000 -0500
++++ sphinxcontrib-websupport/tests/root/autodoc.txt	1969-12-31 18:00:00.000000000 -0600
+@@ -1,49 +0,0 @@
+-Autodoc tests
+-=============
+-
+-Just testing a few autodoc possibilities...
+-
+-.. automodule:: util
+-
+-.. automodule:: test_autodoc
+-   :members:
+-
+-.. autofunction:: function
+-
+-.. autoclass:: Class
+-   :inherited-members:
+-
+-   Additional content.
+-
+-.. autoclass:: Outer
+-   :members: Inner
+-
+-.. autoattribute:: Class.docattr
+-
+-.. autoexception:: CustomEx
+-   :members: f
+-
+-.. autoclass:: CustomDict
+-   :show-inheritance:
+-   :members:
+-
+-
+-.. automodule:: autodoc_fodder
+-   :noindex:
+-
+-   .. autoclass:: MarkupError
+-
+-
+-.. currentmodule:: test_autodoc
+-
+-.. autoclass:: InstAttCls
+-   :members:
+-
+-   All members (5 total)
+-
+-.. autoclass:: InstAttCls
+-   :members: ca1, ia1
+-
+-   Specific members (2 total)
+-
+-.. automodule:: autodoc_missing_imports
+diff -ruN sphinxcontrib-websupport-1.1.0-orig/tests/root/conf.py sphinxcontrib-websupport/tests/root/conf.py
+--- sphinxcontrib-websupport-1.1.0-orig/tests/root/conf.py	2018-06-03 02:16:57.000000000 -0500
++++ sphinxcontrib-websupport/tests/root/conf.py	2019-01-02 05:26:34.000000000 -0600
+@@ -13,7 +13,6 @@
+ 
+ master_doc = 'contents'
+ source_suffix = ['.txt', '.add', '.foo']
+-source_parsers = {'.foo': 'parsermod.Parser'}
+ 
+ project = 'Sphinx <Tests>'
+ copyright = '2010-2016, Georg Brandl & Team'
+@@ -32,7 +31,7 @@
+ html_theme = 'testtheme'
+ html_theme_path = ['.']
+ html_theme_options = {'testopt': 'testoverride'}
+-html_sidebars = {'**': 'customsb.html',
++html_sidebars = {'**': ['customsb.html'],
+                  'contents': ['contentssb.html', 'localtoc.html',
+                               'globaltoc.html']}
+ html_style = 'default.css'
+@@ -96,11 +95,6 @@
+     return x
+ 
+ 
+-def functional_directive(name, arguments, options, content, lineno,
+-                         content_offset, block_text, state, state_machine):
+-    return [nodes.strong(text='from function: %s' % options['opt'])]
+-
+-
+ class ClassDirective(Directive):
+     option_spec = {'opt': lambda x: x}
+ 
+@@ -110,8 +104,7 @@
+ 
+ def setup(app):
+     app.add_config_value('value_from_conf_py', 42, False)
+-    app.add_directive('funcdir', functional_directive, opt=lambda x: x)
+     app.add_directive('clsdir', ClassDirective)
+     app.add_object_type('userdesc', 'userdescrole', '%s (userdesc)',
+                         userdesc_parse, objname='user desc')
+-    app.add_javascript('file://moo.js')
++    app.add_js_file('file://moo.js')
+diff -ruN sphinxcontrib-websupport-1.1.0-orig/tests/root/contents.txt sphinxcontrib-websupport/tests/root/contents.txt
+--- sphinxcontrib-websupport-1.1.0-orig/tests/root/contents.txt	2018-06-03 02:16:57.000000000 -0500
++++ sphinxcontrib-websupport/tests/root/contents.txt	2019-01-02 05:26:34.000000000 -0600
+@@ -28,7 +28,6 @@
+    extensions
+    footnote
+    lists
+-   otherext
+ 
+    http://sphinx-doc.org/
+    Latest reference <http://sphinx-doc.org/latest/>
+Binary files sphinxcontrib-websupport-1.1.0-orig/tests/root/ext.pyc and sphinxcontrib-websupport/tests/root/ext.pyc differ
+diff -ruN sphinxcontrib-websupport-1.1.0-orig/tests/root/extapi.txt sphinxcontrib-websupport/tests/root/extapi.txt
+--- sphinxcontrib-websupport-1.1.0-orig/tests/root/extapi.txt	2018-06-03 02:16:57.000000000 -0500
++++ sphinxcontrib-websupport/tests/root/extapi.txt	2019-01-02 05:26:34.000000000 -0600
+@@ -3,8 +3,5 @@
+ 
+ Testing directives:
+ 
+-.. funcdir::
+-   :opt: Foo
+-
+ .. clsdir::
+    :opt: Bar
+diff -ruN sphinxcontrib-websupport-1.1.0-orig/tests/root/otherext.foo sphinxcontrib-websupport/tests/root/otherext.foo
+--- sphinxcontrib-websupport-1.1.0-orig/tests/root/otherext.foo	2018-06-03 02:16:57.000000000 -0500
++++ sphinxcontrib-websupport/tests/root/otherext.foo	1969-12-31 18:00:00.000000000 -0600
+@@ -1,2 +0,0 @@
+-The contents of this file are ignored.
+-The file is "parsed" using Parser in the tests/root/parsermod.py file.
+diff -ruN sphinxcontrib-websupport-1.1.0-orig/tests/test_searchadapters.py sphinxcontrib-websupport/tests/test_searchadapters.py
+--- sphinxcontrib-websupport-1.1.0-orig/tests/test_searchadapters.py	2018-06-03 02:53:50.000000000 -0500
++++ sphinxcontrib-websupport/tests/test_searchadapters.py	2019-01-02 05:26:34.000000000 -0600
+@@ -12,7 +12,7 @@
+ from six import StringIO
+ import pytest
+ 
+-from sphinx.websupport import WebSupport
++from sphinxcontrib.websupport import WebSupport
+ 
+ from test_websupport import sqlalchemy_missing
+ from util import rootdir, tempdir, skip_unless_importable
+diff -ruN sphinxcontrib-websupport-1.1.0-orig/tests/test_websupport.py sphinxcontrib-websupport/tests/test_websupport.py
+--- sphinxcontrib-websupport-1.1.0-orig/tests/test_websupport.py	2018-06-03 02:53:50.000000000 -0500
++++ sphinxcontrib-websupport/tests/test_websupport.py	2019-01-02 05:26:34.000000000 -0600
+@@ -9,15 +9,15 @@
+     :license: BSD, see LICENSE for details.
+ """
+ 
+-from sphinx.websupport import WebSupport
+-from sphinx.websupport.errors import DocumentNotFoundError, \
++from sphinxcontrib.websupport import WebSupport
++from sphinxcontrib.websupport.errors import DocumentNotFoundError, \
+     CommentNotAllowedError, UserNotAuthorizedError
+-from sphinx.websupport.storage import StorageBackend
+-from sphinx.websupport.storage.differ import CombinedHtmlDiff
++from sphinxcontrib.websupport.storage import StorageBackend
++from sphinxcontrib.websupport.storage.differ import CombinedHtmlDiff
+ try:
+     from sphinxcontrib.websupport.storage.sqlalchemystorage import Session, \
+         Comment, CommentVote
+-    from sphinx.websupport.storage.sqlalchemy_db import Node
++    from sphinxcontrib.websupport.storage.sqlalchemy_db import Node
+     sqlalchemy_missing = False
+ except ImportError:
+     sqlalchemy_missing = True
+@@ -35,7 +35,7 @@
+         # each test expect result of db value at previous test case.
+         'builddir': tempdir / 'websupport'
+     }
+-    marker = request.node.get_marker('support')
++    marker = request.node.get_closest_marker('support')
+     if marker:
+         settings.update(marker.kwargs)
+ 
+Binary files sphinxcontrib-websupport-1.1.0-orig/tests/util.pyc and sphinxcontrib-websupport/tests/util.pyc differ
+diff -ruN sphinxcontrib-websupport-1.1.0-orig/tox.ini sphinxcontrib-websupport/tox.ini
+--- sphinxcontrib-websupport-1.1.0-orig/tox.ini	2018-06-03 02:46:52.000000000 -0500
++++ sphinxcontrib-websupport/tox.ini	2019-01-02 05:26:34.000000000 -0600
+@@ -12,6 +12,7 @@
+ setenv =
+     SPHINX_TEST_TEMPDIR = {envdir}/testbuild
+     PYTHONDONTWRITEBYTECODE = true
++    PYTHONWARNINGS = all,ignore::DeprecationWarning:docutils.io,ignore::DeprecationWarning:jinja2.utils,ignore::DeprecationWarning:jinja2.runtime,ignore::DeprecationWarning:jinja2.sandbox
+ commands=
+     {envpython} -m pytest tests/ {posargs}
+ 


### PR DESCRIPTION
add py37 variant
add new package sphinxcontrib-websupport-py.
add dependencies and test-dependencies as they show up during the build.