### PR TITLE
CRAN upstream update 20191016

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-backports-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-backports-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.1.4
+Version: 1.1.5
 Revision: 1
 Description: Resolving the function names
 Homepage: https://cran.r-project.org/package=backports
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:backports_%v.tar.gz
-Source-MD5: 0271f2897b4778c4f3a4c655da098257
+Source-MD5: 3e22dd9c53fa5822c14b2d476f86a0ea
 SourceDirectory: backports
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-calibrate-r-1.7.2.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-calibrate-r-1.7.2.info
@@ -1,6 +1,6 @@
 Info2: <<
 
-Package: cran-lambda.r-r%type_pkg[rversion]
+Package: cran-calibrate-r%type_pkg[rversion]
 Distribution: <<
 	(%type_pkg[rversion] = 31 ) 10.9,
 	(%type_pkg[rversion] = 31 ) 10.10,
@@ -12,22 +12,22 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.2.4
+Version: 1.7.2
 Revision: 1
-Description: Modeling Data with Functional Programming
-Homepage: https://cran.r-project.org/package=lambda.r
-License: LGPL
+Description: Calibration of Scatterplot and Biplot Axes
+Homepage: https://cran.r-project.org/package=calibrate
+License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: mirror:custom:lambda.r_%v.tar.gz
-Source-MD5: 861157dc2fe66ce8ed1e755578a57e47
-SourceDirectory: lambda.r
+Source: mirror:custom:calibrate_%v.tar.gz
+Source-MD5: 426de8f93364955067a12fe480bf3f1f
+SourceDirectory: calibrate
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
-	Secondary: https://cran.r-project.org/src/contrib/00Archive/lambda.r
+	Secondary: https://cran.r-project.org/src/contrib/00Archive/calibrate
 <<
 Depends: <<
 	r-base%type_pkg[rversion],
-	cran-formatr-r%type_pkg[rversion]
+	cran-mass-r%type_pkg[rversion]
 <<
 BuildDepends: r-base%type_pkg[rversion]-dev
 CompileScript: <<
@@ -36,22 +36,21 @@ CompileScript: <<
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
-  $BIN_R --verbose CMD build --no-build-vignettes lambda.r
+  $BIN_R --verbose CMD build --no-build-vignettes calibrate
 <<
 InstallScript: <<
   #!/bin/sh -ev
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   mkdir -p %i/lib/R/%type_raw[rversion]/site-library
-  pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library lambda.r
+  pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library calibrate
 <<
 DescDetail: <<
-A language extension to efficiently write functional programs in R. 
-Syntax extensions include multi-part function definitions, pattern 
-matching, guard statements, built-in (optional) type safety.
+Package for drawing calibrated scales with tick marks on
+(non-orthogonal) variable vectors in scatterplots and biplots.
 <<
 DescPackaging: <<
-  R (>= 3.0.0)
+  R (>= 1.8.0)
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-calibrate-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-calibrate-r.info
@@ -1,25 +1,15 @@
 Info2: <<
 
 Package: cran-calibrate-r%type_pkg[rversion]
-Distribution: <<
-	(%type_pkg[rversion] = 31 ) 10.9,
-	(%type_pkg[rversion] = 31 ) 10.10,
-	(%type_pkg[rversion] = 31 ) 10.11,
-	(%type_pkg[rversion] = 31 ) 10.12,
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12
-<<
-Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.7.2
+Type: rversion (3.5)
+Version: 1.7.5
 Revision: 1
 Description: Calibration of Scatterplot and Biplot Axes
 Homepage: https://cran.r-project.org/package=calibrate
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:calibrate_%v.tar.gz
-Source-MD5: 426de8f93364955067a12fe480bf3f1f
+Source-MD5: 9beacc26abb547f26358eb831342a0da
 SourceDirectory: calibrate
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-callr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-callr-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 3.3.1
+Version: 3.3.2
 Revision: 1
 Description: Call R from R
 Homepage: https://cran.r-project.org/package=callr
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:callr_%v.tar.gz
-Source-MD5: c42a80f6cd6cb4c628977b5ce8533f98
+Source-MD5: b9241e4c8c3b90d40734161680543374
 SourceDirectory: callr
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-chemospec-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-chemospec-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 5.0.229
+Version: 5.1.48
 Revision: 1
 Description: Exploratory Chemometrics for Spectroscopy
 Homepage: https://cran.r-project.org/package=ChemoSpec
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:ChemoSpec_%v.tar.gz
-Source-MD5: 192aa1bef09ea6b394577820e33dbbf5
+Source-MD5: 6ba1c6335e74d2922ac36f504d8aa1c9
 SourceDirectory: ChemoSpec
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-covr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-covr-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 3.2.1
+Version: 3.3.1
 Revision: 1
 Description: Test Coverage for Packages
 Homepage: https://cran.r-project.org/package=covr
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:covr_%v.tar.gz
-Source-MD5: 6589bcb7c156b93469aab8141ba3edd5
+Source-MD5: 7e8dd20840a2167f398826f4bcc6f2d9
 SourceDirectory: covr
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -32,6 +32,7 @@ Depends: <<
 	cran-httr-r%type_pkg[rversion],
 	cran-jsonlite-r%type_pkg[rversion],
 	cran-rex-r%type_pkg[rversion],
