### PR TITLE
New upstream version redis 5.0.5

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/redis.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/redis.info
@@ -1,5 +1,5 @@
 Package: redis
-Version: 4.0.11
+Version: 5.0.5
 Revision: 1
 Source: http://download.redis.io/releases/%n-%v.tar.gz
 Maintainer: Kevin Bullock <kbullock@ringworld.org>
@@ -8,10 +8,10 @@ License: BSD
 Description: Advanced in-memory NoSQL database
 Depends: passwd-redis (>= 20131111-1), daemonic (>= 20010902-4)
 BuildDepends: fink (>= 0.32)
-Source-MD5: e62d3793f86a6a0021609c9f905cb960
-Source-Checksum: SHA256(fc53e73ae7586bcdacb4b63875d1ff04f68c5474c1ddeda78f00e5ae2eed1bbb)
+Source-MD5: 2d2c8142baf72e6543174fc7beccaaa1
+Source-Checksum: SHA256(2139009799d21d8ff94fc40b7f36ac46699b9e1254086299f8d3b223ca54a375)
 PatchFile: %n.patch
-PatchFile-MD5: a7d0dad232019a86450b91e37d579782
+PatchFile-MD5: 611ce4c53a546fd7a3d4102c22d20e04
 PatchScript: <<
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 <<
@@ -20,7 +20,7 @@ ConfFiles: <<
 	%p/etc/%n.conf
 	%p/etc/%n-sentinel.conf
 <<
-CompileScript: make
+CompileScript: make MALLOC=jemalloc
 InfoTest: <<
 	TestScript: ./runtest --clients 4 || exit 2
 <<

--- a/10.9-libcxx/stable/main/finkinfo/database/redis.patch
+++ b/10.9-libcxx/stable/main/finkinfo/database/redis.patch
@@ -1,6 +1,6 @@
-diff -x '*~' -urN redis-4.0.9_org/redis.conf redis-4.0.9/redis.conf
---- redis-4.0.9_org/redis.conf	2018-03-26 18:04:15.000000000 +0200
-+++ redis-4.0.9/redis.conf	2018-04-14 13:08:58.000000000 +0200
+diff -x '*~' -urN redis-5.0.5_org/redis.conf redis-5.0.5/redis.conf
+--- redis-5.0.5_org/redis.conf	2019-05-15 18:07:37.000000000 +0200
++++ redis-5.0.5/redis.conf	2019-08-31 21:18:57.000000000 +0200
 @@ -132,8 +132,8 @@
  ################################# GENERAL #####################################
  
@@ -59,9 +59,9 @@ diff -x '*~' -urN redis-4.0.9_org/redis.conf redis-4.0.9/redis.conf
  
  ################################# REPLICATION #################################
  
-diff -x '*~' -urN redis-4.0.9_org/redis.sh redis-4.0.9/redis.sh
---- redis-4.0.9_org/redis.sh	1970-01-01 01:00:00.000000000 +0100
-+++ redis-4.0.9/redis.sh	2018-04-14 13:08:58.000000000 +0200
+diff -x '*~' -urN redis-5.0.5_org/redis.sh redis-5.0.5/redis.sh
+--- redis-5.0.5_org/redis.sh	1970-01-01 01:00:00.000000000 +0100
++++ redis-5.0.5/redis.sh	2019-08-31 21:18:57.000000000 +0200
 @@ -0,0 +1,11 @@
 +#!/bin/sh
 +
@@ -74,10 +74,10 @@ diff -x '*~' -urN redis-4.0.9_org/redis.sh redis-4.0.9/redis.sh
 +        sudo -u redis redis-server "$CONFIG"
 +        ;;
 +esac
-diff -x '*~' -urN redis-4.0.9_org/sentinel.conf redis-4.0.9/sentinel.conf
---- redis-4.0.9_org/sentinel.conf	2018-03-26 18:04:15.000000000 +0200
-+++ redis-4.0.9/sentinel.conf	2018-04-14 13:08:58.000000000 +0200
-@@ -167,7 +167,7 @@
+diff -x '*~' -urN redis-5.0.5_org/sentinel.conf redis-5.0.5/sentinel.conf
+--- redis-5.0.5_org/sentinel.conf	2019-05-15 18:07:37.000000000 +0200
++++ redis-5.0.5/sentinel.conf	2019-08-31 21:18:57.000000000 +0200
+@@ -182,7 +182,7 @@
  #
  # Example:
  #
@@ -86,17 +86,19 @@ diff -x '*~' -urN redis-4.0.9_org/sentinel.conf redis-4.0.9/sentinel.conf
  
  # CLIENTS RECONFIGURATION SCRIPT
  #
-@@ -192,5 +192,5 @@
+@@ -207,7 +207,7 @@
  #
  # Example:
  #
 -# sentinel client-reconfig-script mymaster /var/redis/reconfig.sh
 +# sentinel client-reconfig-script mymaster @PREFIX@/var/redis/reconfig.sh
  
-diff -x '*~' -urN redis-4.0.9_org/src/server.h redis-4.0.9/src/server.h
---- redis-4.0.9_org/src/server.h	2018-03-26 18:04:15.000000000 +0200
-+++ redis-4.0.9/src/server.h	2018-04-14 13:08:58.000000000 +0200
-@@ -109,7 +109,7 @@
+ # SECURITY
+ #
+diff -x '*~' -urN redis-5.0.5_org/src/server.h redis-5.0.5/src/server.h
+--- redis-5.0.5_org/src/server.h	2019-05-15 18:07:37.000000000 +0200
++++ redis-5.0.5/src/server.h	2019-08-31 21:18:57.000000000 +0200
+@@ -111,7 +111,7 @@
  #define CONFIG_DEFAULT_REPL_BACKLOG_TIME_LIMIT (60*60)  /* 1 hour */
  #define CONFIG_REPL_BACKLOG_MIN_SIZE (1024*16)          /* 16k */
  #define CONFIG_BGSAVE_RETRY_DELAY 5 /* Wait a few secs before trying again. */
@@ -105,9 +107,9 @@ diff -x '*~' -urN redis-4.0.9_org/src/server.h redis-4.0.9/src/server.h
  #define CONFIG_DEFAULT_SYSLOG_IDENT "redis"
  #define CONFIG_DEFAULT_CLUSTER_CONFIG_FILE "nodes.conf"
  #define CONFIG_DEFAULT_CLUSTER_ANNOUNCE_IP NULL         /* Auto detect. */
-diff -x '*~' -urN redis-4.0.9_org/tests/support/server.tcl redis-4.0.9/tests/support/server.tcl
---- redis-4.0.9_org/tests/support/server.tcl	2018-03-26 18:04:15.000000000 +0200
-+++ redis-4.0.9/tests/support/server.tcl	2018-04-14 13:08:58.000000000 +0200
+diff -x '*~' -urN redis-5.0.5_org/tests/support/server.tcl redis-5.0.5/tests/support/server.tcl
+--- redis-5.0.5_org/tests/support/server.tcl	2019-05-15 18:07:37.000000000 +0200
++++ redis-5.0.5/tests/support/server.tcl	2019-08-31 21:18:57.000000000 +0200
 @@ -32,25 +32,29 @@
      if {![is_alive $config]} { return }
      set pid [dict get $config pid]


### PR DESCRIPTION
Update redis to latest upstream version 5.0.5.
Compile against jemalloc to solve failed tests.

@krbullock please check the package as the package maintainer or let me know if I should takeover the maintainer role.

