### PR TITLE
fftw3-3.3.8.1: upstream update and make things work on Mojave

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/fftw3.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/fftw3.info
@@ -1,13 +1,14 @@
 Info2: <<
 Package: fftw3
-Version: 3.3.7
-Revision: 2
+Version: 3.3.8
+Revision: 1
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Type: gcc (7)
 
 Source:  ftp://ftp.fftw.org/pub/fftw/fftw-%v.tar.gz
-Source-MD5: 0d5915d7d39b3253c1cc05030d79ac47
+Source-MD5: 8aac833c943d8e90d51b697b27d4384d
+Source-Checksum: SHA1(59831bd4b2705381ee395e54aa6e0069b10c3626)
 BuildDepends:  <<
 	fink (>= 0.24.12-1),
 	gcc%type_raw[gcc]-compiler

--- a/10.9-libcxx/stable/main/finkinfo/sci/fftw3.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/fftw3.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: fftw3
 Version: 3.3.7
-Revision: 1
+Revision: 2
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Type: gcc (7)
@@ -28,11 +28,7 @@ CompileScript: <<
  #!/bin/sh -ev
  gcclib=`%p/bin/gfortran-fsf-%type_raw[gcc] --print-lib`
  FLIBDIR=`dirname $gcclib`
- if [ x%m == x"powerpc" ]; then
-   CC=%p/bin/gcc-fsf-%type_raw[gcc] F77=%p/bin/gfortran-fsf-%type_raw[gcc] FLIBS="-L${FLIBDIR}" ./configure %c --enable-fma
- else
-   CC=%p/bin/gcc-fsf-%type_raw[gcc] F77=%p/bin/gfortran-fsf-%type_raw[gcc] FLIBS="-L${FLIBDIR}" ./configure %c --enable-sse2
- fi
+ CPP=`which cpp` CC=%p/bin/gcc-fsf-%type_raw[gcc] CFLAGS="-I`xcrun --sdk macosx --show-sdk-path`/usr/include" F77=%p/bin/gfortran-fsf-%type_raw[gcc] FLIBS="-L${FLIBDIR}" ./configure %c --enable-sse2
  make
 <<
 InstallScript: <<
@@ -44,11 +40,7 @@ InstallScript: <<
  make clean
  gcclib=`%p/bin/gfortran-fsf-%type_raw[gcc] --print-lib`
  FLIBDIR=`dirname $gcclib`
- if [ x%m == x"powerpc" ]; then
-   CC=%p/bin/gcc-fsf-%type_raw[gcc] F77=%p/bin/gfortran-fsf-%type_raw[gcc] FLIBS="-L${FLIBDIR}" ./configure %c --enable-float --enable-altivec
- else
-   CC=%p/bin/gcc-fsf-%type_raw[gcc] F77=%p/bin/gfortran-fsf-%type_raw[gcc] FLIBS="-L${FLIBDIR}" ./configure %c --enable-float --enable-sse
- fi
+ CPP=`which cpp` CC=%p/bin/gcc-fsf-%type_raw[gcc] CFLAGS="-I`xcrun --sdk macosx --show-sdk-path`/usr/include" F77=%p/bin/gfortran-fsf-%type_raw[gcc] FLIBS="-L${FLIBDIR}" ./configure %c --enable-float --enable-sse
  make
  if [ -f %b/INSTALL_MAKE_CHECK ]; then
    make check 
@@ -92,14 +84,15 @@ DescUsage: <<
 Version 3 API is incompatible with Version 2 API (provided by fftw package)
 <<
 DescPackaging: << 
-Single and double precision libs built, single precision libs have
-altivec support.  Both thread- and openmp-based shared memory
-parallelization libraries are built.
+Single and double precision libraries are built, with both
+thread- and openmp-based shared memory parallelization.
 
 Originally packaged by Jeffrey Whitaker, maintained by Sebastien Maret,
 with updates for compiling 3.3.2 from David M. Rogers.
 
 Prevent configure script from confusing 10.10 (Yosemite) with 10.1 (Puma).
+
+Patched to work on Mojave (and later).
 <<
 Homepage: http://www.fftw.org
 <<


### PR DESCRIPTION
This update is three-fold:
- Make things work on Mojave: this included adding `xcrun` to get the SDK path for `/usr/include`
- Removed a switch for the support of powerpc, which does not apply to the `10.9-libcxx` tree, as powerpc is no longer supported.
- Update to the latest FFTW3 version (3.3.8 from May 2018)

Run and tested on 10.14.2 with Command Line Tools 10.1 and `fink -m build`