### PR TITLE
lz4: update to new upstream version (1.8.3)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/lz4.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/lz4.info
@@ -1,13 +1,13 @@
 Package: lz4
-Version: 1.8.2
+Version: 1.8.3
 Revision: 1
 Description: Fast LZ compression algorithm library
 License: GPL
 
 Source: https://github.com/%n/%n/archive/v%v.tar.gz
 SourceRename: %n-%v.tar.gz
-Source-MD5: c2082b751d75550ec4dc163c773e1a71
-Source-Checksum: SHA1(dc24ee207db0b4481ff5e74b608c1af1c18c5a7c)
+Source-MD5: d5ce78f7b1b76002bbfffa6f78a5fc4e
+Source-Checksum: SHA1(070867abcd93a7245b80ec6fc2ced27c6b8e3e0c)
 
 Depends: %N-shlibs (= %v-%r)
 BuildDepends: fink-package-precedence
@@ -30,7 +30,7 @@ InstallScript: <<
   make install PREFIX=%p DESTDIR=%d
 <<
 
-DocFiles: LICENSE NEWS README.md
+DocFiles: LICENSE NEWS README.md doc
 
 InfoTest: <<
   TestScript: make check || exit 2


### PR DESCRIPTION
Adding the docs directory to lz4.