+	cran-yaml-r%type_pkg[rversion],
 	cran-withr-r%type_pkg[rversion] (>= 1.0.2),
 	libgettext8-shlibs
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-curl-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-curl-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 4.1
+Version: 4.2
 Revision: 1
 Description: Connection Interface to Libcurl
 Homepage: https://cran.r-project.org/package=curl
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:curl_%v.tar.gz
-Source-MD5: 1ed813b1ed147a73cd38bd85f895b7df
+Source-MD5: 5347e69cd7ee4193bd3a6153ee4fc757
 SourceDirectory: curl
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-data.table-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-data.table-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.12.2
+Version: 1.12.4
 Revision: 1
 Description: Extension of data.frame
 Homepage: https://cran.r-project.org/package=data.table
 License: OSI-Approved
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:data.table_%v.tar.gz
-Source-MD5: 93b8f74d38a0819c881576de5883d5cb
+Source-MD5: 8f18d68464663f6daadd1d37c450df8e
 SourceDirectory: data.table
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dt-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dt-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.7
+Version: 0.9
 Revision: 1
 Description: Wrapper of JavaScript Library DataTables
 Homepage: https://cran.r-project.org/package=DT
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:DT_%v.tar.gz
-Source-MD5: 100850037454244675e9600b9dcdbfc8
+Source-MD5: f88e05d62255acc81e818e72311bee0b
 SourceDirectory: DT
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -31,6 +31,7 @@ Depends: <<
 	cran-crosstalk-r%type_pkg[rversion],
 	cran-htmltools-r%type_pkg[rversion] (>= 0.3.6), 
 	cran-htmlwidgets-r%type_pkg[rversion] (>= 1.3), 
+	cran-jsonlite-r%type_pkg[rversion],
 	cran-magrittr-r%type_pkg[rversion],
 	cran-promises-r%type_pkg[rversion]
 <<
@@ -59,6 +60,9 @@ the JavaScript library 'DataTables' (typically via R Markdown
 or Shiny). The 'DataTables' library has been included in 
 this R package. The package name 'DT' is an abbreviation 
 of 'DataTables'.
+<<
+DescPackaging: <<
+  jsonline may not be necessary.
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-hms-r-0.4.2.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-hms-r-0.4.2.info
@@ -1,6 +1,6 @@
 Info2: <<
 
-Package: cran-lambda.r-r%type_pkg[rversion]
+Package: cran-hms-r%type_pkg[rversion]
 Distribution: <<
 	(%type_pkg[rversion] = 31 ) 10.9,
 	(%type_pkg[rversion] = 31 ) 10.10,
@@ -12,46 +12,49 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.2.4
+Version: 0.4.2
 Revision: 1
-Description: Modeling Data with Functional Programming
-Homepage: https://cran.r-project.org/package=lambda.r
-License: LGPL
+Description: Pretty Time of Day
+Homepage: https://cran.r-project.org/package=hms
+License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: mirror:custom:lambda.r_%v.tar.gz
-Source-MD5: 861157dc2fe66ce8ed1e755578a57e47
-SourceDirectory: lambda.r
+Source: mirror:custom:hms_%v.tar.gz
+Source-MD5: cb2583120e8089a6cd4c7e968b6eb950
+SourceDirectory: hms
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
-	Secondary: https://cran.r-project.org/src/contrib/00Archive/lambda.r
+	Secondary: https://cran.r-project.org/src/contrib/00Archive/hms
 <<
 Depends: <<
 	r-base%type_pkg[rversion],
-	cran-formatr-r%type_pkg[rversion]
+	cran-pkgconfig-r%type_pkg[rversion],
+	cran-rlang-r%type_pkg[rversion]
 <<
-BuildDepends: r-base%type_pkg[rversion]-dev
+BuildDepends: <<
+	fink (>= 0.27.2),
+	r-base%type_pkg[rversion]-dev
+<<
 CompileScript: <<
   #!/bin/bash -ev
   export TMPDIR=%b/tmp
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
-  $BIN_R --verbose CMD build --no-build-vignettes lambda.r
+  $BIN_R --verbose CMD build --no-build-vignettes hms
 <<
 InstallScript: <<
   #!/bin/sh -ev
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   mkdir -p %i/lib/R/%type_raw[rversion]/site-library
-  pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library lambda.r
+  pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library hms
 <<
 DescDetail: <<
-A language extension to efficiently write functional programs in R. 
-Syntax extensions include multi-part function definitions, pattern 
-matching, guard statements, built-in (optional) type safety.
+Implements an S3 class for storing and formatting time-of-day values,
+based on the 'difftime' class.
 <<
 DescPackaging: <<
-  R (>= 3.0.0)
+  R (>= 2.15.0)
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-hms-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-hms-r.info
@@ -2,24 +2,20 @@ Info2: <<
 
 Package: cran-hms-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 31 ) 10.9,
-	(%type_pkg[rversion] = 31 ) 10.10,
-	(%type_pkg[rversion] = 31 ) 10.11,
-	(%type_pkg[rversion] = 31 ) 10.12,
 	(%type_pkg[rversion] = 32 ) 10.9,
 	(%type_pkg[rversion] = 32 ) 10.10,
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.4.2
+Type: rversion (3.5 3.4 3.3 3.2)
+Version: 0.5.1
 Revision: 1
 Description: Pretty Time of Day
 Homepage: https://cran.r-project.org/package=hms
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:hms_%v.tar.gz
-Source-MD5: cb2583120e8089a6cd4c7e968b6eb950
+Source-MD5: ddf5323d36067c51d9e5dcf5c8acf336
 SourceDirectory: hms
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -28,7 +24,8 @@ CustomMirror: <<
 Depends: <<
 	r-base%type_pkg[rversion],
 	cran-pkgconfig-r%type_pkg[rversion],
