### PR TITLE
Lazarus: Update to new upstream version (2.0.2)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-doc.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-doc.info
@@ -1,14 +1,14 @@
 Package: lazarus-doc
-Version: 1.8.4
+Version: 2.0.2
 Revision: 1
-Enhances: lazarus-aqua, lazarus-gtk2, lazarus-qt4, lazarus-qt5
+Enhances: lazarus-aqua, lazarus-cocoa, lazarus-gtk2, lazarus-qt4, lazarus-qt5
 Recommends: xchm
 
 License: GPL/LGPL
-Source: mirror:sourceforge:lazarus/Lazarus%%20Documentation/Lazarus%%20%v/doc-chm-fpc3.0.4-laz1.8.zip
-Source-MD5: d0b9c5335c5501db2ee3f049d4479a70
+Source: mirror:sourceforge:lazarus/Lazarus%%20Documentation/Lazarus%%20%v/doc-chm-fpc3.0.4-laz%v.zip
+Source-MD5: 6c188aaf4dcc6e821729703bf188dec8
 
-SourceDirectory: docs_chm
+SourceDirectory: chm
 
 CompileScript: echo "Nothing to compile."
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-carbon.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-carbon.info
@@ -1,11 +1,11 @@
 Package: lazarus-lcl-carbon
-Version: 1.8.4
+Version: 2.0.2
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
-  lazarus-gtk2 (>= 1.8) | lazarus-qt4 (>= 1.8) | 
-  lazarus-qt5 (>= 1.8),
+  lazarus-cocoa (>= 2.0) | lazarus-gtk2 (>= 2.0) |
+  lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
   fpc-cross-i386-darwin (>= 3.0.4)
 <<
 
@@ -15,7 +15,7 @@ Replaces:  lazarus-aqua
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 57aee3f53202f069fbbf4304fd810990
+Source-MD5: 23dd868959c5d57091ce82504ef34e45
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-cocoa-32bit.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-cocoa-32bit.info
@@ -1,18 +1,18 @@
 Package: lazarus-lcl-cocoa-32bit
-Version: 1.8.4
+Version: 2.0.2
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
-  lazarus-aqua (>= 1.8) | lazarus-gtk2 (>= 1.8) | lazarus-qt4 (>= 1.8) | 
-  lazarus-qt5 (>= 1.8),
+  lazarus-aqua (>= 2.0) | lazarus-cocoa (>= 2.0) | lazarus-gtk2 (>= 2.0) | 
+  lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
   fpc-cross-i386-darwin (>= 3.0.4)
 <<
 
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 57aee3f53202f069fbbf4304fd810990
+Source-MD5: 23dd868959c5d57091ce82504ef34e45
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-cocoa.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-cocoa.info
@@ -1,11 +1,11 @@
 Package: lazarus-lcl-cocoa
-Version: 1.8.4
+Version: 2.0.2
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
-  lazarus-aqua (>= 1.8) | lazarus-gtk2 (>= 1.8) | lazarus-qt4 (>= 1.8) | 
-  lazarus-qt5 (>= 1.8),
+  lazarus-aqua (>= 2.0) | lazarus-gtk2 (>= 2.0) | 
+  lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
   fpc (>= 3.0.4)
 <<
 
@@ -15,7 +15,7 @@ Replaces:  lazarus-cocoa
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 57aee3f53202f069fbbf4304fd810990
+Source-MD5: 23dd868959c5d57091ce82504ef34e45
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-gtk2.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-gtk2.info
@@ -1,11 +1,11 @@
 Package: lazarus-lcl-gtk2
-Version: 1.8.4
+Version: 2.0.2
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
-  lazarus-aqua (>= 1.8) | lazarus-qt4 (>= 1.8) | 
-  lazarus-qt5 (>= 1.8),
+  lazarus-aqua (>= 2.0) | lazarus-cocoa (>= 2.0) | 
+  lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
   fpc (>= 3.0.4),
   gtk+2-shlibs,
   glib2-shlibs,
