### PR TITLE
New upstream versions; no significant dependency changes

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-boot-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-boot-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.3-20
+Version: 1.3-23
 Revision: 1
 Description: GNU R Tools for bootstrap methods
 Homepage: https://cran.r-project.org/package=boot
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:boot_%v.tar.gz
-Source-MD5: bb879fb4204a4f94ab82c98dd1ad5eca
+Source-MD5: c823de35d69b0495181d4399d753e9b9
 SourceDirectory: boot
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-cairo-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-cairo-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.5-9
-Revision: 2
+Version: 1.5-10
+Revision: 1
 Description: Graphics device using cairo graphics library
 Homepage: https://cran.r-project.org/package=Cairo
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:Cairo_%v.tar.gz
-Source-MD5: f9deac4d1b1a58fbae96ab60ee27a739
+Source-MD5: 3ca5911938ed8af1f9471ac633ab285b
 SourceDirectory: Cairo
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-cellranger-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-cellranger-r.info
@@ -11,7 +11,7 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2)
+Type: rversion (3.5 3.4 3.3 3.2 3.1)
 Version: 1.1.0
 Revision: 1
 Description: Translate Spreadsheet Cell Ranges

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-clipr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-clipr-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.5.0
+Version: 0.6.0
 Revision: 1
 Description: Read and Write from the System Clipboard
 Homepage: https://cran.r-project.org/package=clipr
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:clipr_%v.tar.gz
-Source-MD5: d5c4ba49bc570bdc51ee954a0aeaf35e
+Source-MD5: f7eff251bda6e0d2e2013221d0806a14
 SourceDirectory: clipr
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-cluster-r-2.0.7.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-cluster-r-2.0.7.info
@@ -7,28 +7,30 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3)
-Version: 2.1.0
+Type: rversion (3.2)
+Version: 2.0.7-1
 Revision: 1
 Description: Cluster Analysis Extended Rousseeuw et al
 Homepage: https://cran.r-project.org/package=cluster
 License: GPL
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
 Source: mirror:custom:cluster_%v.tar.gz
-Source-MD5: cd2ddaaf54689590cb9e0042af7c3a71
+Source-MD5: a37add21b91d3e4f3883d005331e0d45
 SourceDirectory: cluster
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
 	Secondary: https://cran.r-project.org/src/contrib/00Archive/cluster
 <<
 Depends: <<
-	r-base%type_pkg[rversion],
+	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion],
+	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.0-2),
 	gcc5-shlibs,
 	libgettext8-shlibs
 <<
 BuildDepends: <<
 	fink (>= 0.27.2),
-	r-base%type_pkg[rversion]-dev,
+	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion]-dev,
+	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
 	gcc5-compiler,
 	libgettext8-dev
 <<
@@ -57,7 +59,7 @@ Shlibs: <<
   ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/cluster/libs/cluster.dylib 0.0.0 %n (>=2.0.6-1)
 <<
 DescPackaging: <<
-  R (>= 3.3.0), stats, graphics, utils
+  R (>= 3.2.0), stats, graphics, utils
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-cocorresp-r-0.3-0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-cocorresp-r-0.3-0.info
@@ -11,15 +11,15 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4)
-Version: 0.4-0
+Type: rversion (3.5 3.4 3.3 3.2 3.1)
+Version: 0.3-0
 Revision: 1
 Description: Co-correspondence analysis methods
 Homepage: https://cran.r-project.org/web/packages/cocorresp/index.html
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:cocorresp_%v.tar.gz
-Source-MD5: 7c6c69a6b2d297103b6cb5f8b0faf44d
+Source-MD5: c3a91503f47a3a3de8eee76742963c69
 SourceDirectory: cocorresp
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -27,7 +27,7 @@ CustomMirror: <<
 <<
 Depends: <<
 	r-base%type_pkg[rversion],
-	cran-vegan-r%type_pkg[rversion] (>= 2.5-0-1)
+	cran-vegan-r%type_pkg[rversion] (>= 2.2-0-1)
 <<
 BuildDepends: r-base%type_pkg[rversion]-dev
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-coda-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-coda-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.19-2
+Version: 0.19-3
 Revision: 1
 Description: Output analysis and diagnostics for MCMC
 Homepage: https://cran.r-project.org/package=coda
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:coda_%v.tar.gz
-Source-MD5: 0c5d6b732fe5bcb7a8e52ae3ae6a311f
+Source-MD5: 2e32c8217920c2824229217a95fb8228
 SourceDirectory: coda
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-coxme-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-coxme-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.2-10
+Version: 2.2-14
 Revision: 1
 Description: Mixed Effects Cox Models
 Homepage: https://cran.r-project.org/package=coxme
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:coxme_%v.tar.gz
-Source-MD5: d130542c71ae1b0b9118cd6e93ca3b67
+Source-MD5: 2c49cc390eeecd07e063e79ea082fe7b
 SourceDirectory: coxme
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-data.table-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-data.table-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.12.0
+Version: 1.12.2
 Revision: 1
 Description: Extension of data.frame
 Homepage: https://cran.r-project.org/package=data.table
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:data.table_%v.tar.gz
-Source-MD5: 8ee67a2a2cafebad34c6bbdb8770a189
+Source-MD5: 93b8f74d38a0819c881576de5883d5cb
 SourceDirectory: data.table
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dbi-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dbi-r.info
@@ -13,7 +13,7 @@ Distribution: <<
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
 Version: 1.0.0
-Revision: 1
+Revision: 2
 Description: R Database Interface
 Homepage: https://cran.r-project.org/package=DBI
 License: LGPL
@@ -33,7 +33,7 @@ CompileScript: <<
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
-  $BIN_R --verbose CMD build --no-build-vignettes DBI
+  $BIN_R --verbose CMD build --no-build-vignettes --no-manual DBI
 <<
 InstallScript: <<
   #!/bin/sh -ev

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-deldir-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-deldir-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.1-16
+Version: 0.1-22
 Revision: 1
 Description: Delaunay and Dirichlet methods
 Homepage: https://cran.r-project.org/package=deldir
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:deldir_%v.tar.gz
-Source-MD5: 9a0440f3c4029363849584b7f71f76b5
+Source-MD5: b602d776a102f8d90e107797d0fbac38
 SourceDirectory: deldir
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-desolve-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-desolve-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.21
+Version: 1.23
 Revision: 1
 Description: General Solvers for Initial Value Problems
 Homepage: https://cran.r-project.org/package=deSolve
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:deSolve_%v.tar.gz
-Source-MD5: 2472f60045ee71998488600f32dfedc3
+Source-MD5: 07ba97624eed80da6025e614c03b8c99
 SourceDirectory: deSolve
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dplyr-r-0.8.0.1.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dplyr-r-0.8.0.1.info
@@ -2,20 +2,24 @@ Info2: <<
 
 Package: cran-dplyr-r%type_pkg[rversion]
 Distribution: <<
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12,
 	(%type_pkg[rversion] = 32 ) 10.9,
 	(%type_pkg[rversion] = 32 ) 10.10,
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2)
-Version: 0.8.3
+Type: rversion (3.1)
+Version: 0.8.0.1
 Revision: 1
 Description: Grammar of Data Manipulation
 Homepage: https://cran.r-project.org/package=dplyr
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:dplyr_%v.tar.gz
-Source-MD5: 7a2136d96451fa991beca82facfd63be
+Source-MD5: 92e005af7d2759a7e679f0da0a831b5d
 SourceDirectory: dplyr
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -25,6 +29,7 @@ Depends: <<
 	( %type_raw[rversion] >= 3.4 ) r-base%type_pkg[rversion] (>= 3.4.0-2),
 	( %type_raw[rversion] = 3.3 ) r-base%type_pkg[rversion] (>= 3.3.2-2),
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.5-2),
+	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-5),
 	cran-assertthat-r%type_pkg[rversion] (>=0.2.0),
 	cran-bh-r%type_pkg[rversion] (>=1.58.0-1),
 	cran-bindrcpp-r%type_pkg[rversion] (>= 0.2),
