### PR TITLE
gdl-0.9.8-1: upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/gdl.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gdl.info
@@ -1,6 +1,6 @@
 Package: gdl
 Version: 0.9.7
-Revision: 3
+Revision: 4
 Epoch: 1
 Description: GNU Data Language
 License: GPL
@@ -9,10 +9,10 @@ Depends: <<
 	fftw3-shlibs (>= 3.1.1-5),
 	gsl-shlibs,
 	eccodes-shlibs,
-	hdf5.10-shlibs,
+	hdf5.100.v1.10-shlibs,
 	libjpeg9-shlibs,
 	libncurses5-shlibs (>= 5.4-20041023-1006),
-	netcdf-c13-shlibs,
+	netcdf-c15-shlibs,
 	ncurses (>= 5.4-20041023-1006),
 	libproj9-shlibs,
 	libplplot10-shlibs,
@@ -29,12 +29,11 @@ BuildDepends: <<
 	fink-package-precedence,
 	eccodes,
 	gsl,
-	hdf5-cpp11,
-	hdf5.10,
+	hdf5.100.v1.10 (>= 1.10.0-4),
 	libncurses5(>= 5.4-20041023-1006),
 	libplplot10-dev,
 	libpng16,
-	netcdf-c13,
+	netcdf-c15,
 	libproj9,
 	readline6,
 	sed,
@@ -50,6 +49,11 @@ GCC: 4.0
 CompileScript: <<
 #!/bin/bash -efv
 . %p/sbin/fink-buildenv-helper.sh
+if [ $DARWIN_MAJOR_VERSION -ge 18 ]; then
+  sdk_path=`xcrun --sdk macosx --show-sdk-path`
+else
+  sdk_path=
+fi
 mkdir build
 pushd build
 %p/bin/cmake \
@@ -60,7 +64,8 @@ pushd build
 	-DFFTW=ON \
 	-DFFTWDIR=%p \
 	-DHDF5=ON \
-	-DHDF5DIR=%p \
+	-DHDF5DIR=%p/opt/hdf5.v1.10 \
+	-DHDF5_INCLUDE_DIRS=%p/opt/hdf5.v1.10/include \
 	-DHDF=OFF \
 	-DGRIB=ON \
 	-DGRIBDIR=%p \
@@ -76,7 +81,7 @@ pushd build
 	-DNCURSESDIR=%p \
 	-DNETCDF=ON \
 	-DOPENMP=OFF \
-	-DZLIBDIR=`xcrun --sdk macosx --show-sdk-path`/usr/include \
+	-DZLIBDIR=${sdk_path}/usr/include \
 	-DPLPLOTDIR=%p/lib/plplot \
 	-DPLPLOT_INCLUDE_DIR=%p/include \
 	-DPLPLOT_LIBRARIES=%p/lib/plplot \
@@ -118,8 +123,10 @@ compiler. It features a full syntax compatibility with IDL
 DescPort: <<
 Need to define ZLIBDIR using xcrun since 10.14 (XCode 10) since this
 does no longer include a directory /usr/include, but needs to find it
-in the MacOS SDK. Works also for previous versions, at least back to
-Mac OS 10.9.
+in the MacOS SDK. Since using the SDK path does not work for at least
+Mac OS 10.12 with Xcode 9.2, a Darwin version check is included.
+Since CMake flag -DHDF5DIR does not find header files from
+hdf5.100.v1.10, -DHDF5_INCLUDE_DIRS is specified.
 <<
 Homepage: http://gnudatalanguage.sf.net/
 DescPackaging: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/gdl.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gdl.info
@@ -1,6 +1,6 @@
 Package: gdl
-Version: 0.9.7
-Revision: 4
+Version: 0.9.8
+Revision: 1
 Epoch: 1
 Description: GNU Data Language
 License: GPL
@@ -30,7 +30,7 @@ BuildDepends: <<
 	eccodes,
 	gsl,
 	hdf5.100.v1.10 (>= 1.10.0-4),
-	libncurses5(>= 5.4-20041023-1006),
+	libncurses5 (>= 5.4-20041023-1006),
 	libplplot10-dev,
 	libpng16,
 	netcdf-c15,
@@ -42,9 +42,9 @@ BuildDepends: <<
 	x11-dev
 <<
 Source: mirror:sourceforge:gnudatalanguage/gdl-%v.tgz
-Source-MD5: 0cd285d85e00e76e37b92310a76579c2
+Source-MD5: 451532f1263bbaa8745a4ca8978533c0
 PatchFile: gdl.patch
-PatchFile-MD5: b787c5baba0fd1e15e8925a772b275ec
+PatchFile-MD5: cb8c5a7ffbb9a6279f118673330ff03b
 GCC: 4.0
 CompileScript: <<
 #!/bin/bash -efv

--- a/10.9-libcxx/stable/main/finkinfo/sci/gdl.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gdl.patch
@@ -1,6 +1,6 @@
-diff -Nurd gdl-0.9.7-orig/CMakeModules/FindGrib.cmake gdl-0.9.7/CMakeModules/FindGrib.cmake
---- gdl-0.9.7-orig/CMakeModules/FindGrib.cmake	2017-01-21 09:17:12.000000000 +0100
-+++ gdl-0.9.7/CMakeModules/FindGrib.cmake	2017-10-05 21:22:52.000000000 +0200
+diff -Nurd gdl-0.9.8-orig/CMakeModules/FindGrib.cmake gdl-0.9.8/CMakeModules/FindGrib.cmake
+--- gdl-0.9.8-orig/CMakeModules/FindGrib.cmake	2018-03-26 11:57:27.000000000 +0200
++++ gdl-0.9.8/CMakeModules/FindGrib.cmake	2019-03-28 18:01:56.924550580 +0100
 @@ -9,7 +9,7 @@
  #
  
