### PR TITLE
CRAN packages update 20190902

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-aer-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-aer-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.2-6
+Version: 1.2-7
 Revision: 1
 Description: Applied Econometrics with R
 Homepage: https://cran.r-project.org/package=AER
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:AER_%v.tar.gz
-Source-MD5: 2da9530dea10e9c0c976dd061984660c
+Source-MD5: faee7e799310048d6770bb28e3174d05
 SourceDirectory: AER
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-aplpack-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-aplpack-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.3.2
+Version: 1.3.3
 Revision: 1
 Description: Another Plot PACKage
 Homepage: https://cran.r-project.org/package=aplpack
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:aplpack_%v.tar.gz
-Source-MD5: 5898d0babc1cd71139f35b7893695fcb
+Source-MD5: d43cffb1713d8aad135012d401b34cf9
 SourceDirectory: aplpack
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-arules-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-arules-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: cran-arules-r%type_pkg[rversion]
 Type: rversion (3.5 3.4)
-Version: 1.6-3
+Version: 1.6-4
 Revision: 1
 Description: Mining Association Rules 
 Homepage: https://cran.r-project.org/package=arules
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:arules_%v.tar.gz
-Source-MD5: 2f3617dc0cfbddc9ca4e9c8ca60c314e
+Source-MD5: fba1e1bb03f9930ab658d7862221bdac
 SourceDirectory: arules
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-bradleyterry2-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-bradleyterry2-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.0-9
+Version: 1.1-0
 Revision: 1
 Description: Bradley-Terry Models
 Homepage: https://cran.r-project.org/package=BradleyTerry2
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:BradleyTerry2_%v.tar.gz
-Source-MD5: da47a390b55e0671c04fb1ed523429c7
+Source-MD5: ad3dd9353e0246dc6dd223fe0838e087
 SourceDirectory: bradleyterry2
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-broom-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-broom-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.5.1
+Version: 0.5.2
 Revision: 1
 Description: Convert Analysis Objects into Tidy Tibbles
 Homepage: https://cran.r-project.org/package=broom
-License: GPL
+License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:broom_%v.tar.gz
-Source-MD5: 87cc6538d38ddad2fc6c8246c9afcde4
+Source-MD5: 1234d0cb7c470eb9be7e2a8ca17c9a28
 SourceDirectory: broom
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-callr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-callr-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 3.2.0
+Version: 3.3.1
 Revision: 1
 Description: Call R from R
 Homepage: https://cran.r-project.org/package=callr
