### PR TITLE
postgresql upstream updates August 2019

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 10.9
+Version: 10.10
 Revision: 1
 Type: postgresql 10
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 62f755219b9b05c25f24737405a5aae1
-Source-Checksum: SHA256(958b317fb007e94f3bef7e2a6641875db8f7f9d73db9f283324f3d6e8f5b0f54)
+Source-MD5: 3dac8187636fa8237802bef85be78023
+Source-Checksum: SHA256(ad4f9b8575f98ed6091bf9bb2cb16f0e52795a5f66546c1f499ca5c69b21f253)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql11.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql11.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 11.4
+Version: 11.5
 Revision: 1
 Type: postgresql 11
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: dab5eed8a5f9204bf2f03a209eead4c3
-Source-Checksum: SHA256(02802ddffd1590805beddd1e464dd28a46a41a5f1e1df04bab4f46663195cc8b)
+Source-MD5: 580da94f6d85046ff2a228785ab2cc89
+Source-Checksum: SHA256(7fdf23060bfc715144cbf2696cf05b0fa284ad3eb21f0c378591c6bca99ad180)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.4.23
+Version: 9.4.24
 Revision: 1
 Epoch: 1
 Type: postgresql 9.4
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 096f75f97934b11f7f7123a30163058d
-Source-Checksum: SHA256(0d009c08b0c82b12484950bba10ae8bfd6f0c7bafd8f086ab756c483dd231d9b)
+Source-MD5: 5ba0ffe7cb9b97a7d39a2ab7bab9e86c
+Source-Checksum: SHA256(52253d67dd46a7463a9d7c5e82bf959931fa4c11ec56293150210fa82a0f9429)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.5.18
+Version: 9.5.19
 Revision: 1
 Epoch: 1
 Type: postgresql 9.5
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 3a3f8c03fe24f519584e3d6fe08396a7
-Source-Checksum: SHA256(dfc940487ed5acd5f657d6d02d53a18f9699888d4b0f820071e4564ed2f9f3dd)
+Source-MD5: a65c32f211e29afbf35442e0babebbeb
+Source-Checksum: SHA256(960caa26612bca8a3791d1c0bdc5c6d24b3d15841becb617470424edbc5e1bb3)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.6.14
+Version: 9.6.15
 Revision: 1
 Epoch: 1
 Type: postgresql 9.6
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: c2de1b6ebc8e13dea992dffb75b6bc6b
-Source-Checksum: SHA256(3f08c265c9ae814f727461408ab24fdf3d954c4f7ae42d9c97b3c7e03fc31a22)
+Source-MD5: efb0bfbd9926f9491543e5cafd30ddd7
+Source-Checksum: SHA256(3cd9fe9af247167f863030842c1a57f58bdf3e5d50a94997d34a802b6032170a)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1


### PR DESCRIPTION
postgresql upstream updates 11.5 10.10 9.6.15 9.5.19 9.4.24

Upstream updates includes two security fixes:  
- CVE-2019-10208 (PG 9.4 - 11) 
- CVE-2019-10209 (PG 11)