### PR TITLE
migrate mommsen packages to gcc9

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
@@ -1,19 +1,20 @@
 Info3: <<
 Package: cernlib2006
+Type: gcc (9)
 Version: 2006b
-Revision: 29
+Revision: 30
 Description: Paw and other basic executables
 Depends: <<
-  gcc8-shlibs,
+  gcc%type_pkg[gcc]-shlibs,
   x11
 <<
 BuildDepends: <<
   fink-package-precedence (>=0.31-1),
   freetype219 (>= 2.4.11-1),
-  gcc8,
+  gcc%type_pkg[gcc],
   libxt-flat (>=1.1.5-2),
   openmotif4 (>= 2.3.4-13),
-  patchy4-gfortran,
+  patchy4-gfortran (>= 4.15-13),
   x11-dev,
   xcode,
   xmkmf
@@ -22,7 +23,7 @@ Provides: cernlib
 Source: http://cernlib.web.cern.ch/cernlib/download/%v_source/tar/2006_src.tar.gz
 SourceRename: cernlib-%v.tar.gz
 Source-MD5: 750c4804a2366ccd8e80c45a055f8ac5
-Source2: http://cern.ch/~mommsen/fink/%f.patch.gz
+Source2: http://cern.ch/~mommsen/fink/%n-%v-29.patch.gz
 Source2-MD5: 45ae1b9450ee432639000a5beae1462d
 SourceDirectory: 2006/src
 PatchScript: <<
@@ -31,10 +32,13 @@ PatchScript: <<
     "i386")    ARCH="I386" ;;
     "x86_64")  ARCH="QMLXIA64" ;;
   esac
-  gunzip -c ../../%f.patch.gz | \
+  gunzip -c ../../%n-%v-29.patch.gz | \
     /usr/bin/sed -e "{
       s|@PREFIX@|%p|g ;
-      s|@ARCH@|${ARCH}|g
+      s|@ARCH@|${ARCH}|g ;
+      s|gcc8|gcc%type_pkg[gcc]|g;
+      s|gcc-8|gcc-%type_pkg[gcc]|g;
+      s|g++-6|g++-%type_pkg[gcc]|g;
     }" | patch -p1
   perl -pi -e 's|-lXt|%p/lib/libXt-flat/libXt.6.dylib|g' scripts/cernlib
 <<
@@ -128,7 +132,7 @@ SplitOff: <<
   Provides: cernlib-paw++
   Depends: <<
     x11,
-    gcc8-shlibs,
+    gcc%type_pkg[gcc]-shlibs,
     libxt-flat-shlibs (>=1.1.5-2),
     openmotif4-shlibs (>= 2.3.4-13),
     %N (=%v-%r)
@@ -270,7 +274,7 @@ SplitOff5: <<
   Description: CERNLIB patchy utilities
   Package: patchy5-gfortran
   Provides: patchy, patchy5
-  Depends: %N-dev (=%v-%r), gcc8-shlibs
+  Depends: %N-dev (=%v-%r), gcc%type_pkg[gcc]-shlibs
   InstallScript: <<
     #!/bin/sh -ev
     install -d %i/bin

--- a/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
@@ -23,7 +23,7 @@ Provides: cernlib
 Source: http://cernlib.web.cern.ch/cernlib/download/%v_source/tar/2006_src.tar.gz
 SourceRename: cernlib-%v.tar.gz
 Source-MD5: 750c4804a2366ccd8e80c45a055f8ac5
-Source2: http://cern.ch/~mommsen/fink/%n-%v-29.patch.gz
+Source2: http://cern.ch/~mommsen/fink/%f.patch.gz
 Source2-MD5: 45ae1b9450ee432639000a5beae1462d
 SourceDirectory: 2006/src
 PatchScript: <<
@@ -32,7 +32,7 @@ PatchScript: <<
     "i386")    ARCH="I386" ;;
     "x86_64")  ARCH="QMLXIA64" ;;
   esac
-  gunzip -c ../../%n-%v-29.patch.gz | \
+  gunzip -c ../../%f.patch.gz | \
     /usr/bin/sed -e "{
       s|@PREFIX@|%p|g ;
       s|@ARCH@|${ARCH}|g ;

--- a/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
@@ -3,6 +3,7 @@ Package: cernlib2006
 Type: gcc (9)
 Version: 2006b
 Revision: 30
+Distribution: 10.9, 10.10, 10.11, 10.12, 10.13, 10.14
 Description: Paw and other basic executables
 Depends: <<
   gcc%type_pkg[gcc]-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/sci/geant4.9.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/geant4.9.info