-License: GPL
+License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:callr_%v.tar.gz
-Source-MD5: 0ef93d63ac8d3f413eceb62388d82e40
+Source-MD5: c42a80f6cd6cb4c628977b5ce8533f98
 SourceDirectory: callr
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-car-r-3.0-2.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-car-r-3.0-2.info
@@ -1,0 +1,62 @@
+Info2: <<
+
+Package: cran-car-r%type_pkg[rversion]
+Distribution: <<
+	(%type_pkg[rversion] = 32 ) 10.9,
+	(%type_pkg[rversion] = 32 ) 10.10,
+	(%type_pkg[rversion] = 32 ) 10.11,
+	(%type_pkg[rversion] = 32 ) 10.12
+<<
+Type: rversion (3.5 3.4 3.3 3.2)
+Version: 3.0-2
+Revision: 1
+Description: Companion to Applied Regression
+Homepage: https://cran.r-project.org/package=car
+License: GPL
+Maintainer: None <fink-devel@lists.sourceforge.net>
+Source: mirror:custom:car_%v.tar.gz
+Source-MD5: 97de82388a4f7fa6a5cc5cbe484b8021
+SourceDirectory: car
+CustomMirror: <<
+	Primary: https://cran.r-project.org/src/contrib
+	Secondary: https://cran.r-project.org/src/contrib/00Archive/car
+<<
+Depends: <<
+	r-base%type_pkg[rversion],
+	cran-abind-r%type_pkg[rversion],
+	cran-cardata-r%type_pkg[rversion] (>= 3.0-0),
+	cran-lme4-r%type_pkg[rversion],
+	cran-maptools-r%type_pkg[rversion],
+	cran-mass-r%type_pkg[rversion],
+	cran-mgcv-r%type_pkg[rversion],
+	cran-nlme-r%type_pkg[rversion],
+	cran-nnet-r%type_pkg[rversion],
+	cran-pbkrtest-r%type_pkg[rversion] (>=0.4-4),
+	cran-quantreg-r%type_pkg[rversion],
+	cran-rio-r%type_pkg[rversion]
+<<
+BuildDepends: r-base%type_pkg[rversion]-dev
+CompileScript: <<
+  #!/bin/bash -ev
+  export TMPDIR=%b/tmp
+  BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
+  
+  pushd ..
+  $BIN_R --verbose CMD build --no-build-vignettes car
+<<
+InstallScript: <<
+  #!/bin/sh -ev
+  BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
+  
+  mkdir -p %i/lib/R/%type_raw[rversion]/site-library
+  pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library car
+<<
+DescDetail: <<
+This package accompanies J. Fox and S. Weisberg, An R Companion to
+Applied Regression, Second Edition, Sage, 2011.
+<<
+DescPackaging: <<
+  R (>= 3.2.0)
+<<
+
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-car-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-car-r.info
@@ -7,15 +7,15 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2)
-Version: 3.0-2
+Type: rversion (3.5)
+Version: 3.0-3
 Revision: 1
 Description: Companion to Applied Regression
 Homepage: https://cran.r-project.org/package=car
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:car_%v.tar.gz
-Source-MD5: 97de82388a4f7fa6a5cc5cbe484b8021
+Source-MD5: 7662cd153bc873aaf8fcb369e6776411
 SourceDirectory: car
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-caret-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-caret-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5)
-Version: 6.0-82
+Version: 6.0-84
 Revision: 1
 Description: Classification and Regression Training
 Homepage: https://cran.r-project.org/package=caret
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:caret_%v.tar.gz
-Source-MD5: 6b4004660b59a270b0e56cb945a2ea4a
+Source-MD5: 87a9c52a4b445e6a4e14e7db3153b572
 SourceDirectory: caret
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-chron-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-chron-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.3-53
+Version: 2.3-54
 Revision: 1
 Description: Chronological objects
 Homepage: https://cran.r-project.org/package=chron
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:chron_%v.tar.gz
-Source-MD5: 7e5d7d7de3bc988f58fd2e8314ae88dc
+Source-MD5: 896064867fcf32f40f21f7317217f420
 SourceDirectory: chron
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-coin-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-coin-r.info
@@ -1,25 +1,15 @@
 Info2: <<
 
 Package: cran-coin-r%type_pkg[rversion]
-Distribution: <<
-	(%type_pkg[rversion] = 31 ) 10.9,
-	(%type_pkg[rversion] = 31 ) 10.10,
-	(%type_pkg[rversion] = 31 ) 10.11,
-	(%type_pkg[rversion] = 31 ) 10.12,
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12
-<<
 Type: rversion (3.5 3.4)
-Version: 1.3-0
+Version: 1.3-1
 Revision: 1
 Description: Conditional Inference Procedures
 Homepage: https://cran.r-project.org/package=coin
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:coin_%v.tar.gz
-Source-MD5: 3a0e023da6d1bae0b8b7c87aac763f20
+Source-MD5: 2f6cd1280b854ec10434b553b50707ad
 SourceDirectory: coin
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -27,10 +17,8 @@ CustomMirror: <<
 <<
 Depends: <<
 	fink (>= 0.27.2), 
-	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion],
-	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.0-2),
-	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-3),
-	cran-libcoin-r%type_pkg[rversion] (>= 1.0-0-1),
+	r-base%type_pkg[rversion],
+	cran-libcoin-r%type_pkg[rversion] (>= 1.0-0),
 	cran-matrixstats-r%type_pkg[rversion] (>= 0.54.0),
 	cran-modeltools-r%type_pkg[rversion] (>= 0.2-9),
 	cran-multcomp-r%type_pkg[rversion],
@@ -41,9 +29,7 @@ Depends: <<
 <<
 BuildDepends: <<
 	fink (>= 0.27.2), 
-	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion]-dev,
-	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
-	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3),
+	r-base%type_pkg[rversion]-dev,
 	gcc5-compiler,
 	libgettext8-dev
 <<
