### PR TITLE
pycodestyle 2.5.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pycodestyle-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pycodestyle-py.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: pycodestyle-py%type_pkg[python]
-Version: 2.4.0
+Version: 2.5.0
 Revision: 1
 Type: python (2.7 3.4 3.5 3.6 3.7)
 
@@ -14,7 +14,7 @@ License: BSD
 Homepage: https://pypi.org/project/pycodestyle
 
 Source: https://files.pythonhosted.org/packages/source/p/pycodestyle/pycodestyle-%v.tar.gz
-Source-Checksum: SHA256(cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a)
+Source-Checksum: SHA256(e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c)
 
 Depends: python%type_pkg[python]
 BuildDepends: fink (>= 0.24.12), setuptools-tng-py%type_pkg[python]


### PR DESCRIPTION
Fixes test failure in testsuite.test_all.PycodestyleTestCase for py >= 36.