### PR TITLE
nco-4.8.1-1: upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/nco.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/nco.info
@@ -1,6 +1,6 @@
 Info2:<<
 Package: nco
-Version: 4.7.9
+Version: 4.8.1
 Revision: 1
 Description: The NetCDF Operators
 License: GPL3
@@ -96,8 +96,8 @@ Replaces: <<
 # Unpack Phase:
 Source: https://github.com/nco/nco/archive/%v.tar.gz
 SourceRename: %n-%v.tar.gz
-Source-MD5: 6ad3febf223f676ca9281c39c48fb9f3
-Source-Checksum: SHA1(a45fb9097078038842b64e3b85f5dd2f1fa2f275)
+Source-MD5: 547209b355cc20b87f6e093fbf810557
+Source-Checksum: SHA1(4ceab5676690a04058f71794541cc14800278eae)
 
 # Patch Phase:
 PatchScript:  <<
@@ -127,6 +127,7 @@ CompileScript: <<
 	export	NETCDF_INC=%p \
 		NETCDF_LIB=%p \
 		NETCDF4_ROOT=%p
+	export PERL5LIB=$PERL5LIB:%p/lib/perl5/5.18.2
 	export PATH=%p/opt/texinfo-legacy/bin:$PATH
 	%{default_script}
 	fink-package-precedence --prohibit-bdep=%N-dap,%N-opendap,%N-netcdf,%N .

--- a/10.9-libcxx/stable/main/finkinfo/sci/nco.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/nco.info
@@ -127,8 +127,6 @@ CompileScript: <<
 	export	NETCDF_INC=%p \
 		NETCDF_LIB=%p \
 		NETCDF4_ROOT=%p
-	export PERL5LIB=$PERL5LIB:%p/lib/perl5/5.18.2
-	export PATH=%p/opt/texinfo-legacy/bin:$PATH
 	%{default_script}
 	fink-package-precedence --prohibit-bdep=%N-dap,%N-opendap,%N-netcdf,%N .
 <<


### PR DESCRIPTION
This is the result of an upstream update from version 4.7.9 to 4.8.1.

The addition of the `export PERL5LIB` is necessary as the package looks for `Locale/Messages.pm`, which is only available in the directory `%p/lib/perl5/5.18.2`

If there is a way to avoid hardcoding that path, please let me know.

Successfully built with `fink -m build` on Mac OS 10.14.5 with Command Line Tools 10.2