### PR TITLE
Texi2html onboard perl

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5162.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5162.info
@@ -1,6 +1,7 @@
 Package: perl5162
 Version: 5.16.2
 Revision: 103
+# sync changes from here into texi2html-perl5162 pkg if appropriate
 Distribution: 10.10, 10.11, 10.12, 10.13, 10.14
 Depends: %n-core (>= %v-%r)
 Conflicts: perl5123, perl5124, perl5162, perl5182

--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5162.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5162.info
@@ -21,8 +21,6 @@ lib tree.  Without these, upgrading or downgrading Perl breaks all of
 the binary modules.
 <<
 DescPort: <<
-Disabled 'make test', since one test fails.
-
 Because the perl build system is designed to download source files for
 "extra" perlmodules directly from CPAN, we do not include those "extra" 
 perlmodules in this package.  For that reason, the following packages

--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5182.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5182.info
@@ -21,8 +21,6 @@ lib tree.  Without these, upgrading or downgrading Perl breaks all of
 the binary modules.
 <<
 DescPort: <<
-Disabled 'make test', since one test fails.
-
 Because the perl build system is designed to download source files for
 "extra" perlmodules directly from CPAN, we do not include those "extra" 
 perlmodules in this package.  For that reason, the following packages

--- a/10.9-libcxx/stable/main/finkinfo/text/texi2html-10.13.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/texi2html-10.13.info
@@ -2,7 +2,7 @@ Package: texi2html
 Version: 1.82
 Revision: 103
 Distribution: 10.13
-# dist-difference due to availability of perl5.16 from apple
+# dist-difference due to variety of perl5.16 suppliers
 Depends: <<
 	perl5162-core,
 	texinfo (>= 4.1-3)
@@ -93,8 +93,11 @@ reasons due to randomized hash ordering). On 10.9, /usr/bin/perl is
 5.16; on 10.10+, /usr/bin/perl is 5.18 but on 10.10-10.12, there is
 still /usr/bin/perl5.16 and that also exists back on 10.9. We
 therefore hardcode /usr/bin/perl5.16 on 10.9-12 to reduce dependency
-on fink's perl5162 for this low-level package. That leaves 10.13+ as
-the only ones that actually need to depend on and hardocde fink's.
+on fink's perl5162 for this low-level package. But perl5162 has build
+problems on 10.14 whose only solution would propagate a binary (.deb)
+variation into many -pm5162 packages so on 10.13 we use fink's but on
+10.14 we have an onboard copy of perl5162 so fink doesn't need to (try
+to) keep supporting an actual perl5162 suite.
 <<
 License: GPL
 Homepage: http://www.nongnu.org/texi2html/

--- a/10.9-libcxx/stable/main/finkinfo/text/texi2html-10.13.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/texi2html-10.13.info
@@ -27,7 +27,6 @@ InfoTest: <<
 		make check TESTS_ENVIRONMENT='PERL_INTERP=$(PERL)' || exit 2
 	<<
 <<
-ConfigureParams: --mandir=%p/share/man --infodir=%p/share/info
 PatchScript: <<
 	%{default_script}
 	perl -pi -e 's| sed | gsed |g' test/run_test.sh
@@ -84,22 +83,18 @@ Any pkg that builddepends on this one, and calls it with the '-l2h' option,
 must also BuildDepend on latex2html.
 <<
 DescPackaging: <<
-Note that the latest version of texi2html (provided by OS X 10.4) is not
-backward compatible and causes some other packages to break.  Fink's
-texi2html package should be left at version 1.64 until this is resolved.
-
 Previous versions by Christian Schaffner <chris01@users.sourceforge.net>
 
-Update to 1.82 since 1.64 is incompatible with texinfo 5.0. Disable those
-tests known to produce different output on darwin's system perl.
+Disable some tests known to produce different output on darwin's
+system perl.
 
 Stick with perl5.16 (else fails self-tests, among other possible
 reasons due to randomized hash ordering). On 10.9, /usr/bin/perl is
 5.16; on 10.10+, /usr/bin/perl is 5.18 but on 10.10-10.12, there is
 still /usr/bin/perl5.16 and that also exists back on 10.9. We
 therefore hardcode /usr/bin/perl5.16 on 10.9-12 to reduce dependency
