### PR TITLE
python2 & 3 on MacOS 10.14

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/python27.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python27.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: python%type_pkg[python]
 Version: 2.7.15
-Revision: 1
+Revision: 2
 Epoch: 1
 Type: python 2.7
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
@@ -81,10 +81,11 @@ ConfigureParams: <<
 CompileScript: <<
 #!/bin/sh -ex
 
-	# for OS X 10.14, ensure full SDK is available
+	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
 		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-		export CFLAGS="-I$SDK_PATH/usr/include"
+		export CFLAGS="-Wno-nullability-completeness"
+		export CPPFLAGS="-I$SDK_PATH/usr/include"
 		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/python34.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python34.info
@@ -4,7 +4,7 @@ Package: python%type_pkg[python]
 # OPENSSL110 FTBFS
 # Will never support OPENSSL110. 3.5+ do.
 Version: 3.4.9
-Revision: 1
+Revision: 2
 Type: python 3.4
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/languages/python34.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python34.info
@@ -91,10 +91,11 @@ ConfigureParams: <<
 CompileScript: <<
 #!/bin/sh -ex
 
-	# for OS X 10.14, ensure full SDK is available
+	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
 		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-		export CFLAGS="-I$SDK_PATH/usr/include"
+		export CFLAGS="-Wno-nullability-completeness"
+		export CPPFLAGS="-I$SDK_PATH/usr/include"
 		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/python35.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python35.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: python%type_pkg[python]
 Version: 3.5.6
-Revision: 1
+Revision: 2
 Type: python 3.5
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/languages/python35.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python35.info
@@ -89,10 +89,11 @@ ConfigureParams: <<
 CompileScript: <<
 #!/bin/sh -ex
 
-	# for OS X 10.14, ensure full SDK is available
+	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
 		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-		export CFLAGS="-I$SDK_PATH/usr/include"
+		export CFLAGS="-Wno-nullability-completeness"
+		export CPPFLAGS="-I$SDK_PATH/usr/include"
 		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/python36.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python36.info
@@ -88,10 +88,11 @@ ConfigureParams: <<
 CompileScript: <<
 #!/bin/sh -ex
 
-	# for OS X 10.14, ensure full SDK is available
+	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
 		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-		export CFLAGS="-I$SDK_PATH/usr/include"
+		export CFLAGS="-Wno-nullability-completeness"
+		export CPPFLAGS="-I$SDK_PATH/usr/include"
 		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/python36.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python36.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: python%type_pkg[python]
 Version: 3.6.8
-Revision: 1
+Revision: 2
 Type: python 3.6
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: python%type_pkg[python]
 Version: 3.7.2
-Revision: 1
+Revision: 2
 Type: python 3.7
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -91,10 +91,11 @@ ConfigureParams: <<
 CompileScript: <<
 #!/bin/sh -ex
 
-	# for OS X 10.14, ensure full SDK is available
+	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
 		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-		export CFLAGS="-I$SDK_PATH/usr/include"
+		export CFLAGS="-Wno-nullability-completeness"
+		export CPPFLAGS="-I$SDK_PATH/usr/include"
 		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi
 


### PR DESCRIPTION
Updated python27, python34, python35, python36 and python37 to build with fink installed versions of readline6 and db4 ahead of the SDK versions for MacOS 10.14.X.