### PR TITLE
Scipy update to 1.2.1 and Python 3.7 built against new OpenBLAS package

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
@@ -1,0 +1,94 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+Package: openblas
+Version: 0.3.5
+Revision: 1
+Type: gcc (8)
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+
+BuildDependsOnly: true
+BuildDepends: fink (>= 0.30.0), gcc%type_raw[gcc]-compiler
+Conflicts: atlas
+
+Source: https://github.com/xianyi/OpenBLAS/archive/v0.3.5.tar.gz
+Source-MD5: 579bda57f68ea6e9074bf5780e8620bb
+SourceRename: OpenBLAS-%v.tar.gz
+PatchFile: %n.patch
+PatchFile-MD5: ceb1e323762c1dc7ff1896787ef9140b
+
+PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
+
+SetCC: gcc-%type_raw[gcc]
+
+CompileScript: make FC=gfortran-fsf-%type_raw[gcc] COMMON_OPT='-O2 -msse -mtune=intel' NO_AVX2=1 USE_THREAD=1 libs netlib re_lapack shared
+
+InstallScript: <<
+	make FC=gfortran-fsf-%type_raw[gcc] COMMON_OPT='-O2 -msse -mtune=intel' NO_AVX2=1 USE_THREAD=1 PREFIX=%i install
+	install_name_tool -id %p/lib/libopenblas-r%v.dylib %i/lib/libopenblas-r%v.dylib
+	perl -pi -e 's|%i|%p|;' %i/lib/pkgconfig/openblas.pc %i/lib/cmake/openblas/OpenBLASConfig.cmake
+<<
+
+InfoTest: <<
+	TestScript: <<
+		#!/bin/sh -ev
+		make FC=gfortran-fsf-%type_raw[gcc] COMMON_OPT='-O2 -msse -mtune=intel' NO_AVX2=1 USE_THREAD=1 tests | tee tests.log
+		grep -i fail tests.log
+		grep -c PASSED tests.log
+		cd benchmark
+		make FC=gfortran-fsf-%type_raw[gcc] COMMON_OPT='-O2 -msse -mtune=intel' NO_AVX2=1 USE_THREAD=1 veclib goto # atlas
+		# this creates a ton of *.veclib, *.goto, *.atlas executables to be compared in performance...
+	<<
+<<
+
+Splitoff: <<
+	Package: %N-shlibs
+	Depends: gcc%type_raw[gcc]-shlibs
+	DocFiles: LICENSE USAGE.md
+	Files: lib/libopenblas-r%v.dylib
+	Shlibs: %p/lib/libopenblas-r%v.dylib 0.0.0 %v (>= 0.3.5-1)
+<<
+
+DocFiles: LICENSE README.md USAGE.md Changelog.txt CONTRIBUTORS.md BACKERS.md GotoBLAS_0*.txt benchmark/scripts
+License: BSD
+Homepage: https://www.openblas.net
+
+Description: Optimized BLAS library based on GotoBLAS2
+DescDetail: <<
+BLAS stands for Basic Linear Algebra Subprograms. BLAS provides standard
+interfaces for linear algebra, including BLAS1 (vector-vector operations),
+BLAS2 (matrix-vector operations), and BLAS3 (matrix-matrix operations).
+In general, BLAS is the computational kernel ("the bottom of the food chain")
+in linear algebra or scientific applications. Thus, if BLAS implementation is
+highly optimized, the whole application can get substantial benefit.
+
+As BLAS is a standardized interface, you can refer to the documentation of its
+reference implementation at netlib.org. Calls from C go through its CBLAS
+interface, so your code will need to include the provided cblas.h in addition
+to linking with -lopenblas.
+A single-precision matrix multiplication will look like
+
+#include <cblas.h>
+...
+cblas_sgemm(CblasRowMajor, CblasNoTrans,
+            CblasNoTrans, M, N, K, 1.0, A, K, B, N, 0.0, result, N);
+
+where M,N,K are the dimensions of your data.
+
+OpenBLAS is an open source BLAS library forked from GotoBLAS2-1.13 BSD version.
+Since Mr. Kazushige Goto left TACC, GotoBLAS is no longer being maintained.
+Thus this project was created to continue developing OpenBLAS/GotoBLAS.
+<<
+DescPackaging: <<
+Setup with architecture-independent version and some patches from MacPorts
+https://github.com/macports/macports-ports/blob/master/math/OpenBLAS/Portfile
+Build with FSF gcc8 to ensure optimum compatibility with gfortran.
+cblas.h conflicts with header from atlas.
+TestScript also builds executables in benchmark/, but currently does not run
+them (producing ~200 lines of timing output each); benchmark scripts are
+added to docs.
+Optimisation flags chosen to create binary packages that should work on
+anything from Pentium with SSE upwards, with tuning up to Haswell & Silvermont
+CPUs with AVX2 (most recent supported by gcc8).
+<<
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
@@ -1,41 +1,42 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: openblas
-Version: 0.3.5
+Version: 0.3.6
 Revision: 1
 Type: gcc (8)
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
 
 BuildDependsOnly: true
 BuildDepends: fink (>= 0.30.0), gcc%type_raw[gcc]-compiler
