### PR TITLE
pipdeptree-py: update to (0.13.1) and bug fix.

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pipdeptree-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pipdeptree-py.info
@@ -1,7 +1,7 @@
 Info2: <<
 
 Package: pipdeptree-py%type_pkg[python]
-Version: 0.13.0
+Version: 0.13.1
 Revision: 1
 License: OSI-Approved
 Type: python (2.7 3.4 3.5 3.6 3.7)
@@ -14,8 +14,11 @@ Depends: <<
 BuildDepends: setuptools-tng-py%type_pkg[python]
 
 Source: https://files.pythonhosted.org/packages/source/p/pipdeptree/pipdeptree-%v.tar.gz
-Source-MD5: 1cbdbd185f3e09106930549bbef0a9a1
+Source-MD5: 3315f0878b3bd75ce9bd46f17418e6dc
 
+Patchscript: <<
+  sed -i.bak 's|from pip._internal import|from pip._internal.utils.misc import|g' pipdeptree.py
+<<
 CompileScript: %p/bin/python%type_raw[python] setup.py build
 InstallScript: <<
   #!/bin/sh -ev


### PR DESCRIPTION
The update to the new upstream version (0.13.1) fixes issue #327.