### PR TITLE
eccodes-2.12.0: upstream and dependencies update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
@@ -12,8 +12,8 @@ Source: https://software.ecmwf.int/wiki/download/attachments/45757960/%n-%v-Sour
 Source-MD5: a812b5837901526905b020d328d8007c
 Source-Checksum: SHA1(dff83137e95520462118a5cc65b58157d40e736d)
 PatchFile: eccodes.patch
-PatchFile-MD5: 43ec7477a96e37e7a951faae7019622b
-PatchFile-Checksum: SHA1(6d04866b20c96813524a46b3a365844d4866fb1f)
+PatchFile-MD5: 4fc2a180dcdf2c577ce213884a297fb4
+PatchFile-Checksum: SHA1(f9af183e1998bee05317c2f2e3a2d28a5e1fb51f)
 
 SourceDirectory: %n-%v-Source
 BuildDependsOnly: true
@@ -193,6 +193,10 @@ DescPackaging: <<
 For the time being, did not include Python interface.
 Split off Fortran interface to avoid that users of the C library would need
 to install gcc?-shlib as well.
+While the CMake system normally searches for HDF5, no HDF5 headers or
+function calls are used anywhere in the code, hence a patch was
+introduced to no longer search for HDF5. Ignore the notice that the
+optional HDF5 package was not found.
 The packages eccodes and eccodes-fortran clash with their grib-api 
 counterparts because they share common header files that ought to make
 the move to the eccodes library transparent to grib-api users.

--- a/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
@@ -1,16 +1,16 @@
 Info2: <<
 Package: eccodes
-Version: 2.10.0
+Version: 2.12.0
 Revision: 1
-Type: gcc (7)
+Type: gcc (8)
 Description: Coding/encoding ECMWF files, C headers/docs
 Homepage: https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home
 License: BSD
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Source: https://software.ecmwf.int/wiki/download/attachments/45757960/%n-%v-Source.tar.gz
-Source-MD5: c32ba54676b2fa5e1ebd782528185cdd
-Source-Checksum: SHA1(a9c30907fde1631ffddaa445e0e260fa2c4ca6be)
+Source-MD5: a812b5837901526905b020d328d8007c
+Source-Checksum: SHA1(dff83137e95520462118a5cc65b58157d40e736d)
 PatchFile: eccodes.patch
 PatchFile-MD5: 43ec7477a96e37e7a951faae7019622b
 PatchFile-Checksum: SHA1(6d04866b20c96813524a46b3a365844d4866fb1f)
@@ -20,19 +20,18 @@ BuildDependsOnly: true
 BuildDepends: <<
 	cmake,
 	gcc%type_pkg[gcc]-compiler,
-	hdf5.10,
 	libjasper.1,
 	libjpeg9,
 	libopenjp2.7,
 	libpng16,
-	netcdf-c13,
+	netcdf-c15,
 	fink-package-precedence
 <<
 Depends: %N-shlibs
 Conflicts: grib-api
 Replaces: grib-api
 UseMaxBuildJobs: true
-DocFiles: AUTHORS COPYING ChangeLog INSTALL LICENSE NEWS NOTICE README
+DocFiles: AUTHORS COPYING ChangeLog INSTALL LICENSE NEWS NOTICE README.md
 
 CompileScript: <<
 	#!/bin/sh -ev
@@ -63,7 +62,7 @@ CompileScript: <<
 <<
 
 InfoTest: <<
-	TestSource: http://download.ecmwf.org/test-data/grib_api/eccodes_test_data.tar.gz
+	TestSource: http://download.ecmwf.org/test-data/eccodes/eccodes_test_data.tar.gz
 	TestSource-MD5: d5c9ee69f3a699c46f64c84e80d0f5de
 	TestSource-Checksum: SHA1(013a64e57c0cc7a649a8b00df8851c7f36c4c8f8)
 	TestSourceExtractDir: %n-%v-Source/build
@@ -110,16 +109,15 @@ InstallScript: <<
 SplitOff: <<
 	Package: %N-shlibs
 	Depends: <<
-		hdf5.10-shlibs,
 		libjasper.1-shlibs,
 		libjpeg9-shlibs,
 		libopenjp2.7-shlibs,
 		libpng16-shlibs,
-		netcdf-c13-shlibs
+		netcdf-c15-shlibs
 	<<
 	Suggests: %N-bin
 	Files: lib/libeccodes.0.dylib share/eccodes
-	DocFiles: AUTHORS COPYING ChangeLog INSTALL LICENSE NEWS NOTICE README
+	DocFiles: AUTHORS COPYING ChangeLog INSTALL LICENSE NEWS NOTICE README.md
 	Description: Coding/decoding ECMWF files, C library
 	Shlibs: <<
 		%p/lib/libeccodes.0.dylib 0.0.0 %n (>= 2.4.1-1)
@@ -130,15 +128,14 @@ SplitOff2: <<
 	Package: %N-bin
 	Depends: <<
 		%N-shlibs (>= %v-%r),
-		hdf5.10-shlibs,
 		libjasper.1-shlibs,
 		libjpeg9-shlibs,
 		libopenjp2.7-shlibs,
 		libpng16-shlibs,
-		netcdf-c13-shlibs
+		netcdf-c15-shlibs
 	<<
 	Files: bin