-on fink's perl5162 for this low-level package. That leaves 10.13 as
-the only one that actually needs to depend on and hardocde fink's.
+on fink's perl5162 for this low-level package. That leaves 10.13+ as
+the only ones that actually need to depend on and hardocde fink's.
 <<
 License: GPL
 Homepage: http://www.nongnu.org/texi2html/

--- a/10.9-libcxx/stable/main/finkinfo/text/texi2html-10.14.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/texi2html-10.14.info
@@ -1,10 +1,13 @@
 Package: texi2html
 Version: 1.82
-Revision: 103
+Revision: 203
 Distribution: 10.14
-# dist-difference due to availability of perl5.16 from apple
+# dist-difference due to variety of perl5.16 suppliers
+# When killing off texi2html-perl5162, C/R as ">=" its last known
+# %v-%r so that it will be forced out, but not inhibited at higher %r
+# should we need to revive it again later.
 Depends: <<
-	perl5162-core,
+	texi2html-perl5162,
 	texinfo (>= 4.1-3)
 <<
 BuildDepends: <<
@@ -38,7 +41,7 @@ PatchScript: <<
 <<
 CompileScript: <<
 	# texi2html has known compatibility issues with perl 5.18
-	./configure %c PERL=%p/bin/perl5.16.2
+	./configure %c PERL=%p/lib/%n/bin/perl5.16.2
 	# echo '#define DEFAULT_INFOPATH "%p/share/info:%p/info:/usr/local/share/info:/usr/local/lib/info:/usr/local/info:/usr/share/info:."' >>config.h
 	make
 <<
@@ -93,8 +96,11 @@ reasons due to randomized hash ordering). On 10.9, /usr/bin/perl is
 5.16; on 10.10+, /usr/bin/perl is 5.18 but on 10.10-10.12, there is
 still /usr/bin/perl5.16 and that also exists back on 10.9. We
 therefore hardcode /usr/bin/perl5.16 on 10.9-12 to reduce dependency
-on fink's perl5162 for this low-level package. That leaves 10.13+ as
-the only ones that actually need to depend on and hardocde fink's.
+on fink's perl5162 for this low-level package. But perl5162 has build
+problems on 10.14 whose only solution would propagate a binary (.deb)
+variation into many -pm5162 packages so on 10.13 we use fink's but on
+10.14 we have an onboard copy of perl5162 so fink doesn't need to (try
+to) keep supporting an actual perl5162 suite.
 <<
 License: GPL
 Homepage: http://www.nongnu.org/texi2html/

--- a/10.9-libcxx/stable/main/finkinfo/text/texi2html-10.14.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/texi2html-10.14.info
@@ -27,7 +27,6 @@ InfoTest: <<
 		make check TESTS_ENVIRONMENT='PERL_INTERP=$(PERL)' || exit 2
 	<<
 <<
-ConfigureParams: --mandir=%p/share/man --infodir=%p/share/info
 PatchScript: <<
 	%{default_script}
 	perl -pi -e 's| sed | gsed |g' test/run_test.sh
@@ -84,22 +83,18 @@ Any pkg that builddepends on this one, and calls it with the '-l2h' option,
 must also BuildDepend on latex2html.
 <<
 DescPackaging: <<
-Note that the latest version of texi2html (provided by OS X 10.4) is not
-backward compatible and causes some other packages to break.  Fink's
-texi2html package should be left at version 1.64 until this is resolved.
-
 Previous versions by Christian Schaffner <chris01@users.sourceforge.net>
 
-Update to 1.82 since 1.64 is incompatible with texinfo 5.0. Disable those
-tests known to produce different output on darwin's system perl.
+Disable some tests known to produce different output on darwin's
+system perl.
 
 Stick with perl5.16 (else fails self-tests, among other possible
 reasons due to randomized hash ordering). On 10.9, /usr/bin/perl is
 5.16; on 10.10+, /usr/bin/perl is 5.18 but on 10.10-10.12, there is
 still /usr/bin/perl5.16 and that also exists back on 10.9. We
 therefore hardcode /usr/bin/perl5.16 on 10.9-12 to reduce dependency
-on fink's perl5162 for this low-level package. That leaves 10.13 as
-the only one that actually needs to depend on and hardocde fink's.
+on fink's perl5162 for this low-level package. That leaves 10.13+ as
+the only ones that actually need to depend on and hardocde fink's.
 <<
 License: GPL
 Homepage: http://www.nongnu.org/texi2html/

