### PR TITLE
pysocks-py is a newer fork of socksipy-py

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/gsutil-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/gsutil-py.info
@@ -2,7 +2,7 @@ Info2: <<
 
 Package: gsutil-py%type_pkg[python]
 Version: 3.37
-Revision: 1
+Revision: 2
 Type: python (2.7)
 
 Source: https://pypi.python.org/packages/source/g/gsutil/gsutil-%v.tar.gz
@@ -11,7 +11,7 @@ Depends: <<
   python%type_pkg[python],
   boto-py%type_pkg[python] (>= 2.9.1),
   crcmod-py%type_pkg[python] (>= 1.7),
-  socksipy-py%type_pkg[python] (>= 1.01),
+  pysocks-py%type_pkg[python] (>= 1.6.8-1),
   google-api-python-client-py%type_pkg[python]
 <<
 BuildDepends: setuptools-tng-py%type_pkg[python]

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pysocks-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pysocks-py.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: pysocks-py%type_pkg[python]
 Version: 1.6.8
-Revision: 1
+Revision: 2
 Type: python (2.7 3.4 3.5 3.6 3.7)
 Description: Python SOCKS client module
 
@@ -15,6 +15,8 @@ Source-Checksum: SHA256(3fe52c55890a248676fd69dc9e3c4e811718b777834bcaab7a8125cf
 
 Depends: python%type_pkg[python]
 BuildDepends: fink (>= 0.24.12), setuptools-tng-py%type_pkg[python]
+Conflicts: socksipy-py%type_pkg[python]
+Replaces: socksipy-py%type_pkg[python]
 
 CompileScript: %p/bin/python%type_raw[python] setup.py build
 

--- a/10.9-libcxx/stable/main/finkinfo/web/socksipy-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/socksipy-py.info
@@ -2,7 +2,7 @@ Info2: <<
 
 Package: socksipy-py%type_pkg[python]
 Version: 1.02
-Revision: 1
+Revision: 2
 Type: python (2.7)
 
 # The author created a 
@@ -11,6 +11,8 @@ Source: http://vislab-ccom.unh.edu/~schwehr/software/fink/socksipy-%v.tar.xz
 Source-MD5: a3b160b02d8ea42464a7ccccee0bc294
 Depends: python%type_pkg[python]
 BuildDepends: fink (>= 0.32)
+Conflicts: pysocks-py%type_pkg[python]
+Replaces: pysocks-py%type_pkg[python]
 CompileScript: %p/bin/python%type_raw[python] setup.py build
 InstallScript: %p/bin/python%type_raw[python] setup.py install --root %d
 License: BSD


### PR DESCRIPTION
The two packages both install a socks.py which obviously conflicts.
gsutil-py is the only package that uses socksipy so switch it to pysocks to avoid the conflict. See https://github.com/fink/fink-distributions/issues/237