### PR TITLE
cdo-1.9.6-1: upstream and dependency update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: cdo%type_pkg[-openmp]
 Version: 1.9.5
-Revision: 1
+Revision: 2
 Description: Climate Data Operators
 HomePage: https://code.zmaw.de/projects/cdo
 License: GPL
@@ -11,18 +11,16 @@ Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 # Prerequisites
 BuildDepends: <<
-	hdf5.10,
-	hdf5-cpp11,
-	netcdf-c13,
+	hdf5.100.v1.10 (>= 1.10.0-4),
+	netcdf-c15,
 	(%type_raw[-openmp] = -openmp) gcc%type_pkg[gcc]-compiler,
 	szip,
 	eccodes,
 	fink-package-precedence
 <<
 Depends: <<
-	hdf5.10-shlibs,
-	hdf5-cpp11-shlibs,
-	netcdf-c13-shlibs,
+	hdf5.100.v1.10-shlibs,
+	netcdf-c15-shlibs,
 	(%type_raw[-openmp] = -openmp) gcc%type_pkg[gcc]-shlibs,
 	szip-shlibs,
 	eccodes-shlibs
@@ -42,7 +40,7 @@ PatchFile-Checksum: SHA1(ad2e5a212fb976e9d8b193327c398746e4233374)
 NoSetLDFLAGS: true
 ConfigureParams: <<
 	--with-netcdf=%p \
-	--with-hdf5=%p \
+	--with-hdf5=%p/opt/hdf5.v1.10 \
 	--with-szlib=%p \
 	--with-grib-api=no \
 	--with-eccodes=%p \

--- a/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: cdo%type_pkg[-openmp]
-Version: 1.9.5
-Revision: 3
+Version: 1.9.6
+Revision: 1
 Description: Climate Data Operators
 HomePage: https://code.zmaw.de/projects/cdo
 License: GPL
@@ -29,12 +29,12 @@ Conflicts: %{Ni}, %{Ni}-openmp
 Replaces: %{Ni}, %{Ni}-openmp
 
 # Unpack Phase:
-Source: https://code.mpimet.mpg.de/attachments/download/18264/%{Ni}-%v.tar.gz
-Source-MD5: 0c60f2c94dc5c76421ecf363153a5043
-Source-Checksum: SHA1(68f545e79b000037d00c4151fd2a0ac9f314a9d8)
+Source: https://code.mpimet.mpg.de/attachments/download/19299/%{Ni}-%v.tar.gz
+Source-MD5: 322f56c5e13f525c585ee5318d4435db
+Source-Checksum: SHA1(1c694f87756bebe9cadc91f457d3a303c3f9767d)
 PatchFile: %{Ni}.patch
-PatchFile-MD5: c64f67a48883677eec092b205d7e1c9a
-PatchFile-Checksum: SHA1(ad2e5a212fb976e9d8b193327c398746e4233374)
+PatchFile-MD5: ad655e198b8c9b047aae19b3c6a4720e
+PatchFile-Checksum: SHA1(9704b82d6ef825bf9624755bce1ffd1630990b4c)
 
 # Compile Phase:
 NoSetLDFLAGS: true
@@ -88,6 +88,5 @@ Use cdo-openmp to include parallelization.
 DescPort: <<
 - test needs make -j1, otherwise some tests will fail.
 - disabled tsformat.test with nc4 since it miraculously fails.
-- patch for Gradsdes.cc as otherwise Gradsdes.test fails.
 <<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
@@ -1,11 +1,11 @@
 Info2: <<
 Package: cdo%type_pkg[-openmp]
 Version: 1.9.5
-Revision: 2
+Revision: 3
 Description: Climate Data Operators
 HomePage: https://code.zmaw.de/projects/cdo
 License: GPL
-Type: gcc (7), -openmp (. -openmp)
+Type: gcc (8), -openmp (. -openmp)
 
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/cdo.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cdo.patch
@@ -9,24 +9,3 @@ diff -Nurd cdo-1.9.5-orig/test/tsformat.test.in cdo-1.9.5/test/tsformat.test.in
  }
  #
  function testfunc()
-diff -Nurd cdo-1.9.5-orig/src/Gradsdes.cc cdo-1.9.5/src/Gradsdes.cc
---- cdo-1.9.5-orig/src/Gradsdes.cc	2018-08-06 14:03:46.000000000 +0200
-+++ cdo-1.9.5/src/Gradsdes.cc	2018-09-04 10:13:24.471952112 +0200
-@@ -975,7 +975,7 @@
- 
-   int operatorID = cdoOperatorID();
- 
--  const char *datfile = cdoGetStreamName(0).c_str();
-+  char *datfile = strdup(cdoGetStreamName(0).c_str());
-   size_t len = strlen(datfile);
-   char *ctlfile = (char *) Malloc(len + 10);
-   strcpy(ctlfile, datfile);
-@@ -1127,7 +1127,7 @@
-     {
-       datfile = strrchr(datfile, '/');
-       if (datfile == 0)
--        datfile = cdoGetStreamName(0).c_str();
-+        datfile = strdup(cdoGetStreamName(0).c_str());
-       else
-         datfile++;
-       fprintf(gdp, "DSET  ^%s\n", datfile);


### PR DESCRIPTION
This updates `cdo` to version 1.9.6 and updates the following dependencies:
gcc7 -> gcc8
netcdf-c13 -> netcdf-c15
hdf5.10 -> hdf5.100.v1.10

Built and tested (both `cdo` and `cdo-openmp` on MacOS 10.14.4 with Command Line Tools 10.2

This replaces closed PR #357 