--- a/10.9-libcxx/stable/main/finkinfo/text/texi2html-perl5162-deployment_target.patch
+++ b/10.9-libcxx/stable/main/finkinfo/text/texi2html-perl5162-deployment_target.patch
@@ -1,0 +1,155 @@
+--- a/hints/darwin.sh
++++ b/hints/darwin.sh
+@@ -143,7 +143,7 @@ esac
+ 
+ # Shared library extension is .dylib.
+ # Bundle extension is .bundle.
+-ld='cc';
++
+ so='dylib';
+ dlext='bundle';
+ usedl='define';
+@@ -167,28 +167,137 @@ case "$ccdlflags" in		# If passed in from command line, presume user knows best
+ ;;
+ esac
+ 
++# Allow the user to override ld, but modify it as necessary below
++case "$ld" in
++    '') case "$cc" in
++        # If the cc is explicitly something else than cc (or empty),
++        # set the ld to be that explicitly something else.  Conversely,
++        # if the cc is 'cc' (or empty), set the ld to be 'cc'.
++        cc|'') ld='cc';;
++        *) ld="$cc" ;;
++        esac
++        ;;
++esac
++
++# From http://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/mk/platform/Darwin.mk
++#
++# OS, Kernel, Xcode Version
++# Note that Xcode gets updates on older systems sometimes.
++# pkgsrc generally expects that the most up-to-date xcode available for
++# an OS version is installed
++#
++# Codename        OS      Kernel  Xcode
++# Cheetah         10.0.x  1.3.1
++# Puma            10.1    1.4.1
++#                 10.1.x  5.x.y
++# Jaguar          10.2.x  6.x.y
++# Panther         10.3.x  7.x.y
++# Tiger           10.4.x  8.x.y   2.x (gcc 4.0, 4.0.1 from 2.2)
++# Leopard         10.5.x  9.x.y   3.x (gcc 4.0.1, 4.0.1 and 4.2.1 from 3.1)
++# Snow Leopard    10.6.x  10.x.y  3.2+ (gcc 4.0.1 and 4.2.1)
++# Lion            10.7.x  11.x.y  4.1 (llvm gcc 4.2.1)
++# Mountain Lion   10.8.x  12.x.y  4.5 (llvm gcc 4.2.1)
++# Mavericks       10.9.x  13.x.y  6 (llvm clang 6.0)
++# Yosemite        10.10.x 14.x.y  6 (llvm clang 6.0)
++# El Capitan      10.11.x 15.x.y  7 (llvm clang 7.0)
++
++# MACOSX_DEPLOYMENT_TARGET selects the minimum OS level we want to support
++#
++# It is needed for OS releases before 10.6.
++#
++# https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/cross_development/Configuring/configuring.html
++#
++# If it is set, we also propagate its value to ccflags and ldflags
++# using the -mmacosx-version-min flag.  If it is not set, we use
++# the OS X release as the min value for the flag.
++
++# Adds "-mmacosx-version-min=$2" to "$1" unless it already is there.
++add_macosx_version_min () {
++  local v
++  eval "v=\$$1"
++  case " $v " in
++  *"-mmacosx-version-min"*)
++     echo "NOT adding -mmacosx-version-min=$2 to $1 ($v)" >&4
++     ;;
++  *) echo "Adding -mmacosx-version-min=$2 to $1" >&4
++     eval "$1='$v -mmacosx-version-min=$2'"
++     ;;
++  esac
++}
++
+ # Perl bundles do not expect two-level namespace, added in Darwin 1.4.
+ # But starting from perl 5.8.1/Darwin 7 the default is the two-level.
+-case "$osvers" in
+-1.[0-3].*)
++case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
++1.[0-3].*) # OS X 10.0.x
+    lddlflags="${ldflags} -bundle -undefined suppress"
+    ;;
+-1.*)
++1.*)       # OS X 10.1
+    ldflags="${ldflags} -flat_namespace"
+    lddlflags="${ldflags} -bundle -undefined suppress"
+    ;;
+-[2-6].*)
++[2-6].*)   # OS X 10.1.x - 10.2.x (though [2-4] never existed publicly)
+    ldflags="${ldflags} -flat_namespace"
+    lddlflags="${ldflags} -bundle -undefined suppress"
+    ;;
+-*) 
++[7-9].*)   # OS X 10.3.x - 10.5.x
+    lddlflags="${ldflags} -bundle -undefined dynamic_lookup"
+    case "$ld" in
+-       *MACOSX_DEVELOPMENT_TARGET*) ;;
++       *MACOSX_DEPLOYMENT_TARGET*) ;;
+        *) ld="env MACOSX_DEPLOYMENT_TARGET=10.3 ${ld}" ;;
+    esac
+    ;;
++*)        # OS X 10.6.x - current
++   # The MACOSX_DEPLOYMENT_TARGET is not needed,
++   # but the -mmacosx-version-min option is always used.
++
++   # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
++   # capturing its value and adding it to the flags.
++    case "$MACOSX_DEPLOYMENT_TARGET" in
++    10.*)
++      add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
++      add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
++      ;;
++    '')
++      # Empty MACOSX_DEPLOYMENT_TARGET is okay.
++      ;;
++    *)
++      cat <<EOM >&4
++
++*** Unexpected MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET
++***
++*** Please either set it to 10.something, or to empty.
++
++EOM
++      exit 1
++      ;;
++    esac
++
++    # Keep the prodvers leading whitespace (Configure magic).
++    # Cannot use $osvers here since that is the kernel version.
++    # sw_vers output                 what we want
++    # "ProductVersion:    10.10.5"   "10.10"
++    # "ProductVersion:    10.11"     "10.11"
++        prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
++    case "$prodvers" in
++    10.*)
++      add_macosx_version_min ccflags $prodvers
++      add_macosx_version_min ldflags $prodvers
++      ;;
++    *)
++      cat <<EOM >&4
++
++*** Unexpected product version $prodvers.
++***
++*** Try running sw_vers and see what its ProductVersion says.
++
++EOM
++      exit 1
++    esac
++
++   lddlflags="${ldflags} -bundle -undefined dynamic_lookup"
++   ;;
+ esac
++
+ ldlibpthname='DYLD_LIBRARY_PATH';
+ 
+ # useshrplib=true results in much slower startup times.

