### PR TITLE
postgresql upstream updates June 2019

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 10.8
+Version: 10.9
 Revision: 1
 Type: postgresql 10
 Description: PostgreSQL open-source database
@@ -30,9 +30,9 @@ BuildDepends: <<
 Provides: postgresql-server
 GCC: 4.0
 
-Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 8a575258e57ba5ccf63fe916ecbcae8d
-Source-Checksum: SHA256(b198c2aadf1d68308127a0f5b51dbe798958ffe60dd999134f6495c489afcd5d)
+Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
+Source-MD5: 62f755219b9b05c25f24737405a5aae1
+Source-Checksum: SHA256(958b317fb007e94f3bef7e2a6641875db8f7f9d73db9f283324f3d6e8f5b0f54)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql11.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql11.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 11.3
+Version: 11.4
 Revision: 1
 Type: postgresql 11
 Description: PostgreSQL open-source database
@@ -30,9 +30,9 @@ BuildDepends: <<
 Provides: postgresql-server
 GCC: 4.0
 
-Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: c2a729b754b8de86a969c86ec25db076
-Source-Checksum: SHA256(2a85e082fc225944821dfd23990e32dfcd2284c19060864b0ad4ca537d30522d)
+Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
+Source-MD5: dab5eed8a5f9204bf2f03a209eead4c3
+Source-Checksum: SHA256(02802ddffd1590805beddd1e464dd28a46a41a5f1e1df04bab4f46663195cc8b)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.4.22
+Version: 9.4.23
 Revision: 1
 Epoch: 1
 Type: postgresql 9.4
@@ -31,9 +31,9 @@ BuildDepends: <<
 Provides: postgresql-server
 GCC: 4.0
 
-Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: ad80a06d86a08614bb5c3e9afa37086a
-Source-Checksum: SHA256(d6aa4c2b9204e375545b9845b0e5957b34affff1783863a80a194f2b2833c66b)
+Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
+Source-MD5: 096f75f97934b11f7f7123a30163058d
+Source-Checksum: SHA256(0d009c08b0c82b12484950bba10ae8bfd6f0c7bafd8f086ab756c483dd231d9b)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.5.17
+Version: 9.5.18
 Revision: 1
 Epoch: 1
 Type: postgresql 9.5
@@ -31,9 +31,9 @@ BuildDepends: <<
 Provides: postgresql-server
 GCC: 4.0
 
-Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 3438df58c4a4c95dace516c9a0590d64
-Source-Checksum: SHA256(88f9e37a0069f2fd4442d1d0d5d811d3121cac685514435b0248d0674723f705)
+Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
+Source-MD5: 3a3f8c03fe24f519584e3d6fe08396a7
+Source-Checksum: SHA256(dfc940487ed5acd5f657d6d02d53a18f9699888d4b0f820071e4564ed2f9f3dd)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.6.13
+Version: 9.6.14
 Revision: 1
 Epoch: 1
 Type: postgresql 9.6
@@ -31,9 +31,9 @@ BuildDepends: <<
 Provides: postgresql-server
 GCC: 4.0
 
-Source: http://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: f361e2ddcd2c31049789ef66f8841de5
-Source-Checksum: SHA256(ecbed20056296a65b6a4f5526c477e3ae5cc284cb01a15507785ddb23831e9a4)
+Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
+Source-MD5: c2de1b6ebc8e13dea992dffb75b6bc6b
+Source-Checksum: SHA256(3f08c265c9ae814f727461408ab24fdf3d954c4f7ae42d9c97b3c7e03fc31a22)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1


### PR DESCRIPTION
postgresql upstream updates  11.4 10.9 9.6.14 9.5.18 9.4.23.
Upstream updates includes security fix for CVE-2019-10164 
