### PR TITLE
New upstream versions based on bioconductor 3.6

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biobase-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biobase-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: bioconductor-biobase-r%type_pkg[rversion]
 Type: rversion (3.5 3.4)
-Version: 2.34.0
+Version: 2.38.0
 Revision: 1
 Description: Base functions for Bioconductor
-Homepage: http://www.bioconductor.org/packages/3.4/bioc/html/Biobase.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/Biobase.html
 License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.4/bioc/src/contrib/Biobase_%v.tar.gz
-Source-MD5: b761d9241462a4c6403731203c9fbb94
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/Biobase_%v.tar.gz
+Source-MD5: a1ae4cdc46d3877cf2a4427acdb56c9b
 SourceDirectory: Biobase
 Depends: <<
 	r-base%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biocgenerics-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biocgenerics-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2)
-Version: 0.22.0
+Version: 0.24.0
 Revision: 1
 Description: S4 generic functions for Bioconductor
-Homepage: http://bioconductor.org/packages/3.5/bioc/html/BiocGenerics.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/BiocGenerics.html
 License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://bioconductor.org/packages/3.5/bioc/src/contrib/BiocGenerics_%v.tar.gz
-Source-MD5: ef910f2011c0652e1f5fdf3b14219490
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/BiocGenerics_%v.tar.gz
+Source-MD5: f96a130d6a251fd176535aec95f3c1f3
 SourceDirectory: BiocGenerics
 Depends: <<
 	r-base%type_pkg[rversion]

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-graph-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-graph-r.info
@@ -2,18 +2,18 @@ Info2: <<
 
 Package: bioconductor-graph-r%type_pkg[rversion]
 Type: rversion (3.5 3.4)
-Version: 1.52.0
+Version: 1.56.0
 Revision: 1
 Description: Package to handle graph data structures
-Homepage: http://www.bioconductor.org/packages/3.4/bioc/html/graph.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/graph.html
 License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.4/bioc/src/contrib/graph_%v.tar.gz
-Source-MD5: a2f2cf1b4b83208e9746770bd2f5b925
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/graph_%v.tar.gz
+Source-MD5: 5ee188ea1de591bba6106bb862d98e07
 SourceDirectory: graph
 Depends: <<
 	r-base%type_pkg[rversion],
-	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.14.0),
+	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.13.11),
 	libgettext8-shlibs
 <<
 BuildDepends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-impute-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-impute-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: bioconductor-impute-r%type_pkg[rversion]
 Type: rversion (3.5 3.4)
-Version: 1.48.0
+Version: 1.52.0
 Revision: 1
 Description: Imputation for microarray data
-Homepage: http://www.bioconductor.org/packages/3.4/bioc/html/impute.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/impute.html
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.4/bioc/src/contrib/impute_%v.tar.gz
-Source-MD5: b8495a77bd675a86228a5bb5800a84c8
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/impute_%v.tar.gz
+Source-MD5: deec278b7fb9df661b498d2908dc754a
 SourceDirectory: impute
 Depends: <<
 	r-base%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-iranges-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-iranges-r.info
@@ -2,25 +2,25 @@ Info2: <<
 
 Package: bioconductor-iranges-r%type_pkg[rversion]
 Type: rversion (3.5 3.4)
-Version: 2.8.2
+Version: 2.12.0
 Revision: 1
 Description: Manipulating intervals on sequences
-Homepage: http://www.bioconductor.org/packages/3.4/bioc/html/IRanges.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/IRanges.html
 License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.4/bioc/src/contrib/IRanges_%v.tar.gz
-Source-MD5: ae1e6b78c6b84e4df6bec44e98e2136c
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/IRanges_%v.tar.gz
+Source-MD5: 9b0f46a04d130e7cced74d8b689c312a
 SourceDirectory: IRanges
 Depends: <<
 	r-base%type_pkg[rversion],
-	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.15.10),
-	bioconductor-s4vectors-r%type_pkg[rversion] (>= 0.9.48),
+	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.23.3),
+	bioconductor-s4vectors-r%type_pkg[rversion] (>= 0.15.5),
 	libgettext8-shlibs
 <<
 BuildDepends: <<
 	r-base%type_pkg[rversion]-dev,
 	cran-rcpp-r%type_pkg[rversion]-dev,
-	bioconductor-s4vectors-r%type_pkg[rversion]-dev (>= 0.6.0),
+	bioconductor-s4vectors-r%type_pkg[rversion]-dev (>= 0.15.5),
 	libgettext8-dev
 <<
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-limma-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-limma-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: bioconductor-limma-r%type_pkg[rversion]
 Type: rversion (3.5 3.4)
