### PR TITLE
Numpy update to 1.16.3 built against OpenBLAS

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/numpy-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/numpy-py.info
@@ -55,12 +55,12 @@ InstallScript: <<
         cd test
         PATH=%i/bin:$PATH
         export LANG=en_US.UTF-8 PYTHONPATH=%i/lib/python%type_raw[python]/site-packages
-        # Test framework in 1.16.3 only returns True/False; invert to get exit code 0 on success.
+        # Pytest framework in 1.16.3 only returns True/False; invert to get exit code 0 on success.
         %p/bin/python%type_raw[python] -B -c "import numpy, sys; sys.exit(not numpy.test())" || exit 2
     fi
 <<
 InfoTest: <<
-    TestDepends: nose-py%type_pkg[python]
+    TestDepends: pytest-py%type_pkg[python]
     TestScript: touch %b/INSTALL_MAKE_CHECK
 <<
 DocFiles: LICENSE.txt

--- a/10.9-libcxx/stable/main/finkinfo/sci/numpy-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/numpy-py.info
@@ -19,7 +19,7 @@ Source: https://pypi.io/packages/source/n/numpy/numpy-%v.zip
 Source-Checksum: SHA256(78a6f89da87eeb48014ec652a65c4ffde370c036d780a995edaeb121d3625621)
 #SourceRename: numpy-%v.zip
 PatchFile: numpy-py.patch
-PatchFile-MD5: cc31d86e01c58157aacfed17b5d558f2
+PatchFile-MD5: 4df9416c7b63e3cde94b1d700cdc4d75
 Conflicts: <<
     f2py-py%type_pkg[python],
     scipy-py%type_pkg[python] (<= 1:0.4)
@@ -55,12 +55,12 @@ InstallScript: <<
         cd test
         PATH=%i/bin:$PATH
         export LANG=en_US.UTF-8 PYTHONPATH=%i/lib/python%type_raw[python]/site-packages
-        # Pytest framework in 1.16.3 only returns True/False; invert to get exit code 0 on success.
+        # Test framework in 1.16.3 only returns True/False; invert to get exit code 0 on success.
         %p/bin/python%type_raw[python] -B -c "import numpy, sys; sys.exit(not numpy.test())" || exit 2
     fi
 <<
 InfoTest: <<
-    TestDepends: pytest-py%type_pkg[python]
+    TestDepends: nose-py%type_pkg[python]
     TestScript: touch %b/INSTALL_MAKE_CHECK
 <<
 DocFiles: LICENSE.txt

--- a/10.9-libcxx/stable/main/finkinfo/sci/numpy-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/numpy-py.info
@@ -1,61 +1,67 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: numpy-py.patch -*-
-Info4: <<
+Info2: <<
 Package: numpy-py%type_pkg[python]
-Version: 1.14.5
-Revision: 2
+Version: 1.16.3
+Revision: 1
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Type: python (2.7 3.4 3.5 3.6 3.7)
 Depends: <<
-	python%type_pkg[python]
+    python%type_pkg[python],
+    openblas-shlibs
 <<
 BuildDepends: <<
-	cython-py%type_pkg[python],
-	setuptools-tng-py%type_pkg[python]
+    cython-py%type_pkg[python],
+    openblas,
+    setuptools-tng-py%type_pkg[python]
 <<
-BuildConflicts: atlas
+#BuildConflicts: atlas
 Source: https://pypi.io/packages/source/n/numpy/numpy-%v.zip
-Source-Checksum: SHA256(a4a433b3a264dbc9aa9c7c241e87c0358a503ea6394f8737df1683c7c9a102ac)
+Source-Checksum: SHA256(78a6f89da87eeb48014ec652a65c4ffde370c036d780a995edaeb121d3625621)
 #SourceRename: numpy-%v.zip
 PatchFile: numpy-py.patch
-PatchFile-MD5: 385d529a33d4ba9fd1c8f453b70a6df0
+PatchFile-MD5: cc31d86e01c58157aacfed17b5d558f2
 Conflicts: <<
