### PR TITLE
cdo-1.9.6-1: upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: cdo%type_pkg[-openmp]
-Version: 1.9.5
+Version: 1.9.6
 Revision: 1
 Description: Climate Data Operators
 HomePage: https://code.zmaw.de/projects/cdo
@@ -31,12 +31,12 @@ Conflicts: %{Ni}, %{Ni}-openmp
 Replaces: %{Ni}, %{Ni}-openmp
 
 # Unpack Phase:
-Source: https://code.mpimet.mpg.de/attachments/download/18264/%{Ni}-%v.tar.gz
-Source-MD5: 0c60f2c94dc5c76421ecf363153a5043
-Source-Checksum: SHA1(68f545e79b000037d00c4151fd2a0ac9f314a9d8)
+Source: https://code.mpimet.mpg.de/attachments/download/19299/%{Ni}-%v.tar.gz
+Source-MD5: 322f56c5e13f525c585ee5318d4435db
+Source-Checksum: SHA1(1c694f87756bebe9cadc91f457d3a303c3f9767d)
 PatchFile: %{Ni}.patch
-PatchFile-MD5: c64f67a48883677eec092b205d7e1c9a
-PatchFile-Checksum: SHA1(ad2e5a212fb976e9d8b193327c398746e4233374)
+PatchFile-MD5: ad655e198b8c9b047aae19b3c6a4720e
+PatchFile-Checksum: SHA1(9704b82d6ef825bf9624755bce1ffd1630990b4c)
 
 # Compile Phase:
 NoSetLDFLAGS: true
@@ -90,6 +90,5 @@ Use cdo-openmp to include parallelization.
 DescPort: <<
 - test needs make -j1, otherwise some tests will fail.
 - disabled tsformat.test with nc4 since it miraculously fails.
-- patch for Gradsdes.cc as otherwise Gradsdes.test fails.
 <<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/cdo.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cdo.patch
@@ -9,24 +9,3 @@ diff -Nurd cdo-1.9.5-orig/test/tsformat.test.in cdo-1.9.5/test/tsformat.test.in
  }
  #
  function testfunc()
-diff -Nurd cdo-1.9.5-orig/src/Gradsdes.cc cdo-1.9.5/src/Gradsdes.cc
---- cdo-1.9.5-orig/src/Gradsdes.cc	2018-08-06 14:03:46.000000000 +0200
-+++ cdo-1.9.5/src/Gradsdes.cc	2018-09-04 10:13:24.471952112 +0200
-@@ -975,7 +975,7 @@
- 
-   int operatorID = cdoOperatorID();
- 
--  const char *datfile = cdoGetStreamName(0).c_str();
-+  char *datfile = strdup(cdoGetStreamName(0).c_str());
-   size_t len = strlen(datfile);
-   char *ctlfile = (char *) Malloc(len + 10);
-   strcpy(ctlfile, datfile);
-@@ -1127,7 +1127,7 @@
-     {
-       datfile = strrchr(datfile, '/');
-       if (datfile == 0)
--        datfile = cdoGetStreamName(0).c_str();
-+        datfile = strdup(cdoGetStreamName(0).c_str());
-       else
-         datfile++;
-       fprintf(gdp, "DSET  ^%s\n", datfile);


### PR DESCRIPTION
One less patch is needed with this update.

Built and tested with `fink -m build` on MacOS 10.14.3 with Command Line Tools 10.1