### PR TITLE
libcdio13/15: fix detection of recent OS X

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libcdio13-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libcdio13-shlibs.info
@@ -2,7 +2,7 @@ Package: libcdio13-shlibs
 # Version 0.92 removes the libcdio_cdda and libcdio_paranoia libraries.
 # Also jumps to libN=15.
 Version: 0.83
-Revision: 4
+Revision: 5
 Description: CD Input and Control Library
 License: GPL
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
@@ -35,8 +35,10 @@ PatchScript: <<
 	# nieder (0.80) Add these missing .pc files to the install list:
 	#perl -pi -e 's|libcdio.pc  \\|libcdio_cdda.pc libcdio_paranoia.pc $&|g' Makefile.in
 
-	# Fix detection for 10.9 and 10.10
-	perl -pi -e 's|0-2|0-4|g' configure
+	# Fix detection for newer 10.x. See:
+	# http://git.savannah.gnu.org/cgit/libcdio.git/commit/configure.ac?id=4b25820f5bc460f5226ca9181d52db15cf960d11
+	# and parent revisions thereof. Fixed in 0.93
+	perl -pi -e 's|darwin1\[0-2\]|darwin[1-9][0-9]|g' configure
 
 	# Patch configure to not link like Puma on Yosemite
 	perl -pi.bak -e 's|10\.\[012\]\*|10.[012][,.]*|g' configure

--- a/10.9-libcxx/stable/main/finkinfo/libs/libcdio15-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libcdio15-shlibs.info
@@ -29,7 +29,6 @@ PatchScript: <<
 
 	# Fix detection for newer 10.x. See:
 	# http://git.savannah.gnu.org/cgit/libcdio.git/commit/configure.ac?id=4b25820f5bc460f5226ca9181d52db15cf960d11
-	# and parent revisions thereof
 	# and parent revisions thereof. Fixed in 0.93
 	perl -pi -e 's|darwin1\[0-2\]|darwin[1-9][0-9]|g' configure
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/libcdio15-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libcdio15-shlibs.info
@@ -4,7 +4,7 @@ Package: libcdio15-shlibs
 # Version 0.93 bumps libcdio to libN=16 and libiso to libN=10.
 # libiso9660++, libudf, and libcdio++ remain at libN=0.
 Version: 0.92
-Revision: 3
+Revision: 4
 Description: CD Input and Control Library
 License: GPL
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
@@ -27,9 +27,11 @@ PatchScript: <<
 	# Fixed in 0.93
 	perl -pi -e 's/(libcdio_la_LIBADD =)/\1 \$(DARWIN_PKG_LIB_HACK) /' lib/driver/Makefile.in
 
-	# Fix detection for 10.9 and 10.10
-	# Fixed in 0.93
-	perl -pi -e 's|0-2|0-4|g' configure
+	# Fix detection for newer 10.x. See:
+	# http://git.savannah.gnu.org/cgit/libcdio.git/commit/configure.ac?id=4b25820f5bc460f5226ca9181d52db15cf960d11
+	# and parent revisions thereof
+	# and parent revisions thereof. Fixed in 0.93
+	perl -pi -e 's|darwin1\[0-2\]|darwin[1-9][0-9]|g' configure
 
 	# Patch configure to not link like Puma on Yosemite
 	perl -pi.bak -e 's|10\.\[012\]\*|10.[012][,.]*|g' configure


### PR DESCRIPTION
libcdio13 and libcdio15 FTBFS on recent 10.x because of a restrictive regexp in ./configure. Fink's patch was not sufficient on the most recent 10.x. Here's upstream's (== libcdio19) latest tweak.