-	cran-rlang-r%type_pkg[rversion]
+	cran-rlang-r%type_pkg[rversion],
+	cran-vctrs-r%type_pkg[rversion] (>=0.2.0)
 <<
 BuildDepends: <<
 	fink (>= 0.27.2),

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-htmltable-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-htmltable-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.13.1
+Version: 1.13.2
 Revision: 1
 Description: Advanced Tables for Markdown/HTML
 Homepage: https://cran.r-project.org/package=htmlTable
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:htmlTable_%v.tar.gz
-Source-MD5: 0c4427501cc47bc3a97d852b545c2141
+Source-MD5: 5e8f386ed5a4bbf61080b1560f617806
 SourceDirectory: htmlTable
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -33,7 +33,7 @@ Depends: <<
 	cran-htmlwidgets-r%type_pkg[rversion],
 	cran-knitr-r%type_pkg[rversion] (>= 1.6),
 	cran-magrittr-r%type_pkg[rversion] (>= 1.5),
-	cran-rstudioapi-r%type_pkg[rversion],
+	cran-rstudioapi-r%type_pkg[rversion] (>= 0.6),
 	cran-stringr-r%type_pkg[rversion]
 <<
 BuildDepends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-htmltools-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-htmltools-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.3.6
+Version: 0.4.0
 Revision: 1
 Description: Tools for HTML
 Homepage: https://cran.r-project.org/package=htmltools
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:htmltools_%v.tar.gz
-Source-MD5: 336419c2143f958862e01ef1bbc9c253
+Source-MD5: af44a5dcbc6231eef324026ac0b95c32
 SourceDirectory: htmltools
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -28,7 +28,8 @@ CustomMirror: <<
 Depends: <<
 	r-base%type_pkg[rversion],
 	cran-digest-r%type_pkg[rversion],
-	cran-rcpp-r%type_pkg[rversion]
+	cran-rcpp-r%type_pkg[rversion],
+	cran-rlang-r%type_pkg[rversion]
 <<
 BuildDepends: <<
 	fink (>= 0.27.2),

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-htmlwidgets-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-htmlwidgets-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.3
+Version: 1.5.1
 Revision: 1
 Description: HTML Widgets for R
 Homepage: https://cran.r-project.org/package=htmlwidgets
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:htmlwidgets_%v.tar.gz
-Source-MD5: 96d7bef8f13fb1609a740486c52d8b48
+Source-MD5: 52d97ed9d87f1ffe908b5926ad3f7b1f
 SourceDirectory: htmlwidgets
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-ks-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-ks-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.11.4
+Version: 1.11.5
 Revision: 1
 Description: Kernel smoothing
 Homepage: https://cran.r-project.org/package=ks
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:ks_%v.tar.gz
-Source-MD5: 63596d5d6aa27bbbd450e50ec7310f2e
+Source-MD5: ef882f241c46ee21ed27e66213067554
 SourceDirectory: ks
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -33,10 +33,8 @@ Depends: <<
 	cran-matrix-r%type_pkg[rversion],
 	cran-mclust-r%type_pkg[rversion],
 	cran-mgcv-r%type_pkg[rversion],
-	cran-misc3d-r%type_pkg[rversion] (>= 0.4-0),
 	cran-multicool-r%type_pkg[rversion],
 	cran-mvtnorm-r%type_pkg[rversion] (>= 1.0-0),
-	cran-rgl-r%type_pkg[rversion] (>= 0.66),
 	libgettext8-shlibs
 <<
 BuildDepends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-later-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-later-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.8.0
+Version: 1.0.0
 Revision: 1
 Description: Utilities for Delaying Function Execution
 Homepage: https://cran.r-project.org/package=later
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:later_%v.tar.gz
-Source-MD5: 71feec14ef4f2297a6289458e10d0544
+Source-MD5: bc8f2d7a016270f60204f1ba1f2c3519
 SourceDirectory: later
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-maptools-r-0.9-5.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-maptools-r-0.9-5.info
@@ -2,20 +2,24 @@ Info2: <<
 
 Package: cran-maptools-r%type_pkg[rversion]
 Distribution: <<
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12,
 	(%type_pkg[rversion] = 32 ) 10.9,
 	(%type_pkg[rversion] = 32 ) 10.10,
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2)
-Version: 0.9-8
+Type: rversion (3.5 3.4 3.3 3.2 3.1)
+Version: 0.9-5
 Revision: 1
 Description: GNU R Tools for handling spatial objects
 Homepage: https://cran.r-project.org/package=maptools
 License: GPL
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
 Source: mirror:custom:maptools_%v.tar.gz
-Source-MD5: a0d4be7222320b085bd2a7746419f955
+Source-MD5: c0b0b1a1b1c47b00b74e1ef7325ff5ed
 SourceDirectory: maptools
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-markdown-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-markdown-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.0
+Version: 1.1
 Revision: 1
 Description: GNU R Tools for making web reports from text
 Homepage: https://cran.r-project.org/package=markdown
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:markdown_%v.tar.gz
-Source-MD5: 18cd558ad494c9ffff482954dae32f18
+Source-MD5: 51fedf7d7f62da1f828a80bd71ccba1d
 SourceDirectory: markdown
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -28,6 +28,7 @@ CustomMirror: <<
 Depends: <<
 	r-base%type_pkg[rversion],
 	cran-mime-r%type_pkg[rversion] (>= 0.3),
+	cran-xfun-r%type_pkg[rversion],
 	libgettext8-shlibs
 <<
 BuildDepends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mgcv-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mgcv-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.8-28
