### PR TITLE
Leftover fixes to django-localflavor-py tests and semanticversion-py BuildDepends

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/semanticversion-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/semanticversion-py.info
@@ -27,7 +27,7 @@ SourceRename: semanticversion-%v.tar.gz
 SourceDirectory: python-semanticversion-%v
 
 Depends: python%type_pkg[python]
-BuildDepends: fink (>= 0.24.12)
+BuildDepends: fink (>= 0.24.12), setuptools-tng-py%type_pkg[python]
 Enhances: django-py%type_pkg[python]
 
 PatchScript: perl -pi.bak -e 's/(    def test_serialization)/    \@unittest.skipUnless(django.VERSION[0] < 2, "Field._get_val_from_obj removed in Django20")\n$1/;' tests/test_django.py

--- a/10.9-libcxx/stable/main/finkinfo/web/django-localflavor-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/django-localflavor-py.info
@@ -14,8 +14,12 @@ Source-Checksum: SHA256(0cee94c4b8f0214a5ba7be7e935019a8c062f4e7726d1df4b1e453cb
 
 DocFiles: LICENSE PKG-INFO README.rst docs/_build/html
 
-# Patch task definitions to include Context argument for compatibility with invoke >= 0.12
-PatchScript: perl -pi.bak -e 's/(def [a-z].*\()([a-z][a-z])/${1}c, ${2}/;s/(def [a-z].*\()(\))/${1}c${2}/;' tasks.py
+# Patch task definitions to include Context argument for compatibility with invoke >= 0.12;
+# point to versioned coverage and django-admin commands
+PatchScript: <<
+   perl -pi.bak -e 's|(def [a-z].*\()([a-z][a-z])|${1}c, ${2}|;s|(def [a-z].*\()(\))|${1}c${2}|;' tasks.py
+   perl -pi -e 's|(coverage)( r)|%p/bin/${1}%type_raw[python]${2}|;s|(`which )(django-admin)(.py`)|%p/bin/${2}%type_raw[python]|;' tasks.py
+<<
 
 CompileScript: <<
    echo Skipping compile stage


### PR DESCRIPTION
Fixing open ends from #331