### PR TITLE
LAPACK fixes and update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/lapack360.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/lapack360.info
@@ -51,7 +51,7 @@ perl -pi -e '	s,\@prefix\@,%p,; \
 				s,-llapack,-lreflapack,' 			< lapack.pc.in > lapack.pc
 perl -pi -e '	s,\@prefix\@,%p,; \
 				s,\@libdir\@,%p/lib/lapack/%v, ; \
-				s,\@LAPACK_VERSION\@,%v,' 			< lapacke/lapacke.pc.in > lapacke.pc
+				s,\@LAPACK_VERSION\@,%v,' 			< LAPACKE/lapacke.pc.in > lapacke.pc
 perl -pi -e '	s,\@prefix\@,%p,; \
 				s,\@libdir\@,%p/lib/lapack/%v, ; \
 				s,\@LAPACK_VERSION\@,%v, ; \
@@ -118,7 +118,7 @@ InstallScript: <<
 	install *.a %i/lib/lapack
 	install SRC/VARIANTS/LIB/*.a %i/lib/lapack
 	mv %i/lib/lapack/liblapack.a %i/lib/lapack/libreflapack.a
-	cd lapacke/include/
+	cd LAPACKE/include/
 	install *.h %i/include/lapack
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/lapack361.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/lapack361.info
@@ -45,15 +45,15 @@ perl -p -e "	s/gfortran/gfortran-fsf-%type_raw[gcc]/ ; \
 				s/(^OPTS\s+=\s+).*/\1-O2 -fimplicit-none -funroll-loops -fPIC $m/ ; \
 				s/gcc/gcc-fsf-%type_raw[gcc]/" \
 													< make.inc.example > make.inc
-perl -pi -e '	s,\@prefix\@,%p,; \
-				s,\@libdir\@,%p/lib/lapack/%v, ; \
+perl -pi -e '	s,\@CMAKE_INSTALL_PREFIX\@,%p,; \
+				s,\@CMAKE_INSTALL_LIBDIR\@,lib/lapack/%v, ; \
 				s,\@LAPACK_VERSION\@,%v, ; \
 				s,-llapack,-lreflapack,' 			< lapack.pc.in > lapack.pc
 perl -pi -e '	s,\@prefix\@,%p,; \
 				s,\@libdir\@,%p/lib/lapack/%v, ; \
-				s,\@LAPACK_VERSION\@,%v,' 			< lapacke/lapacke.pc.in > lapacke.pc
-perl -pi -e '	s,\@prefix\@,%p,; \
-				s,\@libdir\@,%p/lib/lapack/%v, ; \
+				s,\@LAPACK_VERSION\@,%v,' 			< LAPACKE/lapacke.pc.in > lapacke.pc
+perl -pi -e '	s,\@CMAKE_INSTALL_PREFIX\@,%p,; \
+				s,\@CMAKE_INSTALL_LIBDIR\@,lib/lapack/%v, ; \
 				s,\@LAPACK_VERSION\@,%v, ; \
 				s,-lblas,-lrefblas,' 				< BLAS/blas.pc.in > blas.pc
 mkdir -p SRC/VARIANTS/LIB
@@ -119,7 +119,7 @@ InstallScript: <<
 	install *.a %i/lib/lapack
 	install SRC/VARIANTS/LIB/*.a %i/lib/lapack
 	mv %i/lib/lapack/liblapack.a %i/lib/lapack/libreflapack.a
-	cd lapacke/include/
+	cd LAPACKE/include/
 	install *.h %i/include/lapack
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/lapack371.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/lapack371.info
@@ -48,15 +48,15 @@ perl -p -e "	s/gfortran/gfortran-fsf-%type_raw[gcc]/ ; \
 				s/(^OPTS\s+=\s+).*/\1-O2 -fimplicit-none -funroll-loops -fPIC $m/ ; \
 				s/gcc/gcc-fsf-%type_raw[gcc]/" \
 													< make.inc.example > make.inc
-perl -pi -e '	s,\@prefix\@,%p,; \
-				s,\@libdir\@,%p/lib/lapack/%v, ; \
+perl -pi -e '	s,\@CMAKE_INSTALL_FULL_LIBDIR\@,%p/lib/lapack/%v, ; \
+				s,\@CMAKE_INSTALL_FULL_INCLUDEDIR\@,%p/include/lapack, ; \
 				s,\@LAPACK_VERSION\@,%v, ; \
 				s,-llapack,-lreflapack,' 			< lapack.pc.in > lapack.pc
