### PR TITLE
Various updates to NetCDF dependencies

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/gmt.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gmt.info
@@ -1,13 +1,13 @@
 Package: gmt
 Version: 4.5.18
-Revision: 1
+Revision: 2
 Source: ftp://ftp.soest.hawaii.edu/gmt/gmt-%v-src.tar.bz2
 Source2: ftp://ftp.soest.hawaii.edu/gmt/gmt-%v-non-gpl-src.tar.bz2
 Source-MD5: b35cf18fddcf4823dc75b1ea32808d71
 Source2-MD5: fb076a810477f77ef65f84672b2b6ed3
 SourceDirectory: gmt-%v
 
-BuildDepends: fink (>= 0.32), netcdf-c13, gdal2-dev
+BuildDepends: fink (>= 0.32), netcdf-c15, gdal2-dev
 Depends: %n-shlibs (= %v-%r)
 Conflicts: gmt5
 Replaces: gmt5
@@ -33,7 +33,7 @@ SplitOff: <<
 <<
 SplitOff2: <<
   Package: %N-shlibs
-  Depends: netcdf-c13-shlibs, gdal2-shlibs, gshhg (>= 2.3.0)
+  Depends: netcdf-c15-shlibs, gdal2-shlibs, gshhg (>= 2.3.0)
   RuntimeDepends: ghostscript
   Files: lib/*.4.dylib
   Shlibs: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/gmt5.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gmt5.info
@@ -1,6 +1,6 @@
 Package: gmt5
 Version: 5.4.5
-Revision: 1
+Revision: 2
 Source: ftp://ftp.soest.hawaii.edu/gmt/gmt-%v-src.tar.xz
 Source-MD5: 846c7717ca8a6e2c76cc5538331ff59e
 SourceDirectory: gmt-%v
@@ -11,7 +11,7 @@ BuildDepends: <<
   fink (>= 0.32),
   fink-package-precedence,
   cmake,
-  netcdf-c13,
+  netcdf-c15,
   libpcre1,
   libcurl4,
   gdal2-dev,
@@ -67,7 +67,7 @@ SplitOff2: <<
   Package: %N-shlibs
   Files: lib/*.5.*dylib lib/gmt
   Depends: <<
-    netcdf-c13-shlibs,
+    netcdf-c15-shlibs,
     libpcre1-shlibs,
     libcurl4-shlibs,
     gdal2-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/sci/ncview.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/ncview.info
@@ -1,6 +1,6 @@
 Package: ncview
 Version: 2.1.7
-Revision: 2
+Revision: 3
 Description: Graphical display of NetCDF files
 DescDetail: <<
 Ncview is a visual browser for netCDF format files. Typically you would use 
@@ -11,8 +11,8 @@ look at the actual data values, change color maps, invert the data, etc.
 License: GPL/LGPL
 Maintainer: Povl Abrahamsen <epab@bas.ac.uk>
 Homepage: http://meteora.ucsd.edu/~pierce/ncview_home_page.html
-Depends: x11, udunits2, app-defaults, netcdf-c13-shlibs (>= 4.4.0-1), libpng16-shlibs, expat1-shlibs
-BuildDepends: netcdf-c13 (>= 4.4.0-1), x11-dev, udunits2-dev, libpng16, expat1, fink-buildenv-modules (>= 0.1.3-1)
+Depends: x11, udunits2, app-defaults, netcdf-c15-shlibs, libpng16-shlibs, expat1-shlibs
+BuildDepends: netcdf-c15, x11-dev, udunits2-dev, libpng16, expat1, fink-buildenv-modules (>= 0.1.3-1)
 Source: ftp://cirrus.ucsd.edu/pub/%n/%n-%v.tar.gz
 Source-MD5: debd6ca61410aac3514e53122ab2ba07
 SourceDirectory: %n-%v

--- a/10.9-libcxx/stable/main/finkinfo/sci/ncview.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/ncview.info
@@ -9,10 +9,10 @@ can view simple movies of the data, view along various dimensions, take a
 look at the actual data values, change color maps, invert the data, etc. 
 <<
 License: GPL/LGPL
-Maintainer: Povl Abrahamsen <epab@bas.ac.uk>
+Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 Homepage: http://meteora.ucsd.edu/~pierce/ncview_home_page.html
-Depends: x11, udunits2, app-defaults, netcdf-c15-shlibs, libpng16-shlibs, expat1-shlibs
-BuildDepends: netcdf-c15, x11-dev, udunits2-dev, libpng16, expat1, fink-buildenv-modules (>= 0.1.3-1)
+Depends: x11, libxt-shlibs, udunits2, app-defaults, netcdf-c15-shlibs, libpng16-shlibs, expat1-shlibs
+BuildDepends: netcdf-c15, x11-dev, libxt, udunits2-dev, libpng16, expat1, fink-buildenv-modules (>= 0.1.3-1)
 Source: ftp://cirrus.ucsd.edu/pub/%n/%n-%v.tar.gz
 Source-MD5: debd6ca61410aac3514e53122ab2ba07
 SourceDirectory: %n-%v

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-cxx4.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-cxx4.info
@@ -1,6 +1,6 @@
 Package: netcdf-cxx4
 Version: 4.3.0
-Revision: 1
+Revision: 2
 BuildDependsOnly: true
 GCC: 4.0
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
@@ -10,7 +10,7 @@ Depends: <<
 	netcdf-bin (>= 4.3.0-2)
 <<
 BuildDepends: <<
-	netcdf-c13,
+	netcdf-c15,
 	doxygen, 
 	fink-package-precedence, 
  	libcurl4,
@@ -60,7 +60,7 @@ InstallScript: <<
 <<
 SplitOff: <<
   Package: %N-shlibs
-  Depends: netcdf-c13-shlibs
+  Depends: netcdf-c15-shlibs
   Conflicts: netcdf-absoft-shlibs
   Replaces: <<
   		netcdf-absoft-shlibs, 
@@ -106,7 +106,7 @@ DescPort: <<
 CXXFLAGS=-O2 is essential to avoid debugging mode flags (-g).
 <<
 DescUsage: <<
-When building by hand, make sure netcdf-c13 is installed.
+When building by hand, make sure netcdf-c15 is installed.
 <<
 Homepage: http://www.unidata.ucar.edu/software/netcdf/
 License: OSI-Approved


### PR DESCRIPTION
This PR as a replacement for PR #375 and updates the dependencies netcdf-c13 -> netcdf-c15

In the following packages:
ncview
netcdf-cxx4
gmt5
gmt

All are built and tested with fink -m build on MacOS 10.14.3 with Command Line Tools 10.1