### PR TITLE
cdo-1.9.7.1: upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: cdo%type_pkg[-openmp]
-Version: 1.9.6
+Version: 1.9.7.1
 Revision: 1
 Description: Climate Data Operators
 HomePage: https://code.zmaw.de/projects/cdo
@@ -29,9 +29,9 @@ Conflicts: %{Ni}, %{Ni}-openmp
 Replaces: %{Ni}, %{Ni}-openmp
 
 # Unpack Phase:
-Source: https://code.mpimet.mpg.de/attachments/download/19299/%{Ni}-%v.tar.gz
-Source-MD5: 322f56c5e13f525c585ee5318d4435db
-Source-Checksum: SHA1(1c694f87756bebe9cadc91f457d3a303c3f9767d)
+Source: https://code.mpimet.mpg.de/attachments/download/20124/%{Ni}-%v.tar.gz
+Source-MD5: 39ccf8f0c41f358668487f5542bb83c1
+Source-Checksum: SHA1(5ece5d0cd5d4554bbb93ad65be6069a0efce5b1c)
 PatchFile: %{Ni}.patch
 PatchFile-MD5: ad655e198b8c9b047aae19b3c6a4720e
 PatchFile-Checksum: SHA1(9704b82d6ef825bf9624755bce1ffd1630990b4c)


### PR DESCRIPTION
Simple upstream update to `cdo` and `cdo-openmp`.
Compiled and tested successfully with "fink -m build" on Mac OS 10.14.6 with Command Line Tools 10.3