@@ -44,6 +49,7 @@ BuildDepends: <<
 	( %type_raw[rversion] >= 3.4 ) r-base%type_pkg[rversion]-dev (>= 3.4.0-2),
 	( %type_raw[rversion] = 3.3 ) r-base%type_pkg[rversion]-dev (>= 3.3.2-2),
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
+	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3),
 	cran-bindrcpp-r%type_pkg[rversion]-dev (>= 0.2),
 	texlive-base
 <<
@@ -84,6 +90,6 @@ A fast, consistent tool for working with data frame like
 objects, both in memory and out of memory.
 <<
 DescPackaging: <<
-  R (>=3.2.0)
+  R (>=3.1.2)
 <<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dt-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dt-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.5
+Version: 0.7
 Revision: 1
 Description: Wrapper of JavaScript Library DataTables
 Homepage: https://cran.r-project.org/package=DT
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:DT_%v.tar.gz
-Source-MD5: e7d1074021168776f2bac89071c694b5
+Source-MD5: 100850037454244675e9600b9dcdbfc8
 SourceDirectory: DT
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-e1071-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-e1071-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.7-1
+Version: 1.7-2
 Revision: 1
 Description: GNU R Tools for bunch of functions
 Homepage: https://cran.r-project.org/package=e1071
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:e1071_%v.tar.gz
-Source-MD5: 14471a50d020d6d3a713fb88c79e9e63
+Source-MD5: ae47bd1c4596a5e4e5f235cdd74859ec
 SourceDirectory: e1071
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-evaluate-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-evaluate-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.13
+Version: 0.14
 Revision: 1
 Description: GNU R Tools for command-line behavior
 Homepage: https://cran.r-project.org/package=evaluate
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:evaluate_%v.tar.gz
-Source-MD5: c46bc0303c00f1763e0ad6b70108119b
+Source-MD5: 8bcf26d1cc5b3f8fc14056ddfebcd295
 SourceDirectory: evaluate
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-evtree-r-1.0-7.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-evtree-r-1.0-7.info
@@ -1,16 +1,25 @@
 Info2: <<
 
 Package: cran-evtree-r%type_pkg[rversion]
-
-Type: rversion (3.5 3.4 3.3)
-Version: 1.0-8
+Distribution: <<
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12,
+	(%type_pkg[rversion] = 32 ) 10.9,
+	(%type_pkg[rversion] = 32 ) 10.10,
+	(%type_pkg[rversion] = 32 ) 10.11,
+	(%type_pkg[rversion] = 32 ) 10.12
+<<
+Type: rversion (3.5 3.4 3.3 3.2 3.1)
+Version: 1.0-7
 Revision: 1
 Description: Evolutionary Learning
 Homepage: https://cran.r-project.org/package=evtree
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:evtree_%v.tar.gz
-Source-MD5: 52b5bf9c1e770437a0419407870eac2f
+Source-MD5: 59b7e17fe55b36eae33ab54195e2ab57
 SourceDirectory: evtree
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-factominer-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-factominer-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.41
+Version: 1.42
 Revision: 1
 Description: Multivariate Data Analysis and Data Mining
 Homepage: https://cran.r-project.org/package=FactoMineR
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:FactoMineR_%v.tar.gz
-Source-MD5: 01a95b8bdcc3e51c8a1ac8178de6c895
+Source-MD5: c5f36466e39704e52a409e570aeb22e7
 SourceDirectory: FactoMineR
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-fields-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-fields-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 9.6
+Version: 9.8-3
 Revision: 1
 Description: Tools for spatial data
 Homepage: https://cran.r-project.org/package=fields
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:fields_%v.tar.gz
-Source-MD5: 32cc746f3aa2ad667a1175b881b95520
+Source-MD5: 618c7e6da8e39e341138c200793ef1f8
 SourceDirectory: fields
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-forecast-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-forecast-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 8.5
+Version: 8.7
 Revision: 1
 Description: Forecasting functions 
 Homepage: https://cran.r-project.org/package=forecast
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:forecast_%v.tar.gz
-Source-MD5: 5424b79afb40b5a0243faf11a5a279c8
+Source-MD5: f6d15aef6568519d9a3e7f88ddea987d
 SourceDirectory: forecast
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-formatr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-formatr-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.5
+Version: 1.7
 Revision: 1
 Description: GNU R Tools for formatting R source code
 Homepage: https://cran.r-project.org/package=formatR
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:formatR_%v.tar.gz
-Source-MD5: ac735515b8e4c32097154f1b68c5ecc7
+Source-MD5: 1b223bdb396ef14597e8a449c53af2fb
 SourceDirectory: formatR
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-fs-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-fs-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.2.7
+Version: 1.3.1
 Revision: 1
 Description: Cross-Platform File System Operations
 Homepage: https://cran.r-project.org/package=fs
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:fs_%v.tar.gz
-Source-MD5: 03bd6a60edcc5445c3e5edb88e2a99f6
+Source-MD5: 77015cf58e80bc80f6c849e5d7749828
 SourceDirectory: fs
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gam-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gam-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.16
+Version: 1.16.1
 Revision: 1
 Description: Generalized Additive Models
 Homepage: https://cran.r-project.org/package=gam
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:gam_%v.tar.gz
-Source-MD5: cc79b5768d3735fa73be30be9840d815
+Source-MD5: b086aed7c6ae36b61823c4218dc5782e
 SourceDirectory: gam
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-ggplot2-r-3.1.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-ggplot2-r-3.1.0.info
@@ -2,20 +2,24 @@ Info2: <<
 
 Package: cran-ggplot2-r%type_pkg[rversion]
 Distribution: <<
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12,
 	(%type_pkg[rversion] = 32 ) 10.9,
 	(%type_pkg[rversion] = 32 ) 10.10,
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2)
-Version: 3.2.0
+Type: rversion (3.5 3.4 3.3 3.2 3.1)
+Version: 3.1.0
 Revision: 1
 Description: Implementation of the Grammar of Graphics
 Homepage: https://cran.r-project.org/package=ggplot2
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:ggplot2_%v.tar.gz
-Source-MD5: 11bdbfbfda4373d221aff262f948f97b
+Source-MD5: 974188a999d71abaf4f303bb1ac61c49
 SourceDirectory: ggplot2
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -29,7 +33,7 @@ Depends: <<
 	cran-mass-r%type_pkg[rversion],
 	cran-plyr-r%type_pkg[rversion] (>= 1.7.1),
 	cran-reshape2-r%type_pkg[rversion],
