### PR TITLE
sbcl v1.4.16

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -52,7 +52,7 @@ Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
 Source-Checksum: SHA256(d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb)
 
 PatchFile: %n.patch
-PatchFile-MD5: a68f52a0d892c9b3d2628289c9fae0a2
+PatchFile-MD5: 0c73bc0ee9263f08e49ac3cea1a104f0
 PatchScript: <<
 	#!/bin/sh -ex
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
@@ -94,7 +94,7 @@ CompileScript: <<
 	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
 		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-		export CFLAGS="-Wno-nullability-completeness  -Wno-expansion-to-defined -isysroot $SDK_PATH"
+		export CFLAGS="-Wno-nullability-completeness -Wno-expansion-to-defined -isysroot $SDK_PATH"
 		export CPPFLAGS="-I%p/include -I%p/include/ncursesw"
 		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -52,7 +52,7 @@ Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
 Source-Checksum: SHA256(d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb)
 
 PatchFile: %n.patch
-PatchFile-MD5: 0c73bc0ee9263f08e49ac3cea1a104f0
+PatchFile-MD5: a68f52a0d892c9b3d2628289c9fae0a2
 PatchScript: <<
 	#!/bin/sh -ex
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
@@ -94,7 +94,7 @@ CompileScript: <<
 	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
 		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-		export CFLAGS="-Wno-nullability-completeness -isysroot $SDK_PATH"
+		export CFLAGS="-Wno-nullability-completeness  -Wno-expansion-to-defined -isysroot $SDK_PATH"
 		export CPPFLAGS="-I%p/include -I%p/include/ncursesw"
 		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.patch
@@ -39,6 +39,15 @@ diff -ru Python-3.7.2.orig/Lib/test/test_uuid.py Python-3.7.2/Lib/test/test_uuid
 diff -ru Python-3.7.2.orig/Makefile.pre.in Python-3.7.2/Makefile.pre.in
 --- Python-3.7.2.orig/Makefile.pre.in	2018-12-23 16:37:36.000000000 -0500
 +++ Python-3.7.2/Makefile.pre.in	2018-12-29 21:34:03.000000000 -0500
+@@ -99,7 +99,7 @@
+ # Both CPPFLAGS and LDFLAGS need to contain the shell's value for setup.py to
+ # be able to build extension modules using the directories specified in the
+ # environment variables
+-PY_CPPFLAGS=	$(BASECPPFLAGS) -I. -I$(srcdir)/Include $(CONFIGURE_CPPFLAGS) $(CPPFLAGS)
++PY_CPPFLAGS=	$(BASECPPFLAGS) -I. -I$(srcdir)/Include $(CPPFLAGS) $(CONFIGURE_CPPFLAGS)
+ PY_LDFLAGS=	$(CONFIGURE_LDFLAGS) $(LDFLAGS)
+ PY_LDFLAGS_NODIST=$(CONFIGURE_LDFLAGS_NODIST) $(LDFLAGS_NODIST)
+ NO_AS_NEEDED=	@NO_AS_NEEDED@
 @@ -640,7 +640,7 @@
  	$(BLDSHARED) $(NO_AS_NEEDED) -o $@ -Wl,-h$@ $^
  

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.patch
@@ -39,15 +39,6 @@ diff -ru Python-3.7.2.orig/Lib/test/test_uuid.py Python-3.7.2/Lib/test/test_uuid
 diff -ru Python-3.7.2.orig/Makefile.pre.in Python-3.7.2/Makefile.pre.in
 --- Python-3.7.2.orig/Makefile.pre.in	2018-12-23 16:37:36.000000000 -0500
 +++ Python-3.7.2/Makefile.pre.in	2018-12-29 21:34:03.000000000 -0500
-@@ -99,7 +99,7 @@
- # Both CPPFLAGS and LDFLAGS need to contain the shell's value for setup.py to
- # be able to build extension modules using the directories specified in the
- # environment variables
--PY_CPPFLAGS=	$(BASECPPFLAGS) -I. -I$(srcdir)/Include $(CONFIGURE_CPPFLAGS) $(CPPFLAGS)
-+PY_CPPFLAGS=	$(BASECPPFLAGS) -I. -I$(srcdir)/Include $(CPPFLAGS) $(CONFIGURE_CPPFLAGS)
- PY_LDFLAGS=	$(CONFIGURE_LDFLAGS) $(LDFLAGS)
- PY_LDFLAGS_NODIST=$(CONFIGURE_LDFLAGS_NODIST) $(LDFLAGS_NODIST)
- NO_AS_NEEDED=	@NO_AS_NEEDED@
 @@ -640,7 +640,7 @@
  	$(BLDSHARED) $(NO_AS_NEEDED) -o $@ -Wl,-h$@ $^
  

