### PR TITLE
delila-bundle: rename binary split

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/delila-bundle.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/delila-bundle.info
@@ -1,5 +1,5 @@
 Package: delila-bundle
-Version: 6
+Version: 7
 Revision: 1
 License: GPL
 
@@ -93,6 +93,7 @@ InstallScript: <<
   rm *.o
   mv cluster cluster-delila
   mv transpose transpose-delila
+  mv split split-delila
   install -c -m 755 * %i/bin/
 <<
 


### PR DESCRIPTION
The binary split replaces the system binary split with a completely different functionality. This prevents building qt4-base-mac and maybe more.