### PR TITLE
Updated ncview to use netcdf-c15

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/ncview.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/ncview.info
@@ -1,6 +1,6 @@
 Package: ncview
 Version: 2.1.7
-Revision: 2
+Revision: 3
 Description: Graphical display of NetCDF files
 DescDetail: <<
 Ncview is a visual browser for netCDF format files. Typically you would use 
@@ -11,8 +11,8 @@ look at the actual data values, change color maps, invert the data, etc.
 License: GPL/LGPL
 Maintainer: Povl Abrahamsen <epab@bas.ac.uk>
 Homepage: http://meteora.ucsd.edu/~pierce/ncview_home_page.html
-Depends: x11, udunits2, app-defaults, netcdf-c13-shlibs (>= 4.4.0-1), libpng16-shlibs, expat1-shlibs
-BuildDepends: netcdf-c13 (>= 4.4.0-1), x11-dev, udunits2-dev, libpng16, expat1, fink-buildenv-modules (>= 0.1.3-1)
+Depends: x11, libxt-shlibs, udunits2, app-defaults, netcdf-c15-shlibs (>= 4.6.3-1), libpng16-shlibs, expat1-shlibs
+BuildDepends: netcdf-c15 (>= 4.6.3-1), x11-dev, libxt, udunits2-dev, libpng16, expat1, fink-buildenv-modules (>= 0.1.3-1)
 Source: ftp://cirrus.ucsd.edu/pub/%n/%n-%v.tar.gz
 Source-MD5: debd6ca61410aac3514e53122ab2ba07
 SourceDirectory: %n-%v


### PR DESCRIPTION
This is an updated package for ncview, to use the latest version of the Netcdf libraries. Also, I spotted that when Fink's libxt is installed, the program is linked to these, so I have included them as a dependency.