@@ -61,15 +47,10 @@ InstallScript: <<
   
   mkdir -p %i/lib/R/%type_raw[rversion]/site-library
   pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library coin
-  if [ "%type_num[rversion]" -lt "34" ]; then
-	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/coin/libs/coin.dylib %i/lib/R/%type_raw[rversion]/site-library/coin/libs/coin.dylib
-  else
-	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/coin/libs/coin.so %i/lib/R/%type_raw[rversion]/site-library/coin/libs/coin.so
-  fi
+  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/coin/libs/coin.so %i/lib/R/%type_raw[rversion]/site-library/coin/libs/coin.so
 <<
 Shlibs: <<
-  ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/coin/libs/coin.so 0.0.0 %n (>= 1.2-0-1)
-  ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/coin/libs/coin.dylib 0.0.0 %n (>= 1.2-0-1)
+  %p/lib/R/%type_raw[rversion]/site-library/coin/libs/coin.so 0.0.0 %n (>= 1.2-0-1)
 <<
 DescDetail: <<
 Conditional inference procedures for the general independence problem

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-coin-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-coin-r.info
@@ -18,7 +18,7 @@ CustomMirror: <<
 Depends: <<
 	fink (>= 0.27.2), 
 	r-base%type_pkg[rversion],
-	cran-libcoin-r%type_pkg[rversion] (>= 1.0-0),
+	cran-libcoin-r%type_pkg[rversion] (>= 1.0-0-1),
 	cran-matrixstats-r%type_pkg[rversion] (>= 0.54.0),
 	cran-modeltools-r%type_pkg[rversion] (>= 0.2-9),
 	cran-multcomp-r%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-copula-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-copula-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.999-19
