### PR TITLE
Bumped aubio to 0.4.7

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sound/libaubio4.info
+++ b/10.9-libcxx/stable/main/finkinfo/sound/libaubio4.info
@@ -1,5 +1,5 @@
 Package: libaubio4
-Version: 0.4.1
+Version: 0.4.7
 Revision: 1
 Description: Library for audio labelling
 DescDetail: <<
@@ -19,7 +19,7 @@ Homepage: http://aubio.org/
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 
 Source: http://aubio.org/pub/aubio-%v.tar.bz2
-Source-MD5: ffe7d24f6bd8e9053aeaba6c0231efb0
+Source-MD5: 1e8deb14b0e45ffadc91dcf7cfaee0c8
 
 Depends: %n-shlibs (= %v-%r)
 BuildDepends: <<


### PR DESCRIPTION
Everything compiles as before, and v0.4.7 represents the last stable release to date.