--- a/10.9-libcxx/stable/main/finkinfo/text/texi2html-perl5162.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/texi2html-perl5162.info
@@ -1,0 +1,74 @@
+Package: texi2html-perl5162
+Version: 5.16.2
+Revision: 203
+# sync changes from here into "real" perl5162 pkg if appropriate
+Distribution: 10.14
+License: Artistic
+Description: Perl 5.16.2 subpackage for texi2html
+DescDetail: <<
+Perl is a high-level programming language with roots in C, sed, awk
+and shell scripting.  Perl is good at handling processes and files,
+and is especially good at handling text.  Perl's hallmarks are
+practicality and efficiency.  While it is used to do a lot of
+different things, Perl's most common applications are system
+administration utilities and web programming.  A large proportion of
+the CGI scripts on the web are written in Perl.
+<<
+DescPort: <<
+Because the perl build system is designed to download source files for
+"extra" perlmodules directly from CPAN, we do not include those "extra" 
+perlmodules in this package.  For that reason, the following packages
+which are Provided by Apple's build of perl5.16.2 on 10.9 are not provided
+here:
+  convert-tnef-pm5162, html-parser-pm5162, 
+  perl-objcbridge-pm5162, scalar-list-utils-pm5162, uri-pm5162, 
+  algorithm-diff-pm5162, class-autouse-pm5162, corefoundation-pm5162, 
+  data-hierarcy-pm5162, freezethaw-pm5162, io-pager-pm5162, 
+  locale-maketext-lexicon-pm5162, perlio-eol-pm5162
+
+"be_BY" locales are known broken on Darwin (at least through Darwin 12), so 
+disable testing them.
+http://grokbase.com/t/perl/perl5-porters/1289z1msea/whats-blocking-5-14-3
+perl bug #35895
+radar://4139653 (?)
+<<
+DescUsage: <<
+This package is for private use of the texi2html package only! It is
+in a special nonstandard location, and omits or re-organizes some
+standard user-facing components of a normal perl-interpretter package
+suite.
+<<
+Source: mirror:cpan:src/5.0/perl-%v.tar.bz2
+Source-MD5: 2818ab01672f005a4e552a713aa27b08
+PatchFile: %n.patch
+PatchFile-MD5: a3486815c04c6618e7cc1c18eb2b6999
+CompileScript: <<
+#!/bin/sh -ev
+ sh Configure -desr -Dcc="gcc" -Dcpp="-gcc -E" -Dprefix=%p/lib/texi2html -Dccflags=-I%p/include -Dldflags=-L%p/lib -Dperladmin=none -Uinstallusrbinperl -Dprivlib="%p/lib/texi2html/lib/perl5-core/5.16.2" -Darchlib="%p/lib/texi2html/lib/perl5-core/5.16.2/darwin-thread-multi-2level" -Dman3dir="%p/lib/texi2html/lib/perl5-core/5.16.2/man/man3" -Dman3ext=3pm -Dscriptdir="%p/lib/texi2html/bin" -Duseithreads -Dinc_version_list=none -Adefine:startperl="#!%p/lib/texi2html/bin/perl5.16.2" -Adefine:perlpath="%p/lib/texi2html/bin/perl5.16.2"
+ make
+<<
+DocFiles: README Copying
+InfoTest: <<
+	TestScript: <<
+		make test || exit 2
+	<<
+<<
+
+InstallScript: <<
+ make install DESTDIR=%d
+ rm -rf %i/lib/texi2html/man
+ rm -rf %i/lib/texi2html/lib/perl5-core/5.16.2/man
+ find %i -name \*.pod -delete
+<<
+DescPackaging: <<
+ We now use lib/perl5-core as the main installation directory to avoid
+ conflicts with fink-installed perl modules.
+
+ This package is only supplied on dists where neither apple nor fink
+ has perl-5.16. Fink's texi2html package is not compatible with
+ perl-5.18, which is all apple has on 10.13+, and fink's perl5162
+ FTBFS and there are legacy binary problem for the likely fix of that.
+ Lots of components that texi2html does not need are omitted.
+<<
+Homepage: http://www.cpan.org/
+Maintainer: Fink Core Group <fink-core@lists.sourceforge.net>

