### PR TITLE
eccodes-2.12.0-2: Getting rid of searching for HDF5

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: eccodes
 Version: 2.12.0
-Revision: 1
+Revision: 2
 Type: gcc (8)
 Description: Coding/encoding ECMWF files, C headers/docs
 Homepage: https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home
@@ -12,8 +12,8 @@ Source: https://software.ecmwf.int/wiki/download/attachments/45757960/%n-%v-Sour
 Source-MD5: a812b5837901526905b020d328d8007c
 Source-Checksum: SHA1(dff83137e95520462118a5cc65b58157d40e736d)
 PatchFile: eccodes.patch
-PatchFile-MD5: 4fc2a180dcdf2c577ce213884a297fb4
-PatchFile-Checksum: SHA1(f9af183e1998bee05317c2f2e3a2d28a5e1fb51f)
+PatchFile-MD5: f76dca72904390e93bb19c1eeb9c1603
+PatchFile-Checksum: SHA1(916b37cb79a7c6c12a1c81fed1d2f2fcfcc38908)
 
 SourceDirectory: %n-%v-Source
 BuildDependsOnly: true

--- a/10.9-libcxx/stable/main/finkinfo/sci/eccodes.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/eccodes.patch
@@ -1,6 +1,6 @@
 diff -Nurd eccodes-2.12.0-Source-orig/cmake/FindNetCDF.cmake eccodes-2.12.0-Source/cmake/FindNetCDF.cmake
 --- eccodes-2.12.0-Source-orig/cmake/FindNetCDF.cmake	2019-02-15 10:44:50.000000000 +0100
-+++ eccodes-2.12.0-Source/cmake/FindNetCDF.cmake	2019-03-19 13:27:22.840759666 +0100
++++ eccodes-2.12.0-Source/cmake/FindNetCDF.cmake	2019-03-25 15:00:24.069712123 +0100
 @@ -78,7 +78,7 @@
  
    # Note: Only the HDF5 C-library is required for NetCDF
@@ -10,9 +10,32 @@ diff -Nurd eccodes-2.12.0-Source-orig/cmake/FindNetCDF.cmake eccodes-2.12.0-Sour
  
    ## netcdf4
  
+@@ -111,8 +111,8 @@
+ 
+   if( NETCDF_FOUND AND HDF5_FOUND )
+     # list( APPEND NETCDF_DEFINITIONS  ${HDF5_DEFINITIONS} )
+-    list( APPEND NETCDF_LIBRARIES    ${HDF5_HL_LIBRARIES} ${HDF5_LIBRARIES}  )
+-    list( APPEND NETCDF_INCLUDE_DIRS ${HDF5_INCLUDE_DIRS} )
++    # list( APPEND NETCDF_LIBRARIES    ${HDF5_HL_LIBRARIES} ${HDF5_LIBRARIES}  )
++    # list( APPEND NETCDF_INCLUDE_DIRS ${HDF5_INCLUDE_DIRS} )
+   endif()
+ 
+   #ecbuild_debug_var( NETCDF_FOUND )
+diff -Nurd eccodes-2.12.0-Source-orig/cmake/contrib/FindNetCDF4.cmake eccodes-2.12.0-Source/cmake/contrib/FindNetCDF4.cmake
+--- eccodes-2.12.0-Source-orig/cmake/contrib/FindNetCDF4.cmake	2019-02-15 10:44:50.000000000 +0100
++++ eccodes-2.12.0-Source/cmake/contrib/FindNetCDF4.cmake	2019-03-25 15:29:19.264443319 +0100
+@@ -106,7 +106,7 @@
+   set(HAS_HDF5 TRUE)
+   set(HDF5_FIND_QUIETLY ${NETCDF_FIND_QUIETLY})
+   set(HDF5_FIND_REQUIRED ${NETCDF_FIND_REQUIRED})
+-  find_package(HDF5)
++#  find_package(HDF5)
+ #        list( APPEND NETCDF_LIBRARIES_DEBUG
+ #            ${HDF5_LIBRARIES_DEBUG} )
+ #        list( APPEND NETCDF_LIBRARIES_RELEASE
 diff -Nurd eccodes-2.12.0-Source-orig/fortran/CMakeLists.txt eccodes-2.12.0-Source/fortran/CMakeLists.txt
 --- eccodes-2.12.0-Source-orig/fortran/CMakeLists.txt	2019-02-15 10:44:55.000000000 +0100
-+++ eccodes-2.12.0-Source/fortran/CMakeLists.txt	2019-03-19 13:25:41.226730415 +0100
++++ eccodes-2.12.0-Source/fortran/CMakeLists.txt	2019-03-25 14:51:09.309393934 +0100
 @@ -43,6 +43,8 @@
      ecbuild_add_library( TARGET     eccodes_f90
                           SOURCES    grib_fortran.c grib_f90.f90 eccodes_f90.f90 grib_kinds.h
@@ -24,7 +47,7 @@ diff -Nurd eccodes-2.12.0-Source-orig/fortran/CMakeLists.txt eccodes-2.12.0-Sour
                          COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/include
 diff -Nurd eccodes-2.12.0-Source-orig/src/CMakeLists.txt eccodes-2.12.0-Source/src/CMakeLists.txt
 --- eccodes-2.12.0-Source-orig/src/CMakeLists.txt	2019-02-15 10:44:55.000000000 +0100
-+++ eccodes-2.12.0-Source/src/CMakeLists.txt	2019-03-19 13:25:41.229526778 +0100
++++ eccodes-2.12.0-Source/src/CMakeLists.txt	2019-03-25 14:51:09.310495327 +0100
 @@ -435,6 +435,8 @@
                                # griby.c gribl.c
                               ${grib_api_srcs}


### PR DESCRIPTION
Despite eccodes not using HDF5, its CMake system tries to find it in two places. One place was already commented out, the second was missed and is added in this patch.
This should allow building eccodes without unnecessary dependencies, irrespective of whether HDF5 is already installed.

See e-mail "phase compiling: eccodes-2.12.0-1 failed" to fink-beginners@lists.sourceforge.net and comment by @dhomeier in PR #373 

Built and tested on MacOS 10.14.3 with Command Line Tools 10.1