### PR TITLE
Add cran rgdal for R-3.5

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rgdal-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rgdal-r.info
@@ -69,6 +69,13 @@ Shlibs: <<
   ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/rgdal/libs/rgdal.so 0.0.0 %n (>= 0.9-2-1)
   ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/rgdal/libs/rgdal.dylib 0.0.0 %n (>= 0.9-2-1)
 <<
+SplitOff: <<
+  Package: %N-dev
+  Description: Headers for CRAN rgdal
+  BuildDependsOnly: true
+  Depends: %N (=%v-%r)
+  Files: lib/R/%type_raw[rversion]/site-library/rgdal/include
+<<
 DescPackaging: <<
   R (>= 2.13.0), methods, sp (>= 1.0-9)
   The latest source is at http://cran.r-project.org/src/contrib,

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rgdal-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rgdal-r.info
@@ -11,15 +11,15 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.4 3.3)
-Version: 1.3-3
+Type: rversion (3.5 3.4 3.3)
+Version: 1.3-6
 Revision: 1
 Description: GNU R Bindings for GDAL
 Homepage: http://cran.r-project.org/web/packages/rgdal/index.html
 License: GPL
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
-Source: https://cran.r-project.org/src/contrib/Archive/rgdal/rgdal_%v.tar.gz
-Source-MD5: 16a68398a6e8b6a84412162f0c7f90fc
+Source: https://cran.r-project.org/src/contrib/rgdal_%v.tar.gz
+Source-MD5: e2e60de68e87c5516fa1d5948c92749f
 SourceDirectory: rgdal
 Depends: <<
 	r-base%type_pkg[rversion],


