### PR TITLE
postgresql updates februar 2019

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
@@ -1,7 +1,7 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 10.6
-Revision: 2
+Version: 10.7
+Revision: 1
 Type: postgresql 10
 Description: PostgreSQL open-source database
 License: BSD
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: caa28a40f64781a9dbf59e9227d32dc4
-Source-Checksum: SHA256(68a8276f08bda8fbefe562faaf8831cb20664a7a1d3ffdbbcc5b83e08637624b)
+Source-MD5: b50adbbf9a8dfa977cd7bfe06dc4a30d
+Source-Checksum: SHA256(bfed1065380c1bba927bfe51f23168471373f26e3324cbad859269cc32733ede)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
@@ -49,7 +49,7 @@ PatchScript: <<
 	fi
 <<
 PatchFile: %n.patch
-PatchFile-MD5: 35ba01b87cfa5ff721077a99f80a744d
+PatchFile-MD5: 0aa33255168ba8b07ba9a98b565ab4d8
 
 SetCPPFLAGS: -DHAVE_OPTRESET -fno-common
 SetLDFLAGS: -F/System/Library/Frameworks -headerpad_max_install_names

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql10.patch
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql10.patch
@@ -1,6 +1,6 @@
-diff -x '*~' -urN postgresql-10.1_original/pgsql.sh postgresql-10.1_patched/pgsql.sh
---- postgresql-10.1_original/pgsql.sh	1970-01-01 01:00:00.000000000 +0100
-+++ postgresql-10.1_patched/pgsql.sh	2017-11-12 21:09:50.000000000 +0100
+diff -x '*~' -urN postgresql-10.7_original/pgsql.sh postgresql-10.7_patched/pgsql.sh
+--- postgresql-10.7_original/pgsql.sh	1970-01-01 01:00:00.000000000 +0100
++++ postgresql-10.7_patched/pgsql.sh	2019-02-16 20:29:36.000000000 +0100
 @@ -0,0 +1,87 @@
 +#!/bin/sh
 +
@@ -89,18 +89,18 @@ diff -x '*~' -urN postgresql-10.1_original/pgsql.sh postgresql-10.1_patched/pgsq
 +esac
 +
 +popd
-diff -x '*~' -urN postgresql-10.1_original/src/Makefile.global.in postgresql-10.1_patched/src/Makefile.global.in
---- postgresql-10.1_original/src/Makefile.global.in	2017-11-07 01:46:52.000000000 +0100
-+++ postgresql-10.1_patched/src/Makefile.global.in	2017-11-12 21:09:50.000000000 +0100
-@@ -333,6 +333,11 @@
- 	rm -rf '$(abs_top_builddir)'/tmp_install
+diff -x '*~' -urN postgresql-10.7_original/src/Makefile.global.in postgresql-10.7_patched/src/Makefile.global.in
+--- postgresql-10.7_original/src/Makefile.global.in	2019-02-11 22:19:36.000000000 +0100
++++ postgresql-10.7_patched/src/Makefile.global.in	2019-02-16 20:38:22.000000000 +0100
+@@ -345,6 +345,11 @@
  	$(MKDIR_P) '$(abs_top_builddir)'/tmp_install/log
  	$(MAKE) -C '$(top_builddir)' DESTDIR='$(abs_top_builddir)'/tmp_install install >'$(abs_top_builddir)'/tmp_install/log/install.log 2>&1
+ 	$(MAKE) -j1 $(if $(CHECKPREP_TOP),-C $(CHECKPREP_TOP),) checkprep >>'$(abs_top_builddir)'/tmp_install/log/install.log 2>&1
 +ifeq ($(shell uname),Darwin)
 +#       fink patch:
 +#       macos with SIP enabled, workarround during make test and stripped DYLD_LIBRARY_PATH
 +	for binary in '$(abs_top_builddir)'/tmp_install$(bindir)/* ; do install_name_tool $$binary -change $(libdir)/libpq.5.dylib '$(abs_top_builddir)'/tmp_install$(libdir)/libpq.5.dylib   >>'$(abs_top_builddir)'/tmp_install/log/install.log 2>&1 ; done
 +endif
  endif
- 	$(if $(EXTRA_INSTALL),for extra in $(EXTRA_INSTALL); do $(MAKE) -C '$(top_builddir)'/$$extra DESTDIR='$(abs_top_builddir)'/tmp_install install >>'$(abs_top_builddir)'/tmp_install/log/install.log || exit; done)
+ endif
  endif

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
@@ -1,7 +1,7 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.4.20
-Revision: 2
+Version: 9.4.21
+Revision: 1
 Epoch: 1
 Type: postgresql 9.4
 Description: PostgreSQL open-source database
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 5821867741c821736266f27b6b8a859a
-Source-Checksum: SHA256(eeb1d8ddb2854c9e4d8b5cbd65665260c0ae8cbcb911003f24c2d82ccb97f87f)
+Source-MD5: d78fa9861f541ccae9800c7465655fb5
+Source-Checksum: SHA256(0049b4d239a00654e792997aff32a0be7a6bdd922b5ca97f1a06797cd4d06006)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
@@ -1,7 +1,7 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.5.15
-Revision: 2
+Version: 9.5.16
+Revision: 1
 Epoch: 1
 Type: postgresql 9.5
 Description: PostgreSQL open-source database
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 70a0af3171b4522c080d0f61584bd7f9
-Source-Checksum: SHA256(dbda3fdefd7f9fd5359a7989085aaef25c9f9d08816eda6378c2575d1ff55444)
+Source-MD5: 20c9cf32158f66aedef6871200227a19
+Source-Checksum: SHA256(a4576c95d4dcee8d4b7835b333d38e909848222e4b87895878bb1c026206e131)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
@@ -1,7 +1,7 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.6.11
-Revision: 2
+Version: 9.6.12
+Revision: 1
 Epoch: 1
 Type: postgresql 9.6
 Description: PostgreSQL open-source database
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: ba589ad4702b4fd0fc86efe2c1a66f78
-Source-Checksum: SHA256(38250adc69a1e8613fb926c894cda1d01031391a03648894b9a6e13ff354a530)
+Source-MD5: adab4bcd346d3a115f6f741b1756cd0f
+Source-Checksum: SHA256(2e8c8446ba94767bda8a26cf5a2152bf0ae68a86aaebf894132a763084579d84)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1


### PR DESCRIPTION
the PR updates the postgresql packages to the latest upstream version.

- postgresql10 update to 10.7
- postgresql96 update to 9.6.12
- postgresql95 update to 9.5.16
- postgresql94 update to 9.4.21

