### PR TITLE
nco-4.7.9-1: upstream and dependency update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/nco.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/nco.info
@@ -1,9 +1,8 @@
 Info2:<<
 Package: nco
-Version: 4.7.8
+Version: 4.7.9
 Revision: 1
-Type: v (4.7.8)
-Description: The NetCDF Operators, using netcdf-4
+Description: The NetCDF Operators
 License: GPL3
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
@@ -11,7 +10,7 @@ Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 Depends: <<
 	expat1-shlibs,
 	gsl-shlibs,
-	netcdf-c13-shlibs,
+	netcdf-c15-shlibs,
 	udunits2,
 	udunits2-shlibs
 <<
@@ -21,8 +20,7 @@ BuildDepends: <<
 	fink (>= 0.28-1),
 	fink-package-precedence,
 	gsl,
-	netcdf-bin (>= 4.4.0-1),
-	netcdf-c13,
+	netcdf-c15,
 	texinfo (>> 4.13),
 	udunits2-dev (>= 2.1.22-1)
 <<
@@ -98,8 +96,8 @@ Replaces: <<
 # Unpack Phase:
 Source: https://github.com/nco/nco/archive/%v.tar.gz
 SourceRename: %n-%v.tar.gz
-Source-MD5: 1d352c69bdd806a686e4bea8b584a8b0
-Source-Checksum: SHA1(9e14a2c5f05ead20a04665261c0fc0c0345edfa1)
+Source-MD5: 6ad3febf223f676ca9281c39c48fb9f3
+Source-Checksum: SHA1(a45fb9097078038842b64e3b85f5dd2f1fa2f275)
 
 # Patch Phase:
 PatchScript:  <<
@@ -144,7 +142,7 @@ InstallScript: <<
 	rm -f %i/lib/libnco_c++* %i/lib/libnco*.la %i/lib/libnco.dylib
 <<
 
-Shlibs: !%p/lib/libnco-%type_raw[v].dylib
+Shlibs: !%p/lib/libnco-%v.dylib
 
 PostInstScript: <<
 	printf "******************************************************************************************\n"


### PR DESCRIPTION
Updated from version 4.7.8 to 4.7.9. En passant updated dependencies:
* netcdf-c13 -> netcdf-c15
* removed BuildDepends on netcdf-bin since it is not used.

Built and tested with `fink -m build nco` on MacOS 10.14.3 with Command Line Tools 10.1