### PR TITLE
Cran blob

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-blob-r-1.1.1.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-blob-r-1.1.1.info
@@ -2,20 +2,24 @@ Info2: <<
 
 Package: cran-blob-r%type_pkg[rversion]
 Distribution: <<
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12,
 	(%type_pkg[rversion] = 32 ) 10.9,
 	(%type_pkg[rversion] = 32 ) 10.10,
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2)
-Version: 1.2.0
+Type: rversion (3.5 3.4 3.3 3.2 3.1)
+Version: 1.1.1
 Revision: 1
 Description: Vectors of Binary Data
 Homepage: https://cran.r-project.org/package=blob
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:blob_%v.tar.gz
-Source-MD5: 43d9d80b6217e6de6ebfdb7a072bd52f
+Source-MD5: d30b62fbb81b7c61593043f2e67b4a6f
 SourceDirectory: blob
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -23,9 +27,7 @@ CustomMirror: <<
 <<
 Depends: <<
 	r-base%type_pkg[rversion],
-	cran-prettyunits-r%type_pkg[rversion],
-	cran-rlang-r%type_pkg[rversion],
-	cran-vctrs-r%type_pkg[rversion] (>=0.2.0)
+	cran-tibble-r%type_pkg[rversion]
 <<
 BuildDepends: r-base%type_pkg[rversion]-dev
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-blob-r-1.1.1.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-blob-r-1.1.1.info
@@ -13,7 +13,7 @@ Distribution: <<
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
 Version: 1.1.1
-Revision: 1
+Revision: 2
 Description: Vectors of Binary Data
 Homepage: https://cran.r-project.org/package=blob
 License: GPL
@@ -27,7 +27,7 @@ CustomMirror: <<
 <<
 Depends: <<
 	r-base%type_pkg[rversion],
-	cran-tibble-r%type_pkg[rversion]
+	cran-prettyunits-r%type_pkg[rversion]
 <<
 BuildDepends: r-base%type_pkg[rversion]-dev
 CompileScript: <<


### PR DESCRIPTION
New upstream version.  This version requires R >= 3.2, hence adding another file to keep cran-blob-r31, with a fix of dependency.

Note that blob is used by several CRAN and bioconductor packages.