-Conflicts: atlas
+Depends: %N-shlibs (= %v-%r)
 
-Source: https://github.com/xianyi/OpenBLAS/archive/v0.3.5.tar.gz
-Source-MD5: 579bda57f68ea6e9074bf5780e8620bb
+Source: https://github.com/xianyi/OpenBLAS/archive/v%v.tar.gz
+Source-MD5: 8a110a25b819a4b94e8a9580702b6495
 SourceRename: OpenBLAS-%v.tar.gz
 PatchFile: %n.patch
-PatchFile-MD5: ceb1e323762c1dc7ff1896787ef9140b
+PatchFile-MD5: f60b9d7d957d04a772814eb61a4d6762
 
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 
-SetCC: gcc-%type_raw[gcc]
+SetCC: gcc-fsf-%type_raw[gcc]
 
-CompileScript: make FC=gfortran-fsf-%type_raw[gcc] COMMON_OPT='-O2 -msse -mtune=intel' NO_AVX2=1 USE_THREAD=1 libs netlib re_lapack shared
+CompileScript: make FC=gfortran-fsf-%type_raw[gcc] COMMON_OPT='-O2 -mtune=intel' USE_THREAD=1 libs netlib re_lapack shared
 
 InstallScript: <<
-	make FC=gfortran-fsf-%type_raw[gcc] COMMON_OPT='-O2 -msse -mtune=intel' NO_AVX2=1 USE_THREAD=1 PREFIX=%i install
-	install_name_tool -id %p/lib/libopenblas-r%v.dylib %i/lib/libopenblas-r%v.dylib
+	make FC=gfortran-fsf-%type_raw[gcc] COMMON_OPT='-O2 -mtune=intel' USE_THREAD=1 PREFIX=%i install
+	install_name_tool -id %p/lib/libopenblas.0.dylib %i/lib/libopenblas.0.dylib
+	mv %i/include/cblas.h %i/include/cblas_openblas.h
 	perl -pi -e 's|%i|%p|;' %i/lib/pkgconfig/openblas.pc %i/lib/cmake/openblas/OpenBLASConfig.cmake
 <<
 
 InfoTest: <<
 	TestScript: <<
 		#!/bin/sh -ev
-		make FC=gfortran-fsf-%type_raw[gcc] COMMON_OPT='-O2 -msse -mtune=intel' NO_AVX2=1 USE_THREAD=1 tests | tee tests.log
+		make FC=gfortran-fsf-%type_raw[gcc] COMMON_OPT='-O2 -mtune=intel' USE_THREAD=1 tests | tee tests.log
 		grep -i fail tests.log
 		grep -c PASSED tests.log
 		cd benchmark
