### PR TITLE
Build maxima v5.41.0 matching sbcl 1.4.16

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/maxima.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/maxima.info
@@ -1,19 +1,19 @@
 Package: maxima
-Version: 5.38.1
-Revision: 4
+Version: 5.41.0
+Revision: 1
 Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 Description: Symbol manipulation program
 License: GPL
 
-BuildDepends: fink (>=0.32), sbcl (=1.3.8-1), texinfo (>=5.2-1)
+BuildDepends: fink (>=0.32), sbcl (=1.4.16-1), texinfo (>=5.2-1)
 RuntimeDepends: gnuplot-bin, rlwrap
 Depends: recode
 Conflicts: maxima, maxima-nox
 Replaces: maxima, maxima-nox
 
 Source: mirror:sourceforge:%n/Maxima-source/%v-source/%n-%v.tar.gz
-Source-MD5:  bc21a56e0e413c24a31408ee5900cb59
-Source-Checksum:  SHA1(db4fb31512299e9971cfbc75cc60ca628861d3f5)
+Source-MD5:  972c51384d7895c88d78eb045c6aedb2
+Source-Checksum:  SHA1(0f69a6603d7334bfec6388151eeb768e8c5e7626)
         
 ConfigureParams: <<
 --infodir='${prefix}/share/info' \

--- a/10.9-libcxx/stable/main/finkinfo/graphics/aquaterm.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/aquaterm.info
@@ -67,7 +67,6 @@ Description: Displays vector graphics in Aqua
 DescPackaging: <<
   Package previously maintained by Jeffrey Whitaker. 
   Package ownership assumed by Kevin Horton as of aquaterm-1.0.1-5.
-  Package ownership assumed by Leigh Smith as of aquaterm-1.1.1-5.
 <<
-Maintainer: Leigh Smith <leigh@leighsmith.com>
+Maintainer: Kevin Horton <khorton02@gmail.com>
 Homepage: http://aquaterm.github.com

--- a/10.9-libcxx/stable/main/finkinfo/graphics/aquaterm.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/aquaterm.info
@@ -1,6 +1,6 @@
 Package: aquaterm
 Version: 1.1.1
-Revision: 4
+Revision: 5
 Source: http://www.kilohotel.com/fink/AquaTerm-%v.tar.gz
 Source-MD5: 9c8da40bda38f4b9f3a57e560fdd9b5c
 BuildDepends: xcode.app
@@ -13,10 +13,12 @@ TarFilesRename: README:README.txt Readme:Readme.txt
 CompileScript: echo nothing to do here, everything is done in the installscript
 InstallScript: <<
  #!/bin/sh -ex
+ . %p/sbin/fink-buildenv-helper.sh
+ if test "$XCODE_MAJOR_VERSION" -ge "10"; then xcodebuildoption="-UseNewBuildSystem=NO"; else xcodebuildoption=""; fi
  if test "%m" = "powerpc"; then archname="ppc"; else archname="%m"; fi
  ARCHS=$archname
  cd aquaterm
- xcodebuild install -target AquaTerm DSTROOT=%d INSTALL_PATH=%p/Applications DYLIB_INSTALL_NAME_BASE=%p/Library/Frameworks GCC_PREPROCESSOR_DEFINITIONS="AQT_APP" ARCHS=$archname MACOSX_DEPLOYMENT_TARGET=10.7
+ xcodebuild install $xcodebuildoption -target AquaTerm DSTROOT=%d INSTALL_PATH=%p/Applications DYLIB_INSTALL_NAME_BASE=%p/Library/Frameworks GCC_PREPROCESSOR_DEFINITIONS="AQT_APP" ARCHS=$archname MACOSX_DEPLOYMENT_TARGET=10.7
  mkdir -p %i/include/aquaterm
  cp AQTAdapter.h aquaterm.h %i/include
  cp AQTAdapter.h %i/include/aquaterm
@@ -65,6 +67,7 @@ Description: Displays vector graphics in Aqua
 DescPackaging: <<
   Package previously maintained by Jeffrey Whitaker. 
   Package ownership assumed by Kevin Horton as of aquaterm-1.0.1-5.
+  Package ownership assumed by Leigh Smith as of aquaterm-1.1.1-5.
 <<
-Maintainer: Kevin Horton <khorton02@gmail.com>
+Maintainer: Leigh Smith <leigh@leighsmith.com>
 Homepage: http://aquaterm.github.com


### PR DESCRIPTION
- Updated maxima v5.41.0 to work with sbcl v1.4.16.
- Incorporates patches to build aquaterm as specified in https://github.com/fink/fink-distributions/pull/334