### PR TITLE
Ugly hack for Xcode 10

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/net/telnet.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/telnet.info
@@ -20,17 +20,30 @@ cp ../../libtelnet-13/LICENSE LICENSE
 <<
 CompileScript: <<
 #!/bin/sh -ev
+xcodevers=`xcodebuild -version 2>/dev/null | head -n 1 | cut -f 2 -d ' ' | cut -f 1 -d.`
+mkdir -p ../finkbuild/%n
+ # Don't use new Xcode build system with Xcode10+
+if [[ $xcodevers -ge 10 ]]; then
+    XCODE_BUILD_FLAG="-UseNewBuildSystem=no"
+    export MACOSX_DEPLOYMENT_TARGET=`xcrun --show-sdk-version`
+fi  
 cd ../../libtelnet-13
-xcodebuild -project libtelnet.xcodeproj -alltargets -configuration Release
+xcodebuild $XCODE_BUILD_FLAG -project libtelnet.xcodeproj -alltargets -configuration Release
 cd ../remote_cmds-%v/telnet.tproj
 # Doesn't build with Fink's make
 # Makefile includes recipes supplied as part of XCode that write and
 # read /tmp/telnet unconditionally and without permission-checking (!)
-/usr/bin/make \
+# Unfortunately, this seems to be fully hardcoded in Xcode 10.
+  /usr/bin/make \
   SRCROOT=../finkbuild/%n/Sources \
   OBJROOT=../finkbuild/%n/Build \
   SYMROOT=../finkbuild/%n/Debug \
   DSTROOT=../finkbuild/%n/Release
+# move build directory for Xcode 10 builds
+if [[ $xcodevers -ge 10 ]]; then
+	/bin/cp -R /tmp/%n/* ../finkbuild/%n/
+	rm -rf /tmp/%n
+fi  
 <<
 InstallScript: <<
 #!/bin/sh -ev
@@ -43,7 +56,7 @@ License: BSD
 Description: Port of NetBSD remote client
 DescDetail: <<
 This package provides the telnet program from Sierra that Apple no longer
-includes on High Sierra.
+includes on High Sierra and later.
 <<
 DescPackaging: <<
 	Move stuff around manually to correspond to Fink standards.

--- a/10.9-libcxx/stable/main/finkinfo/net/telnet.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/telnet.info
@@ -26,6 +26,7 @@ mkdir -p ../finkbuild/%n
 if [[ $xcodevers -ge 10 ]]; then
     XCODE_BUILD_FLAG="-UseNewBuildSystem=no"
     export MACOSX_DEPLOYMENT_TARGET=`xcrun --show-sdk-version`
+    mkdir -p /tmp/%n || exit 2
 fi  
 cd ../../libtelnet-13
 xcodebuild $XCODE_BUILD_FLAG -project libtelnet.xcodeproj -alltargets -configuration Release


### PR DESCRIPTION
Xcode 10 seems no longer to honor the *ROOT variables from the CompileScript and only uses their default values (/tmp/telnet/*).