-		make FC=gfortran-fsf-%type_raw[gcc] COMMON_OPT='-O2 -msse -mtune=intel' NO_AVX2=1 USE_THREAD=1 veclib goto # atlas
+		make FC=gfortran-fsf-%type_raw[gcc] COMMON_OPT='-O2 -mtune=intel' USE_THREAD=1 veclib goto # atlas
 		# this creates a ton of *.veclib, *.goto, *.atlas executables to be compared in performance...
 	<<
 <<
@@ -44,8 +45,8 @@ Splitoff: <<
 	Package: %N-shlibs
 	Depends: gcc%type_raw[gcc]-shlibs
 	DocFiles: LICENSE USAGE.md
-	Files: lib/libopenblas-r%v.dylib
-	Shlibs: %p/lib/libopenblas-r%v.dylib 0.0.0 %v (>= 0.3.5-1)
+	Files: lib/libopenblas.0.dylib
+	Shlibs: %p/lib/libopenblas.0.dylib 0.0.0 %v (>= 0.3.5-1)
 <<
 
 DocFiles: LICENSE README.md USAGE.md Changelog.txt CONTRIBUTORS.md BACKERS.md GotoBLAS_0*.txt benchmark/scripts

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
@@ -20,7 +20,7 @@ PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 
 SetCC: gcc-fsf-%type_raw[gcc]
 
-CompileScript: make FC=gfortran-fsf-%type_raw[gcc] COMMON_OPT='-O2 -mtune=intel' USE_THREAD=1 libs netlib re_lapack shared
+CompileScript: make FC=gfortran-fsf-%type_raw[gcc] COMMON_OPT='-O2 -mtune=intel' USE_THREAD=1 libs netlib shared
 
 InstallScript: <<
 	make FC=gfortran-fsf-%type_raw[gcc] COMMON_OPT='-O2 -mtune=intel' USE_THREAD=1 PREFIX=%i install

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
@@ -1,0 +1,68 @@
+diff -uNr a/Makefile.system b/Makefile.system
+--- a/Makefile.system	2018-12-31 23:09:59.000000000 +0100
++++ b/Makefile.system	2019-03-25 17:07:52.000000000 +0100
+@@ -1206,11 +1206,11 @@
+ 
+ ifneq ($(DYNAMIC_ARCH), 1)
+ ifndef SMP
+-LIBNAME		= $(LIBPREFIX)_$(LIBCORE)$(REVISION).$(LIBSUFFIX)
+-LIBNAME_P	= $(LIBPREFIX)_$(LIBCORE)$(REVISION)_p.$(LIBSUFFIX)
++LIBNAME		= $(LIBPREFIX)$(REVISION).$(LIBSUFFIX)
++LIBNAME_P	= $(LIBPREFIX)$(REVISION)_p.$(LIBSUFFIX)
+ else
+-LIBNAME		= $(LIBPREFIX)_$(LIBCORE)p$(REVISION).$(LIBSUFFIX)
+-LIBNAME_P	= $(LIBPREFIX)_$(LIBCORE)p$(REVISION)_p.$(LIBSUFFIX)
++LIBNAME		= $(LIBPREFIX)$(REVISION).$(LIBSUFFIX)
++LIBNAME_P	= $(LIBPREFIX)$(REVISION)_p.$(LIBSUFFIX)
+ endif
+ else
+ ifndef SMP
+diff -uNr a/benchmark/Makefile b/benchmark/Makefile
+--- a/benchmark/Makefile   2018-12-31 23:09:59.000000000 +0100
++++ b/benchmark/Makefile   2019-03-26 01:39:37.000000000 +0100
+@@ -19,7 +19,8 @@
+ #LIBATLAS = -fopenmp $(ATLAS)/liblapack_atlas.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
+ 
+ # Atlas RHEL and Fedora
+-ATLAS=/usr/lib64/atlas
++# Atlas MacOS X Fink
++ATLAS=@PREFIX@
+ LIBATLAS = -fopenmp $(ATLAS)/liblapack.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
+ 
+ # Intel standard
+diff -uNr a/ctest.c b/ctest.c
+--- a/ctest.c     2019-03-06 19:25:30.000000000 -0800
++++ b/ctest.c     2019-03-06 19:26:06.000000000 -0800
+@@ -113,7 +113,7 @@
+ ARCH_X86_64
+ #endif
+ 
+-#if defined(__powerpc___) || defined(__PPC__) || defined(_POWER)
++#if defined(__powerpc___) || defined(__PPC__) || defined(_POWER) || defined(__POWERPC__)
+ ARCH_POWER
+ #endif
+ 
+diff -uNr common_power.h common_power.h
+--- a/common_power.h	2018-12-31 23:09:59.000000000 +0100
++++ b/common_power.h	2019-03-26 03:04:44.000000000 +0100
+@@ -241,7 +241,7 @@
+ #define HAVE_PREFETCH
+ #endif
+ 
+-#if defined(POWER3) || defined(POWER6) || defined(PPCG4) || defined(CELL) || defined(POWER8)
++#if defined(POWER3) || defined(POWER6) || defined(PPCG4) || defined(CELL) || defined(POWER8) || ( defined(PPC970) && defined(OS_DARWIN) )
+ #define DCBT_ARG	0
+ #else
+ #define DCBT_ARG	8
+diff -uNr param.h param.h
+--- a/param.h     2019-03-06 19:25:33.000000000 -0800
++++ b/param.h     2019-03-06 19:26:06.000000000 -0800
+@@ -1999,7 +1999,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #define ZGEMM_DEFAULT_UNROLL_M 2
+ #define ZGEMM_DEFAULT_UNROLL_N 2
+ 
+-#ifdef OS_LINUX
++#if defined(OS_LINUX) || defined(OS_DARWIN)
+ #if L2_SIZE == 1024976
+ #define SGEMM_DEFAULT_P 320
+ #define DGEMM_DEFAULT_P 256

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
@@ -1,25 +1,35 @@
 diff -uNr a/Makefile.system b/Makefile.system