+Version: 1.8-29
 Revision: 1
 Description: Mixed GAM Computation Vehicle
 Homepage: https://cran.r-project.org/package=mgcv
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:mgcv_%v.tar.gz
-Source-MD5: 8d044bbc17f8e9c3574f3096128dc420
+Source-MD5: 08c1f2a022b60a827d8bab59669252eb
 SourceDirectory: mgcv
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mice-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mice-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 3.4.0
+Version: 3.6.0
 Revision: 1
 Description: Multivariate Imputation by Chained Equations
 Homepage: https://cran.r-project.org/package=mice
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:mice_%v.tar.gz
-Source-MD5: 96356eaa3f64b9028e2b66ee3d204f7f
+Source-MD5: 2c6e04db0cef771f05bfce6b86e65577
 SourceDirectory: mice
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-partykit-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-partykit-r.info
@@ -13,14 +13,14 @@ Distribution: <<
 <<
 # R-restricted by cran-inum-r, cran-libcoin-r
 Type: rversion (3.5 3.4)
-Version: 1.2-4
+Version: 1.2-5
 Revision: 1
 Description: Toolkit for Recursive Partytioning
 Homepage: https://cran.r-project.org/package=partykit
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:partykit_%v.tar.gz
-Source-MD5: aed2642c1091db2ec687952f812c35be
+Source-MD5: f08fbda98a5761998d564b82b91bb387
 SourceDirectory: partykit
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pingr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pingr-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.1.2
+Version: 1.2.0
 Revision: 1
 Description: Check if a Remote Computer is Up
 Homepage: https://cran.r-project.org/package=pingr
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:pingr_%v.tar.gz
-Source-MD5: 1ef367a31f4f2f32b4179d82ed8a97f4
+Source-MD5: 77c6d980b61fd0c0d2c8d7d0cf8d5abc
 SourceDirectory: pingr
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -31,6 +31,7 @@ Depends: <<
 BuildDepends: <<
 	fink (>= 0.27.2),
 	r-base%type_pkg[rversion]-dev,
+	cran-processx-r%type_pkg[rversion],
 	libgettext8-dev
 <<
 UseMaxBuildJobs: false

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pkgbuild-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pkgbuild-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.0.5
+Version: 1.0.6
 Revision: 1
 Description: CommonMark and Github Markdown Rendering in R
 Homepage: https://cran.r-project.org/package=pkgbuild
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:pkgbuild_%v.tar.gz
-Source-MD5: 2e8049d5c4bc587db3acb644592640c1
+Source-MD5: 837229a0d54d31020f61b80da7151e58
 SourceDirectory: pkgbuild
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pkgconfig-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pkgconfig-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.0.2
+Version: 2.0.3
 Revision: 1
 Description: Private Configuration for R Packages
 Homepage: https://cran.r-project.org/package=pkgconfig
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:pkgconfig_%v.tar.gz
-Source-MD5: 65742ce8a9e6d167f5c4181a61ca7ff2
+Source-MD5: 7b9ca1d45d941238381cb55d13ff4d68
 SourceDirectory: pkgconfig
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pls-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pls-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.7-1
+Version: 2.7-2
 Revision: 1
 Description: PLS and PC regression
 Homepage: https://cran.r-project.org/package=pls
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:pls_%v.tar.gz
-Source-MD5: 4c33188189f1bd1ecee5d693ddd9cd99
+Source-MD5: d2eef94f26da7bdadb20e7572d063636
 SourceDirectory: pls
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-polspline-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-polspline-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.1.15
+Version: 1.1.16
 Revision: 1
 Description: Polynomial spline routines
 Homepage: https://cran.r-project.org/package=polspline
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:polspline_%v.tar.gz
-Source-MD5: a5c7552e2c8a399ccfe24f439ce2f78c
+Source-MD5: 23166a883b13a4cd565491553103d8a7
 SourceDirectory: polspline
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-proc-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-proc-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.15.0
+Version: 1.15.3
 Revision: 1
 Description: Display and analyze ROC curves
 Homepage: http://expasy.org/tools/pROC/
 License: GPL
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
 Source: mirror:custom:pROC_%v.tar.gz
-Source-MD5: 0ee5f7339bd0670b72ace44f6f9dfc28
+Source-MD5: 91cc5de97722076926a42ce398d4c58d
 SourceDirectory: pROC
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -29,8 +29,7 @@ Depends: <<
 	fink (>= 0.27.2), 
 	r-base%type_pkg[rversion], 
 	cran-plyr-r%type_pkg[rversion], 
-	cran-rcpp-r%type_pkg[rversion], 
-	cran-ggplot2-r%type_pkg[rversion],
+	cran-rcpp-r%type_pkg[rversion] (>= 0.11.1), 
 	libgettext8-shlibs
 <<
 BuildDepends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-promises-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-promises-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.0.1
+Version: 1.1.0
 Revision: 1
 Description: Promise-Based Asynchronous Programming
 Homepage: https://cran.r-project.org/package=promises
-License: GPL
+License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:promises_%v.tar.gz
-Source-MD5: ba0b1c2d9b26819f48e589732854d7c8
+Source-MD5: be59448d8e118ae9a0a1dcfd42f57b74
 SourceDirectory: promises
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -28,17 +28,17 @@ CustomMirror: <<
 Depends: <<
 	fink (>= 0.27.2),
 	r-base%type_pkg[rversion],
-	cran-bh-r%type_pkg[rversion],
 	cran-later-r%type_pkg[rversion],
 	cran-magrittr-r%type_pkg[rversion],
 	cran-r6-r%type_pkg[rversion],
-	cran-rlang-r%type_pkg[rversion],
-	cran-rcpp-r%type_pkg[rversion]
+	cran-rcpp-r%type_pkg[rversion],
+	cran-rlang-r%type_pkg[rversion]
 <<
 BuildDepends: <<
 	fink (>= 0.27.2),
 	r-base%type_pkg[rversion]-dev,
