### PR TITLE
eccodes-2.13.1: upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: eccodes
-Version: 2.13.0
+Version: 2.13.1
 Revision: 1
 Type: gcc (8)
 Description: Coding/encoding ECMWF files, C headers/docs
@@ -9,8 +9,8 @@ License: BSD
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
 Source: https://software.ecmwf.int/wiki/download/attachments/45757960/%n-%v-Source.tar.gz
-Source-MD5: fc65ff1f0cdf052ba8ff7c9eec2aba97
-Source-Checksum: SHA1(a75ab2aad51083ab6643fa55981572028367bf9d)
+Source-MD5: aad3fad3b26d7ecda32acf91d8e5e0b6
+Source-Checksum: SHA1(a07e5c22ef2b62eeba3b4fc9932c3ac1ba92f002)
 PatchFile: eccodes.patch
 PatchFile-MD5: e7674c52a0453514afb17f108faca082
 PatchFile-Checksum: SHA1(c3e40c3861c66156efe1145222641345f883906d)


### PR DESCRIPTION
Simple upstream update.
Built and tested with `fink -m build` on Mac OS 10.14.6 with Command Line Tools 10.3