### PR TITLE
gmt5-5.4.5-1: Upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/gmt5.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gmt5.info
@@ -1,8 +1,8 @@
 Package: gmt5
-Version: 5.4.4
+Version: 5.4.5
 Revision: 1
 Source: ftp://ftp.soest.hawaii.edu/gmt/gmt-%v-src.tar.xz
-Source-MD5: 91b2651ebf9ff792c11aee3e58c40d9f
+Source-MD5: 846c7717ca8a6e2c76cc5538331ff59e
 SourceDirectory: gmt-%v
 
 Conflicts: gmt


### PR DESCRIPTION
This is an update to the gmt5 package because of an upstream update from version 5.4.4 to 5.4.5. No further changes needed.
Tested on 10.14.2 with Command Line Tools.
fink -m build gmt5 successful.