+Version: 0.999-19.1
 Revision: 1
 Description: Multivariate Dependence with Copulas
 Homepage: https://cran.r-project.org/package=copula
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:copula_%v.tar.gz
-Source-MD5: 41fa02c7a592b389c787e47f4ead5cd8
+Source-MD5: c7f41692382dc3265ac54ed6aeaec984
 SourceDirectory: copula
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-curl-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-curl-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 3.3
+Version: 4.0
 Revision: 1
 Description: Connection Interface to Libcurl
 Homepage: https://cran.r-project.org/package=curl
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:curl_%v.tar.gz
-Source-MD5: 5dc0ba314900d339583a73bec13979e7
+Source-MD5: a1a6ca6e1ad08589b7d2517a1f2a7df5
 SourceDirectory: curl
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-detestset-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-detestset-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.1.5
+Version: 1.1.6
 Revision: 1
 Description: Testset for differential equations
 Homepage: https://cran.r-project.org/package=deTestSet
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:deTestSet_%v.tar.gz
-Source-MD5: 897cbe72a8b319a7fbae5befcc97a342
+Source-MD5: 599c25ab4f2b8cd1c0c70647b652e587
 SourceDirectory: deTestSet
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-doparallel-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-doparallel-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.0.14
+Version: 1.0.15
 Revision: 1
 Description: Foreach parallel adaptor
 Homepage: https://cran.r-project.org/package=gridBase
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:doParallel_%v.tar.gz
-Source-MD5: e78497b69948e6ca83d47065f55ed7bd
+Source-MD5: 97c7b3055db09bf25392c95db67fb5f7
 SourceDirectory: doParallel
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dosnow-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dosnow-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.0.16
+Version: 1.0.18
 Revision: 1
 Description: Foreach Parallel Adaptor for snow
 Homepage: https://cran.r-project.org/package=doSNOW
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:doSNOW_%v.tar.gz
-Source-MD5: 6fc90c6c770d58fb8a1ea67e049f9aef
+Source-MD5: 4ef5a2c412e57303a759fa5971751879
 SourceDirectory: doSNOW
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dtw-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dtw-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.18-1
+Version: 1.21-1
 Revision: 1
 Description: Dynamic time warping algorithms
 Homepage: https://cran.r-project.org/package=dtw
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:dtw_%v.tar.gz
-Source-MD5: 5e9995a198a62f28045c29461265d536
+Source-MD5: 7ed1988fb98a98bf35bf418d575b2f63
 SourceDirectory: dtw
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-effects-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-effects-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5)
-Version: 4.1-0
+Version: 4.1-1
 Revision: 1
 Description: Effect Displays for Models
 Homepage: https://cran.r-project.org/package=effects
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:effects_%v.tar.gz
-Source-MD5: 39e232b1374aae9ab8c6a69fdaefcc9f
+Source-MD5: 7c1400ebde1f80775f1ffb228b0ea699
 SourceDirectory: effects
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-elemstatlearn-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-elemstatlearn-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2015.6.26.1
+Version: 2015.6.26.2
 Revision: 1
 Description: GNU R data sets for learning elementary stats
 Homepage: https://cran.r-project.org/package=ElemStatLearn
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:ElemStatLearn_%v.tar.gz
-Source-MD5: 9e5cc9016206094c073965d7b32d3b0e
+Source-MD5: 9ef3c1289e595c2e9edddbccc885d25a
 SourceDirectory: ElemStatLearn
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-fastica-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-fastica-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.2-1
+Version: 1.2-2
 Revision: 1
 Description: FastICA Algorithms
 Homepage: https://cran.r-project.org/package=fastICA
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:fastICA_%v.tar.gz
-Source-MD5: fbc6b53b7db5ba883ffb6ff314b89327
+Source-MD5: fc54a0e73c46a095a9eba76b152dd393
 SourceDirectory: fastICA
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-foreach-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-foreach-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.4.4
+Version: 1.4.7
 Revision: 1
 Description: Foreach looping construct for R
 Homepage: https://cran.r-project.org/package=foreach
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:foreach_%v.tar.gz
-Source-MD5: c397f4c76a92e52b6fca7f18cb2ee791
+Source-MD5: 74ed846d1832a0e5436402d8bcde8a57
 SourceDirectory: foreach
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-foreign-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-foreign-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.8-71
+Version: 0.8-72
 Revision: 1
 Description: Read Data Stored by Minitab, S, etc
 Homepage: https://cran.r-project.org/package=foreign
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:foreign_%v.tar.gz
-Source-MD5: 2a694a712337294679b20f0033d0e265
+Source-MD5: 4f4032436f383fb5d4a27227bffb2ac1
 SourceDirectory: foreign
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-git2r-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-git2r-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.25.2
+Version: 0.26.1
 Revision: 1
 Description: Provides Access to Git Repositories
 Homepage: https://cran.r-project.org/package=git2r
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:git2r_%v.tar.gz
-Source-MD5: 307447a45411409a4c96cce45ac4a4ca
+Source-MD5: f4632239798a84680ddcab650caaa1df
 Source2: http://www.opensource.apple.com/source/zlib/zlib-43/zlib/zlib.pc?txt
 Source2Rename: zlib.pc
 Source2-MD5: 51a7a85e92c0fafd00adbb1d0c1bc805

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-httr-r-1.4.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-httr-r-1.4.0.info
@@ -2,20 +2,24 @@ Info2: <<
 
 Package: cran-httr-r%type_pkg[rversion]
 Distribution: <<
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12,
 	(%type_pkg[rversion] = 32 ) 10.9,
 	(%type_pkg[rversion] = 32 ) 10.10,
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2)
-Version: 1.4.1
+Type: rversion (3.5 3.4 3.3 3.2 3.1)
+Version: 1.4.0
 Revision: 1
 Description: Tools for working with URLs and HTTP
 Homepage: https://cran.r-project.org/package=httr
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:httr_%v.tar.gz
-Source-MD5: f62588fb6c8b4e243c69e277f7056ec8
+Source-MD5: afa863a39dfc61ac6197a73d8274288b
 SourceDirectory: httr
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -23,7 +27,7 @@ CustomMirror: <<
 <<
 Depends: << 
 	r-base%type_pkg[rversion],
-	cran-curl-r%type_pkg[rversion] (>=3.0.0), 
+	cran-curl-r%type_pkg[rversion] (>=0.9.1), 
 	cran-jsonlite-r%type_pkg[rversion], 
 	cran-mime-r%type_pkg[rversion], 
 	cran-openssl-r%type_pkg[rversion] (>=0.8),
@@ -52,7 +56,7 @@ because it only attempts to encompass the most common operations it
 is also much much simpler.
 <<
 DescPackaging: <<
