### PR TITLE
Ipython 5+ and Notebook Depends

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/appnope-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/appnope-py.info
@@ -1,0 +1,53 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+
+Package: appnope-py%type_pkg[python]
+Version: 0.1.0
+Revision: 1
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+License: BSD
+Type: python (2.7 3.4 3.5 3.6 3.7)
+Homepage: https://pypi.python.org/project/appnope
+Source: https://files.pythonhosted.org/packages/source/a/appnope/appnope-%v.tar.gz
+Source-MD5: 932fbaa73792c9b06754755a774dcac5
+
+Depends: python%type_pkg[python]-shlibs
+BuildDepends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
+
+CompileScript: python%type_raw[python] setup.py build
+InstallScript: <<
+ find build/lib -name '*.py[oc]' -exec rm {} \;
+ python%type_raw[python] setup.py install --root=%d
+<<
+
+Description: Disable App Nap on OS X 10.9+
+
+DescDetail: <<
+Simple package for disabling App Nap on OS X 10.9 (and later?), which can be
+problematic.
+
+To disable App Nap:
+```python
+import appnope
+appnope.nope()
+```
+
+To reenable, for some reason:
+```python
+appnope.nap()
+```
+
+or to only disable App Nap for a particular block:
+```
+with appnope.nope_scope():
+do_important_stuff()
+```
+
+It uses ctypes to wrap a `[NSProcessInfo beginActivityWithOptions]` call to
+disable App Nap.
+<<
+
+DocFiles: README.md
+
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/backcall-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/backcall-py.info
@@ -43,7 +43,7 @@ InfoTest: <<
     TestDepends: pytest-py%type_pkg[python]
     TestScript: <<
         #!/bin/bash -ev
