### PR TITLE
grib-api-1.28.0-1 and grib-api-fortran-1.28.0-1: FINAL upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/grib-api-fortran.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/grib-api-fortran.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: grib-api-fortran
-Version: 1.27.0
+Version: 1.28.0
 Revision: 1
 Type: gcc (7)
 Description: ECMWF GRIB API, Fortran headers
@@ -10,7 +10,8 @@ Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Source: https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-%v-Source.tar.gz
 PatchFile: grib-api.patch
-Source-MD5: b18cacc99909462cc81fb6cd4f0c300f
+Source-MD5: 1b780684ee0aa2770fd410886bf844bf
+Source-Checksum: SHA1(855e826f0a1c326838a6f9806e93c2cd93f18b05)
 PatchFile-MD5: 0448a7a625b66581baab7cc3e5834e71
 
 SourceDirectory: grib_api-%v-Source

--- a/10.9-libcxx/stable/main/finkinfo/sci/grib-api.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/grib-api.info
@@ -1,5 +1,5 @@
 Package: grib-api
-Version: 1.27.0
+Version: 1.28.0
 Revision: 1
 Description: ECMWF GRIB API
 Homepage: https://software.ecmwf.int/wiki/display/GRIB/Home
@@ -8,7 +8,8 @@ Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Source: https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-%v-Source.tar.gz
 PatchFile: %n.patch
-Source-MD5: b18cacc99909462cc81fb6cd4f0c300f
+Source-MD5: 1b780684ee0aa2770fd410886bf844bf
+Source-Checksum: SHA1(855e826f0a1c326838a6f9806e93c2cd93f18b05)
 PatchFile-MD5: 0448a7a625b66581baab7cc3e5834e71
 
 SourceDirectory: grib_api-%v-Source
@@ -28,6 +29,7 @@ CompileScript: <<
 InfoTest: <<
 	TestSource: http://download.ecmwf.org/test-data/grib_api/grib_api_test_data.tar.gz
 	TestSource-MD5: 06e435d61be605ed2481744a1528b2d8
+	TestSource-Checksum: SHA1(80e13f663e4cc7a30b3a11fd42f06cf12b8b8cac)
 	TestSourceExtractDir: grib_api-%v-Source
 	TestScript: <<
 		#!/bin/sh -ev


### PR DESCRIPTION
This is an update to the grib-api and grib-api-fortran packages.
Upstream version 1.28.0, released in December, is the end of the line. The GRIB API will no longer be supported by ECMWF.
We already have the alternative in Fink: eccodes.

Built, tested, and run on Mac OS 10.14.2 with Command Line Tools 10.1 and `fink -m build`.