### PR TITLE
libcurl4: fix include prefix for 10.14

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/net/libcurl4.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/libcurl4.info
@@ -2,7 +2,7 @@
 Info4: <<
 Package: libcurl4
 Version: 7.63.0
-Revision: 1
+Revision: 2
 Description: Lib. for transferring files with URL syntax
 DescDetail: <<
 	curl is a command line tool for transferring files with URL syntax,
@@ -71,8 +71,13 @@ PatchScript: <<
 	perl -pi -e 's|10\.\[012\]\*|10.[012][,.]*|g' configure
 	
 	#Set up to use system's ldap
-	/bin/cp /usr/include/lber*.h .
-	/bin/cp /usr/include/ldap*.h .
+	InclPREFIX="/usr/include"
+	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
+		InclPREFIX="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include" 
+	fi
+
+	/bin/cp $InclPREFIX/lber*.h .
+	/bin/cp $InclPREFIX/ldap*.h .
 	/bin/cp /usr/lib/libldap.dylib .
 <<
 


### PR DESCRIPTION
The files for the copy in the patch script are no longer in /usr/include.