### PR TITLE
eccodes-2.13.0-1: Upstream update and adjustment of dependencies

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: eccodes
-Version: 2.12.0
-Revision: 2
+Version: 2.13.0
+Revision: 1
 Type: gcc (8)
 Description: Coding/encoding ECMWF files, C headers/docs
 Homepage: https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home
@@ -9,19 +9,17 @@ License: BSD
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Source: https://software.ecmwf.int/wiki/download/attachments/45757960/%n-%v-Source.tar.gz
-Source-MD5: a812b5837901526905b020d328d8007c
-Source-Checksum: SHA1(dff83137e95520462118a5cc65b58157d40e736d)
+Source-MD5: fc65ff1f0cdf052ba8ff7c9eec2aba97
+Source-Checksum: SHA1(a75ab2aad51083ab6643fa55981572028367bf9d)
 PatchFile: eccodes.patch
-PatchFile-MD5: f76dca72904390e93bb19c1eeb9c1603
-PatchFile-Checksum: SHA1(916b37cb79a7c6c12a1c81fed1d2f2fcfcc38908)
+PatchFile-MD5: e7674c52a0453514afb17f108faca082
+PatchFile-Checksum: SHA1(c3e40c3861c66156efe1145222641345f883906d)
 
 SourceDirectory: %n-%v-Source
 BuildDependsOnly: true
 BuildDepends: <<
 	cmake,
 	gcc%type_pkg[gcc]-compiler,
-	libjasper.1,
-	libjpeg9,
 	libopenjp2.7,
 	libpng16,
 	netcdf-c15,
@@ -46,7 +44,6 @@ CompileScript: <<
 		-DCMAKE_Fortran_COMPILER=%p/bin/gfortran-fsf-%type_pkg[gcc] \
 		-DENABLE_FORTRAN=on \
 		-DENABLE_NETCDF=on \
-		-DENABLE_JPG=on \
 		-DENABLE_PNG=on \
 		-DENABLE_PYTHON=off \
 		-DOPENJPEG_INCLUDE_DIR=%p/include/openjpeg-2.1 \
@@ -109,8 +106,6 @@ InstallScript: <<
 SplitOff: <<
 	Package: %N-shlibs
 	Depends: <<
-		libjasper.1-shlibs,
-		libjpeg9-shlibs,
 		libopenjp2.7-shlibs,
 		libpng16-shlibs,
 		netcdf-c15-shlibs
@@ -128,8 +123,6 @@ SplitOff2: <<
 	Package: %N-bin
 	Depends: <<
 		%N-shlibs (>= %v-%r),
-		libjasper.1-shlibs,
-		libjpeg9-shlibs,
 		libopenjp2.7-shlibs,
 		libpng16-shlibs,
 		netcdf-c15-shlibs
@@ -157,8 +150,6 @@ SplitOff4: <<
 	Depends: <<
 		%N-shlibs (>= %v-%r),
 		gcc%type_pkg[gcc]-shlibs,
-		libjasper.1-shlibs,
-		libjpeg9-shlibs,
 		libopenjp2.7-shlibs,
 		libpng16-shlibs,
 		netcdf-c15-shlibs

--- a/10.9-libcxx/stable/main/finkinfo/sci/eccodes.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/eccodes.patch
@@ -1,6 +1,26 @@
-diff -Nurd eccodes-2.12.0-Source-orig/cmake/FindNetCDF.cmake eccodes-2.12.0-Source/cmake/FindNetCDF.cmake
---- eccodes-2.12.0-Source-orig/cmake/FindNetCDF.cmake	2019-02-15 10:44:50.000000000 +0100
-+++ eccodes-2.12.0-Source/cmake/FindNetCDF.cmake	2019-03-25 15:00:24.069712123 +0100
+diff -Nurd eccodes-2.13.0-Source.orig/CMakeLists.txt eccodes-2.13.0-Source/CMakeLists.txt
+--- eccodes-2.13.0-Source.orig/CMakeLists.txt	2019-07-08 14:06:44.000000000 +0200
++++ eccodes-2.13.0-Source/CMakeLists.txt	2019-07-19 13:27:24.158310812 +0200
+@@ -196,11 +196,11 @@
+     #       which can affect future package discovery if not undone by the caller.
+     #       The current CMAKE_PREFIX_PATH is backed up as _CMAKE_PREFIX_PATH
+     #
+-    set(CMAKE_WARN_DEPRECATED OFF) # Suppress deprecation message
+-    ecbuild_add_extra_search_paths( jasper )
+-    find_package( Jasper )
+-    set(CMAKE_PREFIX_PATH ${_CMAKE_PREFIX_PATH})    # Restore CMAKE_PREFIX_PATH
+-    set(CMAKE_WARN_DEPRECATED ON)  # Remove suppression
++    # set(CMAKE_WARN_DEPRECATED OFF) # Suppress deprecation message
++    # ecbuild_add_extra_search_paths( jasper )
++    # find_package( Jasper )
++    # set(CMAKE_PREFIX_PATH ${_CMAKE_PREFIX_PATH})    # Restore CMAKE_PREFIX_PATH
++    # set(CMAKE_WARN_DEPRECATED ON)  # Remove suppression
+ 
+     find_package( OpenJPEG )
+ 
+diff -Nurd eccodes-2.13.0-Source.orig/cmake/FindNetCDF.cmake eccodes-2.13.0-Source/cmake/FindNetCDF.cmake
+--- eccodes-2.13.0-Source.orig/cmake/FindNetCDF.cmake	2019-07-08 14:06:42.000000000 +0200
++++ eccodes-2.13.0-Source/cmake/FindNetCDF.cmake	2019-07-19 12:46:28.872987408 +0200
 @@ -78,7 +78,7 @@
  
    # Note: Only the HDF5 C-library is required for NetCDF
