### PR TITLE
gdl-0.9.7-3: Make configuration work for Mojave (find zlib)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/gdl.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gdl.info
@@ -1,6 +1,6 @@
 Package: gdl
 Version: 0.9.7
-Revision: 2
+Revision: 3
 Epoch: 1
 Description: GNU Data Language
 License: GPL
@@ -76,6 +76,7 @@ pushd build
 	-DNCURSESDIR=%p \
 	-DNETCDF=ON \
 	-DOPENMP=OFF \
+	-DZLIBDIR=`xcrun --sdk macosx --show-sdk-path`/usr/include \
 	-DPLPLOTDIR=%p/lib/plplot \
 	-DPLPLOT_INCLUDE_DIR=%p/include \
 	-DPLPLOT_LIBRARIES=%p/lib/plplot \
@@ -91,7 +92,7 @@ pushd build
 	-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING="" \
 	-DCMAKE_OSX_SYSROOT:STRING=/ \
 ..
-make VERBOSE=1
+make
 popd
 fink-package-precedence --depfile-ext='\.d' .
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/gdl.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gdl.info
@@ -115,6 +115,12 @@ GDL is a free IDL (Interactive Data Language) compatible incremental
 compiler. It features a full syntax compatibility with IDL
 6.0. Overall more than 330 library routines are implemented.
 <<
+DescPort: <<
+Need to define ZLIBDIR using xcrun since 10.14 (XCode 10) since this
+does no longer include a directory /usr/include, but needs to find it
+in the MacOS SDK. Works also for previous versions, at least back to
+Mac OS 10.9.
+<<
 Homepage: http://gnudatalanguage.sf.net/
 DescPackaging: <<
 Using ECcodes instead of GRIB API.


### PR DESCRIPTION
This is a simple update that helps to find zlib on Mojave using `xcrun`.

Built and tested on 10.14.3 with Command Line Tools 10.1 and `fink -m build`.

PS: I was not able to get either upstream 0.9.8 or 0.9.9 compiled due to an incompatibility with `plplot` in `src/gdlgstream.hpp`. It is true that Fink's `plplot-5.9.6-5` is very much out of date: upstream is now at 5.14.0. 