### PR TITLE
resolve gnupg2 incompatibility

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/gpgme11.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/gpgme11.info
@@ -13,7 +13,7 @@ BuildDependsOnly: true
 Source: ftp://ftp.gnupg.org/gcrypt/gpgme/gpgme-%v.tar.gz
 Source-MD5: 1f500e7b4e81fcc76b901f1249ec09fc
 PatchFile: %n.patch
-PatchFile-MD5: e0fb33c16b1accfe614c1c8c0e703f8a
+PatchFile-MD5: 4f8ebdf0c2eec8939a018219f9bcb35a
 UseMaxBuildJobs: false
 ConfigureParams: --prefix=%p --infodir=%p/share/info --enable-shared --enable-static --enable-fd-passing --enable-dependency-tracking --with-pic --with-gpg=%p/bin/gpg2
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/crypto/gpgme11.patch
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/gpgme11.patch
@@ -1,6 +1,6 @@
-diff -Nurd -x'*~' gpgme-1.1.8.orig/tests/gpg/Makefile.am gpgme-1.1.8/tests/gpg/Makefile.am
+diff -Nurd gpgme-1.1.8.orig/tests/gpg/Makefile.am gpgme-1.1.8/tests/gpg/Makefile.am
 --- gpgme-1.1.8.orig/tests/gpg/Makefile.am	2008-12-03 08:39:37.000000000 -0500
-+++ gpgme-1.1.8/tests/gpg/Makefile.am	2009-01-07 00:42:46.000000000 -0500
++++ gpgme-1.1.8/tests/gpg/Makefile.am	2019-10-18 14:53:57.000000000 -0400
 @@ -63,7 +63,7 @@
  		--import Alpha/Secret.gpg Zulu/Secret.gpg
  
@@ -10,9 +10,9 @@ diff -Nurd -x'*~' gpgme-1.1.8.orig/tests/gpg/Makefile.am gpgme-1.1.8/tests/gpg/M
  
  ./gpg.conf:
  # This is required for t-sig-notations.
-diff -Nurd -x'*~' gpgme-1.1.8.orig/tests/gpg/mkdemodirs gpgme-1.1.8/tests/gpg/mkdemodirs
+diff -Nurd gpgme-1.1.8.orig/tests/gpg/mkdemodirs gpgme-1.1.8/tests/gpg/mkdemodirs
 --- gpgme-1.1.8.orig/tests/gpg/mkdemodirs	2005-09-08 10:42:32.000000000 -0400
-+++ gpgme-1.1.8/tests/gpg/mkdemodirs	2009-01-07 00:42:46.000000000 -0500
++++ gpgme-1.1.8/tests/gpg/mkdemodirs	2019-10-18 14:56:24.000000000 -0400
 @@ -19,7 +19,9 @@
  
  set -e
@@ -24,3 +24,12 @@ diff -Nurd -x'*~' gpgme-1.1.8.orig/tests/gpg/mkdemodirs gpgme-1.1.8/tests/gpg/mk
  NAMES='Alpha Bravo Charlie Delta Echo Foxtrot Golf Hotel India
         Juliet Kilo Lima Mike November Oscar Papa Quebec Romeo
         Sierra Tango Uniform Victor Whisky XRay Yankee Zulu'
+@@ -44,7 +46,7 @@
+     echo -n " $name"
+     [ -d $name ] && rm -r $name
+     mkdir $name
+-    $GPGDEMO --export-secret-key -o - $name > $name/Secret.gpg
++    $GPGDEMO --export "$(echo $name | tr '[:upper:]' '[:lower:]')@example.net" --export-secret-key -o - $name > $name/Secret.gpg
+     $GPG --homedir $name --allow-secret-key-import --import $name/Secret.gpg
+     $GPGDEMO --export -o - $name > $name/Public.gpg
+     $GPG --homedir $name --import $name/Public.gpg


### PR DESCRIPTION
Add --export option to gpg2 command in mkdemodirs test script to resolve install failure. This resolves issues #472.