-	cran-rlang-r%type_pkg[rversion] (>= 0.3.0),
+	cran-rlang-r%type_pkg[rversion] (>= 0.2.1),
 	cran-scales-r%type_pkg[rversion] (>= 0.5.0),
 	cran-tibble-r%type_pkg[rversion],
 	cran-withr-r%type_pkg[rversion] (>= 2.0.0)

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-glmnet-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-glmnet-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.0-16
+Version: 2.0-18
 Revision: 1
 Description: Lasso and elastic-net regularized models
 Homepage: https://cran.r-project.org/package=glmnet
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:glmnet_%v.tar.gz
-Source-MD5: b08e707a345f1d1e19296b4a4f868059
+Source-MD5: 62bfac200dc439e855870a8f7e0a12bc
 SourceDirectory: glmnet
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gower-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gower-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.2.0
+Version: 0.2.1
 Revision: 1
 Description: Gower's Distance
 Homepage: https://cran.r-project.org/package=gower
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:gower_%v.tar.gz
-Source-MD5: 573cd949848bafcff658b8ea6043d57a
+Source-MD5: e264a32ea2b7f74fac4094973eb5875a
 SourceDirectory: gower
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gss-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gss-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.1-9
+Version: 2.1-10
 Revision: 1
 Description: General Smoothing Splines
 Homepage: https://cran.r-project.org/package=gss
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:gss_%v.tar.gz
-Source-MD5: aff0ecea6701e3b10750da4c579ef5ad
+Source-MD5: 08451d5f4a34a59849a6c763d3aa6fff
 SourceDirectory: gss
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gtable-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gtable-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.2.0
+Version: 0.3.0
 Revision: 1
 Description: Arrange grobs in tables
 Homepage: https://cran.r-project.org/package=gtable
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:gtable_%v.tar.gz
-Source-MD5: 124090ae40b2dd3170ae11180e0d4cab
+Source-MD5: f996c5aa07b0ddaa52dc3a22bf3b2c99
 SourceDirectory: gtable
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gwidgets-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gwidgets-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.0-54
+Version: 0.0-54.1
 Revision: 1
 Description: R interfaces to gWidgets API
 Homepage: https://cran.r-project.org/package=gWidgets
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:gWidgets_%v.tar.gz
-Source-MD5: 629b3fd05850e00390be16326dc47df6
+Source-MD5: f8a2a30177b596eea5f03955aea1c0fc
 SourceDirectory: gWidgets
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-haven-r-2.1.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-haven-r-2.1.0.info
@@ -2,20 +2,24 @@ Info2: <<
 
 Package: cran-haven-r%type_pkg[rversion]
 Distribution: <<
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12,
 	(%type_pkg[rversion] = 32 ) 10.9,
 	(%type_pkg[rversion] = 32 ) 10.10,
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2)
-Version: 2.1.1
+Type: rversion (3.5 3.4 3.3 3.2 3.1)
+Version: 2.1.0
 Revision: 1
 Description: Import and export foreign statistical formats
 Homepage: https://cran.r-project.org/package=haven
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:haven_%v.tar.gz
-Source-MD5: f1883920a72fb564853f8dd7e1a5bf7c
+Source-MD5: 48cf078909db8ad24804c6097db288b0
 SourceDirectory: haven
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -24,6 +28,7 @@ CustomMirror: <<
 Depends: <<
 	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion],
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.0-2),
+	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-3),
 	cran-forcats-r%type_pkg[rversion] (>= 0.2.0),
 	cran-hms-r%type_pkg[rversion],
 	cran-rcpp-r%type_pkg[rversion] (>= 0.11.4),
@@ -35,6 +40,7 @@ BuildDepends: <<
 	fink (>= 0.27.2),
 	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion]-dev,
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
+	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3),
 	cran-rcpp-r%type_pkg[rversion]-dev (>= 0.11.4),
 	libgettext8-dev
 <<
@@ -67,7 +73,7 @@ Import foreign statistical formats into R via the embedded 'ReadStat'
 C library.
 <<
 DescPackaging: <<
-  R (>= 3.2)
+  R (>= 3.1)
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-hexbin-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-hexbin-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.27.2
+Version: 1.27.3
 Revision: 1
 Description: Hexagonal Binning Routines
 Homepage: https://cran.r-project.org/package=hexbin
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:hexbin_%v.tar.gz
-Source-MD5: d9474aa9ec36aecd7e022c8da1e58733
+Source-MD5: a7d07af14e0a30cdff90a90e72728bb2
 SourceDirectory: hexbin
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-httpuv-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-httpuv-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.5.0
+Version: 1.5.1
 Revision: 1
 Description: HTTP and WebSocket Server Library
 Homepage: https://cran.r-project.org/package=httpuv
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:httpuv_%v.tar.gz
-Source-MD5: d83d8006999385bc089ca0607de7deca
+Source-MD5: 74de6d002c3d47e5f693bbeab22e2056
 SourceDirectory: httpuv
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-igraph-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-igraph-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.2.4
+Version: 1.2.4.1
 Revision: 1
 Description: Network analysis and visualization
 Homepage: https://cran.r-project.org/package=igraph
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:igraph_%v.tar.gz
-Source-MD5: 85dcb81dd63931e28fa56b0bfaa81f71
+Source-MD5: eabac29603d0db7c4ad302f839cfefca
 SourceDirectory: igraph
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-inum-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-inum-r.info
@@ -1,25 +1,15 @@
 Info2: <<
 
 Package: cran-inum-r%type_pkg[rversion]
-Distribution: <<
-	(%type_pkg[rversion] = 31 ) 10.9,
-	(%type_pkg[rversion] = 31 ) 10.10,
-	(%type_pkg[rversion] = 31 ) 10.11,
-	(%type_pkg[rversion] = 31 ) 10.12,
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12
-<<
 Type: rversion (3.5 3.4)
-Version: 1.0-0
+Version: 1.0-1
 Revision: 1
 Description: Interval Representation of Vectors
 Homepage: https://cran.r-project.org/package=inum
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:inum_%v.tar.gz
-Source-MD5: 24748676b9e121f537a80343871e3c23
+Source-MD5: 2533893a597d56eef43123499eda3373
 SourceDirectory: inum
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -52,7 +42,7 @@ Enum-type representation of vectors and representation of intervals,
 including a method of coercing variables in data frames.
 <<
 DescPackaging: <<
