### PR TITLE
icon-naming-utils: enable 10.14

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/utils/icon-naming-utils.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/icon-naming-utils.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: icon-naming-utils
 Version: 0.8.90
 Revision: 602
-Distribution: 10.10, 10.11, 10.12, 10.13
+Distribution: 10.10, 10.11, 10.12, 10.13, 10.14
 Type: system-perl (5.18.2)
 Depends: <<
 	system-perl%type_pkg[system-perl],


### PR DESCRIPTION
building the package with -m --build-as-nobody was successful after simply adding 10.14.