### PR TITLE
Removed excessive "<<" in libicu55-dev.info

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libicu55-dev.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libicu55-dev.info
@@ -49,7 +49,6 @@ InfoTest: <<
 		#!/bin/sh -ev
 		export ICU_DATA=%b/build/data/out/build
 		cd build && make -j1 check || exit 2
-	<<
 <<
 InstallScript: <<
 #!/bin/sh -ex


### PR DESCRIPTION
Parsing of libicu55-dev.info failed, because of one excessive "<<"