-  R (>= 3.2.0)
+  R (>= 3.1.0)
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-jade-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-jade-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.0-1
+Version: 2.0-2
 Revision: 1
 Description: JADE and other BSS methods
 Homepage: https://cran.r-project.org/package=JADE
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:JADE_%v.tar.gz
-Source-MD5: 63c41619e08435975bf8ac82aedb2cf4
+Source-MD5: f862ba0f45a06d253af1e39c2a47a041
 SourceDirectory: JADE
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-lava-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-lava-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.6.5
+Version: 1.6.6
 Revision: 1
 Description: Linear Latent Variable Models
 Homepage: https://cran.r-project.org/package=lava
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:lava_%v.tar.gz
-Source-MD5: 944fd716a4b472a9c50eb12c1c330ac8
+Source-MD5: 80317ae6a109aaa7891987f95e696998
 SourceDirectory: lava
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-libcoin-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-libcoin-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4)
-Version: 1.0-4
+Version: 1.0-5
 Revision: 1
 Description: Test Statistics for Permutation Inference
 Homepage: https://cran.r-project.org/package=libcoin
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:libcoin_%v.tar.gz
-Source-MD5: 0dd735f0327e2241c159c723e66291f4
+Source-MD5: 135f455e63511897c97e2656fb40b494
 SourceDirectory: libcoin
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -50,15 +50,10 @@ InstallScript: <<
   
   mkdir -p %i/lib/R/%type_raw[rversion]/site-library
   pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library libcoin
-  if [ "%type_num[rversion]" -lt "34" ]; then
-	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/libcoin/libs/libcoin.dylib %i/lib/R/%type_raw[rversion]/site-library/libcoin/libs/libcoin.dylib
-  else
-	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/libcoin/libs/libcoin.so %i/lib/R/%type_raw[rversion]/site-library/libcoin/libs/libcoin.so
-  fi
+  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/libcoin/libs/libcoin.so %i/lib/R/%type_raw[rversion]/site-library/libcoin/libs/libcoin.so
 <<
 Shlibs: <<
-  ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/libcoin/libs/libcoin.so 0.0.0 %n (>= 0.9-2-1)
-  ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/libcoin/libs/libcoin.dylib 0.0.0 %n (>= 0.9-2-1)
+  %p/lib/R/%type_raw[rversion]/site-library/libcoin/libs/libcoin.so 0.0.0 %n (>= 0.9-2-1)
 <<
 DescDetail: <<
 Basic infrastructure for linear test statistics and permutation

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-magick-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-magick-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.0
+Version: 2.2
 Revision: 1
 Description: Advanced Graphics and Image-Processing in R
 Homepage: https://cran.r-project.org/package=magick
-License: GPL
+License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:magick_%v.tar.gz
-Source-MD5: ef406c7afb576b8000ffdb49b4841e0c
+Source-MD5: 59b36c1980b1a10301397b376fa00c13
 SourceDirectory: magick
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -34,9 +34,9 @@ Depends: <<
 	cran-magrittr-r%type_pkg[rversion],
 	cran-rcpp-r%type_pkg[rversion] (>= 0.12.12),
 	libgettext8-shlibs,
-	libmagickcore7.q16.2-shlibs,
-	libmagickwand7.q16.0-shlibs,
-	libmagick++7.q16.2-shlibs
+	libmagickcore7.q16.6-shlibs,
+	libmagickwand7.q16.6-shlibs,
+	libmagick++7.q16.4-shlibs
 <<
 BuildDepends: <<
 	fink (>= 0.27.2),
@@ -45,9 +45,9 @@ BuildDepends: <<
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3),
 	cran-rcpp-r%type_pkg[rversion]-dev (>= 0.12.12),
 	libgettext8-dev,
-	libmagickcore7.q16.2-dev,
-	libmagickwand7.q16.0-dev,
-	libmagick++7.q16.2-dev,
+	libmagickcore7.q16.6-dev,
+	libmagickwand7.q16.6-dev,
+	libmagick++7.q16.4-dev,
 	pkgconfig
 <<
 GCC: 4.0

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pkgbuild-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pkgbuild-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.0.3
+Version: 1.0.5
 Revision: 1
 Description: CommonMark and Github Markdown Rendering in R
 Homepage: https://cran.r-project.org/package=pkgbuild
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:pkgbuild_%v.tar.gz
-Source-MD5: 825de1949b21946d4447be0db95aa520
+Source-MD5: 2e8049d5c4bc587db3acb644592640c1
 SourceDirectory: pkgbuild
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -27,7 +27,7 @@ CustomMirror: <<
 <<
 Depends: <<
 	r-base%type_pkg[rversion], 
