### PR TITLE
xtide upstream version 2.15.2 and harmonics 20190620

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide-harmonics-us.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide-harmonics-us.info
@@ -1,5 +1,5 @@
 Package: xtide-harmonics-us
-Version: 20151227
+Version: 20190620
 Revision: 1
 Description: US harmonic data for XTide
 DescDetail: <<
@@ -17,8 +17,8 @@ Homepage: http://www.flaterco.com/xtide/
 Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 
 Source: ftp://ftp.flaterco.com/xtide/harmonics-dwf-%v-free.tar.bz2
-Source-MD5: 1c1adf4c8a7d69547f296f783914de5d
-Source-Checksum: SHA1(2df3ae5873f4f17f7e5ec255fec4aebd7ba19b13)
+Source-MD5: ffde40b6fadccefa99fae500ae28e176
+Source-Checksum: SHA1(63c41d37c4e36c402ab0a07ff3371a1189ec4cae)
 SourceDirectory: harmonics-dwf-%v
 
 CompileScript: printf "No compiling needed.\n" 

--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
@@ -205,7 +205,7 @@ SplitOff2: <<
 		include
 	<<
 	BuildDependsOnly: true
-	Replaces:  %N (<< 2.15.2-3)
+	Replaces:  %N (<< 2.15.2-1)
 	Description: Headers for XTide
 	DocFiles: AUTHORS COPYING NEWS README ChangeLog
 	DescPackaging: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: xtide
-Version: 2.15.1
-Revision: 3
-Type: harm (20151227), v (2.15)
+Version: 2.15.2
+Revision: 1
+Type: harm (20190620)
 
 Description: Tide and current prediction software
 License: Public Domain
@@ -18,7 +18,7 @@ BuildDepends: <<
 	fontconfig2-dev,
 	freetype219,
 	libpng16, 
-	libtcd (>= 2.2.5-r3),
+	libtcd (>= 2.2.7-r2),
 	libxaw3dxft (>= 1.6.2-7),
 	xft2-dev,
 	system-xfree86-dev (>= 3:2.7.112-3)
@@ -37,16 +37,14 @@ Depends: <<
 
 Recommends: xtide-coastline (>= 20110414-2)
 
-Source: ftp://ftp.flaterco.com/%n/%n-%type_raw[v].tar.bz2
-Source-MD5: d87d291b38f34baad189f3e618e846ee
-Source-Checksum: SHA1(da09a45d4298bf08240894de85bb1a10a0124552)
+Source: ftp://ftp.flaterco.com/%n/%n-%v.tar.bz2
+Source-MD5: 3d4bd4ef4152809deff9a3b48330fe9d
+Source-Checksum: SHA1(0684d72df6e463822ac36016e248eaea07228340)
 
 PatchScript: <<
 	perl -pi -e 's,(/etc/xtide\.conf),%p\1,g' libxtide/Global.cc README tide.1 xtide.1 xttpd.8
     perl -pi -e 's/(10\.\[012\])\*/\1\,.\*/' configure
 <<
-GCC: 4.0
-
 NoSetLDFLAGS: true
 NoSetCPPFLAGS: true
 #NoSetCXXFLAGS: true
@@ -207,7 +205,7 @@ SplitOff2: <<
 		include
 	<<
 	BuildDependsOnly: true
-	Replaces:  %N (<< 2.15.1-1)
+	Replaces:  %N (<< 2.15.2-3)
 	Description: Headers for XTide
 	DocFiles: AUTHORS COPYING NEWS README ChangeLog
 	DescPackaging: <<


### PR DESCRIPTION
New upstream version of xtide (2.15.2) and US harmonics files (20190620).

Maintainer is @akhansen 
