### PR TITLE
netcdf-c15-4.6.3-1: upstream update and new library version

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c11.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c11.info
@@ -1,6 +1,6 @@
 Package: netcdf-c11
 Version: 4.4.1.1
-Revision: 2
+Revision: 3
 BuildDependsOnly: true
 Maintainer: None <fink-devel@lists.sourceforge.net>
 
@@ -11,7 +11,8 @@ Conflicts: <<
 	netcdf, netcdf7,
 	netcdf-c7,
 	netcdf-c11,
-	netcdf-c13
+	netcdf-c13,
+	netcdf-c15
 <<
 Replaces: <<
 	netcdf-absoft,
@@ -19,7 +20,8 @@ Replaces: <<
 	netcdf7,
 	netcdf-c7,
 	netcdf-c11,
-	netcdf-c13
+	netcdf-c13,
+	netcdf-c15
 <<
 
 Source: ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c13.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c13.info
@@ -1,6 +1,6 @@
 Package: netcdf-c13
 Version: 4.6.2
-Revision: 1
+Revision: 2
 BuildDependsOnly: true
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
@@ -11,7 +11,8 @@ Conflicts: <<
 	netcdf, netcdf7,
 	netcdf-c7,
 	netcdf-c11,
-	netcdf-c13
+	netcdf-c13,
+	netcdf-c15
 <<
 Replaces: <<
 	netcdf-absoft,
@@ -19,7 +20,8 @@ Replaces: <<
 	netcdf7,
 	netcdf-c7,
 	netcdf-c11,
-	netcdf-c13
+	netcdf-c13,
+	netcdf-c15
 <<
 
 Source: ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c15.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c15.info
