### PR TITLE
gmt-6.0.0-1: Introducing GMT 6.0.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/gmt.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gmt.info
@@ -1,6 +1,6 @@
 Package: gmt
 Version: 4.5.18
-Revision: 2
+Revision: 3
 Source: ftp://ftp.soest.hawaii.edu/gmt/gmt-%v-src.tar.bz2
 Source2: ftp://ftp.soest.hawaii.edu/gmt/gmt-%v-non-gpl-src.tar.bz2
 Source-MD5: b35cf18fddcf4823dc75b1ea32808d71
@@ -9,8 +9,8 @@ SourceDirectory: gmt-%v
 
 BuildDepends: fink (>= 0.32), netcdf-c15, gdal2-dev
 Depends: %n-shlibs (= %v-%r)
-Conflicts: gmt5
-Replaces: gmt5
+Conflicts: gmt, gmt5, gmt6
+Replaces: gmt, gmt5, gmt6
 Recommends: %n-doc
 NoSetCPPFLAGS: true
 NoSetLDFLAGS: true
@@ -25,8 +25,8 @@ InstallScript: <<
 <<
 SplitOff: <<
   Package: %N-doc
-  Conflicts: gmt5-doc
-  Replaces: gmt5-doc
+  Conflicts: gmt-doc, gmt5-doc, gmt6-doc
+  Replaces: gmt-doc, gmt5-doc, gmt6-doc
   BuildDependsOnly: True
   Files: share/doc/gmt
   DocFiles: LICENSE.TXT
@@ -49,8 +49,8 @@ SplitOff2: <<
 SplitOff3: <<
   Package: %N-dev
   Depends: %N-shlibs (= %v-%r)
