### PR TITLE
sphinx-py-1.8.4-1: Add missing dependency on typing-py and upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinx-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinx-py.info
@@ -1,8 +1,8 @@
 Info2: <<
 
 Package: sphinx-py%type_pkg[python]
-Version: 1.8.3
-Revision: 2
+Version: 1.8.4
+Revision: 1
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 Type: python (2.7 3.4 3.5 3.6 3.7)
 BuildDepends: <<
@@ -28,7 +28,7 @@ Depends: <<
 <<
 
 Source: https://files.pythonhosted.org/packages/source/S/Sphinx/Sphinx-%v.tar.gz
-Source-MD5: b74f45df555833a3df904d3ecaf6fcd4
+Source-MD5: 8466f512322e81ef2f4da4d1ba61ff2f
 Source2: https://files.pythonhosted.org/packages/source/s/sphinx_rtd_theme/sphinx_rtd_theme-0.4.2.tar.gz
 Source2-MD5: 524ba614e60bf214b621bc259f283ccd
 PatchScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinx-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/sphinx-py.info
@@ -2,7 +2,7 @@ Info2: <<
 
 Package: sphinx-py%type_pkg[python]
 Version: 1.8.3
-Revision: 1
+Revision: 2
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 Type: python (2.7 3.4 3.5 3.6 3.7)
 BuildDepends: <<
@@ -22,6 +22,8 @@ Depends: <<
   requests-py%type_pkg[python],
   six-py%type_pkg[python],
   snowballstemmer-py%type_pkg[python] (>= 1.1-1),
+  (%type_pkg[python] = 27) typing-py%type_pkg[python],
+  (%type_pkg[python] = 34) typing-py%type_pkg[python],
   sphinxcontrib-websupport-py%type_pkg[python]
 <<
 
@@ -101,6 +103,7 @@ Sphinx_rtd themes included with package as it
 is required for the test suite.
 Had to remove source directory before "make doc" because it would get
 in the way with python3.x
+Added typing-py as dependency for Python < 3.5.
 
 `make test` runs '$PYTHON -m pytest', but that's somehow not importing sphinxcontrib_websupport, so we run the pytest command directly instead.
 <<


### PR DESCRIPTION
This PR is twofold:
- Add the dependency on typing-py (for python < v3.5). It was added to the dependencies for the test suite, but not for the package itself.
- En passant, updated to upstream version 1.8.4, released 3 Feb 2019.