### PR TITLE
On Xcode10, the existing hardwired MACOSX_DEPLOYMENT_TARGET=10.3 sett…

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5162-deployment_target.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5162-deployment_target.patch
@@ -1,0 +1,155 @@
+--- a/hints/darwin.sh
++++ b/hints/darwin.sh
+@@ -143,7 +143,7 @@ esac
+ 
+ # Shared library extension is .dylib.
+ # Bundle extension is .bundle.
+-ld='cc';
++
+ so='dylib';
+ dlext='bundle';
+ usedl='define';
+@@ -167,28 +167,137 @@ case "$ccdlflags" in		# If passed in from command line, presume user knows best
+ ;;
+ esac
+ 
++# Allow the user to override ld, but modify it as necessary below
++case "$ld" in
++    '') case "$cc" in
++        # If the cc is explicitly something else than cc (or empty),
++        # set the ld to be that explicitly something else.  Conversely,
++        # if the cc is 'cc' (or empty), set the ld to be 'cc'.
++        cc|'') ld='cc';;
++        *) ld="$cc" ;;
++        esac
++        ;;
++esac
++
++# From http://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/mk/platform/Darwin.mk
++#
++# OS, Kernel, Xcode Version
++# Note that Xcode gets updates on older systems sometimes.
++# pkgsrc generally expects that the most up-to-date xcode available for
++# an OS version is installed
++#
++# Codename        OS      Kernel  Xcode
++# Cheetah         10.0.x  1.3.1
++# Puma            10.1    1.4.1
++#                 10.1.x  5.x.y
++# Jaguar          10.2.x  6.x.y
++# Panther         10.3.x  7.x.y
++# Tiger           10.4.x  8.x.y   2.x (gcc 4.0, 4.0.1 from 2.2)
++# Leopard         10.5.x  9.x.y   3.x (gcc 4.0.1, 4.0.1 and 4.2.1 from 3.1)
++# Snow Leopard    10.6.x  10.x.y  3.2+ (gcc 4.0.1 and 4.2.1)
++# Lion            10.7.x  11.x.y  4.1 (llvm gcc 4.2.1)
++# Mountain Lion   10.8.x  12.x.y  4.5 (llvm gcc 4.2.1)
++# Mavericks       10.9.x  13.x.y  6 (llvm clang 6.0)
++# Yosemite        10.10.x 14.x.y  6 (llvm clang 6.0)
++# El Capitan      10.11.x 15.x.y  7 (llvm clang 7.0)
++
++# MACOSX_DEPLOYMENT_TARGET selects the minimum OS level we want to support
++#
++# It is needed for OS releases before 10.6.
++#
++# https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/cross_development/Configuring/configuring.html
++#
++# If it is set, we also propagate its value to ccflags and ldflags
++# using the -mmacosx-version-min flag.  If it is not set, we use
++# the OS X release as the min value for the flag.
++
++# Adds "-mmacosx-version-min=$2" to "$1" unless it already is there.
++add_macosx_version_min () {
++  local v
++  eval "v=\$$1"
++  case " $v " in
++  *"-mmacosx-version-min"*)
++     echo "NOT adding -mmacosx-version-min=$2 to $1 ($v)" >&4
++     ;;
++  *) echo "Adding -mmacosx-version-min=$2 to $1" >&4
++     eval "$1='$v -mmacosx-version-min=$2'"
++     ;;
++  esac
++}
++
+ # Perl bundles do not expect two-level namespace, added in Darwin 1.4.
+ # But starting from perl 5.8.1/Darwin 7 the default is the two-level.
+-case "$osvers" in
+-1.[0-3].*)
++case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
++1.[0-3].*) # OS X 10.0.x
+    lddlflags="${ldflags} -bundle -undefined suppress"
+    ;;
+-1.*)
++1.*)       # OS X 10.1
+    ldflags="${ldflags} -flat_namespace"
+    lddlflags="${ldflags} -bundle -undefined suppress"
+    ;;
+-[2-6].*)
++[2-6].*)   # OS X 10.1.x - 10.2.x (though [2-4] never existed publicly)
+    ldflags="${ldflags} -flat_namespace"
+    lddlflags="${ldflags} -bundle -undefined suppress"
+    ;;
+-*) 
++[7-9].*)   # OS X 10.3.x - 10.5.x
+    lddlflags="${ldflags} -bundle -undefined dynamic_lookup"
+    case "$ld" in
+-       *MACOSX_DEVELOPMENT_TARGET*) ;;
++       *MACOSX_DEPLOYMENT_TARGET*) ;;
+        *) ld="env MACOSX_DEPLOYMENT_TARGET=10.3 ${ld}" ;;
+    esac
+    ;;
++*)        # OS X 10.6.x - current
++   # The MACOSX_DEPLOYMENT_TARGET is not needed,
++   # but the -mmacosx-version-min option is always used.
++
++   # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
++   # capturing its value and adding it to the flags.
++    case "$MACOSX_DEPLOYMENT_TARGET" in
++    10.*)
++      add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
++      add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
++      ;;
++    '')
++      # Empty MACOSX_DEPLOYMENT_TARGET is okay.
++      ;;
++    *)
++      cat <<EOM >&4
++
++*** Unexpected MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET
++***
++*** Please either set it to 10.something, or to empty.
++
++EOM
++      exit 1
++      ;;
++    esac
++
++    # Keep the prodvers leading whitespace (Configure magic).
++    # Cannot use $osvers here since that is the kernel version.
++    # sw_vers output                 what we want
++    # "ProductVersion:    10.10.5"   "10.10"
++    # "ProductVersion:    10.11"     "10.11"
++        prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
++    case "$prodvers" in
++    10.*)
++      add_macosx_version_min ccflags $prodvers
++      add_macosx_version_min ldflags $prodvers
++      ;;
++    *)
++      cat <<EOM >&4
++
++*** Unexpected product version $prodvers.
++***
++*** Try running sw_vers and see what its ProductVersion says.
++
++EOM
++      exit 1
++    esac
++
++   lddlflags="${ldflags} -bundle -undefined dynamic_lookup"
++   ;;
+ esac
++
+ ldlibpthname='DYLD_LIBRARY_PATH';
+ 
+ # useshrplib=true results in much slower startup times.

