### PR TITLE
Gnutls30 update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/gnutls-2.12-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/gnutls-2.12-shlibs.info
@@ -2,6 +2,7 @@ Package: gnutls-2.12-shlibs
 # Shlibs only stub. Nothing uses this.
 Version: 2.12.24
 Revision: 10
+Distribution: 10.9, 10.10, 10.11, 10.12, 10.13, 10.14, 10.14.5
 Source: ftp://ftp.gnutls.org/gcrypt/gnutls/v2.12/gnutls-%v.tar.xz
 Source-MD5: b09960551d963f1187bb9f87f1577bfa
 GCC: 4.0

--- a/10.9-libcxx/stable/main/finkinfo/crypto/gnutls-2.12-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/gnutls-2.12-shlibs.info
@@ -1,20 +1,19 @@
-Package: gnutls-2.12
+Package: gnutls-2.12-shlibs
+# Shlibs only stub. Nothing uses this.
 Version: 2.12.24
-Revision: 2
+Revision: 10
 Source: ftp://ftp.gnutls.org/gcrypt/gnutls/v2.12/gnutls-%v.tar.xz
 Source-MD5: b09960551d963f1187bb9f87f1577bfa
 GCC: 4.0
-Depends: %N-shlibs (= %v-%r)
-Replaces: gnutls-dev, gnutls, gnutls12, gnutls14, gnutls26, gnutls-2.12, gnutls28, gnutls30
-Conflicts: gnutls-dev, gnutls, gnutls12, gnutls14, gnutls26, gnutls-2.12, gnutls28, gnutls30
+Replaces: gnutls-2.12 (<< 2.12.24-10)
+Conflicts: gnutls-2.12 (<< 2.12.24-10)
 BuildDepends: <<
   fink (>= 0.32-1), fink-package-precedence, gmp5,
   libtool2, libgettext8-dev, libiconv-dev, nettle4a, pkgconfig,
   libtasn1-3, readline7
 <<
-BuildDependsOnly: True
 UseMaxBuildJobs: false
-PatchFile: %n.patch
+PatchFile: gnutls-2.12.patch
 PatchFile-MD5: cd1db6b95cd74c8c55cf866b610ee4a4
 PatchScript: <<
   %{default_script}
@@ -22,40 +21,37 @@ PatchScript: <<
   perl -pi -e 's|LTLIBTASN1|LIBTASN1_LIBS|g' libextra/Makefile.in
 <<
 ConfigureParams: <<
-  --libdir=%p/lib/gnutls-2.12 --without-p11-kit --mandir=%p/share/man --infodir=%p/share/info --enable-dependency-tracking --disable-guile --disable-openpgp-authentication
+  --libdir=%p/lib/gnutls-2.12 \
+  --without-p11-kit \
+  --mandir=%p/share/man \
+  --infodir=%p/share/info \
+  --enable-dependency-tracking \
+  --disable-guile \
+  --disable-openpgp-authentication \
+  --disable-doc \
+  --disable-static
 <<
 CompileScript: <<
   %{default_script}
-  sed -i.orig -e '/Requires.private/s| , zlib||' lib/gnutls.pc
-  fink-package-precedence --prohibit-bdep=gnutls,gnutls-dev,gnutls12,gnutls14,gnutls26 .
+  fink-package-precedence --prohibit-bdep=gnutls26,gnutls-2.12,gnutls28,gnutls30 .
 <<
 InstallScript: <<
   make install DESTDIR=%d
