### PR TITLE
grib-api-fortran-1.28.0-2: Update dependency gcc7 -> gcc8

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/grib-api-fortran.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/grib-api-fortran.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: grib-api-fortran
 Version: 1.28.0
-Revision: 1
-Type: gcc (7)
+Revision: 2
+Type: gcc (8)
 Description: ECMWF GRIB API, Fortran headers
 Homepage: https://software.ecmwf.int/wiki/display/GRIB/Home
 License: BSD


### PR DESCRIPTION
Simple dependency update
Built and tested on MacOS 10.14.4 with Command Line Tools 10.2