### PR TITLE
doxygen: fix cmakefile for Mojave

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/doxygen.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/doxygen.info
@@ -1,7 +1,7 @@
 Info3: <<
 Package: doxygen
 Version: 1.8.14
-Revision: 1
+Revision: 2
 Source: ftp://ftp.stack.nl/pub/users/dimitri/%n-%v.src.tar.gz
 SourceDirectory: %n-%v
 Source-MD5: 41d8821133e8d8104280030553e2b42b
@@ -15,7 +15,7 @@ BuildDepends: <<
 	libiconv-dev
 <<
 PatchFile: %n.patch
-PatchFile-MD5: 649724b9450dbbfe17a4a85b2bb9e748
+PatchFile-MD5: 1326b09641c8268f3c8276515794a0ea
 GCC: 4.0
 CompileScript: <<
 	#!/bin/sh -ev

--- a/10.9-libcxx/stable/main/finkinfo/devel/doxygen.patch
+++ b/10.9-libcxx/stable/main/finkinfo/devel/doxygen.patch
@@ -20,6 +20,15 @@ diff -ruN doxygen-1.8.14-orig/src/portable_c.c doxygen-1.8.14/src/portable_c.c
 doxygen-1.8.14-orig/CMakeLists.txt doxygen-1.8.14/CMakeLists.txt
 --- doxygen-1.8.14-orig/CMakeLists.txt	2017-10-31 14:36:00.000000000 -0500
 +++ doxygen-1.8.14/CMakeLists.txt	2018-10-20 14:05:43.000000000 -0500
+@@ -36,7 +36,7 @@
+   set(sqlite3  "1" CACHE INTERNAL "used in settings.h")
+ endif()
+ 
+-set(MACOS_VERSION_MIN 10.5)
++set(MACOS_VERSION_MIN 10.9)
+ if (use_libclang)
+    set(clang    "1" CACHE INTERNAL "used in settings.h")
+         find_package(LLVM CONFIG REQUIRED)
 @@ -139,20 +139,24 @@
  endif()
  


### PR DESCRIPTION
doxygen refuses to build on 10.14, since it specifies "-mmacosx-version-min=10.5" as a compiler option. This patch changes the minimum version to 10.9, in line with changes to doxygen's source code (though they haven't published a new version yet). Tested on 10.14.2.