---- a/Makefile.system	2018-12-31 23:09:59.000000000 +0100
-+++ b/Makefile.system	2019-03-25 17:07:52.000000000 +0100
-@@ -1206,11 +1206,11 @@
- 
+--- a/Makefile.system	2019-04-29 19:21:59.000000000 +0200
++++ b/Makefile.system	2019-05-03 02:07:52.000000000 +0200
+@@ -1146,8 +1146,8 @@
+ endif
+
+
+-REVISION = -r$(VERSION)
+ MAJOR_VERSION = $(word 1,$(subst ., ,$(VERSION)))
++REVISION = .$(MAJOR_VERSION)
+
+ ifeq ($(DEBUG), 1)
+ COMMON_OPT += -g
+@@ -1217,11 +1217,11 @@
+
  ifneq ($(DYNAMIC_ARCH), 1)
  ifndef SMP
 -LIBNAME		= $(LIBPREFIX)_$(LIBCORE)$(REVISION).$(LIBSUFFIX)
 -LIBNAME_P	= $(LIBPREFIX)_$(LIBCORE)$(REVISION)_p.$(LIBSUFFIX)
 +LIBNAME		= $(LIBPREFIX)$(REVISION).$(LIBSUFFIX)
-+LIBNAME_P	= $(LIBPREFIX)$(REVISION)_p.$(LIBSUFFIX)
++LIBNAME_P	= $(LIBPREFIX)_p$(REVISION).$(LIBSUFFIX)
  else
 -LIBNAME		= $(LIBPREFIX)_$(LIBCORE)p$(REVISION).$(LIBSUFFIX)
 -LIBNAME_P	= $(LIBPREFIX)_$(LIBCORE)p$(REVISION)_p.$(LIBSUFFIX)
 +LIBNAME		= $(LIBPREFIX)$(REVISION).$(LIBSUFFIX)