-	cran-later-r%type_pkg[rversion]-dev
+	cran-later-r%type_pkg[rversion]-dev,
+	cran-rcpp-r%type_pkg[rversion]-dev
 <<
 GCC:4.0
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-quantreg-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-quantreg-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 5.41
+Version: 5.51
 Revision: 1
 Description: Quantile Regression
 Homepage: https://cran.r-project.org/package=quantreg
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:quantreg_%v.tar.gz
-Source-MD5: 70489defc7f68035e01620b9a3a25238
+Source-MD5: 295502cf93419dd0f0064f59b1efee89
 SourceDirectory: quantreg
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -29,9 +29,9 @@ Depends: <<
 	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion],
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.0-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-3),
-	cran-sparsem-r%type_pkg[rversion],
 	cran-matrix-r%type_pkg[rversion],
 	cran-matrixmodels-r%type_pkg[rversion],
+	cran-sparsem-r%type_pkg[rversion],
 	gcc5-shlibs,
 	libgettext8-shlibs
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-qvcalc-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-qvcalc-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.0.0
+Version: 1.0.1
 Revision: 1
 Description: Quasi Variances for Effects in Stat Models
 Homepage: https://cran.r-project.org/package=qvcalc
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:qvcalc_%v.tar.gz
-Source-MD5: eda5fd4fd83b764441dd41849091a883
+Source-MD5: 546f88e70cacd1c36946c1468c08b0f5
 SourceDirectory: qvcalc
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-raster-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-raster-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 2.9-5
+Version: 3.0-7
 Revision: 1
 Description: Geographic data analysis and modeling
 Homepage: https://cran.r-project.org/package=raster
-License: GPL3
+License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:raster_%v.tar.gz
-Source-MD5: 1f124bf92f2a389b549837a4f646e230
+Source-MD5: 5c01eb6cb4aa929aaa7390e4edc2e2b1
 SourceDirectory: raster
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -27,13 +27,14 @@ CustomMirror: <<
 <<
 Depends: <<
 	r-base%type_pkg[rversion],
-	cran-sp-r%type_pkg[rversion] (>= 1.2-0),
 	cran-rcpp-r%type_pkg[rversion],
+	cran-sp-r%type_pkg[rversion] (>= 1.2-0),
 	libgettext8-shlibs
 <<
 BuildDepends: <<
 	fink (>= 0.27.2),
 	r-base%type_pkg[rversion]-dev,
+	cran-rcpp-r%type_pkg[rversion]-dev,
 	cran-sp-r%type_pkg[rversion]-dev,
 	libgettext8-dev
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcmdr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcmdr-r.info
@@ -1,25 +1,15 @@
 Info2: <<
 
 Package: cran-rcmdr-r%type_pkg[rversion]
-Distribution: <<
-	(%type_pkg[rversion] = 31 ) 10.9,
-	(%type_pkg[rversion] = 31 ) 10.10,
-	(%type_pkg[rversion] = 31 ) 10.11,
-	(%type_pkg[rversion] = 31 ) 10.12,
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12
-<<
 Type: rversion (3.5)
-Version: 2.5-2
+Version: 2.6-0
 Revision: 1
 Description: R Commander
 Homepage: https://cran.r-project.org/package=Rcmdr
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:Rcmdr_%v.tar.gz
-Source-MD5: bf3061c0ecf96334597d24ea83e59ff5
+Source-MD5: c5c7cdf33a6072316c9cc6618e4dc9d0
 SourceDirectory: Rcmdr
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -28,19 +18,12 @@ CustomMirror: <<
 Depends: <<
 	r-base%type_pkg[rversion], 
 	cran-abind-r%type_pkg[rversion], 
-	cran-aplpack-r%type_pkg[rversion], 
 	cran-car-r%type_pkg[rversion] (>= 3.0-1), 
 	cran-effects-r%type_pkg[rversion] (>= 4.0-3), 
-	cran-hmisc-r%type_pkg[rversion], 
-	cran-knitr-r%type_pkg[rversion], 
-	cran-leaps-r%type_pkg[rversion], 
-	cran-lmtest-r%type_pkg[rversion], 
-	cran-multcomp-r%type_pkg[rversion] (>= 0.991-2), 
+	cran-formatr-r%type_pkg[rversion], 
+	cran-lme4-r%type_pkg[rversion], 
 	cran-rcmdrmisc-r%type_pkg[rversion] (>= 2.5-0), 
 	cran-relimp-r%type_pkg[rversion] (>= 1.0-5), 
-	cran-rgl-r%type_pkg[rversion] (>= 0.96-0), 
-	cran-rglwidget-r%type_pkg[rversion], 
-	cran-sem-r%type_pkg[rversion] (>= 2.1-1), 
 	cran-tcltk2-r%type_pkg[rversion] (>= 1.2-6), 
 	libgettext8-shlibs, 
 	tcltk

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcmdrplugin.ezr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcmdrplugin.ezr-r.info
@@ -2,30 +2,30 @@ Info2: <<
 
 Package: cran-rcmdrplugin.ezr-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 31 ) 10.9,
-	(%type_pkg[rversion] = 31 ) 10.10,
-	(%type_pkg[rversion] = 31 ) 10.11,
-	(%type_pkg[rversion] = 31 ) 10.12,
 	(%type_pkg[rversion] = 32 ) 10.9,
 	(%type_pkg[rversion] = 32 ) 10.10,
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.32
+Type: rversion (3.5 3.4 3.3 3.2)
+Version: 1.40
 Revision: 1
 Description: Easy R for medical statistics
 Homepage: http://www.jichi.ac.jp/saitama-sct/SaitamaHP.files/statmed.html
 License: GPL
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
 Source: mirror:custom:RcmdrPlugin.EZR_%v.tar.gz
