### PR TITLE
libarchive (and bsdtar) upstream version 3.4.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libarchive31.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libarchive31.info
@@ -1,5 +1,5 @@
 Package: libarchive31
-Version: 3.2.1
+Version: 3.4.0
 Revision: 1
 Description: Archiver library for tar, pax and others
 BuildDepends: fink-package-precedence, bzip2-dev, libiconv-dev, liblzma5, expat1
@@ -8,9 +8,9 @@ BuildDependsOnly: true
 Conflicts: libarchive
 Replaces: libarchive
 Source: http://www.libarchive.org/downloads/libarchive-%v.tar.gz
-Source-MD5: afa257047d1941a565216edbf0171e72
+Source-MD5: 6046396255bd7cf6d0f6603a9bda39ac
 PatchFile: %n.patch
-PatchFile-MD5: 6dca91e03f2e47ac627b8cd8de1ed04a
+PatchFile-MD5: 1c81d2167e23d2fac0c0fe0c7f782593
 PatchScript: <<
 %{default_script}
 LANG=C LC_ALL=C /usr/bin/sed -i.bak 's/^\.Fx/FreeBSD/' libarchive/*.[1-9]
@@ -45,13 +45,13 @@ InstallScript: <<
 DESTDIR=%d make install
 # rm -r %i/bin %i/share/man/man[15]
 <<
-DocFiles: COPYING README NEWS
+DocFiles: COPYING README.md NEWS
 SplitOff: <<
   Package: %N-shlibs
   Depends: bzip2-shlibs, libiconv, liblzma5-shlibs, expat1-shlibs
   Files: lib/libarchive.*.dylib
-  Shlibs: %p/lib/libarchive.13.dylib 16.0.0 %n (>= 3.2.1-1)
-  DocFiles: COPYING README NEWS
+  Shlibs: %p/lib/libarchive.13.dylib 18.0.0 %n (>= 3.4.0-1)
+  DocFiles: COPYING README.md NEWS
 <<
 SplitOff2: <<
   Package: bsdtar
@@ -59,7 +59,7 @@ SplitOff2: <<
   Depends: %N-shlibs (>=%v-%r)
   Conflicts: libarchive (<< 2.8.5-2)
   Files: bin share/man/man[15]
-  DocFiles: COPYING README NEWS
+  DocFiles: COPYING README.md NEWS
   DescUsage: <<
   You can usually use bsdtar and bsdcpio in the same way to GNU tar and cpio
   but there are some differences. Read bsdtar(1) and bsdcpio(1) manpage
@@ -80,7 +80,6 @@ Following formats are supported ('r' for reading and 'w' for writing).
 On read, compression and format are always detected automatically.
 
 [rw] uuencoded files
-[r ] files with RPM wrapper
 [rw] gzip compression
 [rw] bzip2 compression
 [rw] compress/LZW compression
@@ -97,17 +96,19 @@ On read, compression and format are always detected automatically.
      This is the default, which is mostly compatible with the standard tar.
 [rw] POSIX octet-oriented cpio ("odc")
 [rw] SVR4 ASCII cpio ("newc")
-[r ] Binary cpio (big-endian or little-endian)
+[rw] Binary cpio (big-endian or little-endian)
 [ w] shar archives
 [rw] ISO9660 CD-ROM images (with optional Rockridge or Joliet extensions)
 [rw] ZIP archives (with uncompressed or "deflate" compressed entries)
-[rw] GNU and BSD 'ar' archives
+[rw] GNU and BSD 'ar' archives (including 64-bit)
 [rw] 'mtree' format
 [rw] 7-Zip archives
 [r ] Microsoft CAB format
 [r ] LHA and LZH archives
-[r ] RAR archives
+[r ] RAR archives (including RAR 5.0)
+[r ] ZIPX archives (with xz, lzma, ppmd8 and bzip2 compression)
 [rw] XAR archives
+[rw] WARC (ISO 28500:2009) archives
 <<
 DescUsage: <<
 Guide to Documentation installed by this system:

--- a/10.9-libcxx/stable/main/finkinfo/libs/libarchive31.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libarchive31.info
@@ -10,7 +10,7 @@ Replaces: libarchive
 Source: http://www.libarchive.org/downloads/libarchive-%v.tar.gz
 Source-MD5: 6046396255bd7cf6d0f6603a9bda39ac
 PatchFile: %n.patch
-PatchFile-MD5: 1c81d2167e23d2fac0c0fe0c7f782593
+PatchFile-MD5: a1f5a35e024257c2778664992fa8634b
 PatchScript: <<
 %{default_script}
 LANG=C LC_ALL=C /usr/bin/sed -i.bak 's/^\.Fx/FreeBSD/' libarchive/*.[1-9]

--- a/10.9-libcxx/stable/main/finkinfo/libs/libarchive31.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libarchive31.patch
@@ -1,6 +1,6 @@
-diff -Naur libarchive-3.1.2.orig/cpio/bsdcpio.1 libarchive-3.1.2/cpio/bsdcpio.1
---- libarchive-3.1.2.orig/cpio/bsdcpio.1	2013-01-14 01:43:45.000000000 +0000
-+++ libarchive-3.1.2/cpio/bsdcpio.1	2013-08-16 12:31:15.000000000 +0000
+diff -Naur libarchive-3.4.0.orig/cpio/bsdcpio.1 libarchive-3.4.0/cpio/bsdcpio.1
+--- libarchive-3.4.0.orig/cpio/bsdcpio.1	2019-11-10 19:33:26.000000000 +0000
++++ libarchive-3.4.0/cpio/bsdcpio.1	2019-11-10 19:34:33.000000000 +0000
 @@ -123,18 +123,42 @@
  Produce the output archive in the specified format.
  Supported formats include:
@@ -49,9 +49,9 @@ diff -Naur libarchive-3.1.2.orig/cpio/bsdcpio.1 libarchive-3.1.2/cpio/bsdcpio.1
  .El
  .Pp
  The default format is
-diff -Naur libarchive-3.1.2.orig/libarchive/libarchive.3 libarchive-3.1.2/libarchive/libarchive.3
---- libarchive-3.1.2.orig/libarchive/libarchive.3	2013-01-13 21:10:46.000000000 +0000
-+++ libarchive-3.1.2/libarchive/libarchive.3	2013-08-16 08:20:32.000000000 +0000
+diff -Naur libarchive-3.4.0.orig/libarchive/libarchive.3 libarchive-3.4.0/libarchive/libarchive.3
+--- libarchive-3.4.0.orig/libarchive/libarchive.3	2019-11-10 19:33:27.000000000 +0000
++++ libarchive-3.4.0/libarchive/libarchive.3	2019-11-10 19:34:33.000000000 +0000
 @@ -64,6 +64,8 @@
  .It
  ISO9660 CD images (including RockRidge and Joliet extensions),
@@ -61,9 +61,9 @@ diff -Naur libarchive-3.1.2.orig/libarchive/libarchive.3 libarchive-3.1.2/libarc
  Zip archives,
  .It
  ar archives (including GNU/SysV and BSD extensions),
-diff -Naur libarchive-3.1.2.orig/tar/bsdtar.1 libarchive-3.1.2/tar/bsdtar.1
---- libarchive-3.1.2.orig/tar/bsdtar.1	2013-01-14 01:43:45.000000000 +0000
-+++ libarchive-3.1.2/tar/bsdtar.1	2013-08-16 12:33:09.000000000 +0000
+diff -Naur libarchive-3.4.0.orig/tar/bsdtar.1 libarchive-3.4.0/tar/bsdtar.1
+--- libarchive-3.4.0.orig/tar/bsdtar.1	2019-11-10 19:33:27.000000000 +0000
++++ libarchive-3.4.0/tar/bsdtar.1	2019-11-10 19:34:33.000000000 +0000
 @@ -228,12 +228,48 @@
  (c, r, u mode only)
  Use the specified format for the created archive.
@@ -145,9 +145,9 @@ diff -Naur libarchive-3.1.2.orig/tar/bsdtar.1 libarchive-3.1.2/tar/bsdtar.1
  .Pp
  This is a complete re-implementation based on the
  .Xr libarchive 3
-diff -Naur libarchive-3.1.2.orig/tar/bsdtar.c libarchive-3.1.2/tar/bsdtar.c
---- libarchive-3.1.2.orig/tar/bsdtar.c	2013-02-07 23:56:25.000000000 +0000
-+++ libarchive-3.1.2/tar/bsdtar.c	2013-08-16 04:43:55.000000000 +0000
+diff -Naur libarchive-3.4.0.orig/tar/bsdtar.c libarchive-3.4.0/tar/bsdtar.c
+--- libarchive-3.4.0.orig/tar/bsdtar.c	2019-11-10 19:33:27.000000000 +0000
++++ libarchive-3.4.0/tar/bsdtar.c	2019-11-10 19:34:33.000000000 +0000
 @@ -217,8 +217,10 @@
  
  	/* Default: open tape drive. */