-+LIBNAME_P	= $(LIBPREFIX)$(REVISION)_p.$(LIBSUFFIX)
++LIBNAME_P	= $(LIBPREFIX)_p$(REVISION).$(LIBSUFFIX)
  endif
  else
  ifndef SMP
 diff -uNr a/benchmark/Makefile b/benchmark/Makefile
---- a/benchmark/Makefile   2018-12-31 23:09:59.000000000 +0100
-+++ b/benchmark/Makefile   2019-03-26 01:39:37.000000000 +0100
+--- a/benchmark/Makefile   2019-04-29 19:21:59.000000000 +0200
++++ b/benchmark/Makefile   2019-05-03 02:08:58.000000000 +0200
 @@ -19,7 +19,8 @@
  #LIBATLAS = -fopenmp $(ATLAS)/liblapack_atlas.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
  
@@ -30,39 +40,3 @@ diff -uNr a/benchmark/Makefile b/benchmark/Makefile
  LIBATLAS = -fopenmp $(ATLAS)/liblapack.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
  
  # Intel standard
-diff -uNr a/ctest.c b/ctest.c
---- a/ctest.c     2019-03-06 19:25:30.000000000 -0800
-+++ b/ctest.c     2019-03-06 19:26:06.000000000 -0800
-@@ -113,7 +113,7 @@
- ARCH_X86_64
- #endif
- 
--#if defined(__powerpc___) || defined(__PPC__) || defined(_POWER)
-+#if defined(__powerpc___) || defined(__PPC__) || defined(_POWER) || defined(__POWERPC__)
- ARCH_POWER
- #endif
- 
-diff -uNr common_power.h common_power.h
---- a/common_power.h	2018-12-31 23:09:59.000000000 +0100
-+++ b/common_power.h	2019-03-26 03:04:44.000000000 +0100
-@@ -241,7 +241,7 @@
- #define HAVE_PREFETCH
- #endif
- 
--#if defined(POWER3) || defined(POWER6) || defined(PPCG4) || defined(CELL) || defined(POWER8)
-+#if defined(POWER3) || defined(POWER6) || defined(PPCG4) || defined(CELL) || defined(POWER8) || ( defined(PPC970) && defined(OS_DARWIN) )
- #define DCBT_ARG	0
- #else
- #define DCBT_ARG	8
-diff -uNr param.h param.h
---- a/param.h     2019-03-06 19:25:33.000000000 -0800
-+++ b/param.h     2019-03-06 19:26:06.000000000 -0800
-@@ -1999,7 +1999,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- #define ZGEMM_DEFAULT_UNROLL_M 2
- #define ZGEMM_DEFAULT_UNROLL_N 2
- 
--#ifdef OS_LINUX
-+#if defined(OS_LINUX) || defined(OS_DARWIN)
- #if L2_SIZE == 1024976
- #define SGEMM_DEFAULT_P 320
- #define DGEMM_DEFAULT_P 256

--- a/10.9-libcxx/stable/main/finkinfo/sci/scipy-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/scipy-py.info
@@ -1,12 +1,13 @@
 Info2: <<
 Package: scipy-py%type_pkg[python]
-Version: 1.0.0
+Version: 1.2.1
 Epoch: 1
 Revision: 1
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Type: python (2.7 3.4 3.5 3.6), gcc (6)
+Type: python (2.7 3.4 3.5 3.6 3.7), gcc (8)
 Depends: <<
 	cython-py%type_pkg[python],
+	openblas-shlibs,
 	gcc%type_raw[gcc]-shlibs,
 	numpy-py%type_pkg[python] (>= 1.13.3-1),
 	python%type_pkg[python],
@@ -14,6 +15,7 @@ Depends: <<
 <<
 BuildDepends: <<
 	fink (>= 0.32.0),
+	openblas,
 	gcc%type_raw[gcc]-compiler,
 	setuptools-tng-py%type_pkg[python],
 	suitesparse (>= 4.0.2-2),
@@ -23,8 +25,9 @@ BuildConflicts: <<
 	atlas
 <<
 #Source: mirror:sourceforge:scipy/scipy-%v.tar.gz
