### PR TITLE
Epstool update to 3.09 and new source location

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/text/epstool.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/epstool.info
@@ -1,15 +1,22 @@
 Package: epstool
-Version: 3.08
-Revision: 3
+Version: 3.09
+Revision: 1
 BuildDepends: fink-package-precedence
 Depends: ghostscript | ghostscript-nox
 Description: Utility to manipulate EPS files
-Source: ftp://mirror.cs.wisc.edu/pub/mirrors/ghost/ghostgum/%n-%v.tar.gz
-Source-MD5: 465a57a598dbef411f4ecbfbd7d4c8d7 
+Source: http://ghostgum.com.au/download/%n-%v.tar.gz
+Source-MD5: cad2cbbe9ccb22301fb0632407916a26
 PatchFile: %n.patch
-PatchFile-MD5: 262a469e6b2a53b5e120fd866a6c2568
+PatchFile-MD5: c2657133f95be4c346c9bbb1f71d51e7
 UseMaxBuildJobs: false
 SetCFLAGS: -I%p/include -MD
+# 3.09 tarball has permissions completely screwed down under (700 for files and 400 for directories)!
+PatchScript: <<
+	chmod 755 %b
+	find %b -type d -exec chmod 755 {} \;
+	find %b -type f -exec chmod 644 {} \;
+	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
+<<
 CompileScript: <<
 	make epstool
 	fink-package-precedence --depfile-ext='\.d' .
@@ -19,7 +26,7 @@ InstallScript: <<
 <<
 DocFiles: LICENCE
 License: GPL
-Homepage: http://www.cs.wisc.edu/~ghost/gsview/epstool.htm
+Homepage: http://ghostgum.com.au/software/epstool.htm
 Maintainer: Daniel Macks <dmacks@netspace.org>
 DescDetail: <<
 Epstool is a utility to create or extract preview images in EPS files, fix 
@@ -37,6 +44,6 @@ Features:
 DescPackaging:  <<
 	Former Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 
-	Our patch includes debian's 01_fix_open_calls.patch from their
-	epstool-3.08+repack-4
+	Debian's 01_fix_open_calls.patch already merged in 3.09;
+	only patching makefile to point to %p instead of /usr/local
 <<

--- a/10.9-libcxx/stable/main/finkinfo/text/epstool.patch
+++ b/10.9-libcxx/stable/main/finkinfo/text/epstool.patch
@@ -1,9 +1,12 @@
-diff -Nurd -x'*~' epstool-3.08.orig/makefile epstool-3.08/makefile
---- epstool-3.08.orig/makefile	2005-06-10 05:41:00.000000000 -0400
-+++ epstool-3.08/makefile	2016-05-01 16:22:36.000000000 -0400
-@@ -47,8 +47,8 @@
+diff -Nurd -x'*~' epstool-3.09.orig/makefile epstool-3.09/makefile
+--- epstool-3.09.orig/makefile	2015-03-15 11:25:28.000000000 +0100
++++ epstool-3.09/makefile	2019-03-28 15:19:47.000000000 +0100
+@@ -40,10 +40,10 @@
  
- EPSTOOL_ROOT=/usr/local
+ include $(SRCDIR)/common.mak
+ 
+-EPSTOOL_ROOT=/usr/local
++EPSTOOL_ROOT=@PREFIX@
  EPSTOOL_BASE=$(prefix)$(EPSTOOL_ROOT)
 -EPSTOOL_DOCDIR=$(EPSTOOL_BASE)/share/doc/epstool-$(EPSTOOL_VERSION)
 -EPSTOOL_MANDIR=$(EPSTOOL_BASE)/man
@@ -12,24 +15,3 @@ diff -Nurd -x'*~' epstool-3.08.orig/makefile epstool-3.08/makefile
  EPSTOOL_BINDIR=$(EPSTOOL_BASE)/bin
  
  epstool: $(BD)epstool$(EXE)
-diff -Nurd -x'*~' epstool-3.08.orig/src/epstool.c epstool-3.08/src/epstool.c
---- epstool-3.08.orig/src/epstool.c	2005-06-10 05:41:00.000000000 -0400
-+++ epstool-3.08/src/epstool.c	2016-05-01 16:31:59.000000000 -0400
-@@ -2824,7 +2824,7 @@
- 		code = -1;
- 	}
- 	if ((code==0) && stdout_name && (hChildStdoutWr == -1)) {
--	    handle = open(stdout_name, O_WRONLY | O_CREAT);
-+	    handle = open(stdout_name, O_WRONLY | O_CREAT, 0666);
- 	    hChildStdoutWr = dup2(handle, 1);
- 	    if (handle != -1)
- 		close(handle);
-@@ -2832,7 +2832,7 @@
- 		code = -1;
- 	}
- 	if ((code==0) && stderr_name && (hChildStderrWr == -1)) {
--	    handle = open(stderr_name, O_WRONLY | O_CREAT);
-+	    handle = open(stderr_name, O_WRONLY | O_CREAT, 0666);
- 	    hChildStderrWr = dup2(handle, 2);
- 	    if (handle != -1)
- 		close(handle);


### PR DESCRIPTION
With the mirrors all offline I was unable to build the `epstool` package as the original source location has disappeared. It's new location has version `3.09`.