### PR TITLE
image-exiftool-pm new upstream version 11.75

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/image-exiftool-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/image-exiftool-pm.info
@@ -1,29 +1,26 @@
 Info2: <<
 Package: image-exiftool-pm
-Version: 10.80
+Version: 11.75
 Revision: 1
 Description: Read and write image/movie meta information
 Type: perl
 License: Artistic/GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-
 Source: http://www.sno.phy.queensu.ca/~phil/exiftool/Image-ExifTool-%v.tar.gz
-#Source-MD5: 71eb5b335dc3129de5d378294b713c42
-Source-MD5: 4b830155ab20e1f6280d5dec82d521f1
+Source-MD5: c7f86025b01c328f8ad292f84c106ae2
 UpdatePOD: true
 DocFiles: Changes META.yml README
-
-Homepage: http://search.cpan.org/dist/Image-ExifTool
+Homepage: https://sno.phy.queensu.ca/~phil/exiftool/
 DescDetail: <<
-ExifTool provides an extensible set of perl modules to read and
-write meta information in image, audio and video files, including
-the maker note information of many digital cameras by various
-manufacturers such as Canon, Casio, FujiFilm, JVC/Victor, Kodak,
-Leaf, Minolta/Konica-Minolta, Nikon, Olympus/Epson,
-Panasonic/Leica, Pentax/Asahi, Ricoh, Sanyo, Sigma/Foveon and
-Sony.
+ExifTool provides an extensible set of perl modules to read, write, and edit 
+meta information in a wide variety of files. ExifTool supports many different 
+metadata formats including EXIF, GPS, IPTC, XMP, JFIF, GeoTIFF, ICC Profile, 
+Photoshop IRB, FlashPix, AFCP and ID3, as well as the maker notes of many 
+digital cameras by Canon, Casio, DJI, FLIR, FujiFilm, GE, GoPro, HP, 
+JVC/Victor, Kodak, Leaf, Minolta/Konica-Minolta, Motorola, Nikon, Nintendo, 
+Olympus/Epson, Panasonic/Leica, Pentax/Asahi, Phase One, Reconyx, Ricoh, 
+Samsung, Sanyo, Sigma/Foveon and Sony.
 <<
-
 DescPackaging: <<
 	Version 9.27 and prior maintained by Benjamin Reed and Daniel Macks.
 	Previous maintainer to v10.80: Kevin Horton <khorton02@gmail.com>


### PR DESCRIPTION
A simple update to the latest upstream version, 11.75. Tested on 10.14.6.