### PR TITLE
normalize root user ls command behaviour

### DIFF
--- a/inject.pl
+++ b/inject.pl
@@ -30,7 +30,7 @@ use File::Find;
 
 ### list our directories
 
-my @contents = `ls`;
+my @contents = `ls -A | grep -v ^\\\\.`;
 my ($filename,@directories);
 foreach $filename (@contents) {
     chomp($filename);


### PR DESCRIPTION
The "ls" command adds the "-A" option when executed as root. That causes hidden directories to be incorrectly considered for injection (notably, the .git directory), which causes the inject.pl to fail. This is a nuisance when working with a git repository because it picks up the .git directory.  Rather than explicitly excluding the ".git" directory (as is done for the legacy CVS directory) this change resolves the root problem by normalizing the behaviour of the "ls" command as executed by the inject.pl script. This resolves issue 120.