-	f2py-py%type_pkg[python],
-	scipy-py%type_pkg[python] (<= 1:0.4)
+    f2py-py%type_pkg[python],
+    scipy-py%type_pkg[python] (<= 1:0.4)
 <<
 Replaces: <<
-	f2py-py%type_pkg[python],
-	scipy-py%type_pkg[python] (<= 1:0.4),
-	scipy-core-py%type_pkg[python] (<< 1.3.0-6)
+    f2py-py%type_pkg[python],
+    scipy-py%type_pkg[python] (<= 1:0.4),
+    scipy-core-py%type_pkg[python] (<< 1.3.0-6)
 <<
 Provides: f2py-py%type_pkg[python]
-PatchScript: sed 's|@FINKPREFIX@|%p|g' <%{PatchFile} | patch -p1
+PatchScript: <<
+#!/bin/bash -ev
+  cat <<EOF > site.cfg
+[openblas]
+libraries = openblas
+library_dirs = %p/lib
+include_dirs = %p/include
+runtime_library_dirs = %p/lib
+EOF
+    sed 's|@FINKPREFIX@|%p|g' <%{PatchFile} | patch -p1
+<<
 CompileScript: <<
- SHELL=/bin/sh ATLAS=None LAPACK=/usr/lib BLAS=/usr/lib %p/bin/python%type_raw[python] setup.py build
+    ATLAS=None %p/bin/python%type_raw[python] setup.py build
 <<
 InstallScript: <<
 #!/bin/bash -ev
- SHELL=/bin/sh ATLAS=None LAPACK=/usr/lib BLAS=/usr/lib %p/bin/python%type_raw[python] setup.py install --root %d
+    ATLAS=None %p/bin/python%type_raw[python] setup.py install --root %d
+    # remove unversioned instances of f2py (put under update_alternative management instead?)
+    rm %i/bin/f2py %i/bin/f2py[23]
 
- if [ -f %b/INSTALL_MAKE_CHECK ]; then
-   mkdir test
-   cd test
-   PATH=%i/bin:$PATH
-   LANG=en_US.UTF-8 SHELL=/bin/sh PYTHONPATH=%i/lib/python%type_raw[python]/site-packages %p/bin/python%type_raw[python] -B -c "import numpy, sys; e=numpy.test(); sys.exit(len(e.failures)//4 + len(e.errors)*1)"
-   # 3 failures about warnings handling with 1.14.5 in Python 3.7
-   # https://github.com/numpy/numpy/issues/11460
-   # return value 1 already triggers failure in InstallScript
-   TESTRESULT=$?
-   if [ $TESTRESULT -gt 1 ]; then
-     echo "Error: unexpected test failures/errors!"
-     exit $TESTRESULT
-   elif [ $TESTRESULT -gt 0 -a %type_pkg[python] -lt 37 ]; then
-     echo "Warning $TESTRESULT: some unexpected test failures!"
-   fi
- fi
+    if [ -f %b/INSTALL_MAKE_CHECK ]; then
+        mkdir test
+        cd test
+        PATH=%i/bin:$PATH
+        export LANG=en_US.UTF-8 PYTHONPATH=%i/lib/python%type_raw[python]/site-packages
+        # Test framework in 1.16.3 only returns True/False; invert to get exit code 0 on success.
+        %p/bin/python%type_raw[python] -B -c "import numpy, sys; sys.exit(not numpy.test())" || exit 2
+    fi
 <<
 InfoTest: <<
-	TestDepends: nose-py%type_pkg[python]
-	TestScript: touch %b/INSTALL_MAKE_CHECK
+    TestDepends: nose-py%type_pkg[python]
+    TestScript: touch %b/INSTALL_MAKE_CHECK
 <<
 DocFiles: LICENSE.txt
 Description: N-dimensional array package for Python