-  R (>= 3.3.0)
+  R (>= 3.3.0), but the depending library (libcoin) is >=3.4.0.
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-ipred-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-ipred-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.9-8
+Version: 0.9-9
 Revision: 1
 Description: GNU R Tools for improved predictors
 Homepage: https://cran.r-project.org/package=ipred
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:ipred_%v.tar.gz
-Source-MD5: 459ded1f0d5afdbaca643f87006ca045
+Source-MD5: 4587bddb82ce8bd16871f4f0e6bfd87a
 SourceDirectory: ipred
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-iso-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-iso-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.0-17
-Revision: 2
+Version: 0.0-18
+Revision: 1
 Description: Functions to perform isotonic regression
 Homepage: https://cran.r-project.org/package=Iso
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:Iso_%v.tar.gz
-Source-MD5: bf99821efb6a44fa75fdbf5e5c4c91e4
+Source-MD5: b5a318b0cbecf9ba76c1ffd5522bfe42
 SourceDirectory: Iso
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-iterators-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-iterators-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.0.8
+Version: 1.0.10
 Revision: 1
 Description: Iterator construct for R
 Homepage: https://cran.r-project.org/package=iterators
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:iterators_%v.tar.gz
-Source-MD5: 2ded7f82cddd8174f1ec98607946c6ee
+Source-MD5: 8935d3e59e998ae3e1f81cea5ad23789
 SourceDirectory: iterators
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-javagd-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-javagd-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.6-1
-Revision: 2
+Version: 0.6-1.1
+Revision: 1
 Description: Java Graphics Device
 Homepage: https://cran.r-project.org/package=JavaGD
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:JavaGD_%v.tar.gz
-Source-MD5: 42bcace789bea7d6985e1c7b2144c9ae
+Source-MD5: 1dcc86bf9654e5b0b96d3e8bea86e1ef
 SourceDirectory: JavaGD
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-jomo-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-jomo-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.6-7
+Version: 2.6-8
 Revision: 1
 Description: Joint Modelling Multiple Imputation
 Homepage: https://cran.r-project.org/package=jomo
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:jomo_%v.tar.gz
-Source-MD5: d4ac3b2727a2b219122723d67444eb97
+Source-MD5: 45965015c78650ae89bc06fc081c1c41
 SourceDirectory: jomo
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-knitr-r-1.22.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-knitr-r-1.22.info
@@ -11,23 +11,22 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2)
-Version: 1.23
+Type: rversion (3.5 3.4 3.3 3.2 3.1)
+Version: 1.22
 Revision: 1
 Description: GNU R Tools for making web reports from text
 Homepage: https://cran.r-project.org/package=knitr
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:knitr_%v.tar.gz
-Source-MD5: 3fc90a5ba07b978566883dd1c5cd3cd7
+Source-MD5: da6b7c721871d7b079fb5f279f00fe5b
 SourceDirectory: knitr
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
 	Secondary: https://cran.r-project.org/src/contrib/00Archive/knitr
 <<
 Depends: <<
-	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion],
-	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.3-1),
+	r-base%type_pkg[rversion],
 	cran-evaluate-r%type_pkg[rversion] (>= 0.10),
 	cran-digest-r%type_pkg[rversion],
 	cran-formatr-r%type_pkg[rversion] (>= 1.0),
@@ -90,7 +89,7 @@ support to Python and Awk, etc). Many features are borrowed from or
 inspired by Sweave, cacheSweave, pgfSweave, brew and decumar.
 <<
 DescPackaging: <<
-  R (>= 3.2.3)
+  R (>= 2.14.1)
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-labelled-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-labelled-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.1.0
+Version: 2.2.1
 Revision: 1
 Description: Manipulating Labelled Data
 Homepage: https://cran.r-project.org/package=labelled
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:labelled_%v.tar.gz
-Source-MD5: 0138138acecb43a314d4a5cb195a5215
+Source-MD5: 5b081b8aa927b3e8774b8cde778dc57d
 SourceDirectory: labelled
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-lmtest-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-lmtest-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.9-36
+Version: 0.9-37
 Revision: 1
 Description: Testing Linear Regression Models
 Homepage: https://cran.r-project.org/package=lmtest
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:lmtest_%v.tar.gz
-Source-MD5: 5d19542c7ca35d3093655305d8c2fcd2
+Source-MD5: 461f2cac3f460c446b2e87bd61149928
 SourceDirectory: lmtest
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-lpsolve-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-lpsolve-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 5.6.13
+Version: 5.6.13.1
 Revision: 1
 Description: Solve Linear/Integer Programs
 Homepage: https://cran.r-project.org/package=lpSolve
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:lpSolve_%v.tar.gz
-Source-MD5: 8471654d9ae76e0f85ff3449433d4bc1
+Source-MD5: 4153c1e9d16c09d063e53f1befccc54a
 SourceDirectory: lpSolve
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-maldiquant-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-maldiquant-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2)
-Version: 1.19.2
+Version: 1.19.3
 Revision: 1
 Description: Quantitative Analysis of Mass Spec Data
 Homepage: https://cran.r-project.org/package=MALDIquant
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:MALDIquant_%v.tar.gz
-Source-MD5: e5bd7a5c25b0e506779b60e5f8fadce5
+Source-MD5: b446013250bd0348b4b542fcf6a3ef9c
 SourceDirectory: MALDIquant
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-markdown-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-markdown-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.9
+Version: 1.0
 Revision: 1
 Description: GNU R Tools for making web reports from text
 Homepage: https://cran.r-project.org/package=markdown
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:markdown_%v.tar.gz
-Source-MD5: eecc5cce41ffaa3bb0fbede85d59d769
+Source-MD5: 18cd558ad494c9ffff482954dae32f18
 SourceDirectory: markdown
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mass-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mass-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 7.3-51.1
+Version: 7.3-51.4
 Revision: 1
 Description: GNU R data sets for "Modern App. Stat", 4ed
 Homepage: https://cran.r-project.org/package=MASS
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:MASS_%v.tar.gz
-Source-MD5: 99021939fad36a57ecccd79c3abf4156
+Source-MD5: de47a9821cf202349ea173f56efa2719
 SourceDirectory: MASS
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-maxlik-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-maxlik-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.3-4
+Version: 1.3-6
 Revision: 1
 Description: Maximum Likelihood Estimation
 Homepage: https://cran.r-project.org/package=maxLik
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:maxLik_%v.tar.gz
-Source-MD5: dc4713afddb0999c6a3e709e2cd127fe
+Source-MD5: 4e62d272f8d95c148b2d41c2bec05547
 SourceDirectory: maxLik
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mclust-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mclust-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 5.4.3
+Version: 5.4.5
 Revision: 1
 Description: Normal Mixture Modeling
 Homepage: https://cran.r-project.org/package=mclust
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:mclust_%v.tar.gz
-Source-MD5: a8b3b0d1411b2f33db115a8ccc2d51b0
+Source-MD5: 7450afbf6c741672070f323c79a0208f
 SourceDirectory: mclust
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mgcv-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mgcv-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.8-27
+Version: 1.8-28
 Revision: 1
 Description: Mixed GAM Computation Vehicle
 Homepage: https://cran.r-project.org/package=mgcv
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:mgcv_%v.tar.gz
-Source-MD5: a8bba0e97a19315a2f74c69f003bb02d
+Source-MD5: 8d044bbc17f8e9c3574f3096128dc420
 SourceDirectory: mgcv
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mime-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mime-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.6
+Version: 0.7
 Revision: 1
 Description: Map Filenames to MIME Types
 Homepage: https://cran.r-project.org/package=mime
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:mime_%v.tar.gz
-Source-MD5: a033d88ac9bc733868d145fdc44f8c96
+Source-MD5: 4c083166e3371db5289b7b0d6b9e6bbc
 SourceDirectory: mime
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-modeltools-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-modeltools-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.2-21
+Version: 0.2-22
 Revision: 1
 Description: Tools and Classes for Statistical Models
 Homepage: https://cran.r-project.org/package=modeltools
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:modeltools_%v.tar.gz
-Source-MD5: 3bf56b2e7bf78981444385d87eeccdd7
+Source-MD5: 7c9f85cb8655cd4947b90e79ea6e4cad
 SourceDirectory: modeltools
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-monomvn-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-monomvn-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.9-9
+Version: 1.9-10
 Revision: 1
 Description: Estimation for multivariate normal
 Homepage: https://cran.r-project.org/package=monomvn
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:monomvn_%v.tar.gz
-Source-MD5: 0c7873d3ef2e6ff65a2028c9d909747b
+Source-MD5: a020e3e59b64694503f49fdf8d8f012d
 SourceDirectory: monomvn
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-network-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-network-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.14-377
+Version: 1.15
 Revision: 1
 Description: Classes for Relational Data
 Homepage: https://cran.r-project.org/package=network
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:network_%v.tar.gz
-Source-MD5: 3daad9027574886fc5182027c9cac141
+Source-MD5: 989e418abe4946a9e738d8baad256f9a
 SourceDirectory: network
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-nlme-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-nlme-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: cran-nlme-r%type_pkg[rversion]
 Type: rversion (3.5 3.4)