-Source: http://github.com/scipy/scipy/releases/download/v%v/scipy-%v.tar.xz
-Source-MD5: b07961a465964ef3afaf30a91a96d91a
+#Source: http://github.com/scipy/scipy/releases/download/v%v/scipy-%v.tar.xz
+Source: https://files.pythonhosted.org/packages/source/s/scipy/scipy-%v.tar.gz
+Source-Checksum: SHA256(e085d1babcb419bbe58e2e805ac61924dac4ca45a07c9fa081144739e500aa3c)
 PatchScript: <<
 #!/bin/bash -ev
   cat <<EOF > site.cfg
@@ -37,43 +40,44 @@ amd_libs = amd
 library_dirs = %p/lib
 include_dirs = %p/include/suitesparse
 umfpack_libs = umfpack
+
+[openblas]
+libraries = openblas
+library_dirs = %p/lib
+include_dirs = %p/include
+runtime_library_dirs = %p/lib
 EOF
 <<
 NoSetLDFLAGS: true
 CompileScript: <<
 #!/bin/sh -ev
- darwin_vers=`uname -r | cut -d. -f1`
- if [ "$darwin_vers" -ge 11 ]; then
-   export CC=clang
-   export CXX=clang++
-   export FFLAGS=-ff2c
- else
-   export CC=%p/bin/gcc-fsf-%type_raw[gcc]
-   export CXX=%p/bin/g++-fsf-%type_raw[gcc]
- fi
+ export CC=%p/bin/gcc-fsf-%type_raw[gcc]
+ export CXX=%p/bin/g++-fsf-%type_raw[gcc]
  export FC=%p/lib/gcc%type_raw[gcc]/bin/gfortran
  export PATH="%p/lib/gcc%type_raw[gcc]/bin:$PATH"
  export SHELL=/bin/sh
 
- if [ %type_pkg[python] -eq 26 ] ; then
- 	 export LDSHARED="$CC -bundle -L%p/lib/python%type_raw[python]/config -lpython%type_raw[python]"
- fi
-
 # unset LDFLAGS
- ATLAS=None LAPACK=/usr/lib BLAS=/usr/lib %p/bin/python%type_raw[python] setup.py build --fcompiler gnu95
+ ATLAS=None %p/bin/python%type_raw[python] setup.py build --fcompiler gnu95
 <<
 InstallScript: <<
 #!/bin/bash -ev
- ATLAS=None LAPACK=/usr/lib BLAS=/usr/lib %p/bin/python%type_raw[python] setup.py install --root %d
+ ATLAS=None %p/bin/python%type_raw[python] setup.py install --root %d
 
  if [ -f %b/INSTALL_MAKE_CHECK ]; then
    mkdir test
    cd test
-   PYTHONPATH=%i/lib/python%type_raw[python]/site-packages %p/bin/python%type_raw[python] -B -c "import scipy, sys; e=scipy.test(); sys.exit(1-e)"
+   export PYTHONPATH=%i/lib/python%type_raw[python]/site-packages
+   if [ %type_pkg[python] -ge 36 ]; then
+     %p/bin/python%type_raw[python] -B -c "import scipy, sys; e=scipy.test(extra_argv=['-k not test_hrectangular and not test_medium1 and not test_maxiter_worsening']); sys.exit(1-e)" || exit 2
+   else
+     %p/bin/python%type_raw[python] -B -c "import scipy, sys; e=scipy.test(extra_argv=['-k not test_hrectangular and not test_medium1 and not test_maxiter_worsening and not test_ldl_type_size_combinations']); sys.exit(1-e)" || exit 2
+   fi
  fi
 <<
 InfoTest: <<
 TestDepends: pytest-py%type_pkg[python] (>= 3.2.3)
+TestConflicts: pytest-relaxed-py%type_pkg[python]
 TestScript: touch %b/INSTALL_MAKE_CHECK
 <<
 DocFiles: INSTALL.rst.txt LICENSE.txt