-Source-MD5: c7e8bfb1f8424a2aeb98170f146c0bb3
+Source-MD5: 9aa108263609d23b11dea94486bf7742
 SourceDirectory: RcmdrPlugin.EZR
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
 	Secondary: https://cran.r-project.org/src/contrib/00Archive/RcmdrPlugin.EZR
 <<
-Depends: r-base%type_pkg[rversion], cran-rcmdr-r%type_pkg[rversion]
+Depends: <<
+	r-base%type_pkg[rversion], 
+	cran-rcmdr-r%type_pkg[rversion] (>= 2.4.0), 
+	cran-readstata13-r%type_pkg[rversion]
+<<
 BuildDepends: r-base%type_pkg[rversion]-dev
 CompileScript: <<
   #!/bin/sh -ev

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcpparmadillo-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcpparmadillo-r.info
@@ -1,25 +1,15 @@
 Info2: <<
 
 Package: cran-rcpparmadillo-r%type_pkg[rversion]
-Distribution: <<
-	(%type_pkg[rversion] = 31 ) 10.9,
-	(%type_pkg[rversion] = 31 ) 10.10,
-	(%type_pkg[rversion] = 31 ) 10.11,
-	(%type_pkg[rversion] = 31 ) 10.12,
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12
-<<
 Type: rversion (3.5 3.4 3.3)
-Version: 0.9.700.2.0
+Version: 0.9.800.1.0
 Revision: 1
 Description: Rcpp integration for Armadillo
 Homepage: https://cran.r-project.org/package=RcppArmadillo 
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:RcppArmadillo_%v.tar.gz
-Source-MD5: 9833e7007ae33b5a6468af8459494252
+Source-MD5: 3c52f32c0d09a88da53a5c848a3fe473
 SourceDirectory: RcppArmadillo
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -27,18 +17,14 @@ CustomMirror: <<
 <<
 Depends: <<
 	fink (>= 0.27.2), 
-	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion],
-	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.0-2),
-	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-3),
+	r-base%type_pkg[rversion],
 	cran-rcpp-r%type_pkg[rversion] (>= 0.11.0),
 	gcc5-shlibs,
 	libgettext8-shlibs
 <<
 BuildDepends: <<
 	fink (>= 0.27.2), 
-	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion]-dev,
-	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
-	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3),
+	r-base%type_pkg[rversion]-dev,
 	cran-rcpp-r%type_pkg[rversion]-dev (>= 0.11.0),
 	gcc5-compiler,
 	libgettext8-dev

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-recipes-r.-0.1.5info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-recipes-r.-0.1.5info
@@ -2,20 +2,24 @@ Info2: <<
 
 Package: cran-recipes-r%type_pkg[rversion]
 Distribution: <<
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12,
 	(%type_pkg[rversion] = 32 ) 10.9,
 	(%type_pkg[rversion] = 32 ) 10.10,
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2)
-Version: 0.1.7
+Type: rversion (3.5 3.4 3.3 3.2 3.1)
+Version: 0.1.5
 Revision: 1
 Description: Preprocessing Tools to Create Design Matrices
 Homepage: https://cran.r-project.org/package=recipes
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:recipes_%v.tar.gz
-Source-MD5: aa3b8ee320adc5cc99ccc81860e84b49
+Source-MD5: 8f5bd58ea4bb6ec6e475d00a2c0a0902
 SourceDirectory: recipes
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -33,10 +37,10 @@ Depends: <<
 	cran-matrix-r%type_pkg[rversion],
 	cran-purrr-r%type_pkg[rversion] (>= 0.2.3),
 	cran-rcpproll-r%type_pkg[rversion],
-	cran-rlang-r%type_pkg[rversion] (>= 0.4.0),
+	cran-rlang-r%type_pkg[rversion] (>= 0.3.0.1),
 	cran-tibble-r%type_pkg[rversion],
-	cran-tidyr-r%type_pkg[rversion] (>= 0.8.3),
-	cran-tidyselect-r%type_pkg[rversion] (>= 0.2.5),
+	cran-tidyr-r%type_pkg[rversion],
+	cran-tidyselect-r%type_pkg[rversion] (>= 0.1.1),
 	cran-timedate-r%type_pkg[rversion],
 	cran-withr-r%type_pkg[rversion]
 <<
@@ -67,7 +71,7 @@ matrices can then be used as inputs into statistical or machine learning
 models. 
 <<
 DescPackaging: <<
-  R (>= 3.1), but some depending packages (e.g. rlang) require R (>= 3.2).
+  R (>= 3.1)
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rfast-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rfast-r.info
@@ -13,14 +13,14 @@ Distribution: <<
 <<
 # rversion <= 3.4 fail to build (see DescPort)
 Type: rversion (3.5)
-Version: 1.9.3
+Version: 1.9.5
 Revision: 1
 Description: Efficient and Extremely Fast R Functions
 Homepage: https://cran.r-project.org/package=Rfast
-License: BSD
+License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:Rfast_%v.tar.gz
-Source-MD5: 121bb79076dc3a409382dbdc9785f313
+Source-MD5: a35aebda0297b1a99cca651c5cef1326
 SourceDirectory: Rfast
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rgdal-1.4.-4.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rgdal-1.4.-4.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3)
-Version: 1.4-6
+Version: 1.4-4
 Revision: 1
 Description: GNU R Bindings for GDAL
 Homepage: https://cran.r-project.org/package=rgenoud
 License: GPL
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
 Source: mirror:custom:rgdal_%v.tar.gz