@@ -2,7 +2,7 @@ Info3: <<
 Package: geant4.9%type_pkg[cernlib]
 Version: 4.9.4
 Revision: 15
-Type: cernlib (. -cernlib)
+Type: cernlib (. -cernlib), gcc (9)
 Description: Simulation of particle-matter interaction
 DescDetail: <<
 Geant4 is a toolkit for the simulation of the passage of
@@ -49,7 +49,7 @@ BuildDepends: <<
  x11-dev,
  ('%type_pkg[cernlib]' = '-cernlib') cernlib2006-geant321,
  ('%type_pkg[cernlib]' = '-cernlib') cernlib2006-dev,
- ('%type_pkg[cernlib]' = '-cernlib') gcc5
+ ('%type_pkg[cernlib]' = '-cernlib') gcc%type_pkg[gcc]
 <<
 Conflicts: <<
  geant4.9,

--- a/10.9-libcxx/stable/main/finkinfo/sci/geant4.9.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/geant4.9.info
@@ -1,7 +1,7 @@
 Info3: <<
 Package: geant4.9%type_pkg[cernlib]
 Version: 4.9.4
-Revision: 15
+Revision: 16
 Type: cernlib (. -cernlib), gcc (9)
 Description: Simulation of particle-matter interaction
 DescDetail: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/patchy4.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/patchy4.info
@@ -1,11 +1,11 @@
 Info3: <<
 Package: patchy4-%type_pkg[fortran]
-Type: fortran (gfortran)
+Type: fortran (gfortran), gcc (9)
 Version: 4.15
-Revision: 12
+Revision: 13
 Description: CERNLIB patchy utilities
-BuildDepends: gcc8, sed
-Depends: gcc8-shlibs
+BuildDepends: gcc%type_pkg[gcc], sed
+Depends: gcc%type_pkg[gcc]-shlibs
 Provides: patchy
 Source: http://cern.ch/~mommsen/fink/patchy_%v.tar.gz
 Source-MD5: 4f7cb685300dfb89d374bae1f07ab3d1
@@ -13,16 +13,16 @@ SourceDirectory: patchy/%v/src
 CompileScript: <<
   #!/bin/sh -ev
   export PATH=..:.:$PATH
-  %p/bin/sed -i -re 's:fort77:gfortran:g' rceta.sh
+  %p/bin/sed -i -re 's:fort77:gfortran-fsf-%type_pkg[gcc]:g' rceta.sh
   ./rceta.sh
   rm -f rceta.f rceta.o rceta
   %p/bin/sed -i -re "{
-    s:f77:gfortran:g;
-    s:cc :gcc-8 :g;
+    s:f77:gfortran-fsf-%type_pkg[gcc]:g;
+    s:cc :gcc-fsf-%type_pkg[gcc] :g;
     s:-posix::g;
     }" fcasplit.f
   %p/bin/sed -i -re "{
-    s:f77:gfortran:g;
+    s:f77:gfortran-fsf-%type_pkg[gcc]:g;
     s:-posix:-std=legacy:g;
     s:-O2:-O0:g;
     }" p4boot.sh

--- a/10.9-libcxx/stable/main/finkinfo/sci/root-pythia.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/root-pythia.info
@@ -3,7 +3,7 @@ Version: 6.6
 Revision: 15
 Description: Interface libraries Pythia - ROOT
 Depends:  %n-shlibs (=%v-%r)
-BuildDepends: gcc5, cernlib-mclibs
+BuildDepends: gcc9, cernlib-mclibs
 BuildDependsOnly: true
 Source: ftp://root.cern.ch/root/pythia6.tar.gz
 SourceRename: pythia6_%v.tar.gz
@@ -33,7 +33,7 @@ InstallScript: <<
 <<
 SplitOff: <<
    Package: %N-shlibs
-   Depends: gcc5-shlibs
+   Depends: gcc9-shlibs
    InstallScript: <<
       install -m 755 -d %i/lib/root
       install -m 644 libPythia6.*.dylib %i/lib/root

--- a/10.9-libcxx/stable/main/finkinfo/sci/root-pythia.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/root-pythia.info
@@ -1,6 +1,7 @@
 Package: root-pythia
 Version: 6.6
 Revision: 16
+Distribution: 10.9, 10.10, 10.11, 10.12, 10.13
 Description: Interface libraries Pythia - ROOT
 Depends:  %n-shlibs (=%v-%r)
 BuildDepends: gcc9, cernlib-mclibs

--- a/10.9-libcxx/stable/main/finkinfo/sci/root-pythia.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/root-pythia.info
@@ -1,6 +1,6 @@
 Package: root-pythia
 Version: 6.6