@@ -20,7 +20,7 @@ Replaces:  lazarus-gtk2
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 57aee3f53202f069fbbf4304fd810990
+Source-MD5: 23dd868959c5d57091ce82504ef34e45
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-qt4.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-qt4.info
@@ -1,11 +1,11 @@
 Package: lazarus-lcl-qt4
-Version: 1.8.4
+Version: 2.0.2
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
-  lazarus-aqua (>= 1.8) | lazarus-gtk2 (>= 1.8) | 
-  lazarus-qt5 (>= 1.8),
+  lazarus-aqua (>= 2.0) | lazarus-cocoa (>= 2.0) | lazarus-gtk2 (>= 2.0) | 
+  lazarus-qt5 (>= 2.0),
   qt4pas (>= 2.5-3)
 <<
 
@@ -15,7 +15,7 @@ Replaces:  lazarus-qt4
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 57aee3f53202f069fbbf4304fd810990
+Source-MD5: 23dd868959c5d57091ce82504ef34e45
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-qt5.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-qt5.info
@@ -1,11 +1,12 @@
 Package: lazarus-lcl-qt5
-Version: 1.8.4
+Version: 2.0.2
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
-  lazarus-aqua (>= 1.8) | lazarus-gtk2 (>= 1.8) | lazarus-qt4 (>= 1.8),
-  qt5-mac-qtbase-dev-tools, qt5pas (>= 1.8.2)
+  lazarus-aqua (>= 2.0) | lazarus-cocoa (>= 2.0) | lazarus-gtk2 (>= 2.0) |
+  lazarus-qt4 (>= 2.0),
+  qt5-mac-qtbase-dev-tools, qt5pas (>= 2.0)
 <<
 
 Conflicts: lazarus-qt5
@@ -14,7 +15,7 @@ Replaces:  lazarus-qt5
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 57aee3f53202f069fbbf4304fd810990
+Source-MD5: 23dd868959c5d57091ce82504ef34e45
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-win32.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-win32.info
@@ -1,18 +1,18 @@
 Package: lazarus-lcl-win32
-Version: 1.8.4
+Version: 2.0.2
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
-  lazarus-aqua (>= 1.8) | lazarus-gtk2 (>= 1.8) | lazarus-qt4 (>= 1.8) | 
-  lazarus-qt5 (>= 1.8),
+  lazarus-aqua (>= 2.0) | lazarus-cocoa (>= 2.0) | lazarus-gtk2 (>= 2.0) | 
+  lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
   fpc-cross-i386-win32 (>= 3.0.4)
 <<
 
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 57aee3f53202f069fbbf4304fd810990
+Source-MD5: 23dd868959c5d57091ce82504ef34e45
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-win64.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-win64.info
@@ -1,18 +1,18 @@
 Package: lazarus-lcl-win64
-Version: 1.8.4
+Version: 2.0.2
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
-  lazarus-aqua (>= 1.8) | lazarus-gtk2 (>= 1.8) | lazarus-qt4 (>= 1.8) | 
-  lazarus-qt5 (>= 1.8),
+  lazarus-aqua (>= 2.0) | lazarus-cocoa (>= 2.0) | lazarus-gtk2 (>= 2.0) | 
+  lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
   fpc-cross-x86-64-win64 (>= 3.0.4)
 <<
 
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 57aee3f53202f069fbbf4304fd810990
+Source-MD5: 23dd868959c5d57091ce82504ef34e45
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-wince-arm.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-wince-arm.info
@@ -1,18 +1,18 @@
 Package: lazarus-lcl-wince-arm
-Version: 1.8.4
+Version: 2.0.2
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
-  lazarus-aqua (>= 1.8) | lazarus-gtk2 (>= 1.8) | lazarus-qt4 (>= 1.8) | 
-  lazarus-qt5 (>= 1.8),
+  lazarus-aqua (>= 2.0) | lazarus-cocoa (>= 2.0) | lazarus-gtk2 (>= 2.0) | 
+  lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
   fpc-cross-arm-wince (>= 3.0.4)
 <<
 
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 57aee3f53202f069fbbf4304fd810990
+Source-MD5: 23dd868959c5d57091ce82504ef34e45
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-wince-i386.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-wince-i386.info
@@ -1,18 +1,18 @@
 Package: lazarus-lcl-wince-i386