-Version: 3.30.13
+Version: 3.34.9
 Revision: 1
 Description: Linear Models for Microarray Data
-Homepage: http://www.bioconductor.org/packages/3.4/bioc/html/limma.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/limma.html
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.4/bioc/src/contrib/limma_%v.tar.gz
-Source-MD5: 6505fdccd7ae146652224377cd104e6a
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/limma_%v.tar.gz
+Source-MD5: 462d7acaa203cbfd841a6a9d416c1fc5
 SourceDirectory: limma
 Depends: <<
 	r-base%type_pkg[rversion]

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-massspecwavelet-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-massspecwavelet-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: bioconductor-massspecwavelet-r%type_pkg[rversion]
 Type: rversion (3.5 3.4)
-Version: 1.40.0
+Version: 1.44.0
 Revision: 1
 Description: Wavelet-based mass spectrum processing
-Homepage: http://www.bioconductor.org/packages/3.4/bioc/html/MassSpecWavelet.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/MassSpecWavelet.html
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.4/bioc/src/contrib/MassSpecWavelet_%v.tar.gz
-Source-MD5: a3577977a3072ba9d366987e0c34925d
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/MassSpecWavelet_%v.tar.gz
+Source-MD5: d2ae6a2ffffc73447b266b629ee800d1
 SourceDirectory: MassSpecWavelet
 Depends: <<
 	r-base%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-multtest-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-multtest-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: bioconductor-multtest-r%type_pkg[rversion]
 Type: rversion (3.5 3.4)
-Version: 2.32.0
+Version: 2.34.0
 Revision: 1
 Description: Resampling-based multiple hypothesis testing
-Homepage: https://bioconductor.org/packages/release/bioc/html/multtest.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/multtest.html
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://bioconductor.org/packages/release/bioc/src/contrib/multtest_%v.tar.gz
-Source-MD5: edfa82ac11e4f86c438609e9d2128e5c
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/multtest_%v.tar.gz
+Source-MD5: 5e0fb2a8c31f10a980de4f4a802539fd
 SourceDirectory: multtest
 Depends: <<
 	r-base%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-pcamethods-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-pcamethods-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: bioconductor-pcamethods-r%type_pkg[rversion]
 Type: rversion (3.5 3.4)
-Version: 1.66.0
+Version: 1.70.0
 Revision: 1
 Description: Collection of PCA methods
-Homepage: http://www.bioconductor.org/packages/3.4/bioc/html/pcaMethods.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/pcaMethods.html
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.4/bioc/src/contrib/pcaMethods_%v.tar.gz
-Source-MD5: 9667690b43d6c9cda9fc171bf138c322
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/pcaMethods_%v.tar.gz
+Source-MD5: 0d8a133e943071737fd79e8be4447215
 SourceDirectory: pcaMethods
 Depends: <<
 	r-base%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-preprocesscore-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-preprocesscore-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: bioconductor-preprocesscore-r%type_pkg[rversion]
 Type: rversion (3.5 3.4)
-Version: 1.36.0
+Version: 1.40.0
 Revision: 1
 Description: Collection of pre-processing functions
-Homepage: http://www.bioconductor.org/packages/3.4/bioc/html/preprocessCore.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/preprocessCore.html
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.4/bioc/src/contrib/preprocessCore_%v.tar.gz
-Source-MD5: e3a70a55cc19fe3a2d03cce03e542cd5
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/preprocessCore_%v.tar.gz
+Source-MD5: a7e36a083dbe31dee801e18f829b148f
 SourceDirectory: preprocessCore
 Depends: <<
 	r-base%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-protgenerics-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-protgenerics-r.info
@@ -12,19 +12,20 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2)
-Version: 1.6.0
+Version: 1.10.0
 Revision: 1
 Description: S4 generic functions for proteomics
-Homepage: http://www.bioconductor.org/packages/3.4/bioc/html/ProtGenerics.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/ProtGenerics.html
 License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.4/bioc/src/contrib/ProtGenerics_%v.tar.gz
-Source-MD5: adf7d84821b4444336ab9f2d1c4b9eaf
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/ProtGenerics_%v.tar.gz
+Source-MD5: 89cb1502740497c0aa7b969259b1fc98
 SourceDirectory: ProtGenerics
 Depends: <<
 	r-base%type_pkg[rversion],
 	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.14.0)
 <<