-  /bin/mv %i/lib/gnutls-2.12/pkgconfig %i/lib  
+  cd %i; rm -r bin include lib/gnutls-2.12/*.la lib/gnutls-2.12/libgnutls{-extra,,-openssl,xx}.dylib \
+  	lib/gnutls-2.12/pkgconfig share/locale
 <<  
-SplitOff: <<
-  Package: %N-shlibs
-  Depends: <<
-    gmp5-shlibs, libgettext8-shlibs, libhogweed-shlibs,
-    libiconv, libtasn1-3-shlibs, nettle4a-shlibs, readline7-shlibs
-  <<
-  DocFiles: COPYING README lib/COPYING:COPYING.lib libextra/COPYING:COPYING.libextra
-  Files: <<
-    lib/gnutls-2.12/libgnutls.26.dylib
-    lib/gnutls-2.12/libgnutls-extra.26.dylib
-    lib/gnutls-2.12/libgnutls-openssl.27.dylib
-    lib/gnutls-2.12/libgnutlsxx.27.dylib
-  <<
-  Shlibs: <<
-    %p/lib/gnutls-2.12/libgnutls.26.dylib         49.0.0 %n (>= 2.12.20-1)
-    %p/lib/gnutls-2.12/libgnutls-extra.26.dylib   49.0.0 %n (>= 2.12.20-1)
-    %p/lib/gnutls-2.12/libgnutls-openssl.27.dylib 28.0.0 %n (>= 2.12.7-1)
-    %p/lib/gnutls-2.12/libgnutlsxx.27.dylib       28.0.0 %n (>= 2.12.7-1)
-  <<
+Depends: <<
+	gmp5-shlibs, libgettext8-shlibs, libhogweed-shlibs,
+	libiconv, libtasn1-3-shlibs, nettle4a-shlibs, readline7-shlibs
+<<
+Shlibs: <<
+	%p/lib/gnutls-2.12/libgnutls.26.dylib         49.0.0 %n (>= 2.12.20-1)
+	%p/lib/gnutls-2.12/libgnutls-extra.26.dylib   49.0.0 %n (>= 2.12.20-1)
+	%p/lib/gnutls-2.12/libgnutls-openssl.27.dylib 28.0.0 %n (>= 2.12.7-1)
+	%p/lib/gnutls-2.12/libgnutlsxx.27.dylib       28.0.0 %n (>= 2.12.7-1)
 <<
 InfoTest: TestScript: make check || exit 2
-DocFiles: AUTHORS ChangeLog COPYING NEWS README doc/reference/html
-InfoDocs: gnutls.info
+DocFiles: COPYING README lib/COPYING:COPYING.lib libextra/COPYING:COPYING.libextra
 Description: GNU TLS encryption library
 DescDetail: <<
 GnuTLS is a project that aims to develop a library which provides
@@ -77,7 +73,8 @@ DescPort: <<
    for chainverify test, which will not work for us.
 <<
 DescPackaging: <<
-	Does not seem compatible with libtasn1-6 API
+	*shlibs-only stub as of 2.12.4-10 because nothing else is using it.
+	*Does not seem compatible with libtasn1-6 API.
 <<
 License: GPL/LGPL
 Maintainer: Dave Reiser <dbreiser@users.sourceforge.net>

--- a/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-shlibs.info
@@ -1,0 +1,147 @@
+Package: gnutls30-shlibs
+Version: 3.6.10
+Revision: 1
+Source: https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-%v.tar.xz
+Source-MD5: 254e756d882a38ce9ad6f47589330d87
+GCC: 4.0
+Depends: <<
+	gmp5-shlibs,
+	libgettext8-shlibs,
+	libhogweed5-shlibs,
+	libidn2.0-shlibs,
+	libtasn1-6-shlibs (>= 3.9-1),
+	libunistring2-shlibs,
+	nettle7-shlibs
+<<
+BuildDepends: <<
+	autogen (>= 5.18.2-3),
+	autogen-dev,
+	fink (>= 0.32),
+	fink-package-precedence,
+	gmp5,
+	libgettext8-dev,
+	libidn2.0-dev,
+	libtasn1-6-dev (>= 4.12-1),
+	libtool2,
+	libunistring2,
+	nettle7,
+	pkgconfig
+<<
+PatchScript: <<
+	#!/bin/bash -ev
+	%{default_script}
+	#strip unnecessary lines from .pc
+	perl -pi -e "s|^Libs\.private.*\n||g" lib/gnutls.pc.in
+	perl -pi -e "s|\@GNUTLS_REQUIRES_PRIVATE\@\n||g" lib/gnutls.pc.in
+	# clean up -framework flags
+	perl -pi -e 's|-framework Security -framework CoreFoundation|-Wl,-framework,Security -Wl,-framework,CoreFoundation|g' lib/Makefile.in
+<<
+ConfigureParams: <<
+	--libdir=%p/lib/gnutls30 \
+	--with-libintl-prefix=%p \
+	--with-libiconv-prefix=%p \
+	--without-p11-kit \
+	--without-tpm \
+	--enable-openssl-compatibility \
+	--enable-ssl3-support \
+	--enable-dependency-tracking \
+	--disable-silent-rules \
+	--disable-doc \
+	--enable-manpages \
+	--enable-local-libopts \
+	--enable-shared \
+	--disable-static \
+	--disable-guile \
+	--disable-libdane \
+	--with-system-priority-file="%p/etc/gnutls/default-priorities" \
+	ac_cv_prog_AWK=/usr/bin/awk \
+	ac_cv_path_GREP=/usr/bin/grep \
+	ac_cv_path_SED=/usr/bin/sed
+<<
+CompileScript: <<
+	%{default_script}
+	fink-package-precedence --prohibit-bdep=gnutls26,gnutls-2.12,gnutls28,gnutls30 .
+<<
+InstallScript: <<
+	make install DESTDIR=%d
+	/bin/mv %i/lib/gnutls30/pkgconfig %i/lib 
+<<
+
+InfoTest: <<
+	TestDepends: openssl110-dev
+	TestScript: <<
+		make check || exit 2
+		fink-package-precedence --prohibit-bdep=gnutls26,gnutls-2.12,gnutls28,gnutls30 .
+  <<
+<<
+Shlibs: <<
+	%p/lib/gnutls30/libgnutls.30.dylib         57.0.0 %n (>= 3.6.10-1)
+	%p/lib/gnutls30/libgnutls-openssl.27.dylib 28.0.0 %n (>= 3.6.10-1)
+	%p/lib/gnutls30/libgnutlsxx.28.dylib       30.0.0 %n (>= 3.6.10-1)
+<<
+
+SplitOff: <<
+	Package: gnutls30
+	Depends: <<
+		%N (>= %v-%r),
+		gmp5-shlibs,
+		libgettext8-shlibs,
+		libhogweed5-shlibs,
+		libidn2.0-shlibs,
+		libtasn1-6-shlibs (>= 3.9-1),
+		libunistring2-shlibs,
+		nettle7-shlibs
+	<<
+	BuildDependsOnly: True
+	Replaces: <<
+		gnutls26,
+		gnutls-2.12,
+		gnutls28,
+		gnutls30
+	<<
+	Conflicts: <<
+		gnutls26,
+		gnutls-2.12,
+		gnutls28,
+		gnutls30
+	<<
+	DocFiles: AUTHORS ChangeLog LICENSE NEWS README.md THANKS doc/reference/html
+	Files: <<
+		bin
+		include
+		lib/gnutls30/*.la
+		lib/gnutls30/libgnutls{-openssl,,xx}.dylib
+		lib/pkgconfig
+		share/locale
+		share/man
+	<<
+<<
+
+DocFiles: LICENSE NEWS README.md THANKS
+#InfoDocs: gnutls.info
+Description: GNU TLS encryption library
+DescDetail: <<
+GnuTLS is a project that aims to develop a library which provides
+a secure layer, over a reliable transport layer. Currently the GnuTLS
+library implements the proposed standards by the IETF's TLS working group. 
+
+  Quoting from RFC2246 - the TLS 1.0 protocol specification: 
+  "The TLS protocol provides communications privacy over the Internet.
+   The protocol allows client/server applications to communicate in a way that
+   is designed to prevent eavesdropping, tampering, or message forgery."
+<<
+DescPort: <<
+   GnuTLS now uses an internal opencdk, even if the independent lib and headers are installed.
+   Version 3.0.8 had new libversions of the two main shlibs, but the same libversion of openssl
+   lib as 2.12.x -- so all 3 shlibs are installed in a private dir to allow prior shlibs
+   with the same libversion to exist according to policy.
+<<
+DescPackaging: <<
+   dmacks: libunbound is autodetected but was not tracked as a
+   dep. Most users probably didn't have it installed, so we disable
+   libdane (the feature that is enabled by libunbound being detected)
+   for consistent results. Alt would be to enable it an add deps.
+<<
+License: GPL/LGPL
+Maintainer: Dave Reiser <dbreiser@users.sourceforge.net>
+Homepage: http://www.gnutls.org/


### PR DESCRIPTION
New gnutls-3.6.10 that needs a new libN=gnutls30.
Also make the old gnutls-2.12 package an shlibs-only stub because nothing else is using it and no sense in carrying it forward.
