### PR TITLE
postgresql updates Nov  2018

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
@@ -49,7 +49,7 @@ PatchFile: %n.patch
 PatchFile-MD5: 35ba01b87cfa5ff721077a99f80a744d
 
 SetCPPFLAGS: -DHAVE_OPTRESET -fno-common
-SetLDFLAGS: -F/System/Library/Frameworks
+SetLDFLAGS: -F/System/Library/Frameworks -headerpad_max_install_names
 CompileScript: <<
 	#!/bin/sh -xe
 	

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 10.5
+Version: 10.6
 Revision: 1
 Type: postgresql 10
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: a5fe5fdff2d6c28f65601398be0950df
-Source-Checksum: SHA1(8c7b4406b0ba2987f4170657f89908ad47947429)
+Source-MD5: caa28a40f64781a9dbf59e9227d32dc4
+Source-Checksum: SHA256(68a8276f08bda8fbefe562faaf8831cb20664a7a1d3ffdbbcc5b83e08637624b)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
@@ -211,7 +211,8 @@ SplitOff: <<
 		postgresql94-dev,
 		postgresql95-dev,
 		postgresql96-dev,
-		postgresql10-dev
+		postgresql10-dev,
+		postgresql11-dev
 	<<
 	Replaces: <<
 		postgresql92-dev,
@@ -219,7 +220,8 @@ SplitOff: <<
 		postgresql94-dev,
 		postgresql95-dev,
 		postgresql96-dev,
-		postgresql10-dev
+		postgresql10-dev,
+		postgresql11-dev
 	<<
 	BuildDependsOnly: true
 	Files: <<

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
@@ -57,6 +57,12 @@ CompileScript: <<
 	export PYTHON=/usr/bin/python
 	export FLEX=/usr/bin/flex	
 
+        if [[ `uname -r | cut -d. -f1` -eq 15 ]] ; then
+           # fix for Xcode 8 on OS X 10.11
+           export ac_cv_search_clock_gettime=no
+           export ac_cv_func_clock_gettime=no
+        fi
+
 	./configure \
 	--prefix='%p/opt/postgresql-%type_raw[postgresql]' \
 	--docdir='%p/share/doc/%N' \

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.4.19
+Version: 9.4.20
 Revision: 1
 Epoch: 1
 Type: postgresql 9.4
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: c7b24ea742692f33376ee40716f8b3ac
-Source-Checksum: SHA1(7f153fd150a07f7515e7e1aa2e704ce88b13173c)
+Source-MD5: 5821867741c821736266f27b6b8a859a
+Source-Checksum: SHA256(eeb1d8ddb2854c9e4d8b5cbd65665260c0ae8cbcb911003f24c2d82ccb97f87f)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
@@ -212,7 +212,8 @@ SplitOff: <<
 		postgresql94-dev,
 		postgresql95-dev,
 		postgresql96-dev,
-		postgresql10-dev
+		postgresql10-dev,
+		postgresql11-dev
 	<<
 	Replaces: <<
 		postgresql92-dev,
@@ -220,7 +221,8 @@ SplitOff: <<
 		postgresql94-dev,
 		postgresql95-dev,
 		postgresql96-dev,
-		postgresql10-dev
+		postgresql10-dev,
+		postgresql11-dev
 	<<
 	BuildDependsOnly: true
 	Files: <<

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.5.14
+Version: 9.5.15
 Revision: 1
 Epoch: 1
 Type: postgresql 9.5
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 36c51ae03c2cd7606e22b8ba228df304
-Source-Checksum: SHA1(23b29fbf57730c3d0662f5875d5bb8072d9f1074)
+Source-MD5: 70a0af3171b4522c080d0f61584bd7f9
+Source-Checksum: SHA256(dbda3fdefd7f9fd5359a7989085aaef25c9f9d08816eda6378c2575d1ff55444)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
@@ -212,7 +212,8 @@ SplitOff: <<
 		postgresql94-dev,
 		postgresql95-dev,
 		postgresql96-dev,
-		postgresql10-dev
+		postgresql10-dev,
+		postgresql11-dev
 	<<
 	Replaces: <<
 		postgresql92-dev,
@@ -220,7 +221,8 @@ SplitOff: <<
 		postgresql94-dev,
 		postgresql95-dev,
 		postgresql96-dev,
-		postgresql10-dev
+		postgresql10-dev,
+		postgresql11-dev
 	<<
 	BuildDependsOnly: true
 	Files: <<

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.6.10
+Version: 9.6.11
 Revision: 1
 Epoch: 1
 Type: postgresql 9.6
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 9a7f465252c0fbe2212566e3c079e062
-Source-Checksum: SHA1(860ff3e2ce42246f45db1fc4519f972228168242)
+Source-MD5: ba589ad4702b4fd0fc86efe2c1a66f78
+Source-Checksum: SHA256(38250adc69a1e8613fb926c894cda1d01031391a03648894b9a6e13ff354a530)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
@@ -212,7 +212,8 @@ SplitOff: <<
 		postgresql94-dev,
 		postgresql95-dev,
 		postgresql96-dev,
-		postgresql10-dev
+		postgresql10-dev,
+		postgresql11-dev
 	<<
 	Replaces: <<
 		postgresql92-dev,
@@ -220,7 +221,8 @@ SplitOff: <<
 		postgresql94-dev,
 		postgresql95-dev,
 		postgresql96-dev,
-		postgresql10-dev
+		postgresql10-dev,
+		postgresql11-dev
 	<<
 	BuildDependsOnly: true
 	Files: <<


### PR DESCRIPTION
postgresql updates November 2018:

- Update PG 10  to 10.6
- Update PG 9.6  to 9.6.11
- Update PG 9.5  to 9.5.15
- Update PG 9.4  to 9.4.20

Upstream fixed build issues on 10.14 for all supported versions ( Issue #291 ).
Contains preparation for new major version postgresql 11.