-Version: 1.8.4
+Version: 2.0.2
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
-  lazarus-aqua (>= 1.8) | lazarus-gtk2 (>= 1.8) | lazarus-qt4 (>= 1.8) | 
-  lazarus-qt5 (>= 1.8),
+  lazarus-aqua (>= 2.0) | lazarus-cocoa (>= 2.0) | lazarus-gtk2 (>= 2.0) | 
+  lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
   fpc-cross-i386-wince (>= 3.0.4)
 <<
 
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 57aee3f53202f069fbbf4304fd810990
+Source-MD5: 23dd868959c5d57091ce82504ef34e45
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus.info
@@ -1,15 +1,14 @@
 Info2: <<
 Package: lazarus%type_pkg[uitype]
-Type: uitype (-aqua -gtk2 -qt4 -qt5)
-# not working so far: -cocoa
-Version: 1.8.4
+Type: uitype (-aqua -cocoa -gtk2 -qt4 -qt5)
+Version: 2.0.2
 Revision: 1
 License: GPL/LGPL
 
 Recommends: fpc-doc, lazarus-doc, apple-gdb, gdb
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 57aee3f53202f069fbbf4304fd810990
+Source-MD5: 23dd868959c5d57091ce82504ef34e45
 
 SourceDirectory: lazarus
 
@@ -23,30 +22,32 @@ Depends: <<
   (%type_pkg[uitype] = -qt4)  qt4pas (>= 2.5-3),
   (%type_pkg[uitype] = -qt5)  qt5pas (>= 1.8.2)
 <<
-
+ 
 Builddepends: <<
   (%type_pkg[uitype] = -gtk2) gtk+2,
   (%type_pkg[uitype] = -gtk2) gtk+2-dev,
   (%type_pkg[uitype] = -gtk2) glib2-dev,
   (%type_pkg[uitype] = -gtk2) cairo,
-  (%type_pkg[uitype] = -qt4)  qt4pas (>= 2.5-3), qt4pas-dev (>= 2.5-3),
-  (%type_pkg[uitype] = -qt5)  qt5-mac-qtbase, qt5-mac-qtbase-dev-tools
+  (%type_pkg[uitype] = -qt4)  qt4pas     (>= 2.5-3),
+  (%type_pkg[uitype] = -qt4)  qt4pas-dev (>= 2.5-3)
 <<
 
 Conflicts: <<
   (%type_pkg[uitype] = -gtk2)  lazarus-lcl-gtk2,
   (%type_pkg[uitype] = -aqua)  lazarus-lcl-carbon,
+  (%type_pkg[uitype] = -cocoa) lazarus-lcl-cocoa,
   (%type_pkg[uitype] = -qt4)   lazarus-lcl-qt4,
   (%type_pkg[uitype] = -qt5)   lazarus-lcl-qt5,
-  lazarus-aqua, lazarus-gtk2, lazarus-qt4, lazarus-qt5
+  lazarus-aqua, lazarus-cocoa, lazarus-gtk2, lazarus-qt4, lazarus-qt5
 <<
 
 Replaces:  <<
   (%type_pkg[uitype] = -gtk2)  lazarus-lcl-gtk2,
   (%type_pkg[uitype] = -aqua)  lazarus-lcl-carbon,
+  (%type_pkg[uitype] = -cocoa) lazarus-lcl-cocoa,
   (%type_pkg[uitype] = -qt4)   lazarus-lcl-qt4,
   (%type_pkg[uitype] = -qt5)   lazarus-lcl-qt5,
-  lazarus-aqua, lazarus-gtk2, lazarus-qt4, lazarus-qt5
+  lazarus-aqua, lazarus-cocoa, lazarus-gtk2, lazarus-qt4, lazarus-qt5
 <<
 
 BuildDependsOnly: false