-	DocFiles: AUTHORS COPYING ChangeLog INSTALL LICENSE NEWS NOTICE README
+	DocFiles: AUTHORS COPYING ChangeLog INSTALL LICENSE NEWS NOTICE README.md
 	Description: Coding/decoding ECMWF files, user programs
 	Conflicts: grib-api-bin
 	Replaces: grib-api-bin
@@ -151,7 +148,7 @@ SplitOff3: <<
 	Replaces: grib-api-fortran
 	BuildDependsOnly: true
 	Files: include/eccodes.mod include/grib_api.mod lib/pkgconfig/eccodes_f90.pc lib/libeccodes_f90.dylib
-	DocFiles: AUTHORS COPYING ChangeLog INSTALL LICENSE NEWS NOTICE README
+	DocFiles: AUTHORS COPYING ChangeLog INSTALL LICENSE NEWS NOTICE README.md
 	Description: Coding/decoding ECMWF files, Fortran headers
 <<
 
@@ -160,15 +157,14 @@ SplitOff4: <<
 	Depends: <<
 		%N-shlibs (>= %v-%r),
 		gcc%type_pkg[gcc]-shlibs,
-		hdf5.10-shlibs,
 		libjasper.1-shlibs,
 		libjpeg9-shlibs,
 		libopenjp2.7-shlibs,
 		libpng16-shlibs,
-		netcdf-c13-shlibs
+		netcdf-c15-shlibs
 	<<
 	Files: lib/libeccodes_f90.0.dylib
-	DocFiles: AUTHORS COPYING ChangeLog INSTALL LICENSE NEWS NOTICE README
+	DocFiles: AUTHORS COPYING ChangeLog INSTALL LICENSE NEWS NOTICE README.md
 	Description: Coding/decoding ECMWF files, Fortran library
 	Shlibs: <<
 		%p/lib/libeccodes_f90.0.dylib 0.0.0 %n (>= 2.4.1-1)

--- a/10.9-libcxx/stable/main/finkinfo/sci/eccodes.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/eccodes.patch
@@ -1,6 +1,18 @@
-diff -Nurd eccodes-2.6.0-Source.orig/fortran/CMakeLists.txt eccodes-2.6.0-Source/fortran/CMakeLists.txt
---- eccodes-2.6.0-Source.orig/fortran/CMakeLists.txt	2017-12-06 15:12:06.000000000 +0100
-+++ eccodes-2.6.0-Source/fortran/CMakeLists.txt	2017-12-24 14:55:30.384323868 +0100
+diff -Nurd eccodes-2.12.0-Source-orig/cmake/FindNetCDF.cmake eccodes-2.12.0-Source/cmake/FindNetCDF.cmake
+--- eccodes-2.12.0-Source-orig/cmake/FindNetCDF.cmake	2019-02-15 10:44:50.000000000 +0100
++++ eccodes-2.12.0-Source/cmake/FindNetCDF.cmake	2019-03-19 13:27:22.840759666 +0100
+@@ -78,7 +78,7 @@
+ 
+   # Note: Only the HDF5 C-library is required for NetCDF
+   #       ( even for Fortan and CXX bindings)
+-  find_package( HDF5 COMPONENTS C QUIET )
++  # find_package( HDF5 COMPONENTS C QUIET )
+ 
+   ## netcdf4
+ 
+diff -Nurd eccodes-2.12.0-Source-orig/fortran/CMakeLists.txt eccodes-2.12.0-Source/fortran/CMakeLists.txt
+--- eccodes-2.12.0-Source-orig/fortran/CMakeLists.txt	2019-02-15 10:44:55.000000000 +0100
++++ eccodes-2.12.0-Source/fortran/CMakeLists.txt	2019-03-19 13:25:41.226730415 +0100
 @@ -43,6 +43,8 @@
      ecbuild_add_library( TARGET     eccodes_f90
                           SOURCES    grib_fortran.c grib_f90.f90 eccodes_f90.f90 grib_kinds.h
@@ -10,10 +22,10 @@ diff -Nurd eccodes-2.6.0-Source.orig/fortran/CMakeLists.txt eccodes-2.6.0-Source
                           LIBS       eccodes )
      add_custom_command( TARGET     eccodes_f90 POST_BUILD
                          COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/include
-diff -Nurd eccodes-2.6.0-Source.orig/src/CMakeLists.txt eccodes-2.6.0-Source/src/CMakeLists.txt
---- eccodes-2.6.0-Source.orig/src/CMakeLists.txt	2017-12-06 15:12:06.000000000 +0100
-+++ eccodes-2.6.0-Source/src/CMakeLists.txt	2017-12-24 14:55:30.385176268 +0100
-@@ -434,6 +434,8 @@
+diff -Nurd eccodes-2.12.0-Source-orig/src/CMakeLists.txt eccodes-2.12.0-Source/src/CMakeLists.txt
+--- eccodes-2.12.0-Source-orig/src/CMakeLists.txt	2019-02-15 10:44:55.000000000 +0100
++++ eccodes-2.12.0-Source/src/CMakeLists.txt	2019-03-19 13:25:41.229526778 +0100
+@@ -435,6 +435,8 @@
                                # griby.c gribl.c
                               ${grib_api_srcs}
                      GENERATED grib_api_version.c


### PR DESCRIPTION
Updated from version 2.10.0 to 2.12.0. En passant changed dependencies:
gcc7 -> gcc8
netcdf-c13 -> netcdf-c15

Removed dependencies on hdf5: they were not used.

Built and tested with `fink -m build eccodes` on MacOS 10.14.3 with Command Line Tools 10.1