### PR TITLE
Move to gcc9

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/openmpi.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/openmpi.info
@@ -1,12 +1,12 @@
 Info2: <<
 Package: openmpi
 Version: 1.10.7
-Revision: 3
+Revision: 4
 GCC: 4.0
 Description: MPI implementation for parallel computing
 License: BSD
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
-Type: gcc (8)
+Type: gcc (9)
 Depends: <<
 	%N-shlibs (= %v-%r),
 	gcc%type_raw[gcc]-compiler,

--- a/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cdo.info
@@ -1,11 +1,11 @@
 Info2: <<
 Package: cdo%type_pkg[-openmp]
 Version: 1.9.7.1
-Revision: 1
+Revision: 2
 Description: Climate Data Operators
 HomePage: https://code.zmaw.de/projects/cdo
 License: GPL
-Type: gcc (8), -openmp (. -openmp)
+Type: gcc (9), -openmp (. -openmp)
 
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/eccodes.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: eccodes
 Version: 2.13.1
-Revision: 1
-Type: gcc (8)
+Revision: 2
+Type: gcc (9)
 Description: Coding/encoding ECMWF files, C headers/docs
 Homepage: https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home
 License: BSD

--- a/10.9-libcxx/stable/main/finkinfo/sci/fftw3.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/fftw3.info
@@ -1,10 +1,10 @@
 Info2: <<
 Package: fftw3
 Version: 3.3.8
-Revision: 2
+Revision: 3
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
-Type: gcc (8)
+Type: gcc (9)
 
 Source:  ftp://ftp.fftw.org/pub/fftw/fftw-%v.tar.gz
 Source-MD5: 8aac833c943d8e90d51b697b27d4384d

--- a/10.9-libcxx/stable/main/finkinfo/sci/grib-api-fortran.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/grib-api-fortran.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: grib-api-fortran
 Version: 1.28.0
-Revision: 2
-Type: gcc (8)
+Revision: 3
+Type: gcc (9)
 Description: ECMWF GRIB API, Fortran headers
 Homepage: https://software.ecmwf.int/wiki/display/GRIB/Home
 License: BSD

--- a/10.9-libcxx/stable/main/finkinfo/sci/lapack380.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/lapack380.info
@@ -1,8 +1,8 @@
 Info4: <<
 Package: lapack380
 Version: 3.8.0
-Revision: 1
-Type: gcc (8)
+Revision: 2
+Type: gcc (9)
 Description: Reference L_APACK and BLAS libraries
 DescDetail: <<
 This package provides a reference implementation of the LAPACK and BLAS 

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-fortran8.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-fortran8.info
@@ -1,11 +1,11 @@
 Info2: <<
 Package: netcdf-fortran8
 Version: 4.5.1
-Revision: 1
+Revision: 2
 BuildDependsOnly: true
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>
 
-Type: gcc (8)
+Type: gcc (9)
 
 Depends: %n-shlibs (= %v-%r), gcc%type_pkg[gcc]-compiler
 BuildDepends: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/wip.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/wip.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: wip
 Version: 2p3
-Revision: 2009
-Type: gcc (8)
+Revision: 2010
+Type: gcc (9)
 Description: Interactive graphics software package
 License: OSI-Approved
 Maintainer: Remko Scharroo <remkos@users.sourceforge.net>


### PR DESCRIPTION
This updates the following packages to gcc9.
Tested on MacOS 10.15.1 with Command Line Tools 11.2