@@ -76,13 +77,35 @@ Patchscript: <<
   fi
   sed -i.tmp 's|/usr/local/share|%p/share|g'           tools/install/macosx/environmentoptions.xml
   sed -i.tmp 's|/Developer/lazarus|%p/share/lazarus|g' tools/install/macosx/environmentoptions.xml
-  sed -i.tmp 's|<DebuggerFilename Value="/usr/bin/gdb"/>|<DebuggerFilename Value="/usr/bin/gdb"> <History Count="3"> <Item1 Value="/usr/bin/gdb"/> <Item2 Value="%p/bin/fsf-gdb"/> <Item3 Value="%p/bin/gdb"/> </History> </DebuggerFilename>|g'  tools/install/macosx/environmentoptions.xml
+  sed -i.tmp 's|<DebuggerFilename Value="/usr/bin/gdb"/>|<DebuggerFilename Value="/usr/bin/gdb"> <History Count="4"> <Item1 Value="/usr/bin/lldb"/> <Item2 Value="/usr/bin/gdb"/> <Item3 Value="%p/bin/fsf-gdb"/> <Item4 Value="%p/bin/gdb"/> </History> </DebuggerFilename>|g'  tools/install/macosx/environmentoptions.xml
+
+# fix path to X11
+  sed -i.tmp 's|-Fl/usr/X11R6/lib -Fl%p/lib|"-Fl%p/lib -Fl%p/lib/pango-ft219/lib -Fl/opt/X11/lib"|g' ide/Makefile
 
 # fix compilation of bigidecomponents with LCL_PLATFORM=nogui (LCLnogui)
 # with osprinters.pas the line number needs to be given
   sed -i.tmp '50 s|LCLGtk2|LCLnogui}{$I cupsprinters_h.inc}{$ENDIF}{$IFDEF LCLGtk2|g' components/printers/osprinters.pas
   sed -i.tmp '87 s|LCLGtk2|LCLnogui}{$I cupsprinters.inc}{$ENDIF}{$IFDEF LCLGtk2|g' components/printers/osprinters.pas
   sed -i.tmp 's|LCLGtk2|LCLnogui}uses udlgSelectPrinter, udlgPropertiesPrinter, udlgPageSetup;{$I cupsprndialogs.inc}{$ENDIF}{$IFDEF LCLGtk2|g' components/printers/printersdlgs.pp