-        PYTHONPATH=build/lib %p/bin/pytest-%type_raw[python] || exit 1
+        PYTHONPATH=build/lib %p/bin/pytest-%type_raw[python] || exit 2
     <<
     TestSuiteSize: small
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/backcall-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/backcall-py.info
@@ -1,0 +1,59 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+Package: backcall-py%type_pkg[python]
+Version: 0.1.0
+Revision: 1
+Type: python (2.7 3.4 3.5 3.6 3.7)
+Description: Specifications for callback functions
+DescDetail: <<
+This module contains specifications for callback functions passed in to an API.
+If your code lets other people supply callback functions, it's important to
+specify the function signature you expect, and check that functions support
+that. Adding extra parameters later would break other peoples code unless
+you're careful. backcall provides a way of specifying the callback signature
+using a prototype function callback_prototype.
+If the callback takes fewer parameters than your prototype, backcall will wrap
+it in a function that discards the extra arguments. If the callback expects
+more arguments, a TypeError is thrown when it is registered.
+<<
+
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+License: BSD
+Homepage: https://github.com/takluyver/backcall
+
+Source: https://files.pythonhosted.org/packages/source/b/backcall/backcall-%v.tar.gz
+Source-MD5: 87ce0c7839808e6a3427d57df6a792e7
+Source2: https://raw.githubusercontent.com/takluyver/backcall/8eb45a7/LICENSE
+Source2-MD5: 40e56b724d016484a7f790ec826d3ffc
+Source2Rename: %{ni}-%v.LICENSE
+
+Depends: python%type_pkg[python]
+BuildDepends: fink (>= 0.24.12), setuptools-tng-py%type_pkg[python]
+
+CompileScript: <<
+ %p/bin/python%type_raw[python] setup.py build
+ mv ../%{ni}-%v.LICENSE LICENSE
+<<
+
+InstallScript: <<
+ %p/bin/python%type_raw[python] setup.py install --root=%d
+<<
+
+InfoTest: <<
+    TestDepends: pytest-py%type_pkg[python]
+    TestScript: <<
+        #!/bin/bash -ev
+        PYTHONPATH=build/lib %p/bin/pytest-%type_raw[python] || exit 1
+    <<
+    TestSuiteSize: small
+<<
+
+# Add Demo.ipynb and/or docs/ from github?
+DocFiles: LICENSE README.rst PKG-INFO
+DescPackaging: <<
+Development status is classified "pre-alpha" on PyPi, and the actual code has not
+been touched in 4 years, but ipython-6.4 requires this to be imported!
+But maintainer has promised to include LICENSE file in next release (issue #3).
+<<
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/backports.shutil-get-terminal-size-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/backports.shutil-get-terminal-size-py.info
@@ -15,6 +15,16 @@ BuildDepends: fink (>= 0.24.12), setuptools-tng-py%type_pkg[python]
 
 CompileScript: %p/bin/python%type_raw[python] setup.py build
 
+InfoTest: <<
+ TestDepends: <<
+  pytest-py%type_pkg[python]
+ <<
+ TestScript: <<
+  PYTHONPATH=%b/build/lib %p/bin/py.test-%type_raw[python] -vv --capture=sys || exit 2
+  find . -name "*.pyc" -delete
+ <<
+<<
+
 InstallScript: <<
  %p/bin/python%type_raw[python] setup.py install --root=%d
  # We must use the __init__.py from the backports-py package.

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/backports.shutil-get-terminal-size-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/backports.shutil-get-terminal-size-py.info
@@ -1,0 +1,30 @@
+Info2: <<
+Package: backports.shutil-get-terminal-size-py%type_pkg[python]
+Version: 1.0.0
+Revision: 1
+Type: python (2.7)
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+License: BSD
+Homepage: https://pypi.python.org/pypi/backports.shutil_get_terminal_size
+
+Source: https://pypi.python.org/packages/source/b/backports.shutil_get_terminal_size/backports.shutil_get_terminal_size-%v.tar.gz
+Source-MD5: 03267762480bd86b50580dc19dff3c66
+
+Depends: python%type_pkg[python], backports-py%type_pkg[python]
+BuildDepends: fink (>= 0.24.12), setuptools-tng-py%type_pkg[python]
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build
+
+InstallScript: <<
+ %p/bin/python%type_raw[python] setup.py install --root=%d
+ # We must use the __init__.py from the backports-py package.
+ rm %i/lib/python%type_raw[python]/site-packages/backports/__init__.{py,pyc}
+<<
+
+Description: Backport of py33's shutil.get_terminal_size()
+DescDetail: <<
+A backport of the get_terminal_size function from Python 3.3's shutil.
+Unlike the original version it is written in pure Python rather than C,
+so it might be a tiny bit slower.
+<<
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bleach-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bleach-py.info
@@ -1,0 +1,46 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+Package: bleach-py%type_pkg[python]
+Version: 3.1.0
+Revision: 1
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+Type: python (2.7 3.4 3.5 3.6 3.7)
+Depends: python%type_pkg[python], six-py%type_pkg[python], html5lib-py%type_pkg[python] (>= 0.999-1)
+#Source: https://github.com/mozilla/bleach/archive/v%v.tar.gz
+#Source-MD5: 16c3466551d3a5a369a563b5bca5ee44
+#SourceRename: bleach-%v.tar.gz
+Source: https://files.pythonhosted.org/packages/source/b/bleach/bleach-%v.tar.gz
+Source-Checksum: SHA256(3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa)
+CompileScript: <<
+ %p/bin/python%type_raw[python] setup.py build
+<<
+InstallScript: <<
+ %p/bin/python%type_raw[python] setup.py install --root %d
+<<
+InfoTest: <<
+  TestDepends: pytest-py%type_pkg[python], pytest-runner-py%type_pkg[python] 
+  TestScript: <<
+    %p/bin/python%type_raw[python] setup.py pytest --addopts tests
+  <<
+  TestSuiteSize: small
+<<
+
+DocFiles: README.rst LICENSE CHANGES docs/
+Description: Easy allowed-list-based HTML-sanitizing tool
+DescDetail: <<
+Bleach is an allowed-list-based HTML sanitizing library that escapes or strips
+markup and attributes. Bleach can also linkify text safely, applying filters
+that Django's urlize filter cannot, and optionally setting rel attributes,
+even on links already in the text.  
+Bleach is intended for sanitizing text from untrusted sources. If you find
+yourself jumping through hoops to allow your site administrators to do lots
+of things, you're probably outside the use cases. Either trust those users,
+or don't.
+Because it relies on html5lib, Bleach is as good as modern browsers at
+dealing with weird, quirky HTML fragments. And any of Bleach's methods
+will fix unbalanced or mis-nested tags.
+<<
+License: OSI-Approved
+Homepage: http://github.com/mozilla/bleach
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/entrypoints-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/entrypoints-py.info
@@ -21,7 +21,10 @@ CompileScript: <<
   %p/bin/python%type_raw[python] setup.py build
 <<
 InfoTest: <<
-  TestDepends: pytest-py%type_pkg[python]
+  TestDepends: <<
+    pytest-py%type_pkg[python],
+    setuptools-tng-py%type_pkg[python]
+  <<
   TestScript: PYTHONPATH=%b/build/lib %p/bin/python%type_raw[python] -m pytest || exit 2
   TestSuiteSize: small
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/entrypoints-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/entrypoints-py.info
@@ -1,10 +1,10 @@
-Info3: <<
+Info2: <<
 
 Package: entrypoints-py%type_pkg[python]
-Type: python (2.7 3.4 3.5 3.6)
+Type: python (2.7 3.4 3.5 3.6 3.7)
 
-Version: 0.2.3
-Revision: 2
+Version: 0.3
+Revision: 1
 Description: Discover and load entry points from packages
 DescDetail: <<
 Entry points are a way for Python packages to advertise objects with
@@ -12,8 +12,8 @@ some common interface. The most common examples are console_scripts
 entry points, which define shell commands by identifying a Python
 function to run.
 <<
-Source: https://files.pythonhosted.org/packages/27/e8/607697e6ab8a961fc0b141a97ea4ce72cd9c9e264adeb0669f6d194aa626/entrypoints-%v.tar.gz
-Source-MD5: 0d3ad1b0130d91e3596ef3a59f25a56c
+Source: https://files.pythonhosted.org/packages/source/e/entrypoints/entrypoints-%v.tar.gz
+Source-Checksum: SHA256(c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451)
 
 Depends: python%type_pkg[python], (%type_pkg[python] <= 27) configparser-py%type_pkg[python]
 CompileScript: <<
@@ -21,10 +21,9 @@ CompileScript: <<
   %p/bin/python%type_raw[python] setup.py build
 <<
 InfoTest: <<
-  TestScript: <<
-    %p/bin/python%type_raw[python] setup.py check
-    find ./build -name "*.pyc" -delete
-  <<
+  TestDepends: pytest-py%type_pkg[python]
+  TestScript: PYTHONPATH=%b/build/lib %p/bin/python%type_raw[python] -m pytest || exit 2
+  TestSuiteSize: small
 <<
 InstallScript: <<
   %p/bin/python%type_raw[python] setup.py install --root=%d
@@ -33,5 +32,5 @@ DocFiles: doc/*
 License: BSD
 Homepage: https://github.com/takluyver/entrypoints
 Maintainer: Brendan Cully <fink@brendan.cully.org>
-# Info3
+# Info2
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/ipython-genutils-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/ipython-genutils-py.info
@@ -1,3 +1,4 @@
+# -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 
 Package: ipython-genutils-py%type_pkg[python]
@@ -5,14 +6,13 @@ Version: 0.2.0
 Revision: 1
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
 License: BSD
-Type: python (2.7 3.4 3.5 3.6)
-Homepage: https://pypi.python.org/pypi/ipython_genutils
+Type: python (2.7 3.4 3.5 3.6 3.7)
+Homepage: https://pypi.python.org/project/ipython_genutils
 Source: https://files.pythonhosted.org/packages/source/i/ipython_genutils/ipython_genutils-%v.tar.gz
 Source-MD5: 5a4f9781f78466da0ea1a648f3e1f79f
 
-Depends: <<
-    python%type_pkg[python]-shlibs
-<<
+Depends: python%type_pkg[python]-shlibs
+
 BuildDepends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
 
 Description: Vestigial utilities from IPython

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/jdcal-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/jdcal-py.info
@@ -1,7 +1,7 @@
 Info2: <<
 
 Package: jdcal-py%type_pkg[python]
-Version: 1.4
+Version: 1.4.1
 
 Revision: 1
 Homepage: https://pypi.python.org/pypi/jdcal
@@ -11,7 +11,7 @@ Depends: python%type_pkg[python]
 BuildDepends: setuptools-tng-py%type_pkg[python]
 
 Source: https://pypi.io/packages/source/j/jdcal/jdcal-%v.tar.gz
-Source-Checksum: SHA256(ea0a5067c5f0f50ad4c7bdc80abad3d976604f6fb026b0b3a17a9d84bb9046c9)
+Source-Checksum: SHA256(472872e096eb8df219c23f2689fc336668bdb43d194094b5cc1707e1640acfc8)
 
 CompileScript: <<
   #!/bin/bash -ev

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/jdcal-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/jdcal-py.info
@@ -7,7 +7,7 @@ Revision: 1
 Homepage: https://pypi.python.org/pypi/jdcal
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
 Type: python (2.7 3.4 3.5 3.6 3.7)
-Depends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
+Depends: python%type_pkg[python]
 BuildDepends: setuptools-tng-py%type_pkg[python]
 
 Source: https://pypi.io/packages/source/j/jdcal/jdcal-%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/jdcal-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/jdcal-py.info
@@ -1,7 +1,7 @@
 Info2: <<
 
 Package: jdcal-py%type_pkg[python]
-Version: 1.0
+Version: 1.4
 
 Revision: 1
 Homepage: https://pypi.python.org/pypi/jdcal
@@ -10,8 +10,8 @@ Type: python (2.7 3.4 3.5 3.6 3.7)
 Depends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
 BuildDepends: setuptools-tng-py%type_pkg[python]
 
-Source: https://pypi.python.org/packages/source/j/jdcal/jdcal-%v.tar.gz
-Source-MD5: ae4a28210426f575232cb5a48d478d08
+Source: https://pypi.io/packages/source/j/jdcal/jdcal-%v.tar.gz
+Source-Checksum: SHA256(ea0a5067c5f0f50ad4c7bdc80abad3d976604f6fb026b0b3a17a9d84bb9046c9)
 
 CompileScript: <<
   #!/bin/bash -ev

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/jedi-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/jedi-py.info
@@ -1,0 +1,58 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+Package: jedi-py%type_pkg[python]
+Version: 0.13.3
+Revision: 1
+Type: python (2.7 3.4 3.5 3.6 3.7)
+
+Description: Python autocompletion tool for e.g. editors
+DescDetail: <<
+Jedi is a static analysis tool for Python that can be used in IDEs/editors.
+Its historic focus is autocompletion, but it does static analysis for now as
+well. Jedi is fast and is very well tested. It understands Python on a deeper
+level than all other static analysis frameworks for Python.
+Jedi has support for two different goto functions. It is possible to search
+for related names and to list all names in a Python file and infer them.
+Jedi understands docstrings and you can use Jedi autocompletion in your REPL
+as well. Jedi uses a very simple API to connect with IDEs. There is a
+reference implementation as a VIM-Plugin, which uses Jedi's autocompletion, on
+https://github.com/davidhalter/jedi-vim
+We encourage you to use Jedi in your IDEs. It's really easy.
+Jedi can currently be used with Vim, Emacs, Kate, Ipython 6+ and many more.
+<<
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+License: OSI-Approved
+Homepage: https://github.com/davidhalter/jedi
+
+Source: https://files.pythonhosted.org/packages/source/j/jedi/jedi-%v.tar.gz
+Source-Checksum: SHA256(2bb0603e3506f708e792c7f4ad8fc2a7a9d9c2d292a358fbbd58da531695595b)
+
+Depends: python%type_pkg[python], docopt-py%type_pkg[python], parso-py%type_pkg[python] (>= 0.3.0)
+BuildDepends: fink (>= 0.24.12)
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build
+
+InfoTest: <<
+    TestDepends: pytest-py%type_pkg[python], tox-py%type_pkg[python]
+    # loads of errors with tox which keeps trying to write into $HOME/Library/caches
+    # mkdir -p Library/caches
+    # TOX_TESTENV_PASSENV="PYTHONPATH=%b/build/lib HOME=%b" %p/bin/tox-py%type_pkg[python] -e py%type_pkg[python] || TESTFAIL=2
+    # with run-tests, all default tests succeed under Python <= 3.6 (some PEP-related failures with 3.7)
+    TestScript: <<
+        #!/bin/bash -ev
+        TESTFAIL=0
+        echo "backend: QT5Agg" > matplotlibrc
+        # disable thirdparty tests importing a deprecated jedi.parsing submodule:
+        mv test/completion/thirdparty/jedi_{,disabled}.py
+        # some failures in PyQt4_.py, psycopg2_.py and others remaining
+        PYTHONPATH=build/lib %p/bin/python%type_raw[python] test/run.py --thirdparty || TESTFAIL=1
+        find build/lib -name '*.pyc' -exec rm {} \;
+        exit $TESTFAIL
+    <<
+<<
+
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
+
+DocFiles: LICENSE.txt AUTHORS.txt README.rst CHANGELOG.rst PKG-INFO docs/docs
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/nose-warnings-filters-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/nose-warnings-filters-py.info
@@ -1,0 +1,52 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+Package: nose-warnings-filters-py%type_pkg[python]
+Version: 0.1.5
+Revision: 1
+Type: python (2.7 3.4 3.5 3.6 3.7)
+
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+License: OSI-Approved
+Homepage: https://pypi.org/project/nose_warnings_filters/
+
+Description: Allow to inject warning filters in `nosetest`
+
+Source: https://files.pythonhosted.org/packages/source/n/nose_warnings_filters/nose_warnings_filters-%v.tar.gz
+Source-Checksum: SHA256(456c5b2ccca24e1d00a7b558274ebf9318305813dcb9585951a73ae11d76bb9d)
+Source2: https://github.com/Carreau/nose_warnings_filters/raw/master/LICENSE
+Source2-MD5: 7742716e68ed9b3c6353ec51bcf24cd9
+Source3: https://github.com/Carreau/nose_warnings_filters/raw/master/readme.md
+Source3-MD5: a70fd5a786e46c4d40941973b1dc1eea
+
+Depends: python%type_pkg[python], nose-py%type_pkg[python]
+BuildDepends: fink (>= 0.32), setuptools-tng-py%type_pkg[python]
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build
+
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
+
+InfoTest: TestScript: PYTHONPATH=%b/build/lib %p/bin/python%type_raw[python] -m nose || exit 2
+
+DocFiles: ../readme.md ../LICENSE PKG-INFO
+DescDetail: <<
+Allow to inject warning filters during nosetest.
+Put the same arguments as warnings.filterwarnings in setup.cfg at the root of
+your project. Separated each argument by pipes |, one filter per line.
+Whitespace are stripped, for example:
+
+[nosetests]
+warningfilters=default  |.*            |DeprecationWarning |notebook.*
+               ignore   |.*metadata.*  |DeprecationWarning |notebook.*
+               once     |.*schema.*    |UserWarning        |nbfor.*
+               error    |.*warn.*      |DeprecationWarning |notebook.services.*
+
+If you prefer another name for the configuration file, you can tell nose to
+load the configuration using the -c flag: run the tests with
+nosetests -c nose.cfg.
+<<
+
+DescPackaging: <<
+PyPI source has no license or documentation, github releases are only at 0.1.1.
+<<
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pandocfilters-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pandocfilters-py.info
@@ -1,0 +1,45 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+
+Package: pandocfilters-py%type_pkg[python]
+Version: 1.4.2
+Revision: 1
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+License: BSD
+Type: python (2.7 3.4 3.5 3.6 3.7)
+Homepage: http://github.com/jgm/pandocfilters
+Source: https://files.pythonhosted.org/packages/source/p/pandocfilters/pandocfilters-%v.tar.gz
+Source-MD5: dc391791ef54c7de1572d7b46b63361f
+Source-Checksum: SHA256(b3dd70e169bb5449e6bc6ff96aea89c5eea8c5f6ab5e207fc2f521a2cf4a0da9)
+
+Depends: python%type_pkg[python]-shlibs, pandoc
+BuildDepends: python%type_pkg[python], setuptools-tng-py%type_pkg[python], pygraphviz-py%type_pkg[python]
+
+Description: Python utilities for writing pandoc filters
+
+DescDetail: <<
+A Python module for writing pandoc filters.
+Pandoc filters are pipes that read a JSON serialization of the Pandoc
+AST from stdin, transform it in some way, and write it to stdout.
+<<
+
+CompileScript: <<
+ #!/bin/bash -ev
+ %p/bin/python%type_raw[python] setup.py build
+ cd examples
+ # produces some sample sheets, others don't work; pygraphviz required
+ [ %type_pkg[python] -ge 30 ] && %p/bin/2to3-%type_raw[python] $(grep -l '/bin/env python$' *.py)
+ perl -pi.bak -e 's|(bin/env) (python$)|$1 python%type_raw[python]|;' *.py
+ [ %type_pkg[python] -ge 30 ] && perl -pi.bak -e 's|(bin/env) (python3$)|$1 python%type_raw[python]|;' *.py
+ PYTHONPATH=%b/build/lib make
+ find .. -name "*.pyc" -delete
+<<
+
+InstallScript: <<
+ %p/bin/python%type_raw[python] setup.py install --root=%d
+<<
+
+DocFiles: README.rst examples/*.pdf
+
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/parso-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/parso-py.info
@@ -1,0 +1,41 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+Package: parso-py%type_pkg[python]
+Version: 0.3.4
+Revision: 1
+Type: python (2.7 3.4 3.5 3.6 3.7)
+
+Description: Python parser supporting error recovery
+DescDetail: <<
+Parso is a Python parser that supports error recovery and round-trip parsing
+for different Python versions (in multiple Python versions). Parso is also
+able to list multiple syntax errors in your python file.
+Parso has been battle-tested by jedi. It was pulled out of jedi to be useful
+for other projects as well.
+Parso consists of a small API to parse Python and analyse the syntax tree.
+<<
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+License: OSI-Approved
+Homepage: https://github.com/davidhalter/parso
+
+Source: https://files.pythonhosted.org/packages/source/p/parso/parso-%v.tar.gz
+Source-Checksum: SHA256(68406ebd7eafe17f8e40e15a84b56848eccbf27d7c1feb89e93d8fca395706db)
+
+Depends: python%type_pkg[python]
+BuildDepends: fink (>= 0.24.12)
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build
+
+InfoTest: <<
+    TestDepends: pytest-py%type_pkg[python]
+    TestScript: <<
+        PYTHONPATH=build/lib %p/bin/pytest-%type_raw[python] test/test_* || exit 2
+        find build/lib -name '*.pyc' -exec rm {} \;
+    <<
+<<
+
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
+
+DocFiles: LICENSE.txt AUTHORS.txt README.rst CHANGELOG.rst PKG-INFO docs/docs
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/parso-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/parso-py.info
@@ -22,7 +22,7 @@ Source: https://files.pythonhosted.org/packages/source/p/parso/parso-%v.tar.gz
 Source-Checksum: SHA256(68406ebd7eafe17f8e40e15a84b56848eccbf27d7c1feb89e93d8fca395706db)
 
 Depends: python%type_pkg[python]
-BuildDepends: fink (>= 0.24.12)
+BuildDepends: fink (>= 0.24.12), setuptools-tng-py%type_pkg[python]
 
 CompileScript: %p/bin/python%type_raw[python] setup.py build
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pickleshare-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pickleshare-py.info
@@ -1,14 +1,15 @@
+# -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 
 Package: pickleshare-py%type_pkg[python]
-Version: 0.5
+Version: 0.7.5
 Revision: 1
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 License: BSD
 Type: python (2.7 3.4 3.5 3.6 3.7)
-Homepage: https://pypi.python.org/pypi/pickleshare
-Source: https://pypi.python.org/packages/source/p/pickleshare/pickleshare-%v.tar.gz
-Source-MD5: 25337740507cb855ad58bfcf60f7710e
+Homepage: https://pypi.python.org/project/pickleshare
+Source: https://files.pythonhosted.org/packages/source/p/pickleshare/pickleshare-%v.tar.gz
+Source-Checksum: SHA256(87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca)
 
 Depends: <<
     python%type_pkg[python]-shlibs

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/prometheus-client-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/prometheus-client-py.info
@@ -1,0 +1,48 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+Package: prometheus-client-py%type_pkg[python]
+Version: 0.6.0
+Revision: 1
+Type: python (2.7 3.4 3.5 3.6 3.7)
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+
+# pythonhosted distribution is missing LICENSE and tests!
+# Source: https://files.pythonhosted.org/packages/source/p/prometheus_client/prometheus_client-%v.tar.gz
+# Source-Checksum: SHA256(1b38b958750f66f208bcd9ab92a633c0c994d8859c831f7abc1f46724fcee490)
+Source: https://github.com/prometheus/client_python/archive/v%v.tar.gz
+Source-Checksum: SHA256(d1f99fbc91d3191d7dd78808665627fd3df0a34b52e000538cc18e39789a2cd7)
+SourceRename: prometheus_client-%v.tar.gz
+SourceDirectory: client_python-%v
+
+Depends: python%type_pkg[python]
+BuildDepends: setuptools-tng-py%type_pkg[python]
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build
+
+InfoTest: <<
+  TestDepends: <<
+    pytest-py%type_pkg[python],
+    coverage-py%type_pkg[python],
+    flake8-py%type_pkg[python],
+    futures-py%type_pkg[python],
+    py-py%type_pkg[python]
+  <<
+    # twisted-py%type_pkg[python],
+  TestScript: pytest-%type_raw[python] tests || exit 2
+<<
+
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root %d
+
+DocFiles:  README.md MAINTAINERS.md CONTRIBUTING.md LICENSE NOTICE
+
+License: BSD
+Homepage: https://pypi.org/project/prometheus_client/
+Description: Prometheus Python Client
+DescDetail: <<
+Official Python client for the open-source monitoring system Prometheus.
+Four types of metric are offered: Counter, Gauge, Summary and Histogram.
+See the documentation on metric types and instrumentation best practices
+on how to use them. Refer to README.md for basic configuration.
+<<
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/prompt-toolkit-py-1.0.15.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/prompt-toolkit-py-1.0.15.info
@@ -1,0 +1,62 @@
+Info2: <<
+
+Package: prompt-toolkit-py%type_pkg[python]
+Version: 1.0.15
+Revision: 1
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+License: BSD
+Type: python (2.7 3.4 3.5 3.6)
+Homepage: https://pypi.python.org/pypi/prompt_toolkit
+Source: https://files.pythonhosted.org/packages/source/p/prompt_toolkit/prompt_toolkit-%v.tar.gz
+Source-Checksum: SHA256(858588f1983ca497f1cf4ffde01d978a3ea02b01c8a26a8bbc5cd2e66d816917)
+
+Depends: <<
+  python%type_pkg[python]-shlibs,
+  pygments-py%type_pkg[python],
+  six-py%type_pkg[python],
+  wcwidth-py%type_pkg[python]
+<<
+BuildDepends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
+
+CompileScript: python%type_raw[python] setup.py build
+InstallScript: python%type_raw[python] setup.py install --root=%d
+
+InfoTest: <<
+  TestDepends: pytest-py%type_pkg[python]
+  TestConflicts: pytest-relaxed-py%type_pkg[python]
+  TestScript: PYTHONPATH=build/lib %p/bin/python%type_raw[python] -B -m pytest || exit 2
+  TestSuiteSize: small
+<<
+
+Description: Interactive command line building library
+
+DescDetail: <<
+prompt_toolkit is a library for building powerful interactive command lines
+and terminal applications in Python.It can be a pure Python replacement for
+GNU readline, but it can be much more than that.
+
+Some features:
+Syntax highlighting of the input while typing. (For instance, with a Pygments
+lexer.)
+Multi-line input editing.
+Advanced code completion.
+Selecting text for copy/paste. (Both Emacs and Vi style.)
+Mouse support for cursor positioning and scrolling.
+Auto suggestions. (Like fish shell.)
+No global state.
+
+Like readline:
+Both Emacs and Vi key bindings.
+Reverse and forward incremental search.
+Works well with Unicode double width characters. (Chinese input.)
+
+No assumptions about I/O are made. Every prompt_toolkit application should also
+run in a telnet/ssh server or an asyncio process.
+<<
+
+DescPackaging: Compatibility version for ipython-5.x
+
+DocFiles: examples
+
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/prompt-toolkit-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/prompt-toolkit-py.info
@@ -1,0 +1,63 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+
+Package: prompt-toolkit-py%type_pkg[python]
+Version: 2.0.9
+Revision: 1
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+License: BSD
+Type: python (3.4 3.5 3.6 3.7)
+Homepage: https://pypi.python.org/pypi/prompt_toolkit
+Source: https://files.pythonhosted.org/packages/source/p/prompt_toolkit/prompt_toolkit-%v.tar.gz
+Source-Checksum: SHA256(2519ad1d8038fd5fc8e770362237ad0364d16a7650fb5724af6997ed5515e3c1)
+
+Depends: <<
+  python%type_pkg[python]-shlibs,
+  pygments-py%type_pkg[python],
+  six-py%type_pkg[python],
+  wcwidth-py%type_pkg[python]
+<<
+BuildDepends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
+
+CompileScript: python%type_raw[python] setup.py build
+InstallScript: python%type_raw[python] setup.py install --root=%d
+
+InfoTest: <<
+  TestDepends: pytest-py%type_pkg[python]
+  TestConflicts: pytest-relaxed-py%type_pkg[python]
+  TestScript: PYTHONPATH=build/lib %p/bin/python%type_raw[python] -B -m pytest || exit 2
+  TestSuiteSize: small
+<<
+
+Description: Interactive command line building library
+
+DescDetail: <<
+prompt_toolkit is a library for building powerful interactive command lines
+and terminal applications in Python.It can be a pure Python replacement for
+GNU readline, but it can be much more than that.
+
+Some features:
+Syntax highlighting of the input while typing. (For instance, with a Pygments
+lexer.)
+Multi-line input editing.
+Advanced code completion.
+Selecting text for copy/paste. (Both Emacs and Vi style.)
+Mouse support for cursor positioning and scrolling.
+Auto suggestions. (Like fish shell.)
+No global state.
+
+Like readline:
+Both Emacs and Vi key bindings.
+Reverse and forward incremental search.
+Works well with Unicode double width characters. (Chinese input.)
+
+No assumptions about I/O are made. Every prompt_toolkit application should also
+run in a telnet/ssh server or an asyncio process.
+<<
+
+DescPackaging: 2.x available for Python 2.7, but conflicts with ipython-5.x
+
+DocFiles: README.rst AUTHORS.rst CHANGELOG LICENSE PKG-INFO examples
+
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pygraphviz-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pygraphviz-py.info
@@ -26,7 +26,7 @@ CompileScript: %p/bin/python%type_raw[python] setup.py build_ext --include-dirs=
 
 InfoTest: <<
 	# Some tests failing for python2.7, segfaults under python3.x
-	TestDepends: setuptools-tng-py%type_pkg[python], graphviz | graphviz-nox, doctest-ignore-unicode-py%type_pkg[python]
+	TestDepends: setuptools-tng-py%type_pkg[python], graphviz | graphviz-nox, doctest-ignore-unicode-py%type_pkg[python], mock-py%type_pkg[python], nose-py%type_pkg[python]
 	TestScript: %p/bin/python%type_raw[python] setup.py nosetests || exit 1
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pygraphviz-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pygraphviz-py.info
@@ -1,8 +1,9 @@
+# -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: pygraphviz-py%type_pkg[python]
-Version: 1.3rc2
-Revision: 2
-Type: python (2.7)
+Version: 1.5
+Revision: 1
+Type: python (2.7 3.4 3.5 3.6 3.7)
 Description: Python interface for graphviz
 DescDetail: <<
 	PyGraphviz is a Python interface to the Graphviz graph layout and
@@ -14,23 +15,27 @@ Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 License: BSD
 Homepage: http://networkx.lanl.gov/pygraphviz/
 
-Source: https://pypi.python.org/packages/source/p/pygraphviz/pygraphviz-%v.tar.gz
-Source-MD5: 061ff5c4b8ea4b7cd05be0588172ef07
+Source: https://files.pythonhosted.org/packages/source/p/pygraphviz/pygraphviz-%v.zip
+Source-MD5: c186f5f6567e523a862063fc62ddcd2f
+Source-Checksum: SHA256(50a829a305dc5a0fd1f9590748b19fece756093b581ac91e00c2c27c651d319d)
 
 Depends: python%type_pkg[python], libgraphviz238-shlibs | libgraphviz238-nox-shlibs
 BuildDepends: fink (>= 0.24.12), libgraphviz238-dev | libgraphviz238-nox-dev, pkgconfig
 
-CompileScript: %p/bin/python%type_raw[python] setup.py build
+CompileScript: %p/bin/python%type_raw[python] setup.py build_ext --include-dirs=%p/include --library-dirs=%p/lib/graphviz-2.38
 
 InfoTest: <<
+	# Some tests failing for python2.7, segfaults under python3.x
 	TestDepends: setuptools-tng-py%type_pkg[python], graphviz | graphviz-nox, doctest-ignore-unicode-py%type_pkg[python]
-	TestScript: %p/bin/python%type_raw[python] setup_egg.py nosetests || exit 2
+	TestScript: %p/bin/python%type_raw[python] setup.py nosetests || exit 1
 <<
 
 InstallScript: <<
+	find . -name "*.pyc" -delete
 	%p/bin/python%type_raw[python] setup.py install --root=%d
 	mv %i/share/doc/pygraphviz-* %i/share/doc/pygraphviz-py%type_pkg[python]
 <<
 
-DocFiles: PKG-INFO README.txt
+DocFiles: PKG-INFO README.rst LICENSE INSTALL.txt examples
+# Info2
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pygraphviz-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pygraphviz-py.info
@@ -26,7 +26,13 @@ CompileScript: %p/bin/python%type_raw[python] setup.py build_ext --include-dirs=
 
 InfoTest: <<
 	# Some tests failing for python2.7, segfaults under python3.x
-	TestDepends: setuptools-tng-py%type_pkg[python], graphviz | graphviz-nox, doctest-ignore-unicode-py%type_pkg[python], mock-py%type_pkg[python], nose-py%type_pkg[python]
+	TestDepends: <<
+		setuptools-tng-py%type_pkg[python],
+		graphviz | graphviz-nox,
+		doctest-ignore-unicode-py%type_pkg[python],
+		mock-py%type_pkg[python],
+		nose-py%type_pkg[python]
+	<<
 	TestScript: %p/bin/python%type_raw[python] setup.py nosetests || exit 1
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/send2trash-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/send2trash-py.info
@@ -1,0 +1,42 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+Package: send2trash-py%type_pkg[python]
+Version: 1.5.0
+Revision: 1
+Type: python (2.7 3.4 3.5 3.6 3.7)
+
+Description: Send file to trash natively under MacOS X
+DescDetail: <<
+Send2Trash is a small package that sends files to the Trash (or Recycle Bin)
+natively and on all platforms. On OS X, it uses native FSMoveObjectToTrashSync
+Cocoa calls, on Windows, it uses native (and ugly) SHFileOperation win32 calls.
+On other platforms, if PyGObject and GIO are available, it will use this.
+Otherwise, it will fallback to its own implementation of the trash
+specifications from freedesktop.org.
+<<
+DescPort: <<
+``ctypes`` is used to access native libraries, so no compilation is necessary;
+pytest implemented, but no actual tests present.
+<<
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+License: BSD
+Homepage: https://github.com/hsoft/send2trash
+
+Source: https://files.pythonhosted.org/packages/source/S/Send2Trash/Send2Trash-%v.tar.gz
+Source-MD5: eccc3563a305b8cb10001ffd1aa92fa0
+
+Depends: python%type_pkg[python]
+BuildDepends: fink (>= 0.24.12)
+
+CompileScript: true
+
+InfoTest: <<
+    TestDepends: pytest-py%type_pkg[python]
+    TestScript: PYTHONPATH=%b/build/lib %p/bin/pytest-%type_raw[python] || exit 1
+<<
+
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
+
+DocFiles: CHANGES.rst README.rst PKG-INFO
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/send2trash-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/send2trash-py.info
@@ -32,6 +32,7 @@ CompileScript: true
 
 InfoTest: <<
     TestDepends: pytest-py%type_pkg[python]
+    # 1 failing test: https://github.com/hsoft/send2trash/issues/35
     TestScript: PYTHONPATH=%b/build/lib %p/bin/pytest-%type_raw[python] || exit 1
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/testpath-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/testpath-py.info
@@ -24,7 +24,10 @@ InstallScript: <<
 
 InfoTest: <<
   TestDepends: pytest-py%type_pkg[python]
-  TestScript: PYTHONPATH=%b/build/lib %p/bin/python%type_raw[python] -m pytest || exit 2
+  TestScript: <<
+  	PYTHONPATH=%b/build/lib %p/bin/python%type_raw[python] -m pytest || exit 2
+  	find . -name "*.pyc" -delete
+  <<
   TestSuiteSize: small
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/testpath-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/testpath-py.info
@@ -15,20 +15,20 @@ Depends: python%type_pkg[python]-shlibs
 BuildDepends: python%type_pkg[python]
 
 CompileScript: <<
-   %p/bin/python%type_raw[python] setup.py build
+    %p/bin/python%type_raw[python] setup.py build
 <<
 
 InstallScript: <<
-   %p/bin/python%type_raw[python] setup.py install --root %d
+    %p/bin/python%type_raw[python] setup.py install --root %d
 <<
 
 InfoTest: <<
-  TestDepends: pytest-py%type_pkg[python]
-  TestScript: <<
-  	PYTHONPATH=%b/build/lib %p/bin/python%type_raw[python] -m pytest || exit 2
-  	find . -name "*.pyc" -delete
-  <<
-  TestSuiteSize: small
+    TestDepends: pytest-py%type_pkg[python]
+    TestScript: <<
+        PYTHONPATH=%b/build/lib %p/bin/python%type_raw[python] -m pytest || exit 2
+        find . -name "*.pyc" -delete
+    <<
+    TestSuiteSize: small
 <<
 
 Description: Test utilities for files and commands code

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/testpath-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/testpath-py.info
@@ -1,0 +1,43 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+
+Package: testpath-py%type_pkg[python]
+Version: 0.4.2
+Revision: 1
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+License: BSD
+Type: python (2.7 3.4 3.5 3.6 3.7)
+Homepage: https://pypi.python.org/project/testpath
+Source: https://files.pythonhosted.org/packages/source/t/testpath/testpath-%v.tar.gz
+Source-Checksum: SHA256(b694b3d9288dbd81685c5d2e7140b81365d46c29f5db4bc659de5aa6b98780f8)
+
+Depends: python%type_pkg[python]-shlibs
+BuildDepends: python%type_pkg[python]
+
+CompileScript: <<
+   %p/bin/python%type_raw[python] setup.py build
+<<
+
+InstallScript: <<
+   %p/bin/python%type_raw[python] setup.py install --root %d
+<<
+
+InfoTest: <<
+  TestDepends: pytest-py%type_pkg[python]
+  TestScript: PYTHONPATH=%b/build/lib %p/bin/python%type_raw[python] -m pytest || exit 2
+  TestSuiteSize: small
+<<
+
+Description: Test utilities for files and commands code
+
+DescDetail: <<
+Testpath is a collection of utilities for Python code working with files and
+commands. It contains functions to check things on the filesystem, and tools
+for mocking system commands and recording calls to those.
+<<
+
+# ToDo: Sphinx-build doc
+DocFiles: README.rst LICENSE PKG-INFO doc
+
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/traitlets-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/traitlets-py.info
@@ -1,11 +1,11 @@
-Info3: <<
+Info2: <<
 
 Package: traitlets-py%type_pkg[python]
 Version: 4.3.2
 Revision: 1
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 License: BSD
-Type: python (2.7 3.4 3.5 3.6)
+Type: python (2.7 3.4 3.5 3.6 3.7)
 Homepage: https://pypi.python.org/pypi/traitlets
 Source: https://files.pythonhosted.org/packages/source/t/traitlets/traitlets-%v.tar.gz
 Source-MD5: 3068663f2f38fd939a9eb3a500ccc154
@@ -29,5 +29,5 @@ DocFiles: docs examples
 CompileScript: true
 InstallScript: python%type_raw[python] setup.py install --root=%d
 
-# Info3
+# Info2
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/wcwidth-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/wcwidth-py.info
@@ -1,0 +1,49 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+
+Package: wcwidth-py%type_pkg[python]
+Version: 0.1.7
+Revision: 1
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+License: BSD
+Type: python (2.7 3.4 3.5 3.6 3.7)
+Homepage: https://github.com/jquast/wcwidth
+Source: https://files.pythonhosted.org/packages/source/w/wcwidth/wcwidth-%v.tar.gz
+Source-MD5: b3b6a0a08f0c8a34d1de8cf44150a4ad
+
+Depends: python%type_pkg[python]-shlibs
+BuildDepends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
+
+CompileScript: python%type_raw[python] setup.py build
+InstallScript: python%type_raw[python] setup.py install --root=%d
+
+InfoTest: <<
+  TestDepends: pytest-py%type_pkg[python]
+  TestScript: PYTHONPATH=build/lib %p/bin/py.test-%type_raw[python] wcwidth || exit 2
+  TestSuiteSize: small
+<<
+
+Description: Measure number of Terminal column cells
+
+DescDetail: <<
+This library measures the number of Terminal column cells of wide-character
+codes. It is mainly intended for those implementing a Terminal Emulator,
+or programs that carefully produce output to be interpreted by one.
+
+Problem Statement: When printed to the screen, the length of the string is
+usually equal to the number of cells it occupies. However, there are categories
+of characters that occupy 2 cells (full-wide), and others that occupy 0.
+
+Solution: POSIX.1-2001 and POSIX.1-2008 conforming systems provide wcwidth(3)
+and wcswidth(3) C functions of which this python module's functions precisely
+copy. These functions return the number of cells a unicode string is expected
+to occupy.
+
+This library aims to be forward-looking, portable, and most correct. The most
+current release of this API is based on the Unicode Standard release files.
+<<
+
+DocFiles: README.rst
+
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/web/selenium-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/selenium-py.info
@@ -1,0 +1,29 @@
+Info2: <<
+Package: selenium-py%type_pkg[python]
+Version: 3.141.0
+Revision: 1
+Type: python (2.7 3.4 3.5 3.6 3.7)
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+Homepage: https://pypi.org/project/selenium
+LICENSE: OSI-Approved
+
+Source: https://files.pythonhosted.org/packages/source/s/selenium/selenium-%v.tar.gz
+Source-CheckSum: SHA256(deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d)
+Depends: python%type_pkg[python]
+BuildDepends: setuptools-tng-py%type_pkg[python]
+
+CompileScript: echo Skipping compile stage
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
+
+Description: Python bindings for Selenium
+DescDetail: <<
+Python language bindings for Selenium WebDriver.
+The selenium package is used to automate web browser interaction from Python.
+Several browsers/drivers are supported (Firefox, Chrome, Internet Explorer),
+as well as the Remote protocol.
+<<
+
+DocFiles: README.rst CHANGES LICENSE PKG-INFO
+
+# Info2:
+<<

--- a/10.9-libcxx/stable/main/finkinfo/web/zopeevent-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/zopeevent-py.info
@@ -1,0 +1,38 @@
+Info2: <<
+
+Package: zopeevent-py%type_pkg[python]
+Version: 4.4
+Revision: 1
+Description: Very basic event publishing system
+DescDetail: <<
+The zope.event package provides a simple event system, including:
+ An event publishing API, intended for use by applications which are unaware
+ of any subscribers to their events.
+ A very simple event-dispatching system on which more sophisticated event
+ dispatching systems can be built. For example, a type-based event dispatching
+ system that builds on zope.event can be found in zope.component.
+<<
+
+Source: https://pypi.io/packages/source/z/zope.event/zope.event-%v.tar.gz
+Source-Checksum: SHA256(69c27debad9bdacd9ce9b735dad382142281ac770c4a432b533d6d65c4614bcf)
+Type: python (2.7 3.4 3.5 3.6 3.7)
+Depends: python%type_pkg[python]
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
+InfoTest: <<
+ TestDepends: nose-py%type_pkg[python]
+ TestScript: <<
+  %p/bin/nosetests-%type_raw[python] -v
+ <<
+ TestSuiteSize: small
+<<
+
+DocFiles: README.rst CHANGES.rst LICENSE.txt
+License: OSI-Approved
+Homepage: http://pypi.org/project/zope.event
+
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/web/zopeevent-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/zopeevent-py.info
@@ -17,7 +17,9 @@ Source: https://pypi.io/packages/source/z/zope.event/zope.event-%v.tar.gz
 Source-Checksum: SHA256(69c27debad9bdacd9ce9b735dad382142281ac770c4a432b533d6d65c4614bcf)
 Type: python (2.7 3.4 3.5 3.6 3.7)
 Depends: python%type_pkg[python]
-
+BuildDepends: <<
+ setuptools-tng-py%type_pkg[python]
+<<
 CompileScript: %p/bin/python%type_raw[python] setup.py build
 InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
 InfoTest: <<

--- a/10.9-libcxx/stable/main/finkinfo/web/zopeinterface-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/zopeinterface-py.info
@@ -13,6 +13,9 @@ Source: https://pypi.io/packages/source/z/zope.interface/zope.interface-%v.tar.g
 Source-Checksum: SHA256(1b3d0dcabc7c90b470e59e38a9acaa361be43b3a6ea644c0063951964717f0e5)
 Type: python (2.7 3.4 3.5 3.6 3.7)
 Depends: python%type_pkg[python]
+BuildDepends: <<
+ setuptools-tng-py%type_pkg[python]
+<<
 
 CompileScript: %p/bin/python%type_raw[python] setup.py build
 InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d

--- a/10.9-libcxx/stable/main/finkinfo/web/zopeinterface-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/zopeinterface-py.info
@@ -1,7 +1,7 @@
 Info2: <<
 
 Package: zopeinterface-py%type_pkg[python]
-Version: 4.1.2
+Version: 4.6.0
 Revision: 1
 Description: Interface distribution from Zope 3
 DescDetail: <<
@@ -9,16 +9,15 @@ This is a separate distribution of the zope.interface package
 used in Zope 3, along with the packages it depends on.
 <<
 
-Source: http://pypi.python.org/packages/source/z/zope.interface/zope.interface-%v.tar.gz
-Source-MD5: 04298faeaa70b4f3b23fa2ae8987262c
-Source2: http://www.zope.org/Products/Zope/LICENSE.txt
-Source2-MD5: 638c27dc9783a4820f57829a4d856703
-Type: python (2.7 3.4 3.5 3.6)
+Source: https://pypi.io/packages/source/z/zope.interface/zope.interface-%v.tar.gz
+Source-Checksum: SHA256(1b3d0dcabc7c90b470e59e38a9acaa361be43b3a6ea644c0063951964717f0e5)
+Type: python (2.7 3.4 3.5 3.6 3.7)
 Depends: python%type_pkg[python]
 
 CompileScript: %p/bin/python%type_raw[python] setup.py build
 InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
 InfoTest: <<
+ TestDepends: zopeevent-py%type_pkg[python] (>= 4.4)
  TestScript: <<
   %p/bin/python%type_raw[python] -B setup.py test
  <<
@@ -27,7 +26,7 @@ InfoTest: <<
 
 DocFiles: README.rst LICENSE.txt
 License: OSI-Approved
-Homepage: http://pypi.python.org/pypi/zope.interface
+Homepage: http://pypi.org/project/zope.interface
 
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 


### PR DESCRIPTION
Starting a new PR for the IPython/Jupyter/Notebook infrastructure, since #164 has become quite unmanageable with half of the packages already changed elsewhere or committed independently to `master` by now.

This PR contains only updates/Python3.7 extensions and new submissions without any dependencies on the new `ipython-py` package itself, so for this part there should not be any problems with circular (test) dependencies. Enabled strict testing where possible, except for `pygraphviz-py`, which fails on ~24 tests and just returns a warning (`exit 1`).