### PR TITLE
Update ortep3.info

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/ortep3.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/ortep3.info
@@ -1,28 +1,54 @@
 Info2: <<
 
-Package: ortep3
-Version: 1.0.3
-Revision: 12
-Type: gcc (7)
-Depends: gcc%type_pkg[gcc]-shlibs, x11, x11-shlibs
-BuildDepends: fink-package-precedence, gcc%type_pkg[gcc]-compiler, pgplot, x11-dev
-Source: ftp://ftp.ornl.gov/pub/ortep/src/ortep.f
+Package:  ortep3
+Version:  1.0.3
+Revision: 13
+Type: gcc (9)
+Description: Thermal ellipsoid plot program
+BuildDepends: <<
+  gcc%type_pkg[gcc]-compiler,
+  aquaterm-dev, 
+  libpng16,
+  pgplot,
+  x11-dev,
+  fink-package-precedence
+<<
+Depends: <<
+  gcc%type_pkg[gcc]-shlibs,
+  aquaterm-shlibs,
+  libpng16-shlibs,
+  x11,
+  x11-shlibs
+<<
+License: Public Domain
+
+Source: https://github.com/ornl-ndav/ortep/raw/master/ortep.f
+Source-MD5: 76a252c8938e9b23abbfaf1f0b0a2647
 SourceDirectory: .
-Source-MD5: 9af12582aa95d9cc21f18883c2afea20
+
+# Compile Phase (NOTE: there is no configure):
 CompileScript: <<
-  gfortran-fsf-%type_raw[gcc] -fdiagnostics-color=always -o ortep3 ortep.f -L%p/lib/pgplot -lpgplot -L/opt/X11/lib -lX11
+#!/bin/sh -ev
+  gfortran-fsf-%type_raw[gcc] -fdiagnostics-color=always -std=legacy \
+  -lobjc -framework Foundation \
+  -L%p/lib -lpng -laquaterm -L%p/lib/pgplot -lpgplot \
+  -L/opt/X11/lib -lX11 \
+  -o ortep3 ortep.f
+  strip ortep3
+  head -n 20 ortep.f > LICENSE
   fink-package-precedence --no-headers --libs .
 <<
+
 InstallScript: <<
   mkdir -p %i/bin
   cp -p ortep3 %i/bin/
-  head -n 20 ortep.f > LICENSE
 <<
+
 DocFiles: LICENSE
-License: Public Domain
-Homepage: http://www.ornl.gov/sci/ortep/ortep103.html
-Description: Thermal ellipsoid plot program
+
 DescDetail: ...for crystal structure illustrations
+
+Homepage: https://ornl-ndav.github.io/ortep/ortep.html
 Maintainer: Jack Fink <jackfink@users.sourceforge.net>
 
 <<


### PR DESCRIPTION
Update for gcc-9 and several fixes of compile and link errors, re-sorting and make it look nicer. Refers to #484 gcc7 migration tracker. Approval from Jack Fink might be nice, but not necessarily required. I did not do any functional tests beyond starting the program.