@@ -103,10 +107,18 @@ http://thread.gmane.org/gmane.os.macosx.fink.user/28476
 
 Originally packaged by Jeffrey Whitaker.
 
-Build against gcc-6/g++-6/gfortran for darwin10 and earlier. Use
-clang/clang++/gfortran with -ff2c on darwin11 and later. Note that
-the Accelerate framework has single precision rounding issues starting
-with darwin11. All tests passing under darwin14/15.
+Previously built against gcc-6/g++-6/gfortran for darwin10 and earlier,
+against clang/clang++/gfortran with -ff2c on darwin11 and later. Note that
+the Accelerate framework has single precision rounding issues starting with
+darwin11, and its LAPACK interface is no longer supported as of Scipy 1.2.0.
+Linking now to OpenBLAS 0.3.5 and building with gcc8 for all Distributions
+to ensure optimal consistency with gfortran and the OpenBLAS build.
+4 failures 'ValueError: illegal value in 4-th argument of internal lu.getrf'
+in linalg.test_decomp and one failure in test_maxiter_worsening('gmres'):
+'assert_(error <= 5*best_error)' [0.058873428 > 5*0.0088186065 ];
+under Python < 3.6 `test_ldl_type_size_combinations` additionally throws an
+error (sporadically segfault) 'Not equal to tolerance rtol=1e-10, atol=0'
+- marked skip in TestScript; all other tests passing under darwin16.
 
 Set SHELL (%v >= 1.0.0) because fink-bld's shell is /usr/bin/false and 
 several configure test programs require a real shell.


### PR DESCRIPTION
The packaging in this PR is not necessarily finalised, but I am putting this already up for discussion.

Rationale: updating the existing `scipy-py` package to upstream 1.1.0 introduces about a dozen segfaults in the test suite; from 1.2.0 on Scipy no longer officially supports building against Accelerate due to its outdated API - trying to do so introduced another bunch of segfaults in the `linalg` tests. Experimenting with reintroducing ATLAS supports produced rather worse results.
Thus I jumped into the water and packaged OpenBLAS 0.3.5 (the version current Scipy wheels are built against), largely copying from the [MacPorts package](https://github.com/macports/macports-ports/blob/master/math/OpenBLAS/Portfile).

The commits here build for Python versions 2.7-3.7 and pass all tests except for 5-6 failures marked to skip in the `TestScript`. Both builds have been based on `gcc-fsf-8` throughout, since the combination of `clang` and `gfortran` in either or both of `openblas` and `scipy-py` still produced some segfaults in the Scipy tests (in `test_blas`, `test_cython_blas`, `test_nonlin` and `test_arpack`).

Some other specific decisions in the `openblas` packaging:

- `TestScript` builds timing executables in the `benchmark` subdirectory, but does not run them - have not thought of a way to process the ~200 lines of timing output from each in a useful manner. Results are somewhat variable, but generally the OpenBLAS (`*.goto`) ones are slightly faster to 20-30 % slower than the `veclib` equivalents, and 50-100 % faster than the `atlas` ones`.

- Overriding the automatic optimisation flags to create a binary to run on most (all?) `x86_64` hardware still supported. This might carry a small performance penalty compared the build with `-avx2` that is otherwise created on my Core i7 MB Pro, but not very significant given the variation in the timings. Is there still any PowerPC support in Fink?

- The current `openblas.info` is installing directly to `%p/lib` and `%p/include`. This creates a conflict with the `cblas.h` header also installed by `atlas`. Several options to overcome the conflict:
-- MacPorts is renaming the file to `cblas_openblas.h`, but I don't know what their suggestion to build against the OpenBLAS version is.
-- The headers could be moved out into an additional `-dev` `SplitOff`.
-- The entire package could be installed into an `openblas` subdirectory.
-- The headers could be moved into their own `%p/include/%n` subdir.
If the conflict with `atlas` is indeed seen as a problem, I would prefer the last solution - pointing the scipy build to different `include_dirs` in `site.cfg` is trivial, and it would probably also be the least hassle for other packages.