### PR TITLE
netcdf-c13-4.6.2-1: Upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c13.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c13.info
@@ -1,5 +1,5 @@
 Package: netcdf-c13
-Version: 4.6.1
+Version: 4.6.2
 Revision: 1
 BuildDependsOnly: true
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
@@ -22,9 +22,9 @@ Replaces: <<
 	netcdf-c13
 <<
 
-Source: ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-%v.tar.gz
-Source-MD5: ee81c593efc8a6229d9bcb350b6d7849)
-Source-Checksum: SHA1(11912675530db61474b305b572e06f83d682aa2c)
+Source: ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-%v.tar.gz
+Source-MD5: bf608f460b8ba384f261914356e23927
+Source-Checksum: SHA1(f9ec7e2d13e40a05f0bc46c90c007394b883d037)
 SetCFLAGS: -O2
 SetLDFLAGS: -lsz -Wl,-dead_strip_dylibs
 
@@ -118,7 +118,7 @@ Feed -lsz to LDFLAGS so that the build finds libsz.
 Disable building the static library.
 
 Bump revision when HDF5 version is updated.
-There are no longer test failure when building against hdf5.100.v1.8
+There are no longer test failures when building against hdf5.100.v1.8
 (only API version test), yet still building against hdf5.10, as netCDF
 does not require anything newer.
 While there is a BuildDepends on hdf5-cpp11, this is only because one


### PR DESCRIPTION
Unidata introduced a minor upstream revision of the NetCDF C library last November.
With this .info file update Fink gets the benefits of that update (several speed updates).

Built and tested on 10.14.2 with Command Line Tools 10.1 running `fink -m build netcdf-c13`