--- a/10.9-libcxx/stable/main/finkinfo/text/texi2html-perl5162.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/texi2html-perl5162.info
@@ -1,6 +1,6 @@
 Package: texi2html-perl5162
 Version: 5.16.2
-Revision: 203
+Revision: 204
 # sync changes from here into "real" perl5162 pkg if appropriate
 Distribution: 10.14
 License: Artistic
@@ -31,6 +31,11 @@ disable testing them.
 http://grokbase.com/t/perl/perl5-porters/1289z1msea/whats-blocking-5-14-3
 perl bug #35895
 radar://4139653 (?)
+
+Remove M_D_T=10.3 using upstream patch
+https://rt.perl.org/Ticket/Display.html?id=126360
+https://rt.perl.org/Ticket/Display.html?id=128980
+http://perl5.git.perl.org/perl.git/commit/53d1d41c81e1de9cc6416dcae828c13d4c5a470a
 <<
 DescUsage: <<
 This package is for private use of the texi2html package only! It is
@@ -38,10 +43,13 @@ in a special nonstandard location, and omits or re-organizes some
 standard user-facing components of a normal perl-interpretter package
 suite.
 <<
+BuildDepends: fink (>= 0.30.0)
 Source: mirror:cpan:src/5.0/perl-%v.tar.bz2
 Source-MD5: 2818ab01672f005a4e552a713aa27b08
 PatchFile: %n.patch
 PatchFile-MD5: a3486815c04c6618e7cc1c18eb2b6999
+PatchFile2: %n-deployment_target.patch
+PatchFile2-MD5: cba18c557d30c80966b2d8f8d75bdc46
 CompileScript: <<
 #!/bin/sh -ev
  sh Configure -desr -Dcc="gcc" -Dcpp="-gcc -E" -Dprefix=%p/lib/texi2html -Dccflags=-I%p/include -Dldflags=-L%p/lib -Dperladmin=none -Uinstallusrbinperl -Dprivlib="%p/lib/texi2html/lib/perl5-core/5.16.2" -Darchlib="%p/lib/texi2html/lib/perl5-core/5.16.2/darwin-thread-multi-2level" -Dman3dir="%p/lib/texi2html/lib/perl5-core/5.16.2/man/man3" -Dman3ext=3pm -Dscriptdir="%p/lib/texi2html/bin" -Duseithreads -Dinc_version_list=none -Adefine:startperl="#!%p/lib/texi2html/bin/perl5.16.2" -Adefine:perlpath="%p/lib/texi2html/bin/perl5.16.2"

