### PR TITLE
netcdf-fortran8-4.5.1-1: new package needed due to upstream update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-fortran7.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-fortran7.info
@@ -89,7 +89,7 @@ and format support the creation, access, and sharing of scientific data.
 
 This package provides a library, documentation, and examples for interfacing
 with Fortran 77 and Fortran 90 code using the gfortran compiler.  Because the
-library links to libraries from gcc4N-shlibs, a particular gcc4N had to be 
+library links to libraries from gccN-shlibs, a particular gccN had to be 
 chosen.
 <<
 DescPackaging: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-fortran8.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-fortran8.info
@@ -1,7 +1,7 @@
 Info2: <<
-Package: netcdf-fortran7
-Version: 4.4.5
-Revision: 2
+Package: netcdf-fortran8
+Version: 4.5.1
+Revision: 1
 BuildDependsOnly: true
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
@@ -9,8 +9,8 @@ Type: gcc (8)
 
 Depends: %n-shlibs (= %v-%r), gcc%type_pkg[gcc]-compiler
 BuildDepends: <<
-	netcdf-c15 (>= 4.6.2),
-	netcdf-bin (>= 4.4.0-1),
+	netcdf-c15 (>= 4.6.0),
+	netcdf-bin (>= 4.6.0),
 	libcurl4, 
 	szip,
 	flag-sort,
@@ -22,7 +22,7 @@ Conflicts: <<
 	netcdf-g95, 
 	netcdf-gfortran, 
 	netcdf7-gfortran,
-	netcdf-fortran8
+	netcdf-fortran7
 <<
 Replaces: <<
 	netcdf (<= 3.6.1-1003), 
@@ -30,13 +30,13 @@ Replaces: <<
 	netcdf-g95, 
 	netcdf-gfortran, 
 	netcdf7-gfortran,
-	netcdf-fortran8
+	netcdf-fortran7
 <<
 
-Source: ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-fortran-%v.tar.gz
-Source-MD5: 9a9a469fe623f81b48a9d836ea0f97f5
-Source-Checksum: SHA1(96341a5f714591acda147974f4c14f7b6357a320)
-SourceDirectory: netcdf-fortran-%v
+SourceRename: netcdf-fortran-%v.tar.gz
+Source: https://github.com/Unidata/netcdf-fortran/archive/v%v.tar.gz
+Source-MD5: d8b7a7ed682ec42d4503ae4c165079fc
+Source-Checksum: SHA1(e836d73ad16c01382910b0e0d959a16d4279b9d9)
 
 PatchScript: perl -pi -e 's/(10\.\[012\])\*/\1\,.\*/' configure
 
@@ -44,41 +44,40 @@ SetCFLAGS: -O2
 SetLDFLAGS: -lsz -Wl,-dead_strip_dylibs
 
 ConfigureParams: <<
-  --enable-shared --disable-static \
-  FFLAGS=-O2 FCFLAGS=-O2 \
-  FC='flag-sort -r %p/lib/gcc%type_raw[gcc]/bin/gfortran' \
-  F77='flag-sort -r %p/lib/gcc%type_raw[gcc]/bin/gfortran' \
-  F90='flag-sort -r %p/lib/gcc%type_raw[gcc]/bin/gfortran' \
-  --mandir='${prefix}/share/man' \
-  --infodir='${prefix}/share/info' \
-  --docdir='${prefix}/share/doc/netcdf' 
+	--enable-shared --disable-static \
+	FFLAGS=-O2 FCFLAGS=-O2 \
+	FC='flag-sort -r %p/lib/gcc%type_raw[gcc]/bin/gfortran' \
+	F77='flag-sort -r %p/lib/gcc%type_raw[gcc]/bin/gfortran' \
+	F90='flag-sort -r %p/lib/gcc%type_raw[gcc]/bin/gfortran' \
+	--mandir='${prefix}/share/man' \
+	--infodir='${prefix}/share/info' \
+	--docdir='${prefix}/share/doc/netcdf' 
 <<
 CompileScript: <<
 	%{default_script}
 	fink-package-precedence .
 <<
 InfoTest: <<
