### PR TITLE
expect-5.45-205: Needed update to find tcltk (private) headers

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/utils/expect.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/expect.info
@@ -1,6 +1,6 @@
 Package: expect
 Version: 5.45
-Revision: 204
+Revision: 205
 Maintainer: None <fink-devel@lists.sourceforge.net>
 BuildDepends: <<
 	fink-buildenv-modules (>= 0.1.3-1),
@@ -13,7 +13,7 @@ Depends: <<
 Source: mirror:sourceforge:%n/Expect/%v/%n%v.tar.gz
 Source-MD5: 44e1a4f4c877e9ddc5a542dfa7ecc92b
 PatchFile: %n.patch
-PatchFile-MD5: e2b02f12a16076a5460a5559314909b0
+PatchFile-MD5: f0b227a38b679756e9db6ae6a2e2c322
 ConfigureParams: --mandir='$(prefix)/share/man' --with-tcl=%p/lib --with-tk=%p/lib --x-inc=$X11_BASE_DIR/include --x-lib=$X11_BASE_DIR/lib --with-tkinclude=%p/include --with-tclinclude=%p/include/tcltk-private/tcl8.6/generic
 PatchScript: <<
 	%{default_script}

--- a/10.9-libcxx/stable/main/finkinfo/utils/expect.patch
+++ b/10.9-libcxx/stable/main/finkinfo/utils/expect.patch
@@ -39,7 +39,16 @@ diff -uNr expect5.45.orig/Dbg.c expect5.45/Dbg.c
  	/* since user is typing a command, don't interrupt it immediately */
 diff -Nurd -x'*~' expect5.45.orig/configure expect5.45/configure
 --- expect5.45.orig/configure	2010-09-16 16:46:47.000000000 -0400
-+++ expect5.45/configure	2017-10-08 14:41:18.000000000 -0400
++++ expect5.45/configure	2019-03-04 17:34:41.091738377 +0100
+@@ -6288,7 +6288,7 @@
+     echo "$as_me:$LINENO: checking for Tcl private include files" >&5
+ echo $ECHO_N "checking for Tcl private include files... $ECHO_C" >&6
+
+-    TCL_SRC_DIR_NATIVE=`${CYGPATH} ${TCL_SRC_DIR}`
++    TCL_SRC_DIR_NATIVE=`${CYGPATH} ${TCL_SRC_DIR}|sed s:/private::g`
+     TCL_TOP_DIR_NATIVE=\"${TCL_SRC_DIR_NATIVE}\"
+
+     # Check to see if tcl<Plat>Port.h isn't already with the public headers
 @@ -16026,7 +16026,7 @@
      else
          EXP_LIB_FLAG="-lexpect`echo ${EXP_LIB_VERSION} | tr -d .`"


### PR DESCRIPTION
expect-5.45-205: Needed update to find tcltk (private) headers in Fink tree.

Build and tested on MacOS 10.14.3 with command line tools 10.1