--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5162.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5162.info
@@ -1,7 +1,8 @@
 Package: perl5162
 Version: 5.16.2
-Revision: 103
+Revision: 104
 Distribution: 10.10, 10.11, 10.12, 10.13, 10.14
+BuildDepends: fink (>= 0.30.0)
 Depends: %n-core (>= %v-%r)
 Conflicts: perl5123, perl5124, perl5162, perl5182
 Replaces: perl5123, perl5124, perl5162, perl5182
@@ -39,6 +40,11 @@ disable testing them.
 http://grokbase.com/t/perl/perl5-porters/1289z1msea/whats-blocking-5-14-3
 perl bug #35895
 radar://4139653 (?)
+
+Remove M_D_T=10.3 using upstream patch
+https://rt.perl.org/Ticket/Display.html?id=126360
+https://rt.perl.org/Ticket/Display.html?id=128980
+http://perl5.git.perl.org/perl.git/commit/53d1d41c81e1de9cc6416dcae828c13d4c5a470a
 <<
 DescUsage: <<
 Most perl scripts start with #!/usr/bin/perl which will invoke Apple's
@@ -50,6 +56,8 @@ Source: mirror:cpan:src/5.0/perl-%v.tar.bz2
 Source-MD5: 2818ab01672f005a4e552a713aa27b08
 PatchFile: %n.patch
 PatchFile-MD5: a3486815c04c6618e7cc1c18eb2b6999
+PatchFile2: %n-deployment_target.patch
+PatchFile2-MD5: cba18c557d30c80966b2d8f8d75bdc46
 CompileScript: <<
 #!/bin/sh -ev
  sh Configure -desr -Dcc="gcc" -Dcpp="-gcc -E" -Dprefix=%p -Dccflags=-I%p/include -Dldflags=-L%p/lib -Dperladmin=none -Uinstallusrbinperl -Dprivlib="%p/lib/perl5-core/5.16.2" -Darchlib="%p/lib/perl5-core/5.16.2/darwin-thread-multi-2level" -Dman3dir="%p/lib/perl5-core/5.16.2/man/man3" -Dman3ext=3pm -Dscriptdir="%p/bin" -Duseithreads -Dinc_version_list=none -Adefine:startperl="#!%p/bin/perl5.16.2" -Adefine:perlpath="%p/bin/perl5.16.2"


### PR DESCRIPTION
…ing breaks the build.

Use upstream's patch to not set M_D_T for 10.6+ and instead use the correct value of macosx-version-min to match the system.