### PR TITLE
nco-4.8.0-1: Upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/nco.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/nco.info
@@ -1,6 +1,6 @@
 Info2:<<
 Package: nco
-Version: 4.7.9
+Version: 4.8.0
 Revision: 1
 Description: The NetCDF Operators
 License: GPL3
@@ -96,8 +96,8 @@ Replaces: <<
 # Unpack Phase:
 Source: https://github.com/nco/nco/archive/%v.tar.gz
 SourceRename: %n-%v.tar.gz
-Source-MD5: 6ad3febf223f676ca9281c39c48fb9f3
-Source-Checksum: SHA1(a45fb9097078038842b64e3b85f5dd2f1fa2f275)
+Source-MD5: 8ca809dee237e2fc4aa333fea87514e3
+Source-Checksum: SHA1(f664992328ed9176f967cb6eb4b98b3a2fd55944)
 
 # Patch Phase:
 PatchScript:  <<
@@ -127,6 +127,7 @@ CompileScript: <<
 	export	NETCDF_INC=%p \
 		NETCDF_LIB=%p \
 		NETCDF4_ROOT=%p
+	export PERL5LIB=%p/lib/perl5:%p/lib/perl5/darmwin:%p/lib/perl5/5.18.2
 	export PATH=%p/opt/texinfo-legacy/bin:$PATH
 	%{default_script}
 	fink-package-precedence --prohibit-bdep=%N-dap,%N-opendap,%N-netcdf,%N .


### PR DESCRIPTION
Also needed to update PERL5LIB env variable in order to find Locale::Messages perl module.