### PR TITLE
nco-4.7.8-1: Upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/nco.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/nco.info
@@ -1,8 +1,8 @@
 Info2:<<
 Package: nco
-Version: 4.7.7
+Version: 4.7.8
 Revision: 1
-Type: v (4.7.7)
+Type: v (4.7.8)
 Description: The NetCDF Operators, using netcdf-4
 License: GPL3
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
@@ -98,8 +98,8 @@ Replaces: <<
 # Unpack Phase:
 Source: https://github.com/nco/nco/archive/%v.tar.gz
 SourceRename: %n-%v.tar.gz
-Source-MD5: b7fc72b6215421a5348f77e8bc5876fb
-Source-Checksum: SHA1(e24e01d3ca2f4d7b79229e17bf3592cffe47a8e3)
+Source-MD5: 1d352c69bdd806a686e4bea8b584a8b0
+Source-Checksum: SHA1(9e14a2c5f05ead20a04665261c0fc0c0345edfa1)
 
 # Patch Phase:
 PatchScript:  <<


### PR DESCRIPTION
This is a simple update of `nco.info` to cover the new (November 2018) upstream update of the NCO package. Only changed version number and checksums.