-Source-MD5: bf20e586ec550292089b822925e99b1d
+Source-MD5: 88173d7f7ed5ee6e6502000b0adc487b
 SourceDirectory: rgdal
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rgl-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rgl-r.info
@@ -8,14 +8,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2)
-Version: 0.100.26
+Version: 0.100.30
 Revision: 1
 Description: 3D visualization device system
 Homepage: https://cran.r-project.org/package=rgl
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:rgl_%v.tar.gz
-Source-MD5: b54689dfa6d945de2d40a587ac25c383
+Source-MD5: 6eaccdfff3daf586ce0d0d991f2d3270
 SourceDirectory: rgl
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rjsonio-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rjsonio-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.3-1.2
+Version: 1.3-1.3
 Revision: 1
 Description: Serialize R objects to JSON
 Homepage: https://cran.r-project.org/package=RJSONIO
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:RJSONIO_%v.tar.gz
-Source-MD5: b2b074aaa8f230f4fc7d05250c75bf47
+Source-MD5: 7dca503bf6aa023e1df176d0b4520383
 SourceDirectory: RJSONIO
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rmarkdown-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rmarkdown-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.15
+Version: 1.16
 Revision: 1
 Description: Dynamic Documents for R
 Homepage: https://cran.r-project.org/package=rmarkdown
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:rmarkdown_%v.tar.gz
-Source-MD5: 95b0d94dea142c9f952ed07bf99758a3
+Source-MD5: 0e95b411c47ca788c2a9c326aed685fb
 SourceDirectory: rmarkdown
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -33,8 +33,10 @@ Depends: <<
 	cran-jsonlite-r%type_pkg[rversion],
 	cran-knitr-r%type_pkg[rversion] (>= 1.22),
 	cran-mime-r%type_pkg[rversion],
+	cran-rlang-r%type_pkg[rversion],
 	cran-stringr-r%type_pkg[rversion] (>= 1.2.0),
 	cran-tinytex-r%type_pkg[rversion] (>= 0.11),
+	cran-xfun-r%type_pkg[rversion],
 	cran-yaml-r%type_pkg[rversion] (>= 2.1.19)
 <<
 BuildDepends: <<
@@ -60,7 +62,8 @@ DescDetail: <<
 Convert R Markdown documents into a variety of formats.
 <<
 DescPackaging: <<
-  R (>=3.0)
+  R (>=3.0).
+  rlang is not stated in DESCRIPTION but is needed.
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rmpfr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rmpfr-r.info
@@ -1,25 +1,15 @@
 Info2: <<
 
 Package: cran-rmpfr-r%type_pkg[rversion]
-Distribution: <<
-	(%type_pkg[rversion] = 31 ) 10.9,
-	(%type_pkg[rversion] = 31 ) 10.10,
-	(%type_pkg[rversion] = 31 ) 10.11,
-	(%type_pkg[rversion] = 31 ) 10.12,
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12
-<<
 Type: rversion (3.5 3.4)
-Version: 0.7-0
+Version: 0.7-2
 Revision: 1
 Description: Multiple Precision Floating-Point Reliable
 Homepage: https://cran.r-project.org/package=Rmpfr
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:Rmpfr_%v.tar.gz
-Source-MD5: 6063fade5e622b7b0d6b9695e66dd7a6
+Source-MD5: eb5cd8d3d4788ddb59801544f1608239
 SourceDirectory: Rmpfr
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -41,7 +31,6 @@ BuildDepends: <<
 <<
 CompileScript: <<
   #!/bin/bash -ev
-  export TMPDIR=%b/tmp
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
@@ -53,15 +42,10 @@ InstallScript: <<
   
   mkdir -p %i/lib/R/%type_raw[rversion]/site-library
   pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library Rmpfr
-  if [ "%type_num[rversion]" -lt "34" ]; then
-	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/Rmpfr/libs/Rmpfr.dylib %i/lib/R/%type_raw[rversion]/site-library/Rmpfr/libs/Rmpfr.dylib
-  else
-	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/Rmpfr/libs/Rmpfr.so %i/lib/R/%type_raw[rversion]/site-library/Rmpfr/libs/Rmpfr.so
-  fi
+  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/Rmpfr/libs/Rmpfr.so %i/lib/R/%type_raw[rversion]/site-library/Rmpfr/libs/Rmpfr.so
 <<
 Shlibs: <<
-  ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/Rmpfr/libs/Rmpfr.so 0.0.0 %n (>= 0.5-7-1)
-  ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/Rmpfr/libs/Rmpfr.dylib 0.0.0 %n (>= 0.5-7-1)
+  %p/lib/R/%type_raw[rversion]/site-library/Rmpfr/libs/Rmpfr.so 0.0.0 %n (>= 0.5-7-1)
 <<
 DescDetail: <<
 Rmpfr provides (S4 classes and methods for) arithmetic including transcendental

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rsqlite-r-2.1.1.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rsqlite-r-2.1.1.info
@@ -2,20 +2,24 @@ Info2: <<
 
 Package: cran-rsqlite-r%type_pkg[rversion]
 Distribution: <<
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12,
 	(%type_pkg[rversion] = 32 ) 10.9,
 	(%type_pkg[rversion] = 32 ) 10.10,
 	(%type_pkg[rversion] = 32 ) 10.11,
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
-Type: rversion (3.5 3.4 3.3 3.2)
-Version: 2.1.2
+Type: rversion (3.5 3.4 3.3 3.2 3.1)
+Version: 2.1.1
 Revision: 1
 Description: SQLite interface for R
 Homepage: https://cran.r-project.org/package=RSQLite
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:RSQLite_%v.tar.gz
-Source-MD5: a8425543e9d3c6f3d4a7324122d10dae
+Source-MD5: 786eaffa2c3edb28947465455e782675
 SourceDirectory: RSQLite
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -25,7 +29,7 @@ Depends: <<
 	r-base%type_pkg[rversion],
 	cran-bh-r%type_pkg[rversion],
 	cran-bit64-r%type_pkg[rversion],
