### PR TITLE
netcdf-c15-4.7.0-1: Upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c15.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c15.info
@@ -1,12 +1,11 @@
 Package: netcdf-c15
-Version: 4.6.3
+Version: 4.7.0
 Revision: 1
 BuildDependsOnly: true
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Depends: %n-shlibs (= %v-%r)
 BuildDepends: <<
-	doxygen,
 	fink-package-precedence,
 	hdf5.100.v1.10,
 	hdf5-cpp.100.v1.10,
@@ -32,14 +31,13 @@ Replaces: <<
 <<
 
 Source: ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-%v.tar.gz
-Source-MD5: ef0b4d24f2c5a2a424c769cbb91fa45f
-Source-Checksum: SHA1(f165d9d4120dca09dcd49a90f31957640734ad0c)
+Source-MD5: abdb55e6df783b5a4c7645b230ab0b98
+Source-Checksum: SHA1(329e68f0442d484e9f0db87c662b36427ba53b00)
 SetCFLAGS: -O2
-SetLDFLAGS: -lsz -Wl,-dead_strip_dylibs
+SetCPPFLAGS: -I%p/opt/hdf5.v1.10/include
+SetLDFLAGS: -lsz -Wl,-dead_strip_dylibs -L%p/opt/hdf5.v1.10/lib
 
 ConfigureParams: <<
-  CPPFLAGS=-I%p/opt/hdf5.v1.10/include \
-  LDFLAGS=-L%p/opt/hdf5.v1.10/lib \
   --enable-shared --disable-static \
   --mandir='${prefix}/share/man' \
   --docdir='${prefix}/share/doc/%n' \
@@ -143,4 +141,4 @@ Parallel netCDF now requires a parallel HDF5, which Fink doesn't
 currently have, so this package doesn't build that option.
 <<
 Homepage: http://www.unidata.ucar.edu/software/netcdf/
-License: OSI-Approved
+License: BSD


### PR DESCRIPTION
Upstream update to version 4.7.0.
Also updated license, as changed upstream.
Removed unnecessary BuildDepends: doxygen
Moved CPPFLAGS and LDFLAGS from ConfigureParams to SetCPPFLAGS and SetLDFLAGS.

Successfully built and tested with "fink build -m" on Mac OS 10.14.5 with Command Line Tools 10.2.1