-Version: 3.1-137
+Version: 3.1-140
 Revision: 1
 Description: Linear and Nonlinear Mixed Effects Models
 Homepage: https://cran.r-project.org/package=nlme
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:nlme_%v.tar.gz
-Source-MD5: 1a9f73fd036e2406d430008ccf96048b
+Source-MD5: 5e0a17727be4a7ba60ebb2e279189f67
 SourceDirectory: nlme
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-nor1mix-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-nor1mix-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.2-3
+Version: 1.3-0
 Revision: 1
 Description: Normal (1-d) Mixture Models
 Homepage: https://cran.r-project.org/package=nor1mix
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:nor1mix_%v.tar.gz
-Source-MD5: 60eb5cc1ea6b366f53042087a080b105
+Source-MD5: fb216cb1568f84bef8aae7496ec6fbba
 SourceDirectory: nor1mix
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-numderiv-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-numderiv-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2016.8-1
+Version: 2016.8-1.1
 Revision: 1
 Description: Accurate Numerical Derivatives
 Homepage: https://cran.r-project.org/package=numDeriv
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:numDeriv_%v.tar.gz
-Source-MD5: 30e486298d5126d86560095be8e8aac1
+Source-MD5: f894081f6d73822a362f156e849c9657
 SourceDirectory: numDeriv
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-openssl-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-openssl-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.3
+Version: 1.4
 Revision: 1
 Description: Encryption, Signatures and Certificates
 Homepage: https://cran.r-project.org/package=openssl
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:openssl_%v.tar.gz
-Source-MD5: b87ae13050afc27eca05785860b5e9db
+Source-MD5: ba9a80c68c348a5a78b234053c840c61
 SourceDirectory: openssl
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-openxlsx-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-openxlsx-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3)
-Version: 4.1.0
+Version: 4.1.0.1
 Revision: 1
 Description: Read, Write and Edit XLSX Files
 Homepage: https://cran.r-project.org/package=openxlsx
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:openxlsx_%v.tar.gz
-Source-MD5: 5fdee62e96b0d176419cacb5f7a6e125
+Source-MD5: 5f65ab51db0cad0c015678bb71b9073d
 SourceDirectory: openxlsx
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-ordinal-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-ordinal-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2019.3-9
+Version: 2019.4-25
 Revision: 1
 Description: Regression Models for Ordinal Data
 Homepage: https://cran.r-project.org/package=ordinal
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:ordinal_%v.tar.gz
-Source-MD5: e50045480a7471d0eba45e7cf2adf570
+Source-MD5: 57a7558f5ec6ab60b75507fd7ed58ef6
 SourceDirectory: ordinal
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-partykit-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-partykit-r.info
@@ -13,14 +13,14 @@ Distribution: <<
 <<
 # R-restricted by cran-inum-r, cran-libcoin-r
 Type: rversion (3.5 3.4)
-Version: 1.2-3
+Version: 1.2-4
 Revision: 1
 Description: Toolkit for Recursive Partytioning
 Homepage: https://cran.r-project.org/package=partykit
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:partykit_%v.tar.gz
-Source-MD5: ae3b8c0fe2eddf7ad3fcee48d8585c81
+Source-MD5: aed2642c1091db2ec687952f812c35be
 SourceDirectory: partykit
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-permute-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-permute-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.9-4
+Version: 0.9-5
 Revision: 1
 Description: Generating restricted permutations of data
 Homepage: https://cran.r-project.org/package=permute
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:permute_%v.tar.gz
-Source-MD5: 569fc2442d72a1e3b7e2d456019674c9
+Source-MD5: bfbdc3e60f7d750ade47855c2126dcd3
 SourceDirectory: permute
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pmml-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pmml-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.5.7
+Version: 2.0.0
 Revision: 1
 Description: Generate PMML for various models
 Homepage: https://cran.r-project.org/package=pmml
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:pmml_%v.tar.gz
-Source-MD5: 50923350b78d2fb044a74f23f949b50f
+Source-MD5: d863f7b48ab16848d550a8ddd6575ad4
 SourceDirectory: pmml
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pmmltransformations-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pmmltransformations-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.3.2
+Version: 1.3.3
 Revision: 1
 Description: Transforms input data from a PMML perspective
 Homepage: https://cran.r-project.org/package=pmmlTransformations
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:pmmlTransformations_%v.tar.gz
-Source-MD5: 2828e3847053c7a049456651c4da9702
+Source-MD5: f3057df6f847e13c063f8715550ac0e5
 SourceDirectory: pmmlTransformations
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-polspline-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-polspline-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.1.14
+Version: 1.1.15
 Revision: 1
 Description: Polynomial spline routines
 Homepage: https://cran.r-project.org/package=polspline
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:polspline_%v.tar.gz
-Source-MD5: efc9054bf63672318929836657fae0e9
+Source-MD5: a5c7552e2c8a399ccfe24f439ce2f78c
 SourceDirectory: polspline
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-polynomf-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-polynomf-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.1-0
+Version: 2.0-2
 Revision: 1
 Description: Polynomials in R
 Homepage: https://cran.r-project.org/package=PolynomF
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:PolynomF_%v.tar.gz
-Source-MD5: 173bb9d3508e67bdefcba580a695e19f
+Source-MD5: 8597e87b33e1b7a7f3163055822855ae
 SourceDirectory: PolynomF
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-prabclus-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-prabclus-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.2-7
+Version: 2.3-1
 Revision: 1
 Description: Functions for Clustering
 Homepage: https://cran.r-project.org/package=prabclus
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:prabclus_%v.tar.gz
-Source-MD5: b0d2299058a1e0c28c4ff612e2adbb2c
+Source-MD5: ae7c35355522b07ed4a7e5d8a528d042
 SourceDirectory: prabclus
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pracma-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pracma-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.2.2
+Version: 2.2.5
 Revision: 1
 Description: Practical Numerical Math Functions
 Homepage: https://cran.r-project.org/package=pracma
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:pracma_%v.tar.gz
-Source-MD5: a177666659f51ab2472b2604230cbc8a
+Source-MD5: 883347253cee534788d992f7da9d961d
 SourceDirectory: pracma
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-proc-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-proc-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.10.0
+Version: 1.15.0
 Revision: 1
 Description: Display and analyze ROC curves
 Homepage: http://expasy.org/tools/pROC/
 License: GPL
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
 Source: mirror:custom:pROC_%v.tar.gz
-Source-MD5: efb3278a510e1407c1495257ef17232f
+Source-MD5: 0ee5f7339bd0670b72ace44f6f9dfc28
 SourceDirectory: pROC
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-profilemodel-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-profilemodel-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.5-9
+Version: 0.6.0
 Revision: 1
 Description: Inference functions profiling tools
 Homepage: https://cran.r-project.org/package=profileModel
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:profileModel_%v.tar.gz
-Source-MD5: c36fdcdb9a3aeaf31652e3dde2057ded
+Source-MD5: 4e240de72685037b77ce1d82e63c9713
 SourceDirectory: profilemodel
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-progress-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-progress-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.2.0
+Version: 1.2.2
 Revision: 1
 Description: Statnet project common scripts and utilities
 Homepage: https://cran.r-project.org/package=progress
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:progress_%v.tar.gz
-Source-MD5: 2fe471469fa52e93a3cb6c87c0b2203f
+Source-MD5: d1d31b3a7bde43cd6b141bdd7297d523
 SourceDirectory: progress
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-proj4-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-proj4-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.0-9
+Version: 1.0-8
 Revision: 1
 Description: PROJ.4 cartographic projections library for R
 Homepage: http://www.rforge.net/proj4/
 License: GPL
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
 Source: http://www.rforge.net/proj4/snapshot/proj4_%v.tar.gz
