### PR TITLE
eccodes-2.10.0-1: Upstream update and allow finding zlib on 10.14

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: eccodes
-Version: 2.9.0
+Version: 2.10.0
 Revision: 1
 Type: gcc (7)
 Description: Coding/encoding ECMWF files, C headers/docs
@@ -9,9 +9,11 @@ License: BSD
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Source: https://software.ecmwf.int/wiki/download/attachments/45757960/%n-%v-Source.tar.gz
-Source-MD5: fab239b47a0a8a1531b68e1e76374321
+Source-MD5: c32ba54676b2fa5e1ebd782528185cdd
+Source-Checksum: SHA1(a9c30907fde1631ffddaa445e0e260fa2c4ca6be)
 PatchFile: eccodes.patch
 PatchFile-MD5: 43ec7477a96e37e7a951faae7019622b
+PatchFile-Checksum: SHA1(6d04866b20c96813524a46b3a365844d4866fb1f)
 
 SourceDirectory: %n-%v-Source
 BuildDependsOnly: true
@@ -50,6 +52,7 @@ CompileScript: <<
 		-DENABLE_PYTHON=off \
 		-DOPENJPEG_INCLUDE_DIR=%p/include/openjpeg-2.1 \
 		-DOPENJPEG_LIBRARY=%p/lib/libopenjp2.7.dylib \
+		-DZLIB_INCLUDE_DIR=`xcrun --sdk macosx --show-sdk-path`/usr/include \
 		-DCMAKE_MACOSX_RPATH=off \
 		-DCMAKE_OSX_DEPLOYMENT_TARGET= \
 		-DCMAKE_OSX_SYSROOT=/ \
@@ -62,6 +65,7 @@ CompileScript: <<
 InfoTest: <<
 	TestSource: http://download.ecmwf.org/test-data/grib_api/eccodes_test_data.tar.gz
 	TestSource-MD5: d5c9ee69f3a699c46f64c84e80d0f5de
+	TestSource-Checksum: SHA1(013a64e57c0cc7a649a8b00df8851c7f36c4c8f8)
 	TestSourceExtractDir: %n-%v-Source/build
 	TestSuiteSize: large
 	SetLDFLAGS: -headerpad_max_install_names


### PR DESCRIPTION
Upstream update of eccodes, going from 2.9.0 to 2.10.0 (released Dec 2018).
To have CMake find the zlib header on 10.14, `xcrun` is needed to return the prefix needed before `/usr/include`.

Run and tested on 10.14.2 with Command Line Tools 10.1 and `fink -m build`