@@ -10,9 +10,9 @@ diff -Nurd gdl-0.9.7-orig/CMakeModules/FindGrib.cmake gdl-0.9.7/CMakeModules/Fin
  find_path(GRIB_INCLUDE_DIR NAMES grib_api.h)
  include(FindPackageHandleStandardArgs)
  # since there's no grib_api.pc let's check if this installation of grib required jasper and jpeg
-diff -Nurd gdl-0.9.7-orig/CMakeModules/FindLibproj4.cmake gdl-0.9.7/CMakeModules/FindLibproj4.cmake
---- gdl-0.9.7-orig/CMakeModules/FindLibproj4.cmake	2017-01-21 09:17:12.000000000 +0100
-+++ gdl-0.9.7/CMakeModules/FindLibproj4.cmake	2017-01-21 09:17:12.000000000 +0100
+diff -Nurd gdl-0.9.8-orig/CMakeModules/FindLibproj4.cmake gdl-0.9.8/CMakeModules/FindLibproj4.cmake
+--- gdl-0.9.8-orig/CMakeModules/FindLibproj4.cmake	2018-03-26 11:57:27.000000000 +0200
++++ gdl-0.9.8/CMakeModules/FindLibproj4.cmake	2019-03-28 18:01:56.925995875 +0100
 @@ -7,11 +7,11 @@
  #  the Free Software Foundation; either version 2 of the License, or
  #  (at your option) any later version.
@@ -29,25 +29,14 @@ diff -Nurd gdl-0.9.7-orig/CMakeModules/FindLibproj4.cmake gdl-0.9.7/CMakeModules
  include(FindPackageHandleStandardArgs)
  find_package_handle_standard_args(LIBPROJ4 DEFAULT_MSG LIBPROJ4_LIBRARIES LIBPROJ4_INCLUDE_DIR)
  
-diff -Nurd gdl-0.9.7-orig/src/gdlgstream.hpp gdl-0.9.7/src/gdlgstream.hpp
---- gdl-0.9.7-orig/src/gdlgstream.hpp	2017-01-21 09:17:12.000000000 +0100
-+++ gdl-0.9.7/src/gdlgstream.hpp	2017-10-05 21:41:46.000000000 +0200
-@@ -871,16 +871,16 @@
- 
-   //GD: enables overloading scmap0,1... to accelerate plots for X11 and possibly others
-   // Set color map 0 colors by 8 bit RGB values
--  virtual void SetColorMap0( const PLINT *r, const PLINT *g, const PLINT *b, PLINT ncol0 ) {
-+  virtual void SetColorMap0( PLINT *r, PLINT *g, PLINT *b, PLINT ncol0 ) {
-    plstream::scmap0( r, g, b, ncol0);
-   }
-   // Set color map 1 colors by 8 bit RGB values
--  virtual void SetColorMap1( const PLINT *r, const PLINT *g, const PLINT *b, PLINT ncol1 ) {
-+  virtual void SetColorMap1( PLINT *r, PLINT *g, PLINT *b, PLINT ncol1 ) {
-    plstream::scmap1( r, g, b, ncol1);
+diff -Nurd gdl-0.9.8-orig/src/gdlgstream.hpp gdl-0.9.8/src/gdlgstream.hpp
+--- gdl-0.9.8-orig/src/gdlgstream.hpp	2018-03-26 11:57:27.000000000 +0200
++++ gdl-0.9.8/src/gdlgstream.hpp	2019-03-28 18:19:05.875968392 +0100
+@@ -845,7 +845,7 @@
    }
    // Set color map 1 colors using a piece-wise linear relationship between
    // intensity [0,1] (cmap 1 index) and position in HLS or RGB color space.
--  virtual void SetColorMap1l( bool itype, PLINT npts, const PLFLT *intensity, const PLFLT *coord1, const PLFLT *coord2, const PLFLT *coord3, const bool *rev = NULL ) {
+-  virtual void SetColorMap1l( bool itype, PLINT npts, PLFLT *intensity, PLFLT *coord1, PLFLT *coord2, PLFLT *coord3, const bool *rev = NULL ) {
 +  virtual void SetColorMap1l( bool itype, PLINT npts, PLFLT *intensity, PLFLT *coord1, PLFLT *coord2, PLFLT *coord3, bool *rev = NULL ) {
     plstream::scmap1l(itype,npts,intensity,coord1,coord2,coord3,rev);
    }


### PR DESCRIPTION
Update to version 0.9.8.

Also include dependency update:
netcdf-c13 -> netcdf-c15
hdf5.10 -> hdf5.100.v1.10
(hdf5-cpp11 removed as headers are now all in hdf5.100.v1.10)

Additionally, changed introduction of SDK path, now depending on Darwin version, as suggested by @dhomeier in PR #375 

Built and tested on Mac OS 10.14.4 and Command Line Tools 10.2