### PR TITLE
Update mopac7.info

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/mopac7.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/mopac7.info
@@ -1,84 +1,84 @@
 Info2: <<
 
-Package: mopac7
-Version: 1.15
-Revision: 16
-Type: gcc (7)
+Package:  mopac7
+Version:  1.15
+Revision: 19
+Type: gcc (9)
 Depends: <<
-	%N-shlibs (= %v-%r),
-	gcc%type_pkg[gcc]-shlibs
+  %N-shlibs (= %v-%r),
+  gcc%type_pkg[gcc]-shlibs
 <<
 BuildDepends: <<
-	fink-package-precedence,
-	gcc%type_pkg[gcc]-compiler
+  fink-package-precedence,
+  gcc%type_pkg[gcc]-compiler
 <<
 Source: http://www.bioinformatics.org/ghemical/download/current/%n-%v.tar.gz
 Source-MD5: 7e509fd03154b37cc682593365c233f4
 
 PatchScript: <<
-	perl -pi -e 's/verstring=.*compatibility.*/verstring="-compatibility_version \$minor_current -current_version \$minor_current.\$revision"/' ltmain.sh
-	perl -pi -e 's/libmopac7_la_LDFLAGS =/libmopac7_la_LDFLAGS = -Wl,-single_module/' fortran/Makefile.in
-# fix 8 byte / 4 byte problem on 64 bit compilers
-	perl -pi -e 's/#ifndef F2C_INCLUDE/#include <stdint.h>\n\n#ifndef F2C_INCLUDE/'	fortran/mopac7f2c.h
-	perl -pi -e 's/typedef long int integer;/typedef int32_t integer;/' 						fortran/mopac7f2c.h
-	perl -pi -e 's/typedef ulong int uinteger;/typedef uint32_t uinteger;/'					fortran/mopac7f2c.h
+  perl -pi -e 's/verstring=.*compatibility.*/verstring="-compatibility_version \$minor_current -current_version \$minor_current.\$revision"/' ltmain.sh
+  perl -pi -e 's/libmopac7_la_LDFLAGS =/libmopac7_la_LDFLAGS = -Wl,-single_module/' fortran/Makefile.in
+#  fix 8 byte / 4 byte problem on 64 bit compilers
+  perl -pi -e 's/#ifndef F2C_INCLUDE/#include <stdint.h>\n\n#ifndef F2C_INCLUDE/' fortran/mopac7f2c.h
+  perl -pi -e 's/typedef long int integer;/typedef int32_t integer;/'             fortran/mopac7f2c.h
+  perl -pi -e 's/typedef ulong int uinteger;/typedef uint32_t uinteger;/'         fortran/mopac7f2c.h
 <<
 
 SetCFLAGS: -O2
 
-ConfigureParams: --enable-dependency-tracking FFLAGS='-O2 -fdiagnostics-color=always' F77=gfortran-fsf-%type_raw[gcc]
+ConfigureParams: --disable-dependency-tracking FFLAGS='-O2 -fdiagnostics-color=always' F77=gfortran-fsf-%type_raw[gcc]
 
 CompileScript: <<
 #!/bin/sh -ev
-	./configure %c
-	make LDFLAGS="-no-undefined $LDFLAGS"
-	fink-package-precedence --no-headers .
+  ./configure %c
+  make LDFLAGS="-no-undefined $LDFLAGS"
+  fink-package-precedence --no-headers .
 <<
 
 InstallScript: <<
-	make install DESTDIR=%d
-	mkdir -p %i/bin
-	cp -p fortran/.libs/mopac7 %i/bin/
+  make install DESTDIR=%d
+  mkdir -p %i/bin
+  cp -p fortran/.libs/mopac7 %i/bin/
 <<
 
 DocFiles: AUTHORS COPYING ChangeLog NEWS README
 
 InfoTest: <<
-	TestScript: <<
-		#!/bin/sh -ev
-		for test in tests/*.dat; do
-			./run_mopac7 tests/`basename -s .dat $test` || exit 2
-		done
-	<<
+  TestScript: <<
+    #!/bin/sh -ev
+    for test in tests/*.dat; do
+      ./run_mopac7 tests/`basename -s .dat $test` || exit 2
+    done
+  <<
 <<
 
 Splitoff: <<
-	Package: %N-shlibs
-	Depends: gcc%type_pkg[gcc]-shlibs
-	Files: <<
-		lib/libmopac7.1.dylib
-		lib/libmopac7.1.0.13.dylib
-	<<
-	Shlibs: <<
-		%p/lib/libmopac7.1.dylib 2.0.0 %n (>= 1.14-2)
-	<<
-	DocFiles: COPYING
+  Package: %N-shlibs
+  Depends: gcc%type_pkg[gcc]-shlibs
+  Files: <<
+    lib/libmopac7.1.dylib
+    lib/libmopac7.1.0.13.dylib
+  <<
+  Shlibs: <<
+    %p/lib/libmopac7.1.dylib 2.0.0 %n (>= 1.14-2)
+  <<
+  DocFiles: COPYING
 <<
 
 Splitoff2: <<
-	Package: %N-dev
-	Depends: %N-shlibs (= %v-%r)
-	BuildDependsOnly: True
-	Files: <<
-		lib/libmopac7.dylib
-		include
-		lib/*a
-		lib/pkgconfig
-	<<
-	DocFiles: COPYING
+  Package: %N-dev
+  Depends: %N-shlibs (= %v-%r)
+  BuildDependsOnly: True
+  Files: <<
+    lib/libmopac7.dylib
+    include
+    lib/*a
+    lib/pkgconfig
+  <<
+  DocFiles: COPYING
 <<
 
-Homepage: http://mopac7.sourceforge.net
+Homepage: https://sourceforge.net/projects/mopac7
 Maintainer: Jack Fink <jackfink@users.sourceforge.net>
 License: Public Domain
 Description: Powerful, fast semi-empirical package


### PR DESCRIPTION
Update to gcc9, removal of tabs, new homepage and some 64bit fixes. No functional test done. It should resolve #484 gcc7 migration tracker.