### PR TITLE
gsl updated

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gsl-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gsl-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.9-10.3
+Version: 2.1-6
 Revision: 1
 Description: Gnu Scientific Library R wrapper
 Homepage: http://cran.r-project.org/web/packages/gsl/index.html
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:gsl_%v.tar.gz
-Source-MD5: e796a7fee81f8808b249c7efe410721f
+Source-MD5: 740a2339eecea4e1307d74455b83eef1
 SourceDirectory: gsl
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -28,18 +28,19 @@ CustomMirror: <<
 Depends: <<
 	fink (>= 0.27.2),
 	r-base%type_pkg[rversion],
-	gsl-shlibs,
+	gsl25-shlibs,
 	libgettext8-shlibs
 <<
 BuildDepends: <<
 	fink (>= 0.27.2),
 	r-base%type_pkg[rversion]-dev,
-	gsl,
+	gsl25,
 	libgettext8-dev
 <<
 CompileScript: <<
   #!/bin/bash -ev
   export TMPDIR=%b/tmp
+  export GSL_CONFIG=%p/opt/gsl25/bin/gsl-config
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
@@ -58,8 +59,8 @@ InstallScript: <<
   fi
 <<
 Shlibs: <<
-  ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/gsl/libs/gsl.so 0.0.0 %n (>= 1.9-10.3-1)
-  ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/gsl/libs/gsl.dylib 0.0.0 %n (>= 1.9-10.3-1)
+  ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/gsl/libs/gsl.so 0.0.0 %n (>= 2.1-6-1)
+  ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/gsl/libs/gsl.dylib 0.0.0 %n (>= 2.1-6-1)
 <<
 DescDetail: <<
 An R wrapper for the special functions and quasi random number generators

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcppgsl-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcppgsl-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.3.4
+Version: 0.3.6
 Revision: 1
 Description: Rcpp Integration for 'GNU GSL'
 Homepage: https://cran.r-project.org/package=RcppGSL
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:RcppGSL_%v.tar.gz
-Source-MD5: 5f3a2ffdac533a947c7bfc1de008550f
+Source-MD5: 61beb5800974b3b00d15a29d13bd90ee
 SourceDirectory: RcppGSL
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -30,6 +30,7 @@ Depends: <<
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.0-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-3),
 	cran-rcpp-r%type_pkg[rversion] (>= 0.11.0),
+	gsl25-shlibs,
 	libgettext8-shlibs
 <<
 BuildDepends: <<
@@ -38,6 +39,7 @@ BuildDepends: <<
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3),
 	cran-rcpp-r%type_pkg[rversion]-dev (>= 0.11.0),
+	gsl25,
 	libgettext8-dev
 <<
 GCC: 4.0
@@ -46,11 +48,7 @@ CompileScript: <<
   export TMPDIR=%b/tmp
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   pushd ..
-  if [[ %type_raw[rversion] > 2.15 ]]; then
-    $BIN_R --verbose CMD build --no-build-vignettes RcppGSL
-  else
-    $BIN_R --verbose CMD build --no-vignettes RcppGSL
-  fi
+  $BIN_R --verbose CMD build --no-build-vignettes RcppGSL
 <<
 InstallScript: <<
   #!/bin/sh -ev

--- a/10.9-libcxx/stable/main/finkinfo/sci/gsl25.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gsl25.info
@@ -1,31 +1,44 @@
-Package: gsl
-Version: 1.16
-Revision: 3
+Package: gsl25
+Version: 2.6
+Revision: 1
 Description: GNU Scientific Library
 License: GPL
 Maintainer: Sebastien Maret <bmaret@users.sourceforge.net>
 Depends: %n-shlibs (= %v-%r)
 BuildDependsOnly: True
-Conflicts: gsl25
-Replaces: gsl25
-Source: mirror:gnu:gsl/%n-%v.tar.gz
-Source-MD5: e49a664db13d81c968415cd53f62bc8b
-ConfigureParams: --mandir=%i/share/man --infodir=%i/share/info
+Conflicts: gsl
+Replaces: gsl
+Source: mirror:gnu:gsl/gsl-%v.tar.gz
+Source-MD5: bda73a3dd5ff2f30b5956764399db6e7
 PatchScript: <<
 #! /bin/sh -ev
 # Patch configure to not link like Puma on Yosemite
 perl -pi.bak -e 's|10\.\[012\]\*|10.[012][,.]*|g' configure
 <<
+CompileScript: <<
+  #!/bin/bash -ev
+  ./configure --prefix=%p/opt/%N
+  make -j1
+<<
+InstallScript: <<
+  #!/bin/bash -ev  
+  make -j1 DESTDIR=%d install
+<<
+InfoTest: <<
+  TestScript: <<
+    make -j1 check || exit 2
+  <<
+<<
 DocFiles: README COPYING
 SplitOff: <<
   Package: %n-shlibs
   Files: <<
-    lib/libgsl.0.dylib
-    lib/libgslcblas.0.dylib
+    opt/%N/lib/libgsl.25.dylib
+    opt/%N/lib/libgslcblas.0.dylib
   <<
   Shlibs: <<
-    %p/lib/libgsl.0.dylib 18.0.0 gsl (>= 1.16-1)
-    %p/lib/libgslcblas.0.dylib 1.0.0 gsl (>= 1.4-1)
+    %p/opt/%N/lib/libgsl.25.dylib 26.0.0 gsl (>= 2.6-1)
+    %p/opt/%N/lib/libgslcblas.0.dylib 1.0.0 gsl (>= 1.4-1)
   <<
   DocFiles: COPYING
 <<
@@ -35,7 +48,6 @@ programmers. The library provides a wide range of mathematical
 routines such as random number generators, special functions and
 least-squares fitting. There are over 1000 functions in total.
 <<
-InfoDocs: gsl-ref.info
 Homepage: http://www.gnu.org/software/gsl/
 DescPackaging: <<
 Originally packaged by Jeffrey Whitaker.


### PR DESCRIPTION
I created a new package gsl25 (and its variant gsl25-shlibs).  The new package is installed in /sw/opt because it has libgslcblas.0.dylib, which is also installed by gsl-shlibs.

Unfortunately, CRAN packages that depend on the new version of gsl are not buildable at the moment.
