### PR TITLE
ghostscript-9.26-1: Upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/text/ghostscript.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/ghostscript.info
@@ -2,12 +2,12 @@ Info2: <<
 Package: ghostscript%type_pkg[-nox]
 # LIBIDN2 FTBFS; see https://bugs.ghostscript.com/show_bug.cgi?id=698774
 Type: -nox (boolean)
-Version: 9.25
+Version: 9.26
 Revision: 1
 Description: Interpreter for PostScript and PDF
-Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs925/ghostscript-%v.tar.xz
-Source-MD5: d5ac3f3d76cf82a549bafdf86d58395b
-Source-Checksum: SHA1(9d8ddff3382113bf4a1640368350e05652c93613)
+Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs926/ghostscript-%v.tar.xz
+Source-MD5: d86d8e0b368473ca955a94faa5c390d4
+Source-Checksum: SHA1(2727000ebee0d08311705859a31a504e259f0d98)
 PatchFile: ghostscript.patch
 PatchFile-MD5: 441e9a28c4bf84b5056bf60e588ab4b1
 PatchFile-Checksum: SHA1(87448b72d2741c747ced99cc46c2faa070823935)


### PR DESCRIPTION
This is a simple upstream update of ghostscript. Only the version number and checksums needed to be updated.

Prepared and tested on 10.14.2 with Command Line Tools 10.1 and using `fink -m build`