@@ -88,4 +94,5 @@ Dependent packages that see this bug should depend on numpy-py%type_pkg[python] 
 <<
 License: OSI-Approved
 Homepage: http://www.numpy.org
+# Info2
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/numpy-py.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/numpy-py.patch
@@ -1,12 +1,20 @@
-diff -uNr numpy-1.14.5-orig/numpy/distutils/command/build_ext.py numpy-1.14.5/numpy/distutils/command/build_ext.py
---- numpy-1.14.5-orig/numpy/distutils/command/build_ext.py	2018-06-12 14:28:52.000000000 -0500
-+++ numpy-1.14.5/numpy/distutils/command/build_ext.py	2018-08-09 18:48:48.000000000 -0500
-@@ -432,6 +432,11 @@
+diff -uNr numpy-1.16.3-orig/numpy/distutils/command/build_ext.py numpy-1.16.3/numpy/distutils/command/build_ext.py
+--- numpy-1.16.3-orig/numpy/distutils/command/build_ext.py	2019-04-21 12:06:28.000000000 +0200
++++ numpy-1.16.3/numpy/distutils/command/build_ext.py	2019-05-03 16:58:05.000000000 +0200
+@@ -4,6 +4,7 @@
+ from __future__ import division, absolute_import, print_function
+ 
+ import os
++import sys
+ import subprocess
+ from glob import glob
+
+@@ -441,6 +442,11 @@
              unlinkable_fobjects = []
              objects = c_objects + f_objects
  
 +        if sys.platform=='darwin':
-+           ext.extra_link_args.append('-Wl,-undefined -Wl,dynamic_lookup -Wl,-bundle')
++           ext.extra_link_args += ['-Wl,-undefined', '-Wl,dynamic_lookup', '-Wl,-bundle']
 +        else:
 +           ext.extra_link_args.append('-shared')
 +
@@ -16,7 +24,7 @@ diff -uNr numpy-1.14.5-orig/numpy/distutils/command/build_ext.py numpy-1.14.5/nu
 diff -uNr numpy-1.14.5-orig/numpy/distutils/exec_command.py numpy-1.14.5/numpy/distutils/exec_command.py
 --- numpy-1.14.5-orig/numpy/distutils/exec_command.py	2018-06-12 14:28:52.000000000 -0500
 +++ numpy-1.14.5/numpy/distutils/exec_command.py	2018-08-09 21:09:50.000000000 -0500
-@@ -231,7 +231,7 @@
+@@ -273,7 +273,7 @@
  
      if os.name == 'posix' and use_shell:
          # On POSIX, subprocess always uses /bin/sh, override
@@ -25,9 +33,9 @@ diff -uNr numpy-1.14.5-orig/numpy/distutils/exec_command.py numpy-1.14.5/numpy/d
          if is_sequence(command):
              command = [sh, '-c', ' '.join(command)]
          else:
-diff -uNr numpy-1.14.5-orig/numpy/distutils/system_info.py numpy-1.14.5/numpy/distutils/system_info.py
---- numpy-1.14.5-orig/numpy/distutils/system_info.py	2018-06-12 14:28:52.000000000 -0500
-+++ numpy-1.14.5/numpy/distutils/system_info.py	2018-08-09 18:48:48.000000000 -0500
+diff -uNr numpy-1.16.3-orig/numpy/distutils/system_info.py numpy-1.16.3/numpy/distutils/system_info.py
+--- numpy-1.16.3-orig/numpy/distutils/system_info.py	2019-04-21 12:06:28.000000000 +0200
++++ numpy-1.16.3/numpy/distutils/system_info.py	2019-05-03 16:50:31.000000000 +0200
 @@ -85,8 +85,8 @@
  Example:
  ----------
@@ -48,14 +56,13 @@ diff -uNr numpy-1.14.5-orig/numpy/distutils/system_info.py numpy-1.14.5/numpy/di
  # for overriding the names of the atlas libraries
  atlas_libs = lapack, f77blas, cblas, atlas
  