@@ -1,0 +1,138 @@
+Package: netcdf-c15
+Version: 4.6.3
+Revision: 1
+BuildDependsOnly: true
+Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
+
+Depends: %n-shlibs (= %v-%r)
+BuildDepends: doxygen, fink-package-precedence, hdf5.10, hdf5-cpp11, libcurl4, szip
+Conflicts: <<
+	netcdf-absoft,
+	netcdf, netcdf7,
+	netcdf-c7,
+	netcdf-c11,
+	netcdf-c13,
+	netcdf-c15
+<<
+Replaces: <<
+	netcdf-absoft,
+	netcdf,
+	netcdf7,
+	netcdf-c7,
+	netcdf-c11,
+	netcdf-c13,
+	netcdf-c15
+<<
+
+Source: ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-%v.tar.gz
+Source-MD5: ef0b4d24f2c5a2a424c769cbb91fa45f
+Source-Checksum: SHA1(f165d9d4120dca09dcd49a90f31957640734ad0c)
+SetCFLAGS: -O2
+SetLDFLAGS: -lsz -Wl,-dead_strip_dylibs
+
+ConfigureParams: <<
+  --enable-shared --disable-static \
+  --mandir='${prefix}/share/man' \
+  --docdir='${prefix}/share/doc/%n' \
+  --disable-pnetcdf
+<<
+
+CompileScript: <<
+	#!/bin/sh -ev
+	%{default_script}
+	fink-package-precedence .
+<<
+InfoTest: <<
+	TestConfigureParams: --enable-extra-example-tests --disable-dap-remote-tests
+  	TestDepends: sed
+	TestScript: make -j1 check || exit 2
+<<
+InstallScript: <<
+  #!/bin/sh -ev
+  make install DESTDIR=%d
+  # Remove unwanted files from test suite
+  rm -f %i/bin/ocprint %i/lib/libmisc.* %i/lib/libbzip2.*
+  # Add C and CDL examples
+  mkdir -p %i/share/doc/%N/examples
+  cp -pr examples/C* %i/share/doc/%N/examples
+  rm -rf %i/share/doc/%N/examples/C/.{deps,libs}
+  rm -rf %i/share/doc/%N/examples/C/*/.{deps,libs}
+  rm -f %i/share/doc/%N/examples/C/*/*.la
+<<
+SplitOff: <<
+  Package: %N-shlibs
+  Depends: hdf5.10-shlibs, libcurl4-shlibs
+  Conflicts: netcdf-absoft-shlibs
+  Replaces: <<
+  	netcdf-absoft-shlibs, 
+  	netcdf (<= 3.5.0-6), 
+  	netcdf-absoft (<= 3.5.1-2), 
+  	netcdf-shlibs
+  <<
+  Suggests: netcdf-bin (>= 4.3.0)
+  Files: <<
+  	lib/libnetcdf.*.dylib 
+  <<
+  Shlibs: <<
+    %p/lib/libnetcdf.15.dylib 16.0.0 %n (>= 4.6.3-1)
+  <<
+  DocFiles: COPYRIGHT README* RELEASE_NOTES.md
+  Description: Array-based data access, C library
+<<
+SplitOff2: <<
+  Package: netcdf-bin
+  Depends: %N-shlibs (= %v-%r), hdf5.10-shlibs
+  Conflicts: netcdf-absoft-bin, netcdf7-bin
+  Replaces: <<
+  	netcdf-absoft-bin, 
+  	netcdf7-bin, 
+  	netcdf (<= 3.5.0-6), 
+  	netcdf-absoft (<= 3.5.1-2)
+  <<
+  Files: bin/nc{copy,dump,gen,gen3} share/man/man1
+  DocFiles: COPYRIGHT README* RELEASE_NOTES.md
+  Description: Array-based data access, user programs
+<<
+DocFiles: COPYRIGHT README* RELEASE_NOTES.md
+Description: Array-based data access, C headers and docs
+DescDetail: <<
+The netCDF (network Common Data Form) library defines a machine-independent
+format for representing scientific data. Together, the interface, library,
+and format support the creation, access, and sharing of scientific data.
+
+This package provides libraries, documentation and examples for interfacing
+with C code. 
+For libraries, documentation and examples for interfacing
+with C++ install the`netcdf-cxx4' package.
+For libraries, documentation and examples for interfacing
+with Fortran 77 (and Fortran 90) code install the `netcdf-fortran5' package.
+<<
+DescPackaging: <<
+Included examples in documents directory.
+
+Disable remote DAP tests since we aren't supposed to be accessing remote data
+during the build phase.
+
+Feed -lsz to LDFLAGS so that the build finds libsz.
+
+Disable building the static library.
+
+Bump revision when HDF5 version is updated.
+There are no longer test failures when building against hdf5.100.v1.8
+(only API version test), yet still building against hdf5.10, as netCDF
+does not require anything newer.
+While there is a BuildDepends on hdf5-cpp11, this is only because one
+header file in that package should have been in hdf5.10 instead.
+There is NO dependency on hdf5-cpp11-shlibs.
+
+Former Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
+<<
+DescPort: <<
+CFLAGS=-O2 is essential to avoid debugging mode flags (-g).
+<<
+DescUsage: <<
+Parallel netCDF now requires a parallel HDF5, which Fink doesn't
+currently have, so this package doesn't build that option.
+<<
+Homepage: http://www.unidata.ucar.edu/software/netcdf/
+License: OSI-Approved

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c15.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c15.info
@@ -5,7 +5,7 @@ BuildDependsOnly: true
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Depends: %n-shlibs (= %v-%r)
-BuildDepends: doxygen, fink-package-precedence, hdf5.10, hdf5-cpp11, libcurl4, szip
+BuildDepends: doxygen, fink-package-precedence, hdf5.100.v1.10, libcurl4, szip
 Conflicts: <<
 	netcdf-absoft,
 	netcdf, netcdf7,
@@ -31,6 +31,8 @@ SetCFLAGS: -O2
 SetLDFLAGS: -lsz -Wl,-dead_strip_dylibs
 
 ConfigureParams: <<