### PR DESCRIPTION
$ dpkg -L cran-rgdal-r35
/.
/sw
/sw/lib
/sw/lib/R
/sw/lib/R/3.5
/sw/lib/R/3.5/site-library
/sw/lib/R/3.5/site-library/rgdal
/sw/lib/R/3.5/site-library/rgdal/ChangeLog
/sw/lib/R/3.5/site-library/rgdal/data
/sw/lib/R/3.5/site-library/rgdal/data/GridsDatums.rda
/sw/lib/R/3.5/site-library/rgdal/data/nor2k.rda
/sw/lib/R/3.5/site-library/rgdal/DESCRIPTION
/sw/lib/R/3.5/site-library/rgdal/doc
/sw/lib/R/3.5/site-library/rgdal/doc/index.html
/sw/lib/R/3.5/site-library/rgdal/doc/OGR_shape_encoding.pdf
/sw/lib/R/3.5/site-library/rgdal/doc/OGR_shape_encoding.R
/sw/lib/R/3.5/site-library/rgdal/doc/OGR_shape_encoding.Rnw
/sw/lib/R/3.5/site-library/rgdal/etc
/sw/lib/R/3.5/site-library/rgdal/etc/obj_with_comments.RData
/sw/lib/R/3.5/site-library/rgdal/etc/obj_without_comments.RData
/sw/lib/R/3.5/site-library/rgdal/etc/point.cpg
/sw/lib/R/3.5/site-library/rgdal/etc/point.dbf
/sw/lib/R/3.5/site-library/rgdal/etc/point.prj
/sw/lib/R/3.5/site-library/rgdal/etc/point.shp
/sw/lib/R/3.5/site-library/rgdal/etc/point.shx
/sw/lib/R/3.5/site-library/rgdal/etc/point_LinuxGDAL.RData
/sw/lib/R/3.5/site-library/rgdal/etc/point_WinCRAN.RData
/sw/lib/R/3.5/site-library/rgdal/etc/test_dfs.RData
/sw/lib/R/3.5/site-library/rgdal/help
/sw/lib/R/3.5/site-library/rgdal/help/aliases.rds
/sw/lib/R/3.5/site-library/rgdal/help/AnIndex
/sw/lib/R/3.5/site-library/rgdal/help/paths.rds
/sw/lib/R/3.5/site-library/rgdal/help/rgdal.rdb
/sw/lib/R/3.5/site-library/rgdal/help/rgdal.rdx
/sw/lib/R/3.5/site-library/rgdal/html
/sw/lib/R/3.5/site-library/rgdal/html/00Index.html
/sw/lib/R/3.5/site-library/rgdal/html/R.css
/sw/lib/R/3.5/site-library/rgdal/include
/sw/lib/R/3.5/site-library/rgdal/include/projects.h
/sw/lib/R/3.5/site-library/rgdal/INDEX
/sw/lib/R/3.5/site-library/rgdal/libs
/sw/lib/R/3.5/site-library/rgdal/libs/rgdal.so
/sw/lib/R/3.5/site-library/rgdal/LICENSE.TXT
/sw/lib/R/3.5/site-library/rgdal/m4
/sw/lib/R/3.5/site-library/rgdal/m4/ax_cxx_compile_stdcxx.m4
/sw/lib/R/3.5/site-library/rgdal/Meta
/sw/lib/R/3.5/site-library/rgdal/Meta/data.rds
/sw/lib/R/3.5/site-library/rgdal/Meta/features.rds
/sw/lib/R/3.5/site-library/rgdal/Meta/hsearch.rds
/sw/lib/R/3.5/site-library/rgdal/Meta/links.rds
/sw/lib/R/3.5/site-library/rgdal/Meta/nsInfo.rds
/sw/lib/R/3.5/site-library/rgdal/Meta/package.rds
/sw/lib/R/3.5/site-library/rgdal/Meta/Rd.rds
/sw/lib/R/3.5/site-library/rgdal/Meta/vignette.rds
/sw/lib/R/3.5/site-library/rgdal/NAMESPACE
/sw/lib/R/3.5/site-library/rgdal/OSGeo4W_test
/sw/lib/R/3.5/site-library/rgdal/pictures
/sw/lib/R/3.5/site-library/rgdal/pictures/big_int_arc_file.asc
/sw/lib/R/3.5/site-library/rgdal/pictures/cea.tif
/sw/lib/R/3.5/site-library/rgdal/pictures/erdas_spnad83.tif
/sw/lib/R/3.5/site-library/rgdal/pictures/logo.jpg
/sw/lib/R/3.5/site-library/rgdal/pictures/Rlogo.jpg
/sw/lib/R/3.5/site-library/rgdal/pictures/scaleoffset.dat
/sw/lib/R/3.5/site-library/rgdal/pictures/scaleoffset.vrt
/sw/lib/R/3.5/site-library/rgdal/pictures/SOURCES
/sw/lib/R/3.5/site-library/rgdal/pictures/SP27GTIF.TIF
/sw/lib/R/3.5/site-library/rgdal/pictures/test_envi_class.envi
/sw/lib/R/3.5/site-library/rgdal/pictures/test_envi_class.hdr
/sw/lib/R/3.5/site-library/rgdal/R
/sw/lib/R/3.5/site-library/rgdal/R/rgdal
/sw/lib/R/3.5/site-library/rgdal/R/rgdal.rdb
/sw/lib/R/3.5/site-library/rgdal/R/rgdal.rdx
/sw/lib/R/3.5/site-library/rgdal/README
/sw/lib/R/3.5/site-library/rgdal/README.windows
/sw/lib/R/3.5/site-library/rgdal/SVN_VERSION
/sw/lib/R/3.5/site-library/rgdal/vectors
/sw/lib/R/3.5/site-library/rgdal/vectors/airports.gml
/sw/lib/R/3.5/site-library/rgdal/vectors/cities.dbf
/sw/lib/R/3.5/site-library/rgdal/vectors/cities.htm
/sw/lib/R/3.5/site-library/rgdal/vectors/cities.prj
/sw/lib/R/3.5/site-library/rgdal/vectors/cities.sbn
/sw/lib/R/3.5/site-library/rgdal/vectors/cities.sbx
/sw/lib/R/3.5/site-library/rgdal/vectors/cities.shp
/sw/lib/R/3.5/site-library/rgdal/vectors/cities.shx
/sw/lib/R/3.5/site-library/rgdal/vectors/kiritimati_primary_roads.dbf
/sw/lib/R/3.5/site-library/rgdal/vectors/kiritimati_primary_roads.prj
/sw/lib/R/3.5/site-library/rgdal/vectors/kiritimati_primary_roads.sbn
/sw/lib/R/3.5/site-library/rgdal/vectors/kiritimati_primary_roads.sbx
/sw/lib/R/3.5/site-library/rgdal/vectors/kiritimati_primary_roads.shp
/sw/lib/R/3.5/site-library/rgdal/vectors/kiritimati_primary_roads.shx
/sw/lib/R/3.5/site-library/rgdal/vectors/PacoursIKA2.DAT
/sw/lib/R/3.5/site-library/rgdal/vectors/PacoursIKA2.ID
/sw/lib/R/3.5/site-library/rgdal/vectors/PacoursIKA2.MAP
/sw/lib/R/3.5/site-library/rgdal/vectors/PacoursIKA2.TAB
/sw/lib/R/3.5/site-library/rgdal/vectors/ps_cant_31.MID
/sw/lib/R/3.5/site-library/rgdal/vectors/ps_cant_31.MIF
/sw/lib/R/3.5/site-library/rgdal/vectors/scot_BNG.dbf
/sw/lib/R/3.5/site-library/rgdal/vectors/scot_BNG.prj
/sw/lib/R/3.5/site-library/rgdal/vectors/scot_BNG.shp
/sw/lib/R/3.5/site-library/rgdal/vectors/scot_BNG.shx
/sw/lib/R/3.5/site-library/rgdal/vectors/SOURCES
/sw/lib/R/3.5/site-library/rgdal/vectors/test64.csv
/sw/lib/R/3.5/site-library/rgdal/vectors/test64.csvt
/sw/lib/R/3.5/site-library/rgdal/vectors/test64.vrt
/sw/lib/R/3.5/site-library/rgdal/vectors/test_trk2.gpx
/sw/lib/R/3.5/site-library/rgdal/vectors/trin_inca_pl03.dbf
/sw/lib/R/3.5/site-library/rgdal/vectors/trin_inca_pl03.shp
/sw/lib/R/3.5/site-library/rgdal/vectors/trin_inca_pl03.shx
/sw/lib/R/3.5/site-library/rgdal/vectors/Up.dat
/sw/lib/R/3.5/site-library/rgdal/vectors/Up.id
/sw/lib/R/3.5/site-library/rgdal/vectors/Up.ind
/sw/lib/R/3.5/site-library/rgdal/vectors/Up.map
/sw/lib/R/3.5/site-library/rgdal/vectors/Up.tab


$ otool -L /sw/lib/R/3.5/site-library/rgdal/libs/rgdal.so
/sw/lib/R/3.5/site-library/rgdal/libs/rgdal.so:
	/sw/lib/R/3.5/site-library/rgdal/libs/rgdal.so (compatibility version 0.0.0, current version 0.0.0)
	/sw/Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libR.dylib (compatibility version 3.5.0, current version 3.5.2)
	/sw/lib/libgdal.20.dylib (compatibility version 25.0.0, current version 25.1.0)
	/sw/lib/libproj.9.dylib (compatibility version 11.0.0, current version 11.0.0)
	/sw/lib/libintl.8.dylib (compatibility version 10.0.0, current version 10.5.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1349.8.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.5.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.60.2)