-Revision: 15
+Revision: 16
 Description: Interface libraries Pythia - ROOT
 Depends:  %n-shlibs (=%v-%r)
 BuildDepends: gcc9, cernlib-mclibs

--- a/10.9-libcxx/stable/main/finkinfo/sci/root5.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/root5.info
@@ -1,8 +1,8 @@
 Info3: <<
 Package: root5%type_pkg[-x11]%type_pkg[-cernlib]%type_pkg[-pythia]
-Version: 5.34.36
-Revision: 3
-Distribution: 10.9, 10.10, 10.11
+Version: 5.34.38
+Revision: 1
+Distribution: 10.9, 10.10, 10.11, 10.12, 10.13
 Type: <<
  -x11 (boolean),
  -cernlib (boolean),
@@ -41,7 +41,7 @@ BuildDepends: <<
  (%type_pkg[-x11]) mesa,
  (%type_pkg[-x11]) x11-dev,
  (%type_pkg[-x11]) xft2-dev (>= 2.2.0-2),
- (%type_pkg[-cernlib]) gcc5,
+ (%type_pkg[-cernlib]) gcc9,
  (%type_pkg[-pythia]) root-pythia,
  (%type_pkg[-pythia]) pythia8.2
 <<
@@ -66,10 +66,10 @@ Replaces: <<
  root5-x11-cernlib-pythia
 <<
 Source: https://root.cern.ch/download/root_v%v.source.tar.gz
-Source-MD5: 6a1ad549b3b79b10bbb1f116b49067ee
+Source-MD5: c0e3a2ddd7dfab17db4a8e8dc042a579
 SourceDirectory: root
 PatchFile: %{ni}.patch
-PatchFile-MD5: 3113baa384e12f656f5775f98347f69f
+PatchFile-MD5: a691bfbcaeeb0910749df573fe66c0bc
 PatchScript: <<
  patch -p1 < %{PatchFile}
  /usr/bin/sed -i '.bak' -e 's:python :%p/bin/python2.7 :' bindings/pyroot/Module.mk cint/cintex/Module.mk
@@ -284,7 +284,7 @@ SplitOff: <<
     (%type_pkg[-x11]) mesa-shlibs,
     (%type_pkg[-x11]) x11-shlibs,
     (%type_pkg[-x11]) xft2-shlibs (>= 2.2.0-2),
-    (%type_pkg[-cernlib]) gcc5-shlibs,
+    (%type_pkg[-cernlib]) gcc9-shlibs,
     (%type_pkg[-pythia]) pythia8.2-shlibs,
     (%type_pkg[-pythia]) root-pythia-shlibs
    <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/root5.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/root5.patch
@@ -95,20 +95,17 @@ index c0d03c1..24b3eff 100644
        return s
 diff --git a/config/Makefile.macosx64 b/config/Makefile.macosx64
 index 8ee0d8b..2513ef7 100644
---- a/config/Makefile.macosx64
+--- a/rooconfig/Makefile.macosx64
 +++ b/config/Makefile.macosx64
-@@ -116,11 +116,7 @@ LDFLAGS      += -bind_at_load
+@@ -76,7 +76,7 @@
+ SOFLAGS       = -dynamiclib -single_module -Wl,-dead_strip_dylibs \
+                 -install_name $(LIBDIR)/
  endif
- endif
- endif
--ifeq ($(subst $(MACOSX_MINOR),,1234),1234)
 -SOEXT         = so
--else
- SOEXT         = dylib
--endif
-
++SOEXT         = dylib
+ 
  # System libraries:
- SYSLIBS       = -lm $(FINK_LDFLAGS) $(OSTHREADLIBDIR) \
+ SYSLIBS       = -lm $(OSTHREADLIBDIR) \
 diff --git a/configure b/configure
 index d2cb00f..33f413c 100755
 --- a/configure

--- a/10.9-libcxx/stable/main/finkinfo/sci/xrootd4.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xrootd4.info
@@ -1,6 +1,7 @@
 Package: xrootd4
 Version: 4.8.1
 Revision: 1
+Distribution: 10.9, 10.10, 10.11, 10.12, 10.13
 Description: Distributed access to data repositories
 GCC: 4.0
 


### PR DESCRIPTION
Migrates @mommsen packages to gcc9

* root5 moves to the latest (from 2018) of the 5x release series and was made available through 10.13 where I could test. Not clear why it was previously kept out of 10.12+.
* geant4.9 is not at the last of the 4.9 series (that's 4.9.6p4) but I didn't try to increase the Fink version.

This corresponds to #481 and #489