@@ -21,9 +41,9 @@ diff -Nurd eccodes-2.12.0-Source-orig/cmake/FindNetCDF.cmake eccodes-2.12.0-Sour
    endif()
  
    #ecbuild_debug_var( NETCDF_FOUND )
-diff -Nurd eccodes-2.12.0-Source-orig/cmake/contrib/FindNetCDF4.cmake eccodes-2.12.0-Source/cmake/contrib/FindNetCDF4.cmake
---- eccodes-2.12.0-Source-orig/cmake/contrib/FindNetCDF4.cmake	2019-02-15 10:44:50.000000000 +0100
-+++ eccodes-2.12.0-Source/cmake/contrib/FindNetCDF4.cmake	2019-03-25 15:29:19.264443319 +0100
+diff -Nurd eccodes-2.13.0-Source.orig/cmake/contrib/FindNetCDF4.cmake eccodes-2.13.0-Source/cmake/contrib/FindNetCDF4.cmake
+--- eccodes-2.13.0-Source.orig/cmake/contrib/FindNetCDF4.cmake	2019-07-08 14:06:42.000000000 +0200
++++ eccodes-2.13.0-Source/cmake/contrib/FindNetCDF4.cmake	2019-07-19 12:46:28.873674192 +0200
 @@ -106,7 +106,7 @@
    set(HAS_HDF5 TRUE)
    set(HDF5_FIND_QUIETLY ${NETCDF_FIND_QUIETLY})
@@ -33,22 +53,22 @@ diff -Nurd eccodes-2.12.0-Source-orig/cmake/contrib/FindNetCDF4.cmake eccodes-2.
  #        list( APPEND NETCDF_LIBRARIES_DEBUG
  #            ${HDF5_LIBRARIES_DEBUG} )
  #        list( APPEND NETCDF_LIBRARIES_RELEASE
-diff -Nurd eccodes-2.12.0-Source-orig/fortran/CMakeLists.txt eccodes-2.12.0-Source/fortran/CMakeLists.txt
---- eccodes-2.12.0-Source-orig/fortran/CMakeLists.txt	2019-02-15 10:44:55.000000000 +0100
-+++ eccodes-2.12.0-Source/fortran/CMakeLists.txt	2019-03-25 14:51:09.309393934 +0100
+diff -Nurd eccodes-2.13.0-Source.orig/fortran/CMakeLists.txt eccodes-2.13.0-Source/fortran/CMakeLists.txt
+--- eccodes-2.13.0-Source.orig/fortran/CMakeLists.txt	2019-07-08 14:06:44.000000000 +0200
++++ eccodes-2.13.0-Source/fortran/CMakeLists.txt	2019-07-19 12:46:28.874233497 +0200
 @@ -43,6 +43,8 @@
      ecbuild_add_library( TARGET     eccodes_f90
                           SOURCES    grib_fortran.c grib_f90.f90 eccodes_f90.f90 grib_kinds.h
                           GENERATED  grib_f90.f90 eccodes_f90.f90
-+                         CFLAGS     ${CFLAGS}
 +                         VERSION    0
++                         CFLAGS     ${CFLAGS}
                           LIBS       eccodes )
      add_custom_command( TARGET     eccodes_f90 POST_BUILD
                          COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/include
-diff -Nurd eccodes-2.12.0-Source-orig/src/CMakeLists.txt eccodes-2.12.0-Source/src/CMakeLists.txt
---- eccodes-2.12.0-Source-orig/src/CMakeLists.txt	2019-02-15 10:44:55.000000000 +0100
-+++ eccodes-2.12.0-Source/src/CMakeLists.txt	2019-03-25 14:51:09.310495327 +0100
-@@ -435,6 +435,8 @@
+diff -Nurd eccodes-2.13.0-Source.orig/src/CMakeLists.txt eccodes-2.13.0-Source/src/CMakeLists.txt
+--- eccodes-2.13.0-Source.orig/src/CMakeLists.txt	2019-07-08 14:06:45.000000000 +0200
++++ eccodes-2.13.0-Source/src/CMakeLists.txt	2019-07-19 12:46:28.875081020 +0200
+@@ -436,6 +436,8 @@
                                # griby.c gribl.c
                               ${grib_api_srcs}
                      GENERATED grib_api_version.c


### PR DESCRIPTION
Also removed dependency on libjasper and libjpeg. Jasper support is deprecated by eccodes, and libopenjpeg is sufficient.

Compiled and tested successfully on 10.14.5 with Command Line Tools 10.2.1