-perl -pi -e '	s,\@prefix\@,%p,; \
-				s,\@libdir\@,%p/lib/lapack/%v, ; \
-				s,\@LAPACK_VERSION\@,%v,' 			< lapacke/lapacke.pc.in > lapacke.pc
-perl -pi -e '	s,\@prefix\@,%p,; \
-				s,\@libdir\@,%p/lib/lapack/%v, ; \
+perl -pi -e '	s,\@CMAKE_INSTALL_FULL_LIBDIR\@,%p/lib/lapack/%v, ; \
+				s,\@CMAKE_INSTALL_FULL_INCLUDEDIR\@,%p/include/lapack, ; \
+				s,\@LAPACK_VERSION\@,%v,' 			< LAPACKE/lapacke.pc.in > lapacke.pc
+perl -pi -e '	s,\@CMAKE_INSTALL_FULL_LIBDIR\@,%p/lib/lapack/%v, ; \
+				s,\@CMAKE_INSTALL_FULL_INCLUDEDIR\@,%p/include/lapack, ; \
 				s,\@LAPACK_VERSION\@,%v, ; \
 				s,-lblas,-lrefblas,' 				< BLAS/blas.pc.in > blas.pc
 <<
@@ -121,7 +121,7 @@ InstallScript: <<
 	install *.a %i/lib/lapack
 	install SRC/VARIANTS/*.a %i/lib/lapack
 	mv %i/lib/lapack/liblapack.a %i/lib/lapack/libreflapack.a
-	cd lapacke/include/
+	cd LAPACKE/include/
 	install *.h %i/include/lapack
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/lapack380.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/lapack380.info
@@ -1,0 +1,170 @@
+Info4: <<
+Package: lapack380
+Version: 3.8.0
+Revision: 1
+Type: gcc (8)
+Description: Reference L_APACK and BLAS libraries
+DescDetail: <<
+This package provides a reference implementation of the LAPACK and BLAS 
+libraries (as opposed to the optimized implementations from ATLAS or 
+Accelerate.framework).
+<<
+DescUsage: <<
+This package contains the static libraries and pkgconfig files, as well
+as the LAPACKE headers.
+
+The libraries have been renamed to avoid collisions with their
+counterparts from atlas, libblas.{a,dylib} -> librefblas.{a,dylib} and 
+liblapack.{a,dylib} -> libreflapack.{a.dylib}.
+
+To use the static libraries, you can specify e.g. 
+
+LAPACK_LIBS=-L%p/lib/lapack -lrefblas -lreflapack
+
+The documentation is mostly installed by the atlas-doc package.
+<<
+DescPackaging: <<
+Set gcc-fsf-%type_raw[gcc] as linker for liblapacke.dylib and added
+lapacke_[ds]sytrf_aa_work.o to Makefile targets, as referenced from
+lapacke_[ds]sytrf_aa.o
+<<
+Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
+Homepage: http://www.netlib.org/lapack/
+
+BuildDependsOnly: true
+BuildDepends: gcc%type_pkg[gcc]-compiler
+Depends: %N-shlibs (=%V)
+Conflicts: lapack350, lapack360, lapack361, lapack371
+Replaces: lapack350, lapack360, lapack361, lapack371
+
+Source: http://www.netlib.org/lapack/lapack-%v.tar.gz
+Source-MD5: 96591affdbf58c450d45c1daa540dbd2
+PatchFile: %n.patch
+PatchFile-MD5: 66e3008f7d848fac4a1f7737b64355e9
+
+PatchScript: <<
+#!/bin/sh -ev
+if [ "%m" = "x86_64" ] 
+	then m='-m64'
+	else m='-m32'
+fi
+patch -p1 < %{PatchFile}
+perl -p -e "	s/gfortran/gfortran-fsf-%type_raw[gcc]/ ; \
+				s/(^OPTS\s+=\s+).*/\1-O2 -fimplicit-none -funroll-loops -fPIC $m/ ; \
+				s/gcc/gcc-fsf-%type_raw[gcc]/" \
+													< make.inc.example > make.inc
+perl -pi -e '	s,\@CMAKE_INSTALL_FULL_LIBDIR\@,%p/lib/lapack/%v, ; \
+				s,\@CMAKE_INSTALL_FULL_INCLUDEDIR\@,%p/include/lapack, ; \
+				s,\@LAPACK_VERSION\@,%v, ; \
+				s,-llapack,-lreflapack,' 			< lapack.pc.in > lapack.pc
+perl -pi -e '	s,\@CMAKE_INSTALL_FULL_LIBDIR\@,%p/lib/lapack/%v, ; \
+				s,\@CMAKE_INSTALL_FULL_INCLUDEDIR\@,%p/include/lapack, ; \
+				s,\@LAPACK_VERSION\@,%v,' 			< LAPACKE/lapacke.pc.in > lapacke.pc
+perl -pi -e '	s,\@CMAKE_INSTALL_FULL_LIBDIR\@,%p/lib/lapack/%v, ; \
+				s,\@CMAKE_INSTALL_FULL_INCLUDEDIR\@,%p/include/lapack, ; \
+				s,\@LAPACK_VERSION\@,%v, ; \
+				s,-lblas,-lrefblas,' 				< BLAS/blas.pc.in > blas.pc
+<<
+
+CompileScript: <<
+	#!/bin/sh -ev
+	/usr/bin/make blaslib 
+	/usr/bin/make variants 
+	/usr/bin/make lapackelib
+	/usr/bin/make lib 
+	/usr/bin/make lapack_install
+	# build dylibs the old-fashioned way
+	# do librefblas first
+	if [ "%m" = "x86_64" ] 
+		then m='-m64 '
+		else m='-m32 '
+	fi
+	compilerlib="-L%p/lib/gcc%type_raw[gcc]/lib -lgfortran"
+	gfc='gfortran-fsf-%type_raw[gcc] -O2 -fimplicit-none -funroll-loops -fPIC -fno-common '$m
+	ldf='-Wl,-dead_strip_dylibs -dynamiclib -single_module -install_name '
+	gccc='gcc-fsf-%type_raw[gcc] -O3 -Wl,-dead_strip_dylibs -dynamiclib -single_module -fno-common '$m'-install_name '
+	TMP=`/usr/bin/mktemp -d %b/lap.XXXXXX` || exit 1
+	pushd $TMP
+	ar -x ../librefblas.a
+	$gfc $ldf %p/lib/lapack/%v/librefblas.dylib  $compilerlib *.o -o ../librefblas.dylib
+	popd
+	TMP=`/usr/bin/mktemp -d %b/lap.XXXXXX` || exit 1
+	pushd $TMP
+	ar -x ../liblapack.a
+	$gfc $ldf %p/lib/lapack/%v/libreflapack.dylib  $compilerlib %b/librefblas.dylib *.o -o ../libreflapack.dylib
+	popd
+	TMP=`/usr/bin/mktemp -d %b/lap.XXXXXX` || exit 1
+	pushd $TMP
+	ar -x ../libtmglib.a
+	$gfc $ldf %p/lib/lapack/%v/libtmglib.dylib  $compilerlib %b/librefblas.dylib %b/libreflapack.dylib *.o -o ../libtmglib.dylib
+	popd
+	pushd $TMP
+	ar -x ../liblapacke.a
+	$gccc %p/lib/lapack/%v/liblapacke.dylib  $compilerlib %b/libreflapack.dylib %b/librefblas.dylib *.o -o ../liblapacke.dylib
+	popd
+	for statlib in SRC/VARIANTS/*.a ; do
+		dynlib=lib`basename $statlib .a`.dylib
+		instname=%p/lib/lapack/%v/$dynlib
+		TMP=`/usr/bin/mktemp -d %b/lap.XXXXXX` || exit 1
+		pushd $TMP
+		ar -x ../$statlib
+		$gfc $ldf $instname $compilerlib %b/librefblas.dylib %b/libreflapack.dylib *.o  -o %b/$dynlib 
+		popd
+	done
+ <<
+
+InfoTest: TestScript: /usr/bin/make -j1 blas_testing lapack_testing variants_testing || exit 2
+
+InstallScript: <<
+	#!/bin/sh -ev
+	install -d %i/lib/lapack/pkgconfig
+	install -d %i/include
+	install -d %i/include/lapack
+	install *.pc %i/lib/lapack/pkgconfig
+	install -d %i/lib/lapack/%v
+	install *.dylib %i/lib/lapack/%v
+	install *.a %i/lib/lapack
+	install SRC/VARIANTS/*.a %i/lib/lapack
+	mv %i/lib/lapack/liblapack.a %i/lib/lapack/libreflapack.a
+	cd LAPACKE/include/
+	install *.h %i/include/lapack
+<<
+
+DocFiles: LICENSE DOCS/lapacke.pdf SRC/VARIANTS/README:README.variants
+License: BSD
+
+Splitoff: <<
+	Package: %N-shlibs
+	Files: lib/lapack/%v/*.dylib
+	Depends: gcc%type_pkg[gcc]-shlibs
+	Shlibs: <<
+		%p/lib/lapack/%v/libcholrl.dylib 0.0.0 %n (>=3.4.1-1)
+		%p/lib/lapack/%v/libcholtop.dylib 0.0.0 %n (>=3.4.1-1)
+        %p/lib/lapack/%v/libreflapack.dylib 0.0.0 %n (>=3.4.1-1)
+        %p/lib/lapack/%v/liblapacke.dylib 0.0.0 %n (>=3.4.1-1)
+        %p/lib/lapack/%v/liblucr.dylib 0.0.0 %n (>=3.4.1-1)
+        %p/lib/lapack/%v/liblull.dylib 0.0.0 %n (>=3.4.1-1)
+        %p/lib/lapack/%v/liblurec.dylib 0.0.0 %n (>=3.4.1-1)
+        %p/lib/lapack/%v/libqrll.dylib 0.0.0 %n (>=3.4.1-1)
+        %p/lib/lapack/%v/librefblas.dylib 0.0.0 %n (>=3.4.1-1)
+        %p/lib/lapack/%v/libtmglib.dylib 0.0.0 %n (>=3.4.1-1)
+	<<
+	DocFiles: LICENSE DOCS/lapacke.pdf SRC/VARIANTS/README:README.variants
+	DescUsage: <<
+		This package contains the shared libraries.  
+
+		The libraries have been renamed to avoid collisions with their
+		counterparts from atlas, libblas.{a,dylib} -> librefblas.{a,dylib} and 
+		liblapack.{a,dylib} -> libreflapack.{a.dylib}.
+
+		To use the shared libraries, you can either specify e.g. 
+		LAPACK_LIBS=-L%p/lib/lapack/%v -lrefblas -lreflapack
+
+		or use e.g.
+
+		export PKG_CONFIG_PATH=%p/lib/lapack/pkgconfig:$PKG_CONFIG_PATH 
+		LAPACK_LIBS=`pkg-config --libs lapack`
+	<<
+<<
+
+<<

--- a/10.9-libcxx/stable/main/finkinfo/sci/lapack380.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/lapack380.patch
@@ -1,0 +1,34 @@
+--- lapack-3.7.1-orig/LAPACKE/src/Makefile	2017-06-18 00:46:53.000000000 +0200
++++ lapack-3.7.1/LAPACKE/src/Makefile	2017-10-10 17:22:22.081979028 +0200
+@@ -1102,6 +1102,7 @@
+ lapacke_dsytrf_rook_work.o \
+ lapacke_dsytrf_aa.o \
+ lapacke_dsytrf_aa_2stage.o \
++lapacke_dsytrf_aa_work.o \
+ lapacke_dsytrf_aa_2stage_work.o \
+ lapacke_dsytrf_rk.o \
+ lapacke_dsytrf_rk_work.o \
+@@ -1662,6 +1663,7 @@
+ lapacke_ssytrf_rook_work.o \
+ lapacke_ssytrf_aa.o \
+ lapacke_ssytrf_aa_2stage.o \
++lapacke_ssytrf_aa_work.o \
+ lapacke_ssytrf_aa_2stage_work.o \
+ lapacke_ssytrf_rk.o \
+ lapacke_ssytrf_rk_work.o \
+@@ -2412,9 +2412,15 @@
+ ../../$(LAPACKELIB): $(OBJ_A) $(OBJ_B) $(DEPRECATED) $(EXTENDED) $(MATGEN)
+ 	$(ARCH) $(ARCHFLAGS) $@ $(OBJ_A)
+ 	$(ARCH) $(ARCHFLAGS) $@ $(OBJ_B)
++ifdef BUILD_DEPRECATED
+ 	$(ARCH) $(ARCHFLAGS) $@ $(DEPRECATED)
++endif
++ifdef USEEXBLAS
+ 	$(ARCH) $(ARCHFLAGS) $@ $(EXTENDED)
++endif
++ifdef LAPACKE_WITH_TMG
+ 	$(ARCH) $(ARCHFLAGS) $@ $(MATGEN)
++endif
+ 	$(RANLIB) $@
+ 
+ clean: cleanobj


### PR DESCRIPTION
I was unable to build the `lapack360` and upwards packages on case-sensitive HFS due to spelling/capitalisation errors in the .info files.
Also, from 3.6.1 to 3.7.1 various changes in the format of the `lapack*.pc.in` and `blas.pc.in` files were introduced, causing the existing `PatchScript`s to create .pc files with invalid `pkgconfig` paths.
Added fixes here plus update to the latest upstream version 3.8.0.