### PR TITLE
postgresql updates May 19

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 10.7
+Version: 10.8
 Revision: 1
 Type: postgresql 10
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: b50adbbf9a8dfa977cd7bfe06dc4a30d
-Source-Checksum: SHA256(bfed1065380c1bba927bfe51f23168471373f26e3324cbad859269cc32733ede)
+Source-MD5: 8a575258e57ba5ccf63fe916ecbcae8d
+Source-Checksum: SHA256(b198c2aadf1d68308127a0f5b51dbe798958ffe60dd999134f6495c489afcd5d)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.4.21
+Version: 9.4.22
 Revision: 1
 Epoch: 1
 Type: postgresql 9.4
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: d78fa9861f541ccae9800c7465655fb5
-Source-Checksum: SHA256(0049b4d239a00654e792997aff32a0be7a6bdd922b5ca97f1a06797cd4d06006)
+Source-MD5: ad80a06d86a08614bb5c3e9afa37086a
+Source-Checksum: SHA256(d6aa4c2b9204e375545b9845b0e5957b34affff1783863a80a194f2b2833c66b)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.5.16
+Version: 9.5.17
 Revision: 1
 Epoch: 1
 Type: postgresql 9.5
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 20c9cf32158f66aedef6871200227a19
-Source-Checksum: SHA256(a4576c95d4dcee8d4b7835b333d38e909848222e4b87895878bb1c026206e131)
+Source-MD5: 3438df58c4a4c95dace516c9a0590d64
+Source-Checksum: SHA256(88f9e37a0069f2fd4442d1d0d5d811d3121cac685514435b0248d0674723f705)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.6.12
+Version: 9.6.13
 Revision: 1
 Epoch: 1
 Type: postgresql 9.6
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: adab4bcd346d3a115f6f741b1756cd0f
-Source-Checksum: SHA256(2e8c8446ba94767bda8a26cf5a2152bf0ae68a86aaebf894132a763084579d84)
+Source-MD5: f361e2ddcd2c31049789ef66f8841de5
+Source-Checksum: SHA256(ecbed20056296a65b6a4f5526c477e3ae5cc284cb01a15507785ddb23831e9a4)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1


### PR DESCRIPTION
latest updates for postgresql packages:
- postgresql10 update to 10.8
- postgresql96 update to 9.6.13
- postgresql95 update to 9.5.17
- postgresql94 update to 9.4.22