### PR TITLE
Gracegtk and qrupdate updates: gcc and lapack

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/gracegtk.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gracegtk.info
@@ -48,7 +48,13 @@ Source-MD5: ff3b343b71516a58819da005d10b5973
 Source-Checksum: SHA1(9c37e8ac2bbb777bbafa34b738171b12a486e61c)
 SourceDirectory: %{ni}-%v
 ###
+PatchFile: %{ni}.patch
+PatchFile-MD5: 67a5cbb5796d955b64aa130d6d72d9e6
+# PatchFile includes fixes related to upstream tickets:
+#   https://sourceforge.net/p/gracegtk/tickets/8/
+#   https://sourceforge.net/p/gracegtk/tickets/9/
 PatchScript: <<
+	%{default_script}
 	perl -pi -e 's/\b(bool)\b/my\1/g' src/gw_list.c src/gw_list.h src/gg_hotwin.c
 	perl -pi -e 's,${prefix}/%{ni},${prefix}/share/%{ni},' configure
 	perl -pi -e 's/(TEXDOCS\s+=\s+FAQ.tex\s+)Tutorial.tex\s+UsersGuide.tex/\1GraceGTK.tex/' doc/Makefile

--- a/10.9-libcxx/stable/main/finkinfo/sci/gracegtk.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gracegtk.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: gracegtk%type_pkg[-blas]
 Version: 0.9.5
-Type: v (2016_08_30_17h14), gcc (6), lapack (3.6.0), -blas (. -ref -atlas)
-Revision: 1
+Type: v (2016_08_30_17h14), gcc (9), lapack (3.8.0), -blas (. -ref -atlas)
+Revision: 2
 ###
 Depends: <<
 	(%type_raw[-blas] = -atlas) atlas-shlibs, 
@@ -26,7 +26,7 @@ BuildDepends: <<
 	cairo (>= 1.12.8-1),
 	fftw3,
 	fink-package-precedence,
-	freetype219,
+	freetype219 (>= 2.6-1),
 	fontconfig2-dev,
 	gcc%type_pkg[gcc]-compiler,
 	glib2-dev (>= 2.22.0-1),

--- a/10.9-libcxx/stable/main/finkinfo/sci/gracegtk.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gracegtk.patch
@@ -1,0 +1,37 @@
+diff -Nurd -x'*~' gracegtk-0.9.5.orig/contours/Makefile gracegtk-0.9.5/contours/Makefile
+--- gracegtk-0.9.5.orig/contours/Makefile	2011-06-16 06:34:46.000000000 -0400
++++ gracegtk-0.9.5/contours/Makefile	2019-11-02 23:15:18.000000000 -0400
+@@ -20,7 +20,7 @@
+ 
+ CFLAGS = -g -Wall
+ # Computing level sets can take time, so we use -O2
+-FFLAGS = -O2
++FFLAGS = -O2 -std=legacy
+ # FFLAGS = -g
+ 
+ LD=$(CC)
+diff -Nurd -x'*~' gracegtk-0.9.5.orig/loess/Makefile gracegtk-0.9.5/loess/Makefile
+--- gracegtk-0.9.5.orig/loess/Makefile	2012-03-09 11:39:42.000000000 -0500
++++ gracegtk-0.9.5/loess/Makefile	2019-11-02 23:15:05.000000000 -0400
+@@ -20,8 +20,8 @@
+ # FCFLAGS = -g -Wall
+ # Computing level sets can take time, so we use -O2
+ # FFFLAGS = -O2
+-FFLAGS = -g
+-CFLAGS = -g
++FFLAGS = -g -std=legacy
++CFLAGS = -g -I../src
+ 
+ LD=$(CC)
+ 
+diff -Nurd -x'*~' gracegtk-0.9.5.orig/loess/loessc.c gracegtk-0.9.5/loess/loessc.c
+--- gracegtk-0.9.5.orig/loess/loessc.c	2012-02-27 04:10:20.000000000 -0500
++++ gracegtk-0.9.5/loess/loessc.c	2019-11-02 23:09:45.000000000 -0400
+@@ -4,6 +4,7 @@
+ #include "../config.h"
+ 
+ #include "S.h"
++#include "utils.h"
+ 
+ #define	min(x,y)  ((x) < (y) ? (x) : (y))
+ #define	max(x,y)  ((x) > (y) ? (x) : (y))

