### PR TITLE
pyqt5-mac-py: fix issue with py27 variant

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
@@ -50,7 +50,8 @@ Depends: <<
   qt5-mac-qtwidgets-shlibs (>= 5.6.0-1),
   qt5-mac-qtxml-shlibs (>= 5.6.0-1),
   qt5-mac-qtxmlpatterns-shlibs (>= 5.6.0-1),
-  sip-py%type_pkg[python] (>= 4.19.12-1)
+  sip-py%type_pkg[python] (>= 4.19.12-1),
+  ( %type_pkg[python] <= 27 ) enum34-py%type_pkg[python]
 <<
 BuildDepends:<<
 #  ( %type_pkg[python] <= 27 ) dbus1.3-dev,


### PR DESCRIPTION
This minimal patch fixes the issue with missing enum34-py27 dependence from the mailing list for the py27 variant.

Other potential issues are neglected at this point.