+# bioconductor-biocgenerics-r%type_pkg[rversion] may be removed.
 BuildDepends: <<
 	r-base%type_pkg[rversion]-dev
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-qvalue-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-qvalue-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.6.0
+Version: 2.10.0
 Revision: 1
 Description: Q-value estimation
-Homepage: http://www.bioconductor.org/packages/3.4/bioc/html/qvalue.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/qvalue.html
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.4/bioc/src/contrib/qvalue_%v.tar.gz
-Source-MD5: be8b7972cb37667edd96948c9b56ce89
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/qvalue_%v.tar.gz
+Source-MD5: dd9291ec9f97fddfbab304344b50694a
 SourceDirectory: qvalue
 Depends: <<
 	r-base%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-rgraphviz-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-rgraphviz-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.18.0
+Version: 2.22.0
 Revision: 1
 Description: Plotting capabilities for R graph objects
-Homepage: https://www.bioconductor.org/packages/3.4/bioc/html/Rgraphviz.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/Rgraphviz.html
 License: OSI-Approved
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: https://www.bioconductor.org/packages/3.4/bioc/src/contrib/Rgraphviz_%v.tar.gz
-Source-MD5: 0c55f4c53a311f1e5ba9028d865afd09
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/Rgraphviz_%v.tar.gz
+Source-MD5: 6efe4b4433c7f6fea73f330dff238c94
 SourceDirectory: Rgraphviz
 Depends: <<
 	r-base%type_pkg[rversion],
@@ -60,7 +60,7 @@ Shlibs: <<
   ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/Rgraphviz/libs/Rgraphviz.dylib 0.0.0 %n (>=1.0-37-1)
 <<
 DescDetail: <<
-nterfaces R with the AT and T graphviz library for plotting R graph
+Interfaces R with the AT and T graphviz library for plotting R graph
 objects from the graph package. Users on all platforms must install
 graphviz; see the README file, available in the source distribution
 of this file, for details.

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-s4vectors-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-s4vectors-r.info
@@ -2,18 +2,18 @@ Info2: <<
 
 Package: bioconductor-s4vectors-r%type_pkg[rversion]
 Type: rversion (3.5 3.4)
-Version: 0.12.2
+Version: 0.16.0
 Revision: 1
 Description: S4 implementation of vectors and lists
-Homepage: http://www.bioconductor.org/packages/3.4/bioc/html/S4Vectors.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/S4Vectors.html
 License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.4/bioc/src/contrib/S4Vectors_%v.tar.gz
-Source-MD5: df48bd8a07a23fc72a0401173d2a8167
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/S4Vectors_%v.tar.gz
+Source-MD5: 46c027075a43476bca84bd9052d72b1a
 SourceDirectory: S4Vectors
 Depends: <<
 	r-base%type_pkg[rversion],
-	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.15.10)
+	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.23.3)
 <<
 BuildDepends: <<
 	r-base%type_pkg[rversion]-dev

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-siggenes-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-siggenes-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.48.0
+Version: 1.52.0
 Revision: 1
 Description: Multiple testing using SAM and EBAM
-Homepage: http://www.bioconductor.org/packages/3.4/bioc/html/siggenes.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/siggenes.html
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.4/bioc/src/contrib/siggenes_%v.tar.gz
-Source-MD5: 768b519560144ba058352bb58747f426
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/siggenes_%v.tar.gz
+Source-MD5: 0037bfecd8f8b5e7a932392bbd27f722
 SourceDirectory: siggenes
 Depends: <<
 	r-base%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-sspa-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-sspa-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: bioconductor-sspa-r%type_pkg[rversion]
 Type: rversion (3.5 3.4)
-Version: 2.14.0
+Version: 2.18.0
 Revision: 1
 Description: General Sample Size and Power Analysis
-Homepage: http://www.bioconductor.org/packages/3.4/bioc/html/SSPA.html
+Homepage: http://www.bioconductor.org/packages/3.6/bioc/html/SSPA.html
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.4/bioc/src/contrib/SSPA_%v.tar.gz
-Source-MD5: 776bc39b0f187432c29b8ecf60027220
+Source: http://www.bioconductor.org/packages/3.6/bioc/src/contrib/SSPA_%v.tar.gz
+Source-MD5: 888b4282886ce5bceffe49a294284ac9
 SourceDirectory: SSPA
 Depends: <<
 	r-base%type_pkg[rversion],


### PR DESCRIPTION
Simply updated the bioconductor modules to the latest versions of the upstream.