### PR TITLE
Building git-lfs using fink gnumake 4.2.1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/git-lfs.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/git-lfs.info
@@ -17,32 +17,41 @@ License: BSD
 Homepage: https://git-lfs.github.com
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 
-Source: none
+Source: https://github.com/%n/%n/releases/download/v%v/%n-v%v.tar.gz
 Source-Checksum: SHA256(f1963ad88747577ffeeb854649aeacaa741c59be74683da4d46b129a72d111b7)
 SourceDirectory: %n-%v
+
+# The latest Makefile of git-lfs uses git itself, which expects there to be a git repo
+# with a .git directory to build within. So we must patch to remove the calls to git and
+# fix @! which was causing gnumake to screw up.
+PatchFile: git-lfs.patch
+PatchFile-MD5: 365843d57b751dcc9a49652596da9e40
 
 Depends: git (>= 2.11.0-1)
 BuildDepends: go (>= 1.12.8-1), ronn-rb25 | ronn-rb24 | ronn-rb23 | ronn-rb22 | ronn-rb21 | ronn-rb20
 
-# The latest Makefile of git-lfs uses git itself, which expects there to be a git repo
-# with a .git directory to build within. So we download *and* clone the repo.
 CompileScript: <<
 	#!/bin/sh -ev
-	
-	git clone https://github.com/git-lfs/git-lfs.git
-	cd git-lfs
-	git checkout v%v
-	%p/bin/make
-	%p/bin/make man
+	export GOPATH=%b
+
+	rm $GOPATH/go.mod
+	mkdir -p src/github.com/git-lfs
+	ln -s %b src/github.com/git-lfs/git-lfs
+
+	pushd  src/github.com/git-lfs/git-lfs
+	make
+	popd
+
+	make man
 <<
 
 InstallScript: <<
 	install -d -m 0755 %i/bin
-	install -m 0755 git-lfs/bin/git-lfs %i/bin
+	install -m 0755 bin/git-lfs %i/bin
 	
 	install -d -m 0755 %i/share/man/man1
-	install -m 0644 git-lfs/man/*.1 %i/share/man/man1
+	install -m 0644 man/*.1 %i/share/man/man1
 	
 <<
 
-DocFiles: git-lfs/man/*.1.html git-lfs/CHANGELOG.md git-lfs/CONTRIBUTING.md git-lfs/LICENSE.md git-lfs/README.md
+DocFiles: man/*.1.html CHANGELOG.md CONTRIBUTING.md LICENSE.md README.md

--- a/10.9-libcxx/stable/main/finkinfo/devel/git-lfs.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/git-lfs.info
@@ -1,6 +1,6 @@
-# -*- coding: ascii; tab-width: 4 -*-
+# -*- coding: utf-8; tab-width: 4 -*-
 Package: git-lfs
-Version: 2.8.0
+Version: 2.9.0
 Revision: 1
 Description: Git Large File Storage extension
 DescDetail: <<
@@ -17,35 +17,32 @@ License: BSD
 Homepage: https://git-lfs.github.com
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 
-Source: https://github.com/%n/%n/releases/download/v%v/%n-v%v.tar.gz
-Source-Checksum: SHA256(3347bbe6055b38902e4ef65d0f0aa00b3f100b2ad67a43aee6f340e4eb731535)
+Source: none
+Source-Checksum: SHA256(f1963ad88747577ffeeb854649aeacaa741c59be74683da4d46b129a72d111b7)
 SourceDirectory: %n-%v
 
 Depends: git (>= 2.11.0-1)
 BuildDepends: go (>= 1.12.8-1), ronn-rb25 | ronn-rb24 | ronn-rb23 | ronn-rb22 | ronn-rb21 | ronn-rb20
 
+# The latest Makefile of git-lfs uses git itself, which expects there to be a git repo
+# with a .git directory to build within. So we download *and* clone the repo.
 CompileScript: <<
 	#!/bin/sh -ev
-	export GOPATH=%b
 	
-	rm $GOPATH/go.mod
-	mkdir -p src/github.com/git-lfs
-	ln -s %b src/github.com/git-lfs/git-lfs
-	
-	pushd  src/github.com/git-lfs/git-lfs
-	make
-	popd
-	
-	make man
+	git clone https://github.com/git-lfs/git-lfs.git
+	cd git-lfs
+	git checkout v%v
+	%p/bin/make
+	%p/bin/make man
 <<
 
 InstallScript: <<
 	install -d -m 0755 %i/bin
-	install -m 0755 bin/git-lfs %i/bin
+	install -m 0755 git-lfs/bin/git-lfs %i/bin
 	
 	install -d -m 0755 %i/share/man/man1
-	install -m 0644 man/*.1 %i/share/man/man1
+	install -m 0644 git-lfs/man/*.1 %i/share/man/man1
 	
 <<
 
-DocFiles: man/*.1.html CHANGELOG.md CONTRIBUTING.md LICENSE.md README.md
+DocFiles: git-lfs/man/*.1.html git-lfs/CHANGELOG.md git-lfs/CONTRIBUTING.md git-lfs/LICENSE.md git-lfs/README.md

--- a/10.9-libcxx/stable/main/finkinfo/devel/git-lfs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/devel/git-lfs.patch
@@ -1,0 +1,27 @@
+diff --git a/Makefile b/Makefile
+index e5535574..6b5574d4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,11 +1,11 @@
+ # GIT_LFS_SHA is the '--short'-form SHA1 of the current revision of Git LFS.
+-GIT_LFS_SHA ?= $(shell git rev-parse --short HEAD)
++GIT_LFS_SHA = 4085a56d
+ # VERSION is the longer-form describe output of the current revision of Git LFS,
+ # used for identifying intermediate releases.
+ #
+ # If Git LFS is being built for a published release, VERSION and GIT_LFS_SHA
+ # should be identical.
+-VERSION ?= $(shell git describe HEAD)
++VERSION = v2.9.0-42-g4085a56d
+ 
+ # GO is the name of the 'go' binary used to compile Git LFS.
+ GO ?= go
+@@ -435,7 +435,7 @@ endif
+ # are vendored in via vendor (see: above).
+ .PHONY : lint
+ lint : $(SOURCES)
+-	@! $(GO) list -f '{{ join .Deps "\n" }}' . \
++	$(GO) list -f '{{ join .Deps "\n" }}' . \
+ 	| $(XARGS) $(GO) list -f \
+ 		'{{ if and (not .Standard) (not .Module) }} \
+ 			{{ .ImportPath }} \


### PR DESCRIPTION
Added patch to remove the use of git which was failing to retrieve the version number correctly, and `@!` which was causing gnumake v4.2.1 (as installed by fink) to fail to build.