-@@ -262,20 +262,16 @@
+@@ -274,20 +274,14 @@
              add_system_root(os.path.join(conda_dir, 'Library'))
-                         
+ 
  else:
 -    default_lib_dirs = libpaths(['/usr/local/lib', '/opt/lib', '/usr/lib',
 -                                 '/opt/local/lib', '/sw/lib'], platform_bits)
-+    default_lib_dirs = libpaths(['@FINKPREFIX@/lib',
-+                                 '/usr/lib'], platform_bits)
++    default_lib_dirs = libpaths(['@FINKPREFIX@/lib', '/usr/lib'], platform_bits)
      default_runtime_dirs = []
 -    default_include_dirs = ['/usr/local/include',
 -                            '/opt/include', '/usr/include',
@@ -64,14 +71,14 @@ diff -uNr numpy-1.14.5-orig/numpy/distutils/system_info.py numpy-1.14.5/numpy/di
 -                            '/opt/local/include', '/sw/include',
 -                            '/usr/include/suitesparse']
 -    default_src_dirs = ['.', '/usr/local/src', '/opt/src', '/sw/src']
-+    default_include_dirs = ['@FINKPREFIX@/include',
-+                            '/usr/include']
++    default_include_dirs = ['@FINKPREFIX@/include', '/usr/include']
 +    default_src_dirs = ['.']
  
 -    default_x11_lib_dirs = libpaths(['/usr/X11R6/lib', '/usr/X11/lib',
-+    default_x11_lib_dirs = libpaths(['/opt/X11/lib', '/usr/X11/lib',
-                                      '/usr/lib'], platform_bits)
+-                                     '/usr/lib'], platform_bits)
 -    default_x11_include_dirs = ['/usr/X11R6/include', '/usr/X11/include',
++    default_x11_lib_dirs = libpaths(['/opt/X11/lib', '/usr/X11/lib', '/usr/lib'],
++                                    platform_bits)
 +    default_x11_include_dirs = ['/opt/X11/include', '/usr/X11/include',
                                  '/usr/include']
  

--- a/10.9-libcxx/stable/main/finkinfo/sci/numpy-py.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/numpy-py.patch
@@ -83,3 +83,23 @@ diff -uNr numpy-1.16.3-orig/numpy/distutils/system_info.py numpy-1.16.3/numpy/di
                                  '/usr/include']
  
      if os.path.exists('/usr/lib/X11'):
+diff -uNr numpy-1.16.3-orig/numpy/lib/tests/test_mixins.py numpy-1.16.3/numpy/lib/tests/test_mixins.py
+--- numpy-1.16.3-orig/numpy/lib/tests/test_mixins.py	2019-02-21 17:33:42.000000000 +0100
++++ numpy-1.16.3/numpy/lib/tests/test_mixins.py	2019-05-17 02:31:25.000000000 +0200
+@@ -9,6 +9,7 @@
+ 
+ 
+ PY2 = sys.version_info.major < 3
++PY34 = sys.version_info.major == 3 and sys.version_info.minor < 5
+ 
+ 
+ # NOTE: This class should be kept as an exact copy of the example from the
+@@ -204,7 +205,7 @@
+         array_like = ArrayLike(array)
+         expected = ArrayLike(np.float64(5))
+         _assert_equal_type_and_value(expected, np.matmul(array_like, array))
+-        if not PY2:
++        if not PY2 and not PY34:
+             _assert_equal_type_and_value(
+                 expected, operator.matmul(array_like, array))
+             _assert_equal_type_and_value(


### PR DESCRIPTION
Updated to latest upstream and adapted TestInfo; cleaned up setup calls. Atlas no longer seems to interfere with the build, but OpenBLAS is automatically detected and will be linked to, if installed. Made it a dependency for consistent builds and in line with the Scipy 1.2 update.
py27-37 versions tested on 10.12.7 with no failures (linking to VecLib produced 1 failure).