### PR TITLE
lxml-py update and Python 3.7 version

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/cssselect-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/cssselect-py.info
@@ -1,14 +1,19 @@
+# -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 
 Package: cssselect-py%type_pkg[python]
-Version: 1.0.1
+Version: 1.0.3
 Revision: 1
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 License: BSD
-Type: python (2.7 3.4 3.5 3.6)
-Homepage: https://pypi.python.org/pypi/Babel
-Source: https://files.pythonhosted.org/packages/source/c/cssselect/cssselect-%v.tar.gz
-Source-MD5: 3fa03bf82a9f0b1223c0f1eb1369e139
+Type: python (2.7 3.4 3.5 3.6 3.7)
+Homepage: https://pypi.python.org/project/cssselect
+# Missing tests directory in pypi tarball
+#Source: https://files.pythonhosted.org/packages/source/c/cssselect/cssselect-%v.tar.gz
+#Source-Checksum: SHA256(066d8bc5229af09617e24b3ca4d52f1f9092d9e061931f4184cd572885c23204)
+Source: https://github.com/scrapy/cssselect/archive/v%v.tar.gz
+Source-Checksum: SHA256(203d9691c42c13cffe26a2f8fc714977882fcf54a6df82c8eda3371f6beaecdb)
+SourceRename: cssselect-%v.tar.gz
 
 Depends: python%type_pkg[python]-shlibs
 BuildDepends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
@@ -30,6 +35,10 @@ DocFiles: LICENSE README.rst
 CompileScript: true
 InstallScript: <<
   python%type_raw[python] setup.py install --root=%d
+<<
+InfoTest: <<
+  TestDepends: pytest-py%type_pkg[python], lxml-py%type_pkg[python]
+  TestScript: %p/bin/python%type_raw[python] setup.py pytest || exit 2
 <<
 
 # Info2

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/cssselect-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/cssselect-py.info
@@ -38,7 +38,7 @@ InstallScript: <<
 <<
 InfoTest: <<
   TestDepends: pytest-py%type_pkg[python], lxml-py%type_pkg[python]
-  TestScript: %p/bin/python%type_raw[python] setup.py pytest || exit 2
+  TestScript: %p/bin/pytest-%type_raw[python] || exit 2
 <<
 
 # Info2

--- a/10.9-libcxx/stable/main/finkinfo/text/lxml-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/lxml-py.info
@@ -1,15 +1,18 @@
+# -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: lxml-py%type_pkg[python]
-Type: python (2.7 3.4 3.5 3.6)
+Type: python (2.7 3.4 3.5 3.6 3.7)
 
-Version: 3.4.4
+Version: 4.2.5
 Revision: 1
 
-Source: https://pypi.python.org/packages/source/l/lxml/lxml-%v.tar.gz
-Source-MD5: a9a65972afc173ec7a39c585f4eea69c
+Source: https://files.pythonhosted.org/packages/source/l/lxml/lxml-%v.tar.gz
+Source-Checksum: SHA256(36720698c29e7a9626a0dc802ef8885f8f0239bfd1689628ecd459a061f2807f)
 
 BuildDepends: libxml2, libxslt, python%type_pkg[python], setuptools-tng-py%type_pkg[python]
 Depends:  libxml2-shlibs, libxslt-shlibs, python%type_pkg[python] 
+Recommends: cssselect-py%type_pkg[python]
+
 CompileScript: <<
   %p/bin/python%type_raw[python] setup.py build
 <<
@@ -19,12 +22,16 @@ InstallScript: <<
   cp -r doc/* %i/share/doc/%n/
 <<
 
-# Test does not yet work
-#InfoTest: <<
-#  TestScript: <<
-#    %p/bin/python%type_raw[python] test.py -p -v || exit 2
-#  <<
-#<<
+# test.py loads from src/lxml, seems impossible to point it to the build/ dir
+# (although cfg.basedir should allow this...) - need to build extensions there again.
+InfoTest: <<
+  TestDepends: pytest-py%type_pkg[python]
+  TestScript: <<
+    %p/bin/python%type_raw[python] setup.py build_ext --inplace
+    %p/bin/python%type_raw[python] test.py -p -v || exit 2
+  <<
+  TestSuiteSize: medium
+<<
 
 DocFiles: CHANGES.txt CREDITS.txt INSTALL.txt LICENSES.txt MANIFEST.in PKG-INFO README.rst TODO.txt
 Description: Binding for the libxml2 and libxslt
@@ -52,7 +59,7 @@ enough.
 <<
 License: BSD
 #Homepage: http://www.ltg.ed.ac.uk/software/xml/
-Homepage: http://codespeak.net/lxml/
+Homepage: https://lxml.de/
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 
 # End INFO2


### PR DESCRIPTION
Updating `lxml-py` to 4.2.5 and adding a `py37` variant as discussed in #288 - this reduces the no. of skipped tests in `html5lib-py` by ~ 4000-5000.
Also adding an update of `cssselect-py` with a near-circular dependency: cssselect tests critically depend on lxml, while some lxml tests (possibly only one) require cssselect, but will automatically be skipped otherwise. I have therefore just made `cssselect-py` a `Recommends` of `lxml-py` and a `TestDepends` vice-versa.
lxml's `test.py` insists on loading the module from the `src/lxml` path, which forced me to run an additional inplace build. One might perhaps just manually install the `*.so` files from `build/lib*`, but this seemed a bit hackish to me...