--- a/10.9-libcxx/stable/main/finkinfo/libs/libarchive31.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libarchive31.patch
@@ -64,7 +64,7 @@ diff -Naur libarchive-3.1.2.orig/libarchive/libarchive.3 libarchive-3.1.2/libarc
 diff -Naur libarchive-3.1.2.orig/tar/bsdtar.1 libarchive-3.1.2/tar/bsdtar.1
 --- libarchive-3.1.2.orig/tar/bsdtar.1	2013-01-14 01:43:45.000000000 +0000
 +++ libarchive-3.1.2/tar/bsdtar.1	2013-08-16 12:33:09.000000000 +0000
-@@ -197,12 +197,48 @@
+@@ -228,12 +228,48 @@
  (c, r, u mode only)
  Use the specified format for the created archive.
  Supported formats include
@@ -119,7 +119,7 @@ diff -Naur libarchive-3.1.2.orig/tar/bsdtar.1 libarchive-3.1.2/tar/bsdtar.1
  .Xr libarchive-formats 5
  for more information about currently-supported formats.
  In r and u modes, when extending an existing archive, the format specified
-@@ -213,12 +249,7 @@
+@@ -244,12 +280,7 @@
  .Pa -
  for standard input or standard output.
  The default varies by system;
@@ -133,7 +133,7 @@ diff -Naur libarchive-3.1.2.orig/tar/bsdtar.1 libarchive-3.1.2/tar/bsdtar.1
  .It Fl Fl gid Ar id
  Use the provided group id number.
  On extract, this overrides the group id in the archive;
-@@ -1025,10 +1056,7 @@
+@@ -1172,10 +1203,7 @@
  public-domain implementation (circa November, 1987)
  was quite influential, and formed the basis of GNU tar.
  GNU tar was included as the standard system tar
@@ -148,7 +148,7 @@ diff -Naur libarchive-3.1.2.orig/tar/bsdtar.1 libarchive-3.1.2/tar/bsdtar.1
 diff -Naur libarchive-3.1.2.orig/tar/bsdtar.c libarchive-3.1.2/tar/bsdtar.c
 --- libarchive-3.1.2.orig/tar/bsdtar.c	2013-02-07 23:56:25.000000000 +0000
 +++ libarchive-3.1.2/tar/bsdtar.c	2013-08-16 04:43:55.000000000 +0000
-@@ -208,8 +208,10 @@
+@@ -217,8 +217,10 @@
  
  	/* Default: open tape drive. */
  	bsdtar->filename = getenv("TAPE");


### PR DESCRIPTION
An update to the latest upstream version 3.4.0. Tested on 10.14.5 and 10.15.

The previous update was made by @nieder in 2016, noting a "maintainer timeout".
