### PR TITLE
python-2.7.16-2 and python-3.7.2-3: Avoid failing module builds on 10.14

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/python27.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python27.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: python%type_pkg[python]
 Version: 2.7.16
-Revision: 1
+Revision: 2
 Epoch: 1
 Type: python 2.7
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
@@ -82,7 +82,7 @@ CompileScript: <<
 	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
 		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-		export CFLAGS="-Wno-nullability-completeness -isysroot $SDK_PATH"
+		export CFLAGS="-Wno-nullability-completeness -I$SDK_PATH/usr/local"
 		export CPPFLAGS="-I%p/include -I%p/include/ncursesw"
 		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi

--- a/10.9-libcxx/stable/main/finkinfo/languages/python27.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python27.info
@@ -82,8 +82,8 @@ CompileScript: <<
 	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
 		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-		export CFLAGS="-Wno-nullability-completeness -I$SDK_PATH/usr/include"
-		export CPPFLAGS="-I%p/include -I%p/include/ncursesw"
+		export CFLAGS="-Wno-nullability-completeness"
+		export CPPFLAGS="-I%p/include -I%p/include/ncursesw -I$SDK_PATH/usr/include"
 		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/python27.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python27.info
@@ -82,7 +82,7 @@ CompileScript: <<
 	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
 		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-		export CFLAGS="-Wno-nullability-completeness -I$SDK_PATH/usr/local"
+		export CFLAGS="-Wno-nullability-completeness -I$SDK_PATH/usr/include"
 		export CPPFLAGS="-I%p/include -I%p/include/ncursesw"
 		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -94,8 +94,8 @@ CompileScript: <<
 	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
 		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-		export CFLAGS="-Wno-nullability-completeness -Wno-expansion-to-defined -I$SDK_PATH/usr/include"
-		export CPPFLAGS="-I%p/include -I%p/include/ncursesw"
+		export CFLAGS="-Wno-nullability-completeness -Wno-expansion-to-defined"
+		export CPPFLAGS="-I%p/include -I%p/include/ncursesw -I$SDK_PATH/usr/include"
 		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -94,7 +94,7 @@ CompileScript: <<
 	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
 		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-		export CFLAGS="-Wno-nullability-completeness -Wno-expansion-to-defined -I$SDK_PATH/usr/local"
+		export CFLAGS="-Wno-nullability-completeness -Wno-expansion-to-defined -I$SDK_PATH/usr/include"
 		export CPPFLAGS="-I%p/include -I%p/include/ncursesw"
 		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: python%type_pkg[python]
 Version: 3.7.2
-Revision: 2
+Revision: 3
 Type: python 3.7
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Depends: <<
@@ -94,7 +94,7 @@ CompileScript: <<
 	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
 		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-		export CFLAGS="-Wno-nullability-completeness -Wno-expansion-to-defined -isysroot $SDK_PATH"
+		export CFLAGS="-Wno-nullability-completeness -Wno-expansion-to-defined -I$SDK_PATH/usr/local"
 		export CPPFLAGS="-I%p/include -I%p/include/ncursesw"
 		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi


### PR DESCRIPTION
Replaced `-isysroot $SDK_PATH` by `-I$SDK_PATH/usr/include` in CFLAGS setting.
This is because `-isysroot` appears to suppress `-I%p/include`.

The same approach was used in `python34.info`, `python35.info`, `python36.info`

This fixed issue #363.