### PR TITLE
nginx 1.14.2

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/web/nginx.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/nginx.info
@@ -1,5 +1,5 @@
 Package: nginx
-Version: 1.12.2
+Version: 1.14.2
 Revision: 1
 Description: Small, powerful, scalable web/proxy server
 License: BSD
@@ -15,8 +15,10 @@ Depends: <<
 	system-perl
 <<
 BuildDepends: <<
+	fink-package-precedence,
 	gd3,
 	geoip-dev,
+	libiconv-dev,
 	libpcre1,
 	libxml2,
 	libxslt,
@@ -28,15 +30,17 @@ Provides: httpd
 Replaces: nginx, nginx-cur
 Conflicts: nginx, nginx-cur
 Source: http://nginx.org/download/%n-%v.tar.gz
-Source-MD5: 4d2fc76211435f029271f1cf6d7eeae3
-Source-Checksum: SHA1(6b41d63befa4f52b0724b533e6292a6671b71fdc)
+Source-MD5: 239b829a13cea1d244c1044e830bd9c2
+Source-Checksum: SHA1(4b4df8786b44e79cffd2e002a070e27fd774a17f)
 PatchScript: <<
   /usr/bin/sed -i "" -e 's/"\$ENV{NGX_PM_CFLAGS}",/"\$ENV{NGX_PM_CFLAGS}", LDDLFLAGS => "\$Config{lddlflags} \$ENV{LDFLAGS}",/g' \
     -e 's/use 5.006001;/use 5.006001; use Config;/g' \
     src/http/modules/perl/Makefile.PL
+  # Don't try to detect MacPorts external libraries. Use Fink's.
+  perl -pi -e 's|/opt/local|%p|g; s|/usr/include|%p/include|g' auto/lib/{geoip,google-perftools,libgd,libxslt,openssl,pcre}/conf
 <<
 SetCFLAGS: -g -O2 -fstack-protector -Wformat -Werror=format-security -fPIE
-SetCPPFLAGS: -D_FORTIFY_SOURCE=2 
+SetCPPFLAGS: -D_FORTIFY_SOURCE=2 -MD
 SetCXXFLAGS: -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIE
 SetLDFLAGS: -Wl,-read_only_stubs -Wl,-bind_at_load -fPIE -Wl,-pie
 ConfigureParams: <<
@@ -88,6 +92,7 @@ CompileScript: <<
  MYPERL="$(/usr/bin/perl -w -Mstrict -E 'my $vers = $^V; $vers =~ tr/[0-9.]//cd; print $vers . "\n";')"
  ./configure %c --with-perl_modules_path=%p/lib/perl5/$MYPERL
  make INSTALLSITEMAN3DIR=%p/share/man/man3
+ fink-package-precedence --depfile-ext='\.d' .
 <<
 InstallScript: <<
 #!/bin/sh -ex
@@ -182,6 +187,11 @@ DescDetail: <<
 <<
 DescPackaging: <<
  Former maintainer: Andreas "gecko" Gockel
+ 
+ Uses homebuilt library detection that assumes things in /usr/include. This misses libxml2
+ among others, so we make sure it finds our own:
+ https://github.com/fink/fink-distributions/issues/395
+ https://trac.nginx.org/nginx/ticket/1765
 <<
 InfoTest: <<
  TestScript: echo "Nothing to test here"


### PR DESCRIPTION
Update to latest stable nginx release.
Fix library detection so that it doesn't search/#include /usr/include headers but then link %p libraries.
Fixes #395.