### PR TITLE
Remove -r31 variant from pkgmaker; Add -r31 variant at a lower version

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pkgmaker-r-0.22.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pkgmaker-r-0.22.info
@@ -11,15 +11,15 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2)
-Version: 0.27
+Type: rversion (3.5 3.4 3.3 3.2 3.1)
+Version: 0.22
 Revision: 1
 Description: Package development utilities
 Homepage: https://cran.r-project.org/package=pkgmaker
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:pkgmaker_%v.tar.gz
-Source-MD5: aae175024694d6098c3d6dd067122995
+Source-MD5: fbed0dc26cef901c30a59ede12e32b56
 SourceDirectory: pkgmaker
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -67,7 +67,7 @@ This package provides some low-level utilities to use for
  interface(s) are more than likely to happen.
 <<
 DescPackaging: <<
-  R (>= 3.0.0), but it loads 3.2.0 function (isNamespaceLoaded).
+  R (>= 3.0.0)
 <<
 
 <<


### PR DESCRIPTION
cran-pkgmaker-r version 0.27 uses a R-3.2 function (isNamespaceLoaded), and thus cran-pkgmaker-r31 is not buildable.