+  CPPFLAGS=-I%p/opt/hdf5.v1.10/include \
+  LDFLAGS=-L%p/opt/hdf5.v1.10/lib \
   --enable-shared --disable-static \
   --mandir='${prefix}/share/man' \
   --docdir='${prefix}/share/doc/%n' \
@@ -61,7 +63,7 @@ InstallScript: <<
 <<
 SplitOff: <<
   Package: %N-shlibs
-  Depends: hdf5.10-shlibs, libcurl4-shlibs
+  Depends: hdf5.100.v1.10-shlibs, libcurl4-shlibs
   Conflicts: netcdf-absoft-shlibs
   Replaces: <<
   	netcdf-absoft-shlibs, 
@@ -81,7 +83,7 @@ SplitOff: <<
 <<
 SplitOff2: <<
   Package: netcdf-bin
-  Depends: %N-shlibs (= %v-%r), hdf5.10-shlibs
+  Depends: %N-shlibs (= %v-%r), hdf5.100.v1.10-shlibs
   Conflicts: netcdf-absoft-bin, netcdf7-bin
   Replaces: <<
   	netcdf-absoft-bin, 
@@ -118,12 +120,8 @@ Feed -lsz to LDFLAGS so that the build finds libsz.
 Disable building the static library.
 
 Bump revision when HDF5 version is updated.
-There are no longer test failures when building against hdf5.100.v1.8
-(only API version test), yet still building against hdf5.10, as netCDF
-does not require anything newer.
-While there is a BuildDepends on hdf5-cpp11, this is only because one
-header file in that package should have been in hdf5.10 instead.
-There is NO dependency on hdf5-cpp11-shlibs.
+Needed to set CPPFLAGS and LDFLAGS, otherwise configure does not find
+HDF5 headers or library.
 
 Former Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c15.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c15.info
@@ -5,7 +5,14 @@ BuildDependsOnly: true
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Depends: %n-shlibs (= %v-%r)
-BuildDepends: doxygen, fink-package-precedence, hdf5.100.v1.10, libcurl4, szip
+BuildDepends: <<
+	doxygen,
+	fink-package-precedence,
+	hdf5.100.v1.10,
+	hdf5-cpp.100.v1.10,
+	libcurl4,
+	szip
+<<
 Conflicts: <<
 	netcdf-absoft,
 	netcdf, netcdf7,
@@ -120,6 +127,9 @@ Feed -lsz to LDFLAGS so that the build finds libsz.
 Disable building the static library.
 
 Bump revision when HDF5 version is updated.
+While there is a BuildDepends on hdf5-cpp.100.v1.10, this is only because
+one header file in that package should have been in hdf5.100.v1.10 instead.
+There is NO dependency on hdf5-cpp.100.v1.10-shlibs.
 Needed to set CPPFLAGS and LDFLAGS, otherwise configure does not find
 HDF5 headers or library.
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c7.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c7.info
@@ -1,6 +1,6 @@
 Package: netcdf-c7
 Version: 4.3.3.1
-Revision: 4
+Revision: 5
 BuildDependsOnly: true
 Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 
@@ -11,7 +11,8 @@ Conflicts: <<
 	netcdf, netcdf7,
 	netcdf-c7,
 	netcdf-c11,
-	netcdf-c13
+	netcdf-c13,
+	netcdf-c15
 <<
 Replaces: <<
 	netcdf-absoft,
@@ -19,7 +20,8 @@ Replaces: <<
 	netcdf7,
 	netcdf-c7,
 	netcdf-c11,
-	netcdf-c13
+	netcdf-c13,
+	netcdf-c15
 <<
 
 PatchFile: %n.patch


### PR DESCRIPTION
Library version number changed from `libnetcdf.13.dylib` to `libnetcdf.15.dylib`, hence new package.
When accepted, I'll forthwith update packages to link against `netcdf-c15-shlibs`, where appropriate.

Removed from configuration `--disable-cdf5` which was introduced in package version 4.6.1 because of bug; fixed since 4.6.2.

All versions built and tested with `fink -m build` on MacOS 10.14.3 with Command Line Tools 10.1.