### PR TITLE
lazarus: fix dependecies for 10.14

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus.info
@@ -78,6 +78,9 @@ Patchscript: <<
   sed -i.tmp 's|/Developer/lazarus|%p/share/lazarus|g' tools/install/macosx/environmentoptions.xml
   sed -i.tmp 's|<DebuggerFilename Value="/usr/bin/gdb"/>|<DebuggerFilename Value="/usr/bin/gdb"> <History Count="3"> <Item1 Value="/usr/bin/gdb"/> <Item2 Value="%p/bin/fsf-gdb"/> <Item3 Value="%p/bin/gdb"/> </History> </DebuggerFilename>|g'  tools/install/macosx/environmentoptions.xml
 
+# fix path to X11
+  sed -i.tmp 's|-Fl/usr/X11R6/lib -Fl%p/lib|"-Fl%p/lib -Fl%p/lib/pango-ft219/lib -Fl/opt/X11/lib"|g' ide/Makefile
+
 # fix compilation of bigidecomponents with LCL_PLATFORM=nogui (LCLnogui)
 # with osprinters.pas the line number needs to be given
   sed -i.tmp '50 s|LCLGtk2|LCLnogui}{$I cupsprinters_h.inc}{$ENDIF}{$IFDEF LCLGtk2|g' components/printers/osprinters.pas
@@ -108,8 +111,11 @@ CompileScript: <<
     # 64 bit nogui units
     make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options"
   elif [ "%type_raw[uitype]" == "-gtk2" ]; then
-    make bigide    LCL_PLATFORM=gtk2   OPT="$debug_options -dHasX -Fl%p/lib/pango-ft219/lib/ -k-framework -kApplicationServices"
-    # 32 bit nogui units
+    make bigide    LCL_PLATFORM=gtk2   OPT="$debug_options -dHasX \
+         -FfApplicationServices \
+         -k-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib \
+         -k-L/opt/X11/lib -k-L%p/lib -k-L%p/lib/pango-ft219/lib "
+# 32 bit nogui units
     make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options" $carbon_arch
 #  elif [ "%type_raw[uitype]" == "-cocoa" ]; then
 #    make all       LCL_PLATFORM=cocoa  OPT="$debug_options"
@@ -216,7 +222,14 @@ Crosscompilation is available for:
 
 CPU_SOURCE is needed to build the 32bit version on 64bit systems.
 Otherwise building svn2revisioninc crashes.
-gtk2-64bit needs additional -k-framework -kApplicationServices
+gtk2-64bit needs additional -FfApplicationServices
+Strangly -Fl%p/lib and similar do not really work and ld complains about
+missing symbols.
+  -k-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+needs to be before -k-L/sw/lib. Otherwise libiconv from fink might be 
+taken, which has linux type symbols iconv* instead of libiconv* as set in 
+the fpc rtl file /sw/share/fpcsrc/rtl/unix/cwstring.pp. If the fink 
+version is taken there are linker errors about undefined symbols iconv*.
 <<
 
 Homepage: http://wiki.freepascal.org/Main_Page

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus.info
@@ -3,7 +3,7 @@ Package: lazarus%type_pkg[uitype]
 Type: uitype (-aqua -gtk2 -qt4 -qt5)
 # not working so far: -cocoa
 Version: 1.8.4
-Revision: 1
+Revision: 2
 License: GPL/LGPL
 
 Recommends: fpc-doc, lazarus-doc, apple-gdb, gdb
@@ -23,14 +23,14 @@ Depends: <<
   (%type_pkg[uitype] = -qt4)  qt4pas (>= 2.5-3),
   (%type_pkg[uitype] = -qt5)  qt5pas (>= 1.8.2)
 <<
-
+ 
 Builddepends: <<
   (%type_pkg[uitype] = -gtk2) gtk+2,
   (%type_pkg[uitype] = -gtk2) gtk+2-dev,
   (%type_pkg[uitype] = -gtk2) glib2-dev,
   (%type_pkg[uitype] = -gtk2) cairo,
-  (%type_pkg[uitype] = -qt4)  qt4pas (>= 2.5-3), qt4pas-dev (>= 2.5-3),
-  (%type_pkg[uitype] = -qt5)  qt5-mac-qtbase, qt5-mac-qtbase-dev-tools
+  (%type_pkg[uitype] = -qt4)  qt4pas     (>= 2.5-3),
+  (%type_pkg[uitype] = -qt4)  qt4pas-dev (>= 2.5-3)
 <<
 
 Conflicts: <<
@@ -115,16 +115,16 @@ CompileScript: <<
 #    make all       LCL_PLATFORM=cocoa  OPT="$debug_options"
 #    # 64 bit nogui units
 #    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options"
-  elif [ "%type_raw[uitype]" == "-qt4" ]; then
-    make bigide    LCL_PLATFORM=qt OPT="$debug_options"
-    # 64 bit nogui units
-    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options"
-  elif [ "%type_raw[uitype]" == "-qt5" ]; then
-    # build lazarus
-    make bigide    LCL_PLATFORM=qt5 OPT="$debug_options -Ff%p/lib/qt5-mac/lib"
-    install_name_tool -change Qt5Pas.framework/Versions/1/Qt5Pas %p/lib/qt5-mac/lib/Qt5Pas.framework/Versions/1/Qt5Pas lazarus
-    # 64 bit nogui units
-    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options"
+#  elif [ "%type_raw[uitype]" == "-qt4" ]; then
+#    make bigide    LCL_PLATFORM=qt OPT="$debug_options"
+#    # 64 bit nogui units
+#    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options"
+#  elif [ "%type_raw[uitype]" == "-qt5" ]; then
+#    # build lazarus
+#    make bigide    LCL_PLATFORM=qt5 OPT="$debug_options -Ff%p/lib/qt5-mac/lib"
+#    install_name_tool -change Qt5Pas.framework/Versions/1/Qt5Pas %p/lib/qt5-mac/lib/Qt5Pas.framework/Versions/1/Qt5Pas lazarus
+#    # 64 bit nogui units
+#    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options"
   fi
 
 # ** Finish compiling Lazarus **


### PR DESCRIPTION
-qt4 and -qt5 do not build until qt4 and qt5 packages are fixed.