-Source-MD5: de103b030101e001e9a8a9a91200faa8
+Source-MD5: c471199d86fba2357522f9f4cb878227
 SourceDirectory: proj4
 Depends: <<
 	fink (>= 0.27.2),

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-purrr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-purrr-r.info
@@ -13,7 +13,7 @@ Distribution: <<
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
 Version: 0.3.2
-Revision: 1
+Revision: 2
 Description: Functional Programming Tools
 Homepage: https://cran.r-project.org/package=purrr
 License: GPL
@@ -53,7 +53,7 @@ CompileScript: <<
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
-  $BIN_R --verbose CMD build --no-build-vignettes purrr
+  $BIN_R --verbose CMD build --no-build-vignettes --no-manual purrr
 <<
 InstallScript: <<
   #!/bin/sh -ev

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-quadprog-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-quadprog-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.5-5
-Revision: 4
+Version: 1.5-7
+Revision: 1
 Description: Functionss for Quadratic Programming Problems
 Homepage: https://cran.r-project.org/package=quadprog
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:quadprog_%v.tar.gz
-Source-MD5: 8442f37afd8d0b19b12e77d63e6515ad
+Source-MD5: 336292e718bd2e52680a85d82df57884
 SourceDirectory: quadprog
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-quantmod-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-quantmod-r.info
@@ -8,14 +8,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2)
-Version: 0.4-13
+Version: 0.4-15
 Revision: 1
 Description: Quantitative Financial Modelling Framework
 Homepage: https://cran.r-project.org/package=quantmod
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:quantmod_%v.tar.gz
-Source-MD5: 3b9eb2762cc25a461bb981c238f92ef8
+Source-MD5: a7afd5700dc7fbcceb45f74e0a2a0754
 SourceDirectory: quantmod
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-quantreg-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-quantreg-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 5.38
+Version: 5.41
 Revision: 1
 Description: Quantile Regression
 Homepage: https://cran.r-project.org/package=quantreg
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:quantreg_%v.tar.gz
-Source-MD5: 8a126e8763925ab5f14ca8b26b6128a6
+Source-MD5: 70489defc7f68035e01620b9a3a25238
 SourceDirectory: quantreg
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-qvcalc-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-qvcalc-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.9-1
+Version: 1.0.0
 Revision: 1
 Description: Quasi Variances for Effects in Stat Models
 Homepage: https://cran.r-project.org/package=qvcalc
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:qvcalc_%v.tar.gz
-Source-MD5: cda49256c257e01a8a8b1c67bcf82eea
+Source-MD5: eda5fd4fd83b764441dd41849091a883
 SourceDirectory: qvcalc
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-r.utils-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-r.utils-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.8.0
+Version: 2.9.0
 Revision: 1
 Description: Various programming utilities
 Homepage: https://cran.r-project.org/package=R.utils
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:R.utils_%v.tar.gz
-Source-MD5: 56bbdf8bca68b9e61aa868819aeed7b2
+Source-MD5: 355f7525f3d4cfa2361c4ded1711b48e
 SourceDirectory: R.utils
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-raster-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-raster-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.8-19
+Version: 2.9-5
 Revision: 1
 Description: Geographic data analysis and modeling
 Homepage: https://cran.r-project.org/package=raster
 License: GPL3
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:raster_%v.tar.gz
-Source-MD5: c65e7db7413a25c050a1706bbfa18d0a
+Source-MD5: 1f124bf92f2a389b549837a4f646e230
 SourceDirectory: raster
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rastervis-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rastervis-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.45
+Version: 0.46
 Revision: 1
 Description: Visualization methods for raster
 Homepage: https://cran.r-project.org/package=rasterVis
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:rasterVis_%v.tar.gz
-Source-MD5: 550d82c747eff366334419e1aa445b25
+Source-MD5: 9e9e046bcecd75d3bfecbc15385dc7e7
 SourceDirectory: rasterVis
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcpparmadillo-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcpparmadillo-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3)
-Version: 0.9.300.2.0
+Version: 0.9.500.2.0
 Revision: 1
 Description: Rcpp integration for Armadillo
 Homepage: http://cran.r-project.org/web/packages/RcppArmadillo/index.html
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:RcppArmadillo_%v.tar.gz
-Source-MD5: 21aead0dd2b7fbc711aef944334b3c2b
+Source-MD5: af8c165135c566d99865976ddafdc8ad
 SourceDirectory: RcppArmadillo
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rdpack-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rdpack-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4)
-Version: 0.10-1
+Version: 0.11-0
 Revision: 1
 Description: Update/Manipulate Rd Documentation Objects
 Homepage: https://cran.r-project.org/package=Rdpack
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:Rdpack_%v.tar.gz
-Source-MD5: 5dffb58739e9513794adbb4575b783e1
+Source-MD5: 09694a7dcce3ff8c24ea3a3c14d66f42
 SourceDirectory: Rdpack
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-readxl-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-readxl-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.3.0
+Version: 1.3.1
 Revision: 1
 Description: Read Excel Files
 Homepage: https://cran.r-project.org/package=readxl
 License: GPL3
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:readxl_%v.tar.gz
-Source-MD5: 1942dbd154aeb0944ec77c190dcef801
+Source-MD5: 2face1053adb5104f8347fcd1897d7ad
 SourceDirectory: readxl
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-reshape-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-reshape-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.8.7
+Version: 0.8.8
 Revision: 1
 Description: Flexibly reshape data
 Homepage: https://cran.r-project.org/package=reshape
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:reshape_%v.tar.gz
-Source-MD5: 0b0eececc5eb74dea9d59a985bce6211
+Source-MD5: 91d3accf0a36d467d0f64eb94223e601
 SourceDirectory: reshape
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rgdal-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rgdal-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3)
-Version: 1.3-6
+Version: 1.4-4
 Revision: 1
 Description: GNU R Bindings for GDAL
 Homepage: https://cran.r-project.org/package=rgenoud
 License: GPL
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
 Source: mirror:custom:rgdal_%v.tar.gz