--- a/10.9-libcxx/stable/main/finkinfo/text/texi2html-perl5162.patch
+++ b/10.9-libcxx/stable/main/finkinfo/text/texi2html-perl5162.patch
@@ -1,0 +1,11 @@
+--- a/lib/locale.t	2011-06-07 16:04:05.000000000 -0400
++++ b/lib/locale.t	2013-02-24 07:37:45.000000000 -0500
+@@ -648,7 +648,7 @@
+     if ($v >= 8 and $v < 10) {
+ 	debug "# Skipping eu_ES, be_BY locales -- buggy in Darwin\n";
+ 	@Locale = grep ! m/^(eu_ES(?:\..*)?|be_BY\.CP1131)$/, @Locale;
+-    } elsif ($v < 12) {
++    } elsif ($v < 13) {
+ 	debug "# Skipping be_BY locales -- buggy in Darwin\n";
+ 	@Locale = grep ! m/^be_BY\.CP1131$/, @Locale;
+     }

--- a/10.9-libcxx/stable/main/finkinfo/text/texi2html.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/texi2html.info
@@ -2,7 +2,7 @@ Package: texi2html
 Version: 1.82
 Revision: 3
 Distribution: 10.9, 10.10, 10.11, 10.12
-# dist-difference due to availability of perl5.16 from apple
+# dist-difference due to variety of perl5.16 suppliers
 Depends: <<
 	texinfo (>= 4.1-3)
 <<
@@ -92,8 +92,11 @@ reasons due to randomized hash ordering). On 10.9, /usr/bin/perl is
 5.16; on 10.10+, /usr/bin/perl is 5.18 but on 10.10-10.12, there is
 still /usr/bin/perl5.16 and that also exists back on 10.9. We
 therefore hardcode /usr/bin/perl5.16 on 10.9-12 to reduce dependency
-on fink's perl5162 for this low-level package. That leaves 10.13+ as
-the only ones that actually need to depend on and hardocde fink's.
+on fink's perl5162 for this low-level package. But perl5162 has build
+problems on 10.14 whose only solution would propagate a binary (.deb)
+variation into many -pm5162 packages so on 10.13 we use fink's but on
+10.14 we have an onboard copy of perl5162 so fink doesn't need to (try
+to) keep supporting an actual perl5162 suite.
 <<
 License: GPL
 Homepage: http://www.nongnu.org/texi2html/

--- a/10.9-libcxx/stable/main/finkinfo/text/texi2html.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/texi2html.info
@@ -26,7 +26,6 @@ InfoTest: <<
 		make check TESTS_ENVIRONMENT='PERL_INTERP=$(PERL)' || exit 2
 	<<
 <<
-ConfigureParams: --mandir=%p/share/man --infodir=%p/share/info
 PatchScript: <<
 	%{default_script}
 	perl -pi -e 's| sed | gsed |g' test/run_test.sh
@@ -83,22 +82,18 @@ Any pkg that builddepends on this one, and calls it with the '-l2h' option,
 must also BuildDepend on latex2html.
 <<
 DescPackaging: <<
-Note that the latest version of texi2html (provided by OS X 10.4) is not
-backward compatible and causes some other packages to break.  Fink's
-texi2html package should be left at version 1.64 until this is resolved.
-
 Previous versions by Christian Schaffner <chris01@users.sourceforge.net>
 
-Update to 1.82 since 1.64 is incompatible with texinfo 5.0. Disable those
-tests known to produce different output on darwin's system perl.
+Disable some tests known to produce different output on darwin's
+system perl.
 
 Stick with perl5.16 (else fails self-tests, among other possible
 reasons due to randomized hash ordering). On 10.9, /usr/bin/perl is
 5.16; on 10.10+, /usr/bin/perl is 5.18 but on 10.10-10.12, there is
 still /usr/bin/perl5.16 and that also exists back on 10.9. We
 therefore hardcode /usr/bin/perl5.16 on 10.9-12 to reduce dependency
-on fink's perl5162 for this low-level package. That leaves 10.13 as
-the only one that actually needs to depend on and hardocde fink's.
+on fink's perl5162 for this low-level package. That leaves 10.13+ as
+the only ones that actually need to depend on and hardocde fink's.
 <<
 License: GPL
 Homepage: http://www.nongnu.org/texi2html/


### PR DESCRIPTION
Creating a private perl5162 interpretter (hidden in lib/texi2html) for texi2html to use on platforms where apple doesn't supply perl5162 and we don't feel like having to continue supporting a full user-land perl5162 suite. See PR #339.