--- a/10.9-libcxx/stable/main/finkinfo/languages/sbcl-x86_64.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/sbcl-x86_64.info
@@ -1,6 +1,6 @@
 Package: sbcl
 Architecture: x86_64
-Version: 1.3.8
+Version: 1.4.16
 Revision: 1
 License: BSD
 Description: ANSI Common Lisp implementation
@@ -11,21 +11,22 @@ Maintainer: Jesse Alama <jessealama@fastmail.fm>
 # need to be updated by hand when moving to a new version of the
 # bootstap binary
 
-BuildDepends: fink (>= 0.24.12)
-
+BuildDepends: <<
+    fink (>= 0.24.12),
+    texinfo (>= 6.5-102)
+<<
 Source: mirror:sourceforge:sbcl/sbcl-%v-source.tar.bz2
 Source2: mirror:sourceforge:sbcl/sbcl-1.2.11-x86-64-darwin-binary.tar.bz2
-Source-MD5: f918d0920e08dd10cfa9d9b383cfdb91
+Source-MD5: 050ae4509285e48c69ecc7842ed0200c
 Source2-MD5: a7aa1fcb625dd437df91c550c2e2abd8
 UseMaxBuildJobs: false
 SourceDirectory: %n-%v
 
 PatchFile: %n.patch
-PatchFile-MD5: 743b2e165203e3769349e17386f4ed04
+PatchFile-MD5: 3c34400f1aa1b6d1ff1ee743c30d8118
 PatchScript:  <<
 %{default_script}
 perl -pi -e 's|\(deftest readdir.1|#-darwin\n$&|' contrib/sb-posix/posix-tests.lisp
-perl -pi -e 's|makeinfo|/usr/bin/makeinfo|g' doc/internals/Makefile doc/manual/Makefile
 # Xcode 8 linker now links executables as PIE for all deployment targets
 perl -pi -e 's|0x100000|0x100000 -Wl,-no_pie|g' src/runtime/Config.x86-64-darwin
 <<
@@ -34,7 +35,7 @@ CompileScript: <<
   LISP_FEATURE_DARWIN9_OR_BETTER=1 SBCL_ARCH="x86-64" sh make.sh "../sbcl-1.2.11-x86-64-darwin/src/runtime/sbcl \
      	      --core ../sbcl-1.2.11-x86-64-darwin/output/sbcl.core \
               --disable-debugger --sysinit /dev/null --userinit /dev/null"
-  cd doc/manual ; env MAKEINFO=/usr/bin/makeinfo make html info
+  cd doc/manual ; env MAKEINFO=makeinfo make html info
 <<
 
 InstallScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/languages/sbcl.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/sbcl.patch
@@ -9,3 +9,13 @@ diff -Naur --exclude='*~' sbcl-1.0.37/customize-target-features.lisp sbcl-1.0.37
 +	   (setf features (remove x features))))
 +    ;; Threading support.
 +    (enable :sb-thread)))
+diff -Naur tools-for-build/Makefile.old tools-for-build/Makefile
+--- sbcl-1.4.16.old/tools-for-build/Makefile	2019-02-10 17:20:31.000000000 -0500
++++ sbcl-1.4.16/tools-for-build/Makefile	2019-02-10 17:21:04.000000000 -0500
+@@ -10,5 +10,5 @@
+ -include genesis/Makefile.features
+ -include Config
+ 
+-CPPFLAGS+=-I../src/runtime
++CPPFLAGS:=-I../src/runtime $(CPPFLAGS)
+ LDFLAGS:=$(LDFLAGS)


### PR DESCRIPTION
- Builds sbcl (Steel Bank Common Lisp) on MacOS v10.14.3.
- Reduces warnings building python v3.7 with Xcode compiler.