### PR TITLE
netcdf-fortran7-4.4.5-1: upstream and dependencies update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-fortran7.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-fortran7.info
@@ -1,15 +1,15 @@
 Info2: <<
 Package: netcdf-fortran7
-Version: 4.4.4
-Revision: 4
+Version: 4.4.5
+Revision: 1
 BuildDependsOnly: true
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
-Type: gcc (7)
+Type: gcc (8)
 
 Depends: %n-shlibs (= %v-%r), gcc%type_pkg[gcc]-compiler
 BuildDepends: <<
-	netcdf-c13,
+	netcdf-c15,
 	netcdf-bin (>= 4.4.0-1),
 	libcurl4, 
 	szip,
@@ -32,8 +32,8 @@ Replaces: <<
 <<
 
 Source: ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-fortran-%v.tar.gz
-Source-MD5: e855c789cd72e1b8bc1354366bf6ac72
-Source-Checksum: SHA1(f04e4f2a8d9b2f8a676a621d1f552f0cd98ce265)
+Source-MD5: 9a9a469fe623f81b48a9d836ea0f97f5
+Source-Checksum: SHA1(96341a5f714591acda147974f4c14f7b6357a320)
 SourceDirectory: netcdf-fortran-%v
 
 PatchScript: perl -pi -e 's/(10\.\[012\])\*/\1\,.\*/' configure
@@ -73,9 +73,9 @@ InstallScript: <<
 <<
 SplitOff: <<
   Package: %N-shlibs
-  Depends: netcdf-c13-shlibs, gcc%type_pkg[gcc]-shlibs
+  Depends: netcdf-c15-shlibs, gcc%type_pkg[gcc]-shlibs
   Files: lib/libnetcdff.*.dylib
-  Shlibs: %p/lib/libnetcdff.6.dylib 8.0.0 %n (>= 4.4.4-1)
+  Shlibs: %p/lib/libnetcdff.6.dylib 9.0.0 %n (>= 4.4.5-1)
   DocFiles: COPYRIGHT README.md RELEASE_NOTES.md F03Interfaces_LICENSE
   Description: Array-based data access, Fortran library
 <<
@@ -92,7 +92,7 @@ library links to libraries from gcc4N-shlibs, a particular gcc4N had to be
 chosen.
 <<
 DescUsage: <<
-When building by hand against this package, make sure netcdf-c13 is installed,
+When building by hand against this package, make sure netcdf-c15 is installed,
 since, by policy, this package cannot declare a runtime dependency on it.
 
 It does, however, have a dependency on gcc5-compiler, since that's legit.
@@ -102,7 +102,7 @@ Whoops, this should have been "netcdf-fortran_6_"  Meh.
 
 Manually move docs from the tarball to avoid potentially triggering a rebuild.
 
-Bump revision and versioned dependencies on hdf5.X and netcdf-c13
+Bump revision and versioned dependencies on hdf5.X and netcdf-c15
 when HDF5 (hdf5.X) version is updated.
 
 Specify full path to the "gfortran" executable in gcc4N compiler to avoid 


### PR DESCRIPTION
Updated from version 4.4.4 to 4.4.5. En passant updated dependencies:
gcc7 -> gcc8
netcdf-c13 -> netcdf-c15.

Built and tested with `fink -m build netcdf-fortran7` on MacOS 10.14.3 with Command Line Tools 10.1