-	cran-callr-r%type_pkg[rversion] (>=2.0.0),
+	cran-callr-r%type_pkg[rversion] (>=3.2.0),
 	cran-cli-r%type_pkg[rversion],
 	cran-crayon-r%type_pkg[rversion],
 	cran-desc-r%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-polycor-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-polycor-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: cran-polycor-r%type_pkg[rversion]
 Type: rversion (3.5 3.4 3.3)
-Version: 0.7-9
+Version: 0.7-10
 Revision: 1
 Description: Polychoric and Polyserial Correlations
 Homepage: https://cran.r-project.org/package=polycor
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:polycor_%v.tar.gz
-Source-MD5: 197783428d24895672354a569215fec5
+Source-MD5: 9119d99bad71481afea0a006b8cb4654
 SourceDirectory: polycor
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcmdcheck-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcmdcheck-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.3.2
+Version: 1.3.3
 Revision: 1
 Description: Run 'R CMD check' from 'R'
 Homepage: https://cran.r-project.org/package=rcmdcheck
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:rcmdcheck_%v.tar.gz
-Source-MD5: c783f9a1d7de4ec36f3c23bad824dbef
+Source-MD5: f24d6bc8edc505543c3878f3f6411505
 SourceDirectory: rcmdcheck
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -27,8 +27,8 @@ CustomMirror: <<
 <<
 Depends: <<
 	r-base%type_pkg[rversion],
-	cran-callr-r%type_pkg[rversion] (>= 2.0.0),
-	cran-cli-r%type_pkg[rversion],
+	cran-callr-r%type_pkg[rversion] (>= 3.1.1.9000),
+	cran-cli-r%type_pkg[rversion] (>= 1.1.0),
 	cran-crayon-r%type_pkg[rversion],
 	cran-desc-r%type_pkg[rversion] (>= 1.2.0),
 	cran-digest-r%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcpp-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcpp-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.0.1
+Version: 1.0.2
 Revision: 1
 Description: Seamless R and C++ Integration
 Homepage: https://cran.r-project.org/package=Rcpp
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:Rcpp_%v.tar.gz
-Source-MD5: 7cb06160edf58ddccc4d1c1889cf3804
+Source-MD5: 791b53cf792b1398254f739ea91a3acd
 SourceDirectory: Rcpp
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-remotes-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-remotes-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.0.2
+Version: 2.1.0
 Revision: 1
 Description: R Pkg Installation from Remote Repositories
 Homepage: https://cran.r-project.org/package=remotes
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:remotes_%v.tar.gz
-Source-MD5: acb1db953159b5bbde5aea9bd5a63379
+Source-MD5: ebd638cd3a04f17bb83279ab43e57e1f
 SourceDirectory: remotes
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-whisker-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-whisker-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.3-2
+Version: 0.4
 Revision: 1
 Description: {{mustache}} for R, logicless templating
 Homepage: https://cran.r-project.org/package=whisker
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:whisker_%v.tar.gz
-Source-MD5: c4b9bf9a22e69ce003fe68663ab5e8e6
+Source-MD5: ad148fdbb613eea8d5ec5981d5881d90
 SourceDirectory: whisker
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-xml2-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-xml2-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.2.0
+Version: 1.2.2
 Revision: 1
 Description: Parse XML
 Homepage: https://cran.r-project.org/package=xml2
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:xml2_%v.tar.gz
-Source-MD5: 40e31daf2a4a7c36be9b0bb630399a9c
+Source-MD5: 177e90414196655c7a5f990351c1df02
 SourceDirectory: xml2
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -53,7 +53,7 @@ CompileScript: <<
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
-  $BIN_R --verbose CMD build --no-build-vignettes xml2
+  $BIN_R --verbose CMD build --no-build-vignettes --no-manual xml2
 <<
 InstallScript: <<
   #!/bin/sh -ev


### PR DESCRIPTION
New upstream versions.  

car and httr require R >=3.5 and >=3.2 respectively.  New files are added for older Rs.