### PR TITLE
Updated dependencies gcc7 -> gcc8

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/openmpi.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/openmpi.info
@@ -1,12 +1,12 @@
 Info2: <<
 Package: openmpi
 Version: 1.10.7
-Revision: 2
+Revision: 3
 GCC: 4.0
 Description: MPI implementation for parallel computing
 License: BSD
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
-Type: gcc (7)
+Type: gcc (8)
 Depends: <<
 	%N-shlibs (= %v-%r),
 	gcc%type_raw[gcc]-compiler,

--- a/10.9-libcxx/stable/main/finkinfo/sci/fftw3.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/fftw3.info
@@ -1,10 +1,10 @@
 Info2: <<
 Package: fftw3
 Version: 3.3.8
-Revision: 1
+Revision: 2
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
-Type: gcc (7)
+Type: gcc (8)
 
 Source:  ftp://ftp.fftw.org/pub/fftw/fftw-%v.tar.gz
 Source-MD5: 8aac833c943d8e90d51b697b27d4384d

--- a/10.9-libcxx/stable/main/finkinfo/sci/pgplot.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/pgplot.info
@@ -1,12 +1,9 @@
 Info2: <<
 Package: pgplot
 Version: 5.2.2
+Revision: 15
 
-# note: writes X11 path in a .deb file, so need separate %r if
-# supporting platforms with other locations
-Revision: 14
-
-Type: gcc (7)
+Type: gcc (8)
 Description: Fortran- or C-callable scientific graphics
 Homepage: http://www.astro.caltech.edu/~tjp/pgplot/
 License: OSI-Approved
@@ -15,7 +12,7 @@ Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 Source: ftp://ftp.astro.caltech.edu/pub/pgplot/%n522.tar.gz
 Source-MD5: e8a6e8d0d5ef9d1709dfb567724525ae
 PatchFile: %n.patch
-PatchFile-MD5: 23fa4b644ff300a6db91067f09bb6aa3
+PatchFile-MD5: af5f9086cfd4851855a17a861711c911
 
 SourceDirectory: %n
 BuildDependsOnly: false
@@ -57,6 +54,8 @@ DescPort: <<
  Builds only static libs.
  "BuildDependsOnly: false" because grfont.dat is also needed for execution;
  same with the two profile.d files provided.
+ Writes X11 path in a .deb file, so need separate %r if
+ supporting platforms with other locations
 <<
 DescUsage: <<
  PGPLOT_DIR environment variable set by pgplot.csh(.sh) in

--- a/10.9-libcxx/stable/main/finkinfo/sci/pgplot.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/pgplot.info
@@ -26,7 +26,7 @@ mkdir sys_macosx
 cp %p/share/aquaterm/adapters/%N/g77_gcc_AQT.conf sys_macosx
 cp %p/share/aquaterm/adapters/%N/aqdriv.m drivers
 sed "s|<PREFIX>|%p|g; s|<X11_BASE_DIR>|$X11_BASE_DIR|g" < %{PatchFile} | patch -p1
-perl -pi -e 's|g77|gfortran-fsf-%type_raw[gcc]|g' sys_macosx/g77_gcc_AQT.conf  
+perl -pi -e 's|g77|gfortran-fsf-%type_raw[gcc]|g; s|(CCOMPL=.)(gcc)|${1}gcc-fsf-%type_raw[gcc]|' sys_macosx/g77_gcc_AQT.conf  
 perl -pi -e 's|AquaTerm|aquaterm|g' drivers/aqdriv.m
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/pgplot.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/pgplot.patch
@@ -88,7 +88,7 @@ diff -Nurd -x'*~' pgplot/makemake pgplot-new/makemake
  grtv00.o : $(DRVDIR)/imdef.h
  pgxwin.o : $(DRVDIR)/pgxwin.h
 -pndriv.o : ./png.h ./pngconf.h ./zlib.h ./zconf.h
-+pndriv.o : <PREFIX>/include/png.h <PREFIX>/include/pngconf.h /usr/include/zlib.h /usr/include/zconf.h
++pndriv.o : <PREFIX>/include/png.h <PREFIX>/include/pngconf.h
  
  x2driv.o figdisp_comm.o: $(DRVDIR)/commands.h
  

--- a/10.9-libcxx/stable/main/finkinfo/sci/wip.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/wip.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: wip
 Version: 2p3
-Revision: 2008
-Type: gcc (7)
+Revision: 2009
+Type: gcc (8)
 Description: Interactive graphics software package
 License: OSI-Approved
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>


### PR DESCRIPTION
This updates four of the sci packages to use gcc8 instead of gcc7, i.e.:
fftw3
openmpi
pgplot
wip

pgplot also was patched to work with MacOS 10.14 (where there is no /usr/include).
Otherwise, it is a revision bump and replacement of `Type: gcc (7)` by `Type: gcc (8)` for all four packages.

Built and tested on MacOS 10.14.3 with Command Line Tools 10.1