### PR TITLE
pdflib6-7.0.5p3-1: update source location. Previous one is redirected…

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/pdflib6.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/pdflib6.info
@@ -3,7 +3,7 @@ Version: 7.0.5p3
 Revision: 1
 GCC: 4.0
 BuildDependsOnly: True
-Source: http://www.pdflib.com/binaries/PDFlib/705/PDFlib-Lite-%v.tar.gz
+Source: https://fossies.org/linux/misc/old/PDFlib-Lite-%v.tar.gz
 Source-MD5: 371d332d610a8b21a542bb7a2bdaf954
 BuildDepends: fink (>= 0.24.12-1)
 Depends: %N-shlibs (= %v-%r)


### PR DESCRIPTION
pdflib6-7.0.5p3-1: update source location. Previous one is redirected to HTML page.

No need to update the revision number, as nothing else changes.