### PR TITLE
wget-1.20.1-1: Upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/web/wget.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/wget.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package:  wget%type_pkg[-gnutls]%type_pkg[-idn]
 # OPENSSL110 FTBFS; on hold pending issue #19
-Version: 1.19.5
+Version: 1.20.1
 Revision: 1
 Type: -gnutls (boolean), -idn (boolean)
 Description: Automatic web site retriever (SSL)
@@ -53,8 +53,8 @@ Provides: gnu-wget
 Suggests: ca-bundle
 
 Source: mirror:gnu:%{ni}/%{ni}-%v.tar.gz
-Source-MD5: 2db6f03d655041f82eb64b8c8a1fa7da
-Source-Checksum: SHA1(43b3d09e786df9e8d7aa454095d4ea2d420ae41c)
+Source-MD5: f6ebe9c7b375fc9832fb1b2028271fb7
+Source-Checksum: SHA1(4b1ade04ee7ff30181357e0c66b5ac74e39f79b3)
 
 PatchScript: <<
 #!/bin/sh -ev


### PR DESCRIPTION
This is a simple upstream update for wget. Version 1.20.1 was released Dec 2018.

Built, tested, and run on Mac OS 10.14.2 with Command Line Tools 10.1 and `fink -m build`