-  Conflicts: gmt5-dev
-  Replaces: gmt5-dev
+  Conflicts: gmt-dev, gmt5-dev, gmt6-dev
+  Replaces: gmt-dev, gmt5-dev, gmt6-dev
   BuildDependsOnly: True
   Files: include lib/*.a lib/*.dylib
   DocFiles: ChangeLog LICENSE.TXT README src/README.TRIANGLE src/TRIANGLE.HOWTO

--- a/10.9-libcxx/stable/main/finkinfo/sci/gmt6.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gmt6.info
@@ -1,8 +1,9 @@
-Package: gmt5
-Version: 5.4.5
-Revision: 3
-Source: ftp://ftp.soest.hawaii.edu/gmt/gmt-%v-src.tar.xz
-Source-MD5: 846c7717ca8a6e2c76cc5538331ff59e
+Package: gmt6
+Version: 6.0.0
+Revision: 1
+Source: https://github.com/GenericMappingTools/gmt/releases/download/%v/gmt-%v-src.tar.xz
+Source-MD5: 2721f3bd7f39eb7c8ea261f644c5c36e
+Source-Checksum: SHA1(3f11da2740402d4d1d98c55b46f4f18e050f76c0)
 SourceDirectory: gmt-%v
 
 Conflicts: gmt, gmt5, gmt6
@@ -17,7 +18,7 @@ BuildDepends: <<
   gdal2-dev,
   fftw3 (>= 3.3.3)
 <<
-Depends: %n-shlibs (= %v-%r)
+Depends: %n-shlibs (= %v-%r), ghostscript
 Recommends: %n-doc
 NoSetCPPFLAGS: true
 NoSetLDFLAGS: true
@@ -65,7 +66,7 @@ SplitOff: <<
 <<
 SplitOff2: <<
   Package: %N-shlibs
-  Files: lib/*.5.*dylib lib/gmt
+  Files: lib/*.6.*dylib lib/gmt
   Depends: <<
     netcdf-c15-shlibs,
     libpcre1-shlibs,
@@ -77,10 +78,10 @@ SplitOff2: <<
   <<
   RuntimeDepends: ghostscript
   Shlibs: <<
-    %p/lib/libgmt.5.dylib 5.0.0 %n (>= 5.4.1-1)
-    %p/lib/libpostscriptlight.5.dylib 5.0.0 %n (>= 5.4.1-1)
+    %p/lib/libgmt.6.dylib 6.0.0 %n (>= 5.4.1-1)
+    %p/lib/libpostscriptlight.6.dylib 6.0.0 %n (>= 5.4.1-1)
   <<
-  DocFiles: COPYING.LESSERv3 COPYINGv3 LICENSE.TXT README src/README.TRIANGLE src/TRIANGLE.HOWTO
+  DocFiles: AUTHORS.md COPYING.LESSERv3 COPYINGv3 LICENSE.TXT README.md src/README.TRIANGLE src/TRIANGLE.HOWTO
 <<
 SplitOff3: <<
   Package: %N-dev
@@ -89,25 +90,31 @@ SplitOff3: <<
   Replaces: gmt-dev, gmt5-dev, gmt6-dev
   BuildDependsOnly: True
   Files: include lib/*.dylib
-  DocFiles: COPYING.LESSERv3 COPYINGv3 LICENSE.TXT README src/README.TRIANGLE src/TRIANGLE.HOWTO
+  DocFiles: AUTHORS.md COPYING.LESSERv3 COPYINGv3 LICENSE.TXT README.md src/README.TRIANGLE src/TRIANGLE.HOWTO
 <<
 Description: Generic Mapping Tools
 DescDetail: <<
-  GMT is an open source collection of about 80 command-line tools
+  GMT is an open source collection of about 90 command-line tools
   for manipulating geographic and Cartesian data sets (including
   filtering, trend fitting, gridding, projecting, etc.) and
   producing PostScript illustrations ranging from simple x-y
   plots via contour maps to artificially illuminated surfaces and
-  3D perspective views; the GMT supplements add another 40 more
+  3D perspective views. The GMT supplements add another 50 more
   specialized and discipline-specific tools. GMT supports over 30
-  map projections and transformations and comes with support data
-  such as GSHHG coastlines, rivers, and political boundaries.
+  map projections and transformations and requires support data
+  such as GSHHG coastlines, rivers, and political boundaries and
+  optionally DCW country polygons.
+
+  GMT is developed and maintained by the GMT Team, with help from
+  a global set of contributors and support by the National Science
+  Foundation. It is released under the GNU Lesser General Public
+  License version 3 or any later version.
 <<
 DescPort: <<
   Switched GMT_INSTALL_TRADITIONAL_FOLDERNAMES=off to use Fink's
   folder organisation instead.
 <<
 License: GPL, Restrictive/Distributable
-DocFiles: COPYING.LESSERv3 COPYINGv3 LICENSE.TXT README src/README.TRIANGLE src/TRIANGLE.HOWTO
+DocFiles: AUTHORS.md COPYING.LESSERv3 COPYINGv3 LICENSE.TXT README.md src/README.TRIANGLE src/TRIANGLE.HOWTO
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 Homepage: http://gmt.soest.hawaii.edu/

--- a/10.9-libcxx/stable/main/finkinfo/sci/gmt6.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gmt6.info
@@ -40,10 +40,13 @@ CompileScript: <<
 	-DGMT_MANDIR=share/man \
 	-DDCW_ROOT=%p/share/gmt/dcw \
 	-DGSHHG_ROOT=%p/share/gmt/gshhg \
+	-DGS_ROOT=%p \
 	-DNETCDF_ROOT=%p \
-	-DFFTW3_ROOT=%p \
+	-DCURL_INCLUDE_DIR=%p/include \
+	-DCURL_LIBRARY=%p/lib/libcurl.dylib \
 	-DGDAL_ROOT=%p \
 	-DPCRE_ROOT=%p \
+	-DFFTW3_ROOT=%p \
 	-DGMT_INSTALL_TRADITIONAL_FOLDERNAMES=off \
 	-DBLA_VENDOR=Apple \
 	-DCMAKE_OSX_DEPLOYMENT_TARGET= \


### PR DESCRIPTION
This is a new branch of the GMT package, thus introducing a new package gmt6.
Built and tested with 'fink -m build' on MacOS 10.15.1 with Command Line Tools 11.0.

Also updated the Conflicts/Replaces lines of packages gmt and gmt5.