### PR TITLE
wxmplot-py: new package

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/wxmplot-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/wxmplot-py.info
@@ -1,0 +1,87 @@
+Info2: <<
+
+Package: wxmplot-py%type_pkg[python]
+Version: 0.9.31
+Revision: 1
+License: OSI-Approved
+Type: python (2.7 3.4 3.5 3.6)
+
+Depends: <<
+  matplotlib-py%type_pkg[python],
+  python%type_pkg[python]
+<<
+BuildDepends: setuptools-tng-py%type_pkg[python]
+
+Source: https://files.pythonhosted.org/packages/source/w/wxmplot/wxmplot-%v.tar.gz
+Source-MD5: 9e2e8b8d31179cac864399b8cc7617f4
+
+CompileScript: <<
+#!/bin/sh -ev
+  %p/bin/python%type_raw[python] setup.py build 
+# Create license file from text of GitHub repository.
+  cat >LICENSE <<EOFCFG
+Copyright, Licensing, and Re-distribution
+-----------------------------------------
+
+This code and all files here are distributed under the following license:
+  
+  Copyright (c) 2018 Matthew Newville, The University of Chicago
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of
+  this software and associated documentation files (the "Software"), to deal in
+  the Software without restriction, including without limitation the rights to
+  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+  of the Software, and to permit persons to whom the Software is furnished to do
+  so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXP80RESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+EOFCFG
+<<
+
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
+
+DocFiles: <<
+  ChangeLog
+  LICENSE
+  PKG-INFO
+  README.md
+  doc
+<<
+
+InfoTest: <<
+  TestDepends: wxpython400-py%type_pkg[python]
+  TestScript: python%type_raw[python] setup.py test || exit 2
+<<
+
+Description: Plotting widgets for wxPython with matplotlib
+
+DescDetail: <<
+The wxmplot python package provides easy-to-use, richly featured plotting
+widgets for wxPython built on top of the wonderful matplotlib library.
+While matplotlib provides excellent general purpose plotting functionality,
+and supports a variety of GUI and non-GUI backends, it does not have a very
+tight integration with any particular GUI toolkit.  Similarly, while
+wxPython has some plotting functionality, it has nothing as good as
+matplotlib.  The wxmplot package attempts to bridge this gap, providing
+wx.Panels for basic 2D line plots and image display that are richly
+featured and provide end-users with interactivity (zooming, reading
+positions, rotating images) and customization (line types, labels, marker
+type, colors, and color tables) of the graphics without having to know
+matplotlib.  Wxmplot does not expose all of matplotlib's capabilities, but
+does provide 2D plotting and image display Panels and Frames can be used
+simply in wxPython applications to handle many use cases.
+<<
+
+Homepage: https://newville.github.io/wxmplot
+Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/sci/wxmplot-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/wxmplot-py.info
@@ -2,12 +2,14 @@ Info2: <<
 
 Package: wxmplot-py%type_pkg[python]
 Version: 0.9.31
-Revision: 1
+Revision: 2
 License: OSI-Approved
 Type: python (2.7 3.4 3.5 3.6)
 
 Depends: <<
   matplotlib-py%type_pkg[python],
+  numpy-py%type_pkg[python],
+  six-py%type_pkg[python],
   python%type_pkg[python]
 <<
 BuildDepends: setuptools-tng-py%type_pkg[python]


### PR DESCRIPTION
Plotting widgets for wxPython with matplotlib. No py37 variant, since matplotlib-py37 is still missing.