### PR TITLE
Fixed git-lfs build, bumped to v2.9.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/git-lfs.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/git-lfs.info
@@ -1,6 +1,6 @@
-# -*- coding: ascii; tab-width: 4 -*-
+# -*- coding: utf-8; tab-width: 4 -*-
 Package: git-lfs
-Version: 2.8.0
+Version: 2.9.0
 Revision: 1
 Description: Git Large File Storage extension
 DescDetail: <<
@@ -17,35 +17,32 @@ License: BSD
 Homepage: https://git-lfs.github.com
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 
-Source: https://github.com/%n/%n/releases/download/v%v/%n-v%v.tar.gz
-Source-Checksum: SHA256(3347bbe6055b38902e4ef65d0f0aa00b3f100b2ad67a43aee6f340e4eb731535)
+Source: none
+Source-Checksum: SHA256(f1963ad88747577ffeeb854649aeacaa741c59be74683da4d46b129a72d111b7)
 SourceDirectory: %n-%v
 
 Depends: git (>= 2.11.0-1)
 BuildDepends: go (>= 1.12.8-1), ronn-rb25 | ronn-rb24 | ronn-rb23 | ronn-rb22 | ronn-rb21 | ronn-rb20
 
+# The latest Makefile of git-lfs uses git itself, which expects there to be a git repo
+# with a .git directory to build within. So we download *and* clone the repo.
 CompileScript: <<
 	#!/bin/sh -ev
-	export GOPATH=%b
 	
-	rm $GOPATH/go.mod
-	mkdir -p src/github.com/git-lfs
-	ln -s %b src/github.com/git-lfs/git-lfs
-	
-	pushd  src/github.com/git-lfs/git-lfs
-	make
-	popd
-	
-	make man
+	git clone https://github.com/git-lfs/git-lfs.git
+	cd git-lfs
+	git checkout v%v
+	%p/bin/make
+	%p/bin/make man
 <<
 
 InstallScript: <<
 	install -d -m 0755 %i/bin
-	install -m 0755 bin/git-lfs %i/bin
+	install -m 0755 git-lfs/bin/git-lfs %i/bin
 	
 	install -d -m 0755 %i/share/man/man1
-	install -m 0644 man/*.1 %i/share/man/man1
+	install -m 0644 git-lfs/man/*.1 %i/share/man/man1
 	
 <<
 
-DocFiles: man/*.1.html CHANGELOG.md CONTRIBUTING.md LICENSE.md README.md
+DocFiles: git-lfs/man/*.1.html git-lfs/CHANGELOG.md git-lfs/CONTRIBUTING.md git-lfs/LICENSE.md git-lfs/README.md


### PR DESCRIPTION
Advanced git-lfs to v2.9.0, revamped installation method to use `git clone`, since the git command is used within Makefile and needs to find a .git directory to work, unpacking a tarball doesn't work.