-	cran-blob-r%type_pkg[rversion] (>=1.2.0),
+	cran-blob-r%type_pkg[rversion] (>=1.1.1),
 	cran-dbi-r%type_pkg[rversion] (>= 1.0.0),
 	cran-memoise-r%type_pkg[rversion],
 	cran-pkgconfig-r%type_pkg[rversion],
@@ -36,7 +40,6 @@ Depends: <<
 BuildDepends: <<
 	fink (>= 0.27.2),
 	r-base%type_pkg[rversion]-dev,
-	cran-rcpp-r%type_pkg[rversion]-dev,
 	libgettext8-dev
 <<
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-seriation-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-seriation-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 1.2-7
+Version: 1.2-8
 Revision: 1
 Description: Infrastructure for seriation
 Homepage: https://cran.r-project.org/package=seriation
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:seriation_%v.tar.gz
-Source-MD5: 7cf9b6fe3261beea35babefbdb6142b0
+Source-MD5: 5ee3309663b4a7c22997d7dcb16029c5
 SourceDirectory: seriation
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-simcomp-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-simcomp-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 3.2
+Version: 3.3
 Revision: 1
 Description: Simultaneous Comparisons for Mult. Endpoints
 Homepage: https://cran.r-project.org/package=SimComp
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:SimComp_%v.tar.gz
-Source-MD5: d31c0a352d6245b20b57dc9e9b9119e3
+Source-MD5: 16a0ef779cbad5bb455a7e4e1e3a0883
 SourceDirectory: SimComp
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-speaq-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-speaq-r.info
@@ -13,14 +13,14 @@ Distribution: <<
 <<
 # Type restricted by Rfast
 Type: rversion (3.5)
-Version: 2.5.0
+Version: 2.6.0
 Revision: 1
 Description: NMR Spectrum Alignment Tools
 Homepage: https://cran.r-project.org/package=speaq
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:speaq_%v.tar.gz
-Source-MD5: 23847e046f44aa874528de33656befa0
+Source-MD5: 1a91f8cd699f59f3ac00395cfe45a7d4
 SourceDirectory: speaq
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-survey-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-survey-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 3.35
+Version: 3.36
 Revision: 1
 Description: Analysis of complex survey samples
 Homepage: https://cran.r-project.org/package=survey
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:survey_%v.tar.gz
-Source-MD5: fa55c9576271fa317112e3c5ef5f8e4d
+Source-MD5: 1052784b0064de8151382b4a6ce40708
 SourceDirectory: survey
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -30,6 +30,7 @@ Depends: <<
 	cran-lattice-r%type_pkg[rversion],
 	cran-matrix-r%type_pkg[rversion],
 	cran-minqa-r%type_pkg[rversion],
+	cran-mitools-r%type_pkg[rversion] (>=2.4),
 	cran-numderiv-r%type_pkg[rversion],
 	cran-survival-r%type_pkg[rversion]
 <<
@@ -60,7 +61,7 @@ Predictive margins by direct standardization. PPS sampling without
 replacement. Principal components, factor analysis.
 <<
 DescPackaging: <<
-  R (>= 2.16.0)
+  R (>= 3.1.0)
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-testit-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-testit-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.9
+Version: 0.10
 Revision: 1
 Description: Simple package for testing R packages
 Homepage: https://cran.r-project.org/package=testit
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:testit_%v.tar.gz
-Source-MD5: e19c52232a32060e86d8bef6f76b7d79
+Source-MD5: 5a8da83b03d6231164506823acaa3a8a
 SourceDirectory: testit
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-ttr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-ttr-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.23-4
+Version: 0.23-5
 Revision: 1
 Description: Technical Trading Rules
 Homepage: https://cran.r-project.org/package=TTR
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:TTR_%v.tar.gz
-Source-MD5: fa8873454a7d9b75ff4040421d4a42a6
+Source-MD5: 60767d71c3db4116c6c53490e14bd2a9
 SourceDirectory: TTR
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-vegan-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-vegan-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: cran-vegan-r%type_pkg[rversion]
 Type: rversion (3.5 3.4)
-Version: 2.5-5
+Version: 2.5-6
 Revision: 1
 Description: Community Ecology Package
 Homepage: https://cran.r-project.org/package=vegan
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:vegan_%v.tar.gz
-Source-MD5: a9c148dcd9df033aeae3631b59bd9a40
+Source-MD5: a616d9a37a0351285707853764add2a1
 SourceDirectory: vegan
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-xfun-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-xfun-r.info
@@ -12,14 +12,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 32 ) 10.12
 <<
 Type: rversion (3.5 3.4 3.3 3.2 3.1)
-Version: 0.9
+Version: 0.10
 Revision: 1
 Description: Misc. functions by Yihui Xie
 Homepage: https://cran.r-project.org/package=xfun
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:xfun_%v.tar.gz
-Source-MD5: a336fa5d53795d1757c5f7b8cb4a6d37
+Source-MD5: 240a08003fc090c2a03cc21e4075afa8
 SourceDirectory: xfun
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib


### PR DESCRIPTION
Regular updates.  Build test on Sierra for R 3.5 and R 3.1.  Dependency checked.  The packages that require a new CRAN package are excluded.