--- a/10.9-libcxx/stable/main/finkinfo/sci/qrupdate.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/qrupdate.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: qrupdate%type_pkg[-blas]
 Version: 1.1.2
-Revision: 10
-Type: -blas (. -atlas -ref), gcc (5), lapack (3.5.0)
+Revision: 11
+Type: -blas (. -atlas -ref), gcc (9), lapack (3.8.0)
 
 Source: mirror:sourceforge:%{Ni}/1.1/%{Ni}-%v.tar.gz
 Source-MD5: 6d073887c6e858c24aeda5b54c57a8c4
@@ -40,18 +40,21 @@ BuildDependsOnly: true
 Conflicts: %{Ni}, %{Ni}-atlas, %{Ni}-ref
 Replaces: %{Ni}, %{Ni}-atlas, %{Ni}-ref
 
+PatchFile: %{ni}.patch
+PatchFile-MD5: 7931184403d475403f20e1c5c6ceaebd
+# PatchFile includes fix related to upstream ticket:
+#   https://sourceforge.net/p/qrupdate/discussion/905477/thread/d81de000c8/
+# but not for:
+#   https://sourceforge.net/p/qrupdate/discussion/905477/thread/31583ddb53/
 PatchScript: <<
 	#!/bin/sh -ev
-	if [ `uname -r | cut -f1 -d.` -ge 9 ]
-		then MYLDFLAGS="-Wl,-dead_strip_dylibs"
-		else MYLDFLAGS=""
-	fi
+	%{default_script}
 	# Beat on Makeconf to make this build like we want
 	sed -i.orig -e 's|/usr/local|%p|g' \
 		-e '/FC/s|gfortran|&-fsf-%type_raw[gcc]|' Makeconf
 	if [ "%type_pkg[-blas]" = "-atlas" ]
 	then
-		perl -pi -e "s|^(BLAS=)-lblas|LDFLAGS=$LDFLAGS $MYLDFLAGS\n\1-ltatlas|" Makeconf
+		perl -pi -e "s|^(BLAS=)-lblas|LDFLAGS=$LDFLAGS\n\1-ltatlas|" Makeconf
 		perl -pi -e "s|^(LAPACK=)-llapack|\1-ltatlas|" Makeconf
 	elif [ "%type_pkg[-blas]" = "-ref" ]
 	then
@@ -73,6 +76,7 @@ PatchScript: <<
 	sed -i.orig -e '/FFLAGS.*LIBS/s|(FFLAGS)|& $(LDFLAGS)|' test/Makefile
 <<
 
+SetLDFLAGS: -Wl,-dead_strip_dylibs
 CompileScript: <<
 	make solib && make lib
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/qrupdate.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/qrupdate.patch
@@ -1,0 +1,12 @@
+diff -Nurd -x'*~' qrupdate-1.1.2.orig/test/utils.f qrupdate-1.1.2/test/utils.f
+--- qrupdate-1.1.2.orig/test/utils.f	2010-02-11 05:45:19.000000000 -0500
++++ qrupdate-1.1.2/test/utils.f	2019-11-03 01:35:23.000000000 -0400
+@@ -68,7 +68,7 @@
+       subroutine zrandg(m,n,x,ldx)
+       integer m,n,ldx
+       double complex x(ldx,*)
+-      external srandg
++      external drandg
+       call drandg(2*m,n,x,2*ldx)
+       end subroutine
+ 


### PR DESCRIPTION
gracegtk is one of the last remaining packages to use gcc6 (#482) and is the only user of lapack360, which is a gcc5 user (#481). Here's an update to gcc9 and to lapack380 (which will need to migrate to gcc9, but may as well only have to bring the latest lapackXXX moving forward). There's a newer version upstream, but it requires a newer gtk stack than fink has at the moment.