### PR TITLE
Scipy build with clang* and update to 1.3.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/scipy-py27.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/scipy-py27.info
@@ -1,13 +1,13 @@
 Info2: <<
-Package: scipy-py%type_pkg[python]
-Version: 1.3.0
+Package: scipy-py27
+Version: 1.2.1
 Epoch: 1
-Revision: 1
+Revision: 2
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Type: python (3.5 3.6 3.7), gcc (8)
+Type: python (2.7), gcc (8)
 Depends: <<
 	cython-py%type_pkg[python],
-	openblas-shlibs (>= 0.3.6-1),
+	openblas-shlibs,
 	gcc%type_raw[gcc]-shlibs,
 	numpy-py%type_pkg[python] (>= 1.13.3-1),
 	python%type_pkg[python],
@@ -15,7 +15,7 @@ Depends: <<
 <<
 BuildDepends: <<
 	fink (>= 0.32.0),
-	openblas (>= 0.3.6-1),
+	openblas,
 	gcc%type_raw[gcc]-compiler,
 	setuptools-tng-py%type_pkg[python],
 	suitesparse (>= 4.0.2-2),
@@ -24,7 +24,7 @@ BuildDepends: <<
 #Source: mirror:sourceforge:scipy/scipy-%v.tar.gz
 #Source: http://github.com/scipy/scipy/releases/download/v%v/scipy-%v.tar.xz
 Source: https://files.pythonhosted.org/packages/source/s/scipy/scipy-%v.tar.gz
-Source-Checksum: SHA256(c3bb4bd2aca82fb498247deeac12265921fe231502a6bc6edea3ee7fe6c40a7a)
+Source-Checksum: SHA256(e085d1babcb419bbe58e2e805ac61924dac4ca45a07c9fa081144739e500aa3c)
 PatchScript: <<
 #!/bin/bash -ev
   cat <<EOF > site.cfg
@@ -60,6 +60,7 @@ CompileScript: <<
  fi
  export FC=%p/lib/gcc%type_raw[gcc]/bin/gfortran
  export PATH="%p/lib/gcc%type_raw[gcc]/bin:$PATH"
+ echo Locale: $LANG
 
 # unset LDFLAGS
  ATLAS=None %p/bin/python%type_raw[python] setup.py build --fcompiler gnu95
@@ -73,12 +74,7 @@ InstallScript: <<
    cd test
    export PYTHONPATH=%i/lib/python%type_raw[python]/site-packages
    export SCIPY_XSLOW=1
-   if [ "$darwin_vers" -ge 18 ]; then
-     # Additional failures in test_onenormest_table_[35]_t_2 on Mojave?
-     %p/bin/python%type_raw[python] -Bc "import scipy, sys; e=scipy.test(extra_argv=['-k not test_onenormest_table_6_t_1']); sys.exit(1-e)" || exit 2
-   else
-     %p/bin/python%type_raw[python] -Bc "import scipy, sys; e=scipy.test(extra_argv=['-k not test_onenormest_table_6_t_1']); sys.exit(1-e)" || exit 2
-   fi
+   %p/bin/python%type_raw[python] -B -c "import scipy, sys; e=scipy.test(extra_argv=['-k not test_onenormest_table_6_t_1']); sys.exit(1-e)" || exit 2
  fi
 <<
 InfoTest: <<


### PR DESCRIPTION
Moved `scipy-py` build back to clang `CC` and `CXX` for `"$darwin_vers" -ge 11` to reduce `linalg` test failures and segfaults in 10.14 (#414) in new revision of `1.2.1` for `py27` (now LTS) and update to upstream `1.3.0` for `py35-py37`.
Tested on 10.12 with `openblas-0.3.6` for all variants; I have not added skip markers for the potential test failures of `test_onenormest_table_[35]_t_2` on 10.14 yet; if someone with 10.14 could check of they still fail for `1.3.0` or other failures popped up, I'll add them later.