-Source-MD5: e2e60de68e87c5516fa1d5948c92749f
+Source-MD5: 88173d7f7ed5ee6e6502000b0adc487b
 SourceDirectory: rgdal
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rjsonio-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rjsonio-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.3-1.1
+Version: 1.3-1.2
 Revision: 1
 Description: Serialize R objects to JSON
 Homepage: https://cran.r-project.org/package=RJSONIO
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:RJSONIO_%v.tar.gz
-Source-MD5: be57e20d6e70f670b264c87cf1bdff95
+Source-MD5: b2b074aaa8f230f4fc7d05250c75bf47
 SourceDirectory: RJSONIO
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rlang-r-0.3.4.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rlang-r-0.3.4.info
@@ -2,20 +2,24 @@ Info2: <<
 
 Package: cran-rlang-r%type_pkg[rversion]
 Distribution: <<
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12,
 	(%type_pkg[rversion] = 32 ) 10.9,
 	(%type_pkg[rversion] = 32 ) 10.10,
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2)
-Version: 0.4.0
+Type: rversion (3.1)
+Version: 0.3.4
 Revision: 1
 Description: Functions for Base Types and Core R
 Homepage: https://cran.r-project.org/package=rlang
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:rlang_%v.tar.gz
-Source-MD5: 51dfcd0c8e46902a6be97d41639910d5
+Source-MD5: c44f84ce72ebc7c3d0d02640c6b12a13
 SourceDirectory: rlang
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -26,6 +30,7 @@ Depends: <<
 	( %type_raw[rversion] >= 3.4 ) r-base%type_pkg[rversion] (>= 3.4.0-2),
 	( %type_raw[rversion] = 3.3 ) r-base%type_pkg[rversion] (>= 3.3.2-2),
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.5-2),
+	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-5),
 	gcc5-shlibs,
 	libgettext8-shlibs
 <<
@@ -34,6 +39,7 @@ BuildDepends: <<
 	( %type_raw[rversion] >= 3.4 ) r-base%type_pkg[rversion]-dev (>= 3.4.0-2),
 	( %type_raw[rversion] = 3.3 ) r-base%type_pkg[rversion]-dev (>= 3.3.2-2),
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
+	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3),
 	gcc5-compiler,
 	libgettext8-dev
 <<
