### PR TITLE
Compile CERNLIB with gcc8

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
@@ -23,7 +23,7 @@ Source: http://cernlib.web.cern.ch/cernlib/download/%v_source/tar/2006_src.tar.g
 SourceRename: cernlib-%v.tar.gz
 Source-MD5: 750c4804a2366ccd8e80c45a055f8ac5
 Source2: http://cern.ch/~mommsen/fink/%f.patch.gz
-Source2-MD5: c66fac9b264147a9bfe1190a2b1441eb
+Source2-MD5: 45ae1b9450ee432639000a5beae1462d
 SourceDirectory: 2006/src
 PatchScript: <<
   #!/bin/sh -ev

--- a/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
@@ -1,16 +1,16 @@
 Info3: <<
 Package: cernlib2006
 Version: 2006b
-Revision: 28
+Revision: 29
 Description: Paw and other basic executables
 Depends: <<
-  gcc6-shlibs,
+  gcc8-shlibs,
   x11
 <<
 BuildDepends: <<
   fink-package-precedence (>=0.31-1),
   freetype219 (>= 2.4.11-1),
-  gcc6,
+  gcc8,
   libxt-flat (>=1.1.5-2),
   openmotif4 (>= 2.3.4-13),
   patchy4-gfortran,
@@ -23,7 +23,7 @@ Source: http://cernlib.web.cern.ch/cernlib/download/%v_source/tar/2006_src.tar.g
 SourceRename: cernlib-%v.tar.gz
 Source-MD5: 750c4804a2366ccd8e80c45a055f8ac5
 Source2: http://cern.ch/~mommsen/fink/%f.patch.gz
-Source2-MD5: e22d3de92971d99f8deea6e34e89a7ea
+Source2-MD5: c66fac9b264147a9bfe1190a2b1441eb
 SourceDirectory: 2006/src
 PatchScript: <<
   #!/bin/sh -ev
@@ -128,7 +128,7 @@ SplitOff: <<
   Provides: cernlib-paw++
   Depends: <<
     x11,
-    gcc6-shlibs,
+    gcc8-shlibs,
     libxt-flat-shlibs (>=1.1.5-2),
     openmotif4-shlibs (>= 2.3.4-13),
     %N (=%v-%r)
@@ -270,7 +270,7 @@ SplitOff5: <<
   Description: CERNLIB patchy utilities
   Package: patchy5-gfortran
   Provides: patchy, patchy5
-  Depends: %N-dev (=%v-%r), gcc6-shlibs
+  Depends: %N-dev (=%v-%r), gcc8-shlibs
   InstallScript: <<
     #!/bin/sh -ev
     install -d %i/bin

--- a/10.9-libcxx/stable/main/finkinfo/sci/patchy4.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/patchy4.info
@@ -2,10 +2,10 @@ Info3: <<
 Package: patchy4-%type_pkg[fortran]
 Type: fortran (gfortran)
 Version: 4.15
-Revision: 11
+Revision: 12
 Description: CERNLIB patchy utilities
-BuildDepends: gcc6, sed
-Depends: gcc6-shlibs
+BuildDepends: gcc8, sed
+Depends: gcc8-shlibs
 Provides: patchy
 Source: http://cern.ch/~mommsen/fink/patchy_%v.tar.gz
 Source-MD5: 4f7cb685300dfb89d374bae1f07ab3d1
@@ -18,7 +18,7 @@ CompileScript: <<
   rm -f rceta.f rceta.o rceta
   %p/bin/sed -i -re "{
     s:f77:gfortran:g;
-    s:cc :gcc-6 :g;
+    s:cc :gcc-8 :g;
     s:-posix::g;
     }" fcasplit.f
   %p/bin/sed -i -re "{


### PR DESCRIPTION
Update CERNLIB and patchy to use gcc8 instead of gcc6.