-	TestConfigureParams:   --enable-extra-example-tests
   	TestDepends: sed
 <<
 InstallScript: <<
-  #!/bin/sh -ev
-  make install DESTDIR=%d
-  # undo the "hack"
-  perl -pi -e 's,fc=.*,fc=\"%p/lib/gcc%type_raw[gcc]/bin/gfortran",' %i/bin/nf-config
-  mkdir -p %i/share/doc
-  mkdir -p %i/share/info
-  # Add examples for F77 and F90
-  mkdir -p %i/share/doc/%N/examples
-  cp -r examples/F* examples/Makefile %i/share/doc/%N/examples
+	#!/bin/sh -ev
+	make install DESTDIR=%d
+	# undo the "hack"
+	perl -pi -e 's,fc=.*,fc=\"%p/lib/gcc%type_raw[gcc]/bin/gfortran",' %i/bin/nf-config
+	mkdir -p %i/share/doc
+	mkdir -p %i/share/info
+	# Add examples for F77 and F90
+	mkdir -p %i/share/doc/%N/examples
+	cp -r examples/F* examples/Makefile %i/share/doc/%N/examples
 <<
 SplitOff: <<
-  Package: %N-shlibs
-  Depends: netcdf-c15-shlibs, gcc%type_pkg[gcc]-shlibs
-  Files: lib/libnetcdff.*.dylib
-  Shlibs: %p/lib/libnetcdff.6.dylib 9.0.0 %n (>= 4.4.5-1)
-  DocFiles: COPYRIGHT README.md RELEASE_NOTES.md F03Interfaces_LICENSE
-  Description: Array-based data access, Fortran library
+	Package: %N-shlibs
+	Depends: netcdf-c15-shlibs (>= 4.6.0), gcc%type_pkg[gcc]-shlibs
+	Files: lib/libnetcdff.*.dylib
+	Shlibs: %p/lib/libnetcdff.7.dylib 8.0.0 %n (>= 4.5.1-1)
+	DocFiles: COPYRIGHT README.md RELEASE_NOTES.md F03Interfaces_LICENSE
+	Description: Array-based data access, Fortran library
 <<
 DocFiles: COPYRIGHT README.md RELEASE_NOTES.md F03Interfaces_LICENSE docs/
 Description: Array-based data access, Fortran headers/doc
@@ -93,7 +92,8 @@ library links to libraries from gcc4N-shlibs, a particular gcc4N had to be
 chosen.
 <<
 DescPackaging: <<
-Whoops, this should have been "netcdf-fortran_6_"  Meh.
+This should have been "netcdf-fortran_7_", but the previous version was
+already incorrectly named netcdf-fortran7, so we inherited this issue.
 
 Manually move docs from the tarball to avoid potentially triggering a rebuild.
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-fortran8.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-fortran8.info
@@ -88,7 +88,7 @@ and format support the creation, access, and sharing of scientific data.
 
 This package provides a library, documentation, and examples for interfacing
 with Fortran 77 and Fortran 90 code using the gfortran compiler.  Because the
-library links to libraries from gcc4N-shlibs, a particular gcc4N had to be 
+library links to libraries from gccN-shlibs, a particular gccN had to be 
 chosen.
 <<
 DescPackaging: <<


### PR DESCRIPTION
This upstream version of netcdf-fortran is said to require netcdf-c >= 4.6.0, whereas for netcdf-fortran-4.4.5 it was >= 4.6.2. The latter was actually not reflected in the package info file, so that is updated here as well.
In addition, Conflicts/Replaces pairs are added between netcdf-fortran7 and netcdf-fortran8.

Note that this package should have been netcdf-fortran_7_ (it contains libnetcdff._7_.dylib) but the previous package was already _incorrectly_ called netcdf-fortran_7_.

Build and tested with `fink -m build` on Mac OS 10.14.6 with Command Line Tools 10.3.

Note: I purposely did not update netcdf-c to the current version 4.7.1 at this time as there is a significant bug in it that fails testing; thus awaiting 4.7.2. Also an upstream update of netcdf-cxx4 is expected soon.