### PR TITLE
bison 3.2

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/bison.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/bison.info
@@ -1,11 +1,10 @@
 Package: bison
-Version: 3.0.5
+Version: 3.2
 Revision: 1
 Source: gnu
 Maintainer: Darian Lanx <dmalloc@users.sourceforge.net>
 BuildDepends: <<
 	fink-package-precedence,
-	gawk,
 	gettext-bin,
 	gettext-tools,
 	libgettext8-dev,
@@ -23,7 +22,10 @@ ConfigureParams: <<
 	--with-libiconv-prefix=%p \
 	--with-libintl-prefix=%p \
 	--mandir=%p/share/man \
-	--infodir=%p/share/info
+	--infodir=%p/share/info \
+	ac_cv_prog_AWK=/usr/bin/awk \
+	ac_cv_path_GREP=/usr/bin/grep \
+	ac_cv_path_SED=/usr/bin/sed
 <<
 UseMaxBuildJobs: false
 CompileScript: <<
@@ -64,15 +66,8 @@ The only C++ is in the self-test suite.
 
 Force use of the system's java at build time because otherwise the package
 will find gcj from gcc4N, if installed.
-
-With format string strictness, High Sierra also enforces that %n isn't
-used in dynamic format strings, but we should just disable its use on
-darwin in general.
-
 <<
 License: GPL/GFDL
 Homepage: http://www.gnu.org/software/bison/bison.html
-Source-MD5: 41ad57813157b61bfa47e33067a9d6f0
-Source-Checksum: SHA1(326135383c6ef4439781f5817475948b28501dbc)
-#PatchFile: %n.patch
-#PatchFile-MD5: d9f45fcd3c6d210fcef71eebbda2f345
+Source-MD5: 094f88d1e35d7e3116d91d7d8863bcde
+Source-Checksum: SHA1(3571e4eba7d3f8f229f0bbcfb431e2c4773ddd7f)


### PR DESCRIPTION
sets several ac_cv_prog macros to be deterministic. GNU-gawk was needed at some point in the past, but it's not needed any more (at least as of 10.11).

Tested on 10.11.