### PR TITLE
Add SDK paths to flag sort so that they're not pushed to the front of…

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/flag-sort.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/flag-sort.info
@@ -1,12 +1,12 @@
 Package: flag-sort
-Version: 0.5
+Version: 0.5.1
 Revision: 1
 
 BuildDepends: fink (>= 0.24.12-1)
 
 Source: none
 PatchFile: %n.patch
-PatchFile-MD5: e051121fb390c9e87462d4f7cb162eed
+PatchFile-MD5: d397ff6d55ba1a3ad94c2cddd636c2f7
 PatchScript: sed 's,@PREFIX@,%p,' < %{PatchFile} | patch -p1
 
 CompileScript: #
@@ -27,6 +27,7 @@ following order:
 	fink %p/opt (self-contained rooted packages)
 	fink %p
 	x11 (and /opt/X11 before /usr/X11 before /usr/X11R6)
+	system $SDK/usr (and Xcode.app SDK before Command Line Tools SDK)
 	system (/usr)
 	/usr/local
 Within each category, order is maintained as given. In addition, lib/

--- a/10.9-libcxx/stable/main/finkinfo/devel/flag-sort.patch
+++ b/10.9-libcxx/stable/main/finkinfo/devel/flag-sort.patch
@@ -1,7 +1,7 @@
-diff -Nurd -x'*~' flag-sort-0.5.orig/flag-sort flag-sort-0.5/flag-sort
---- flag-sort-0.5.orig/flag-sort	1969-12-31 19:00:00.000000000 -0500
-+++ flag-sort-0.5/flag-sort	2012-12-08 15:55:45.000000000 -0500
-@@ -0,0 +1,138 @@
+diff -Nurd -x'*~' flag-sort-0.5.1.orig/flag-sort flag-sort-0.5.1/flag-sort
+--- flag-sort-0.5.1.orig/flag-sort	1969-12-31 19:00:00.000000000 -0500
++++ flag-sort-0.5.1/flag-sort	2019-06-20 21:12:00.000000000 -0500
+@@ -0,0 +1,142 @@
 +#!/usr/bin/perl
 +# -*- mode: Perl; tab-width: 4; -*-
 +
@@ -21,6 +21,10 @@ diff -Nurd -x'*~' flag-sort-0.5.orig/flag-sort flag-sort-0.5/flag-sort
 +	'/usr/X11/include',
 +	'/usr/X11R6/lib',
 +	'/usr/X11R6/include',
++	'/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib',
++	'/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include',
++	'/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib',
++	'/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include',
 +	'/usr/lib',
 +	'/usr/include',
 +	'/usr/local/lib',


### PR DESCRIPTION
… the line.

Fixes #381