@@ -66,7 +72,7 @@ A toolbox for working with base types, core R features like
 the condition system, and core `Tidyverse' features like tidy evaluation.
 <<
 DescPackaging: <<
-  R (>= 3.2.0)
+  R (>= 3.1.0)
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rms-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rms-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2)
-Version: 5.1-3
-Revision: 2
+Version: 5.1-3.1
+Revision: 1
 Description: Regression Modeling Strategies
 Homepage: https://cran.r-project.org/package=rms
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:rms_%v.tar.gz
-Source-MD5: 8677073e5911c61ddb659c2ceec6d5b0
+Source-MD5: 85699d4b9bb0c5f13056a627cd57e85e
 SourceDirectory: rms
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-robustbase-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-robustbase-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.93-4
+Version: 0.93-5
 Revision: 1
 Description: GNU R Tools for robust methods
 Homepage: https://cran.r-project.org/package=robustbase
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:robustbase_%v.tar.gz
-Source-MD5: e8ad4d567caaaaaa3017eedc2f6790e1
+Source-MD5: 539caa30bb62705aba7779214214dfbb
 SourceDirectory: robustbase
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rpart-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rpart-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 4.1-13
+Version: 4.1-15
 Revision: 1
 Description: GNU R Tools for recursive partitioning
 Homepage: https://cran.r-project.org/package=rpart
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:rpart_%v.tar.gz
-Source-MD5: 4a1dbde61f9ec91aa7f10d15526e0dcc
+Source-MD5: 078012c2d1e1ef1f8c53f9d93c5e43f6
 SourceDirectory: rpart
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rserve-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rserve-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.7-3
-Revision: 2
+Version: 1.7-3.1
+Revision: 1
 Description: Binary R server
 Homepage: https://cran.r-project.org/package=Rserve
 License: GPL/OpenSSL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:Rserve_%v.tar.gz
-Source-MD5: 74b9afd03342aa51ae38a160d7008f18
+Source-MD5: eecfde1f7f2aba14a565449671e6e623
 PatchFile: %{ni}.patch
 PatchFile-MD5: 63022dfcdfba50e3fd3a8e327803aff7
 SourceDirectory: Rserve

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-sandwich-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-sandwich-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.5-0
+Version: 2.5-1
 Revision: 1
 Description: GNU R std err estimators for time-series data
 Homepage: https://cran.r-project.org/package=sandwich
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:sandwich_%v.tar.gz
-Source-MD5: 9d099aa01941615f2f72400f462a122e
+Source-MD5: 543e51613620ed2cab375911c3611633
 SourceDirectory: sandwich
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-seriation-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-seriation-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.2-3
+Version: 1.2-7
 Revision: 1
 Description: Infrastructure for seriation
 Homepage: https://cran.r-project.org/package=seriation
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:seriation_%v.tar.gz
-Source-MD5: 4ab936c555833fc8e2825841b629cb30
+Source-MD5: 7cf9b6fe3261beea35babefbdb6142b0
 SourceDirectory: seriation
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-sfsmisc-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-sfsmisc-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2)
-Version: 1.1-3
+Version: 1.1-4
 Revision: 1
 Description: Utilities from Statistik ETH Zurich seminar
 Homepage: https://cran.r-project.org/package=sfsmisc
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:sfsmisc_%v.tar.gz
-Source-MD5: 517fd98cf983e8a5b37cc942ee109572
+Source-MD5: 4ddbdd7189e893b2d5e84095cb2eeffe
 SourceDirectory: sfsmisc
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-sn-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-sn-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.5-3
+Version: 1.5-4
 Revision: 1
 Description: Skew-normal and skew-t distributions
 Homepage: https://cran.r-project.org/package=sn
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:sn_%v.tar.gz
-Source-MD5: 5b8877d4d8ae63b41cb105aaee4e5d5e
+Source-MD5: ec61efb2f77dca5966da5d0be9b37a24
 SourceDirectory: sn
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-spls-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-spls-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.2-2
+Version: 2.2-3
 Revision: 1
 Description: Sparse Partial Least Squares Regression
 Homepage: https://cran.r-project.org/package=spls
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:spls_%v.tar.gz
-Source-MD5: 488218c4634c45725ed7574ad33b982a
+Source-MD5: 273e6be29dd0827df24d61180d78c74b
 SourceDirectory: spls
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-statmod-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-statmod-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.4.30
+Version: 1.4.32
 Revision: 1
 Description: Statistical Modeling
 Homepage: https://cran.r-project.org/package=statmod
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:statmod_%v.tar.gz
-Source-MD5: 34e60132ce3df38208f9dc0db0479151
+Source-MD5: 7417ddbc24cbda42a67bfe6dacec14eb
 SourceDirectory: statmod
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-survival-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-survival-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.43-3
+Version: 2.44-1.1
 Revision: 1
 Description: GNU R Tools for survival analysis
 Homepage: https://cran.r-project.org/package=survival
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:survival_%v.tar.gz
-Source-MD5: 2198f2e8502317258f511a8f19f4f7ab
+Source-MD5: c4058d906a0ba35c559a2a1dfa3dc8fa
 SourceDirectory: survival
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-sys-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-sys-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 3.1
+Version: 3.2
 Revision: 1
 Description: Tools for Running System Commands in R
 Homepage: https://cran.r-project.org/package=sys
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:sys_%v.tar.gz
-Source-MD5: 0bc6d10c4a8100de892fbc41949f24e9
+Source-MD5: 190fca32f95385aef9869793c4f6c5c3
 SourceDirectory: sys
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tibble-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tibble-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.1.1
+Version: 2.1.3
 Revision: 1
 Description: Simple Data Frames
 Homepage: https://cran.r-project.org/package=tibble
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:tibble_%v.tar.gz
-Source-MD5: ef3e099946643032d2ed94ea132dadfb
+Source-MD5: 7e5ed364e6741c7ea2f0fb0caf659094
 SourceDirectory: tibble
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -36,7 +36,7 @@ Depends: <<
 	cran-fansi-r%type_pkg[rversion] (>= 0.4.0),
 	cran-pillar-r%type_pkg[rversion] (>= 1.3.1),
 	cran-pkgconfig-r%type_pkg[rversion] (>= 2.0.2),
-	cran-rlang-r%type_pkg[rversion] (>= 0.3.1),
+	cran-rlang-r%type_pkg[rversion] (>= 0.3.0),
 	libgettext8-shlibs
 <<
 BuildDepends: <<
@@ -54,7 +54,7 @@ CompileScript: <<
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
-  $BIN_R --verbose CMD build --no-build-vignettes tibble
+  $BIN_R --verbose CMD build --no-build-vignettes --no-manual tibble
 <<
 InstallScript: <<
   #!/bin/sh -ev

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tidyselect-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tidyselect-r.info
@@ -11,7 +11,7 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2)
+Type: rversion (3.5 3.4 3.3 3.2 3.1)
 Version: 0.2.5
 Revision: 1
 Description: Select from a Set of Strings
@@ -29,6 +29,7 @@ Depends: <<
 	fink (>= 0.27.2), 
 	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion],
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.0-2),
+	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-3),
 	cran-glue-r%type_pkg[rversion],
 	cran-purrr-r%type_pkg[rversion],
 	cran-rcpp-r%type_pkg[rversion] (>= 0.12.0),
@@ -39,6 +40,7 @@ BuildDepends: <<
 	fink (>= 0.27.2), 
 	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion]-dev,
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
+	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3),
 	cran-rcpp-r%type_pkg[rversion]-dev,
 	libgettext8-dev
 <<
@@ -49,7 +51,7 @@ CompileScript: <<
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
-  $BIN_R --verbose CMD build --no-build-vignettes tidyselect
+  $BIN_R --verbose CMD build --no-build-vignettes --no-manual tidyselect
 <<
 InstallScript: <<
   #!/bin/sh -ev

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tinytex-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tinytex-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.11
+Version: 0.14
 Revision: 1
 Description: Functions to Maintain 'TeX Live'
 Homepage: https://cran.r-project.org/package=tinytex
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:tinytex_%v.tar.gz
-Source-MD5: 3a626343f2ce1d42ad77824fde7bdcf7
+Source-MD5: baca188db3a9980803bbd1f1291c82d0
 SourceDirectory: tinytex
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tseries-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tseries-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.10-46
+Version: 0.10-47
 Revision: 1
 Description: Time series analysis and finance
 Homepage: https://cran.r-project.org/package=tseries
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:tseries_%v.tar.gz
-Source-MD5: ac5e538a1e4f82da9f57d7c81f4b404e
+Source-MD5: 847284122781cf59865d15e3c7d3f3dd
 SourceDirectory: tseries
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tsp-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tsp-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.1-6
+Version: 1.1-7
 Revision: 1
 Description: Traveling Salesperson Problem
 Homepage: https://cran.r-project.org/package=TSP
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:TSP_%v.tar.gz
-Source-MD5: 64263ee0839e357acda5b9a991f8ab8b
+Source-MD5: 5018b6e443038d2aeeef459df42c8cce
 SourceDirectory: TSP
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-v8-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-v8-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.1
+Version: 2.3
 Revision: 1
 Description: Embedded JavaScript Engine for R
 Homepage: https://cran.r-project.org/package=V8
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:V8_%v.tar.gz
-Source-MD5: d6aa7df66a85c5d0d0f1bd253773c4c3
+Source-MD5: c297cf63c5988bb3b8b77299b443046e
 SourceDirectory: V8
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-vgam-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-vgam-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: cran-vgam-r%type_pkg[rversion]
 Type: rversion (3.5 3.4)
-Version: 1.0-6
+Version: 1.1-1
 Revision: 1
 Description: Vector Generalized Linear and Additive Models
 Homepage: https://cran.r-project.org/package=VGAM
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:VGAM_%v.tar.gz
-Source-MD5: 95e64dbd1566d4c6e506d6cdf25e7b16
+Source-MD5: 5bfc37c9bf86e056d4d3d1ba5640b5fb
 SourceDirectory: VGAM
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-visnetwork-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-visnetwork-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1 )
-Version: 2.0.6
+Version: 2.0.7
 Revision: 1
 Description: Network Visualization
 Homepage: https://cran.r-project.org/package=visNetwork
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:visNetwork_%v.tar.gz
-Source-MD5: 233aaae50b3d067d2ff8a0020a477644
+Source-MD5: 5d4241fea4aa864352f01bb6ddf7d2b0
 SourceDirectory: visNetwork
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-waveslim-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-waveslim-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.7.5
-Revision: 3
+Version: 1.7.5.1
+Revision: 1
 Description: Basic wavelet routines
 Homepage: https://cran.r-project.org/package=waveslim
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:waveslim_%v.tar.gz
-Source-MD5: 1fbcd344932c28f407b02a01caa625c8
+Source-MD5: bdb0847f2417f9768ba6921163edcd28
 SourceDirectory: waveslim
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-xfun-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-xfun-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.5
+Version: 0.8
 Revision: 1
 Description: Misc. functions by Yihui Xie
 Homepage: https://cran.r-project.org/package=xfun
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:xfun_%v.tar.gz
-Source-MD5: b7280419b0e783e7da05144dba787ea2
+Source-MD5: da4a9efbff2c49ae652ec8e0847c7d96
 SourceDirectory: xfun
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-xml-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-xml-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 3.98-1.9
+Version: 3.98-1.20
 Revision: 1
 Description: Tools for parsing and generating XML within R
 Homepage: http://www.omegahat.net/RSXML/
 License: BSD
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
 Source: mirror:custom:XML_%v.tar.gz
-Source-MD5: 70dd9d711cf3cbd218eb2b870aee9503
+Source-MD5: 5756618a3c30e2101b3eb50e0f5b1ef4
 SourceDirectory: XML
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-xtable-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-xtable-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.8-3
+Version: 1.8-4
 Revision: 1
 Description: Export tables to LaTeX or HTML
 Homepage: https://cran.r-project.org/package=xtable
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:xtable_%v.tar.gz
-Source-MD5: 10f7aebbf39e64798c1042b2a57a39a0
+Source-MD5: 0a7da6c3b34b2974110a7d00fe9afa79
 SourceDirectory: xtable
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-zcompositions-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-zcompositions-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.2.0
+Version: 1.3.2-1
 Revision: 1
 Description: Treatment of Zero/Missing Values in Data Sets
 Homepage: https://cran.r-project.org/package=zCompositions
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:zCompositions_%v.tar.gz
-Source-MD5: 54b32306abb8415ee47c15c45fc55837
+Source-MD5: 621acb224dd6a61ae98e3e93908253e2
 SourceDirectory: zCompositions
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-zip-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-zip-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.0.1
+Version: 2.0.3
 Revision: 1
 Description: Cross-Platform 'zip' Compression
 Homepage: https://cran.r-project.org/package=zip
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:zip_%v.tar.gz
-Source-MD5: e5309b143d2e786bd612c9f96aca97f6
+Source-MD5: 0a013af74a7b095fd1fbcd890dfe8684
 SourceDirectory: zip
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib


### PR DESCRIPTION
The CRAN packages are updated.  For the packages of which R version requirement has changed, new info files are created for older R.  In some packages, --no-manual has been added.  Tested with r-base31 through r-base35 on two Sierra machine.