+
+# some more fixes for nogui taking cocoa as a template
+# this may break, as soon as cocoa gets working versions
+  cd components/lclextensions/include
+  mkdir nogui
+  cp cocoa/* nogui/
+  cd nogui
+  sed -i.tmp 's|CocoaInt, CocoaGDIObjects, ||g'                                uses.inc
+  sed -i.tmp 's|Cocoa Interface|NoGui Interface|g'                             delphicompat.inc
+  sed -i.tmp 's|\$define HAS_GETCURRENTOBJECT|.$define HAS_GETCURRENTOBJECT|g' delphicompat.inc
+  sed -i.tmp '21,27d' delphicompat.inc
+  sed -i.tmp '46,68d' delphicompat.inc
+
+  cd ../../../virtualtreeview
+  mkdir units/nogui
+  cp    units/cocoa/* units/nogui/
+
+  mkdir include/intf/nogui
+  cp    include/intf/cocoa/* include/intf/nogui/
 <<
 
 UseMaxBuildJobs: false
@@ -102,29 +125,31 @@ CompileScript: <<
 
 # lhelp needs bigidecomponents in addition
 
-  AllUnits="registration lazutils codetools lcl basecomponents bigidecomponents"
   if   [ "%type_raw[uitype]" == "-aqua" ]; then
     make bigide    LCL_PLATFORM=carbon OPT="$debug_options" $carbon_arch
     # 64 bit nogui units
     make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options"
-  elif [ "%type_raw[uitype]" == "-gtk2" ]; then
-    make bigide    LCL_PLATFORM=gtk2   OPT="$debug_options -dHasX -Fl%p/lib/pango-ft219/lib/ -k-framework -kApplicationServices"
+  elif [ "%type_raw[uitype]" == "-cocoa" ]; then
+    make bigide    LCL_PLATFORM=cocoa  OPT="$debug_options"
     # 32 bit nogui units
     make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options" $carbon_arch
-#  elif [ "%type_raw[uitype]" == "-cocoa" ]; then
-#    make all       LCL_PLATFORM=cocoa  OPT="$debug_options"
-#    # 64 bit nogui units
-#    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options"
+  elif [ "%type_raw[uitype]" == "-gtk2" ]; then
+    make bigide    LCL_PLATFORM=gtk2   OPT="$debug_options -dHasX \
+         -FfApplicationServices \
+         -k-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib \
+         -k-L/opt/X11/lib -k-L%p/lib -k-L%p/lib/pango-ft219/lib "
+    # 32 bit nogui units
+    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options" $carbon_arch
   elif [ "%type_raw[uitype]" == "-qt4" ]; then
-    make bigide    LCL_PLATFORM=qt OPT="$debug_options"
-    # 64 bit nogui units
-    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options"
+    make bigide    LCL_PLATFORM=qt     OPT="$debug_options"
+    # 32 bit nogui units
+    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options" $carbon_arch
   elif [ "%type_raw[uitype]" == "-qt5" ]; then
     # build lazarus
     make bigide    LCL_PLATFORM=qt5 OPT="$debug_options -Ff%p/lib/qt5-mac/lib"
     install_name_tool -change Qt5Pas.framework/Versions/1/Qt5Pas %p/lib/qt5-mac/lib/Qt5Pas.framework/Versions/1/Qt5Pas lazarus
-    # 64 bit nogui units
-    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options"
+    # 32 bit nogui units
+    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options" $carbon_arch
   fi
 
 # ** Finish compiling Lazarus **
@@ -195,10 +220,10 @@ forms, buttons, text boxes and so on, which are used to create
 applications with a graphical user interface (GUI).
 
 Release Notes:
-  http://wiki.freepascal.org/Lazarus_1.8.0_release_notes
+  http://wiki.freepascal.org/Lazarus_2.0.2_release_notes
 
-In case of problems, check the page about fixes for version 1.8:
-  http://wiki.freepascal.org/Lazarus_1.8_fixes_branch
+In case of problems, check the page about fixes for version 2.0:
+  http://wiki.freepascal.org/Lazarus_2.0_fixes_branch
 <<
 
 DescUsage: <<
@@ -216,7 +241,14 @@ Crosscompilation is available for:
 
 CPU_SOURCE is needed to build the 32bit version on 64bit systems.
 Otherwise building svn2revisioninc crashes.
-gtk2-64bit needs additional -k-framework -kApplicationServices
+gtk2-64bit needs additional -FfApplicationServices
+Strangly -Fl%p/lib and similar do not really work and ld complains about
+missing symbols.
+  -k-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+needs to be before -k-L/sw/lib. Otherwise libiconv from fink might be 
+taken, which has linux type symbols iconv* instead of libiconv* as set in 
+the fpc rtl file /sw/share/fpcsrc/rtl/unix/cwstring.pp. If the fink 
+version is taken there are linker errors about undefined symbols iconv*.
 <<
 
 Homepage: http://wiki.freepascal.org/Main_Page

--- a/10.9-libcxx/stable/main/finkinfo/devel/qt5pas.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/qt5pas.info
@@ -1,5 +1,5 @@
 Package: qt5pas
-Version: 1.8.4
+Version: 2.0.2
 Revision: 1
 Description: Pascal wrapper for Qt5
 BuildDepends: qt5-mac-qtbase, qt5-mac-qtbase-dev-tools
@@ -8,7 +8,7 @@ License: GPL
 
 # Unpack Phase:
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 57aee3f53202f069fbbf4304fd810990
+Source-MD5: 23dd868959c5d57091ce82504ef34e45
 
 SourceDirectory: lazarus
 


### PR DESCRIPTION
Includes qt5pas. All builds now on 10.14.