### PR TITLE
wget-1.20.1-2: Avoid linking libpcre2 (use libpcre1 always)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/web/wget.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/wget.info
@@ -1,6 +1,5 @@
 Info2: <<
 Package:  wget%type_pkg[-gnutls]%type_pkg[-idn]
-# OPENSSL110 FTBFS; on hold pending issue #19
 Version: 1.20.1
 Revision: 2
 Type: -gnutls (boolean), -idn (boolean)
@@ -108,7 +107,7 @@ The recursive retrieval of HTML pages, as well as FTP sites is
 supported -- you can use Wget to make mirrors of archives and home
 pages, or traverse the web like a WWW robot.
 
-There have been significant changes in the 1.13.x line.
+There have been significant changes since version 1.13.x:
 * All variants include internationalization support.
 * The "wget-gnutls" package uses GNUTLS instead of OpenSSL.
 * The "wget-idn" and "wget-gnutls-idn" packages add IDN/IRIs support.
@@ -136,9 +135,14 @@ DescPackaging: <<
  Automatically replaces prior vintages of wget or wget-ssl.
  No non-ssl version anymore.
 
- Conflicts with versions of fink that rely on the --non-verbose flag to  be 
+ Conflicts with versions of fink that rely on the --non-verbose flag to be 
  present, because wget-1.10.x switched to a more GNU-standard 
  --no-verbose.
+
+ To avoid that the configure script selects either libpcre1 or libpcre2
+ to link to, --enable-pcre --disable-pcre2 was add to ConfigureParams, so
+ that only libpcre1 will be used. This library is more often used in the
+ Fink packages and provides sufficient functionalities.
 
  Now uses gettext8.
 

--- a/10.9-libcxx/stable/main/finkinfo/web/wget.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/wget.info
@@ -2,7 +2,7 @@ Info2: <<
 Package:  wget%type_pkg[-gnutls]%type_pkg[-idn]
 # OPENSSL110 FTBFS; on hold pending issue #19
 Version: 1.20.1
-Revision: 1
+Revision: 2
 Type: -gnutls (boolean), -idn (boolean)
 Description: Automatic web site retriever (SSL)
 Conflicts: <<
@@ -77,6 +77,7 @@ ConfigureParams: <<
 	--infodir=%p/share/info \
  	--mandir=%p/share/man \
  	--enable-dependency-tracking \
+	--enable-pcre --disable-pcre2 \
  	--disable-silent-rules
 <<
 


### PR DESCRIPTION
This is an update since a user found that the binary package was linked against libpcre2 rather than the intended libpcre1.
This is now avoided by adding `--enable-pcre --disable-pcre2` to `configure`.

Built and tested on Mac OS 10.14.2 with Command Line Tools 10.1, with both libpcre1 and libpcre2 installed. Only libpcre1 was now linked as required.