### PR TITLE
PostgreSQL upstream updates November 2019

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 10.10
+Version: 10.11
 Revision: 1
 Type: postgresql 10
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 3dac8187636fa8237802bef85be78023
-Source-Checksum: SHA256(ad4f9b8575f98ed6091bf9bb2cb16f0e52795a5f66546c1f499ca5c69b21f253)
+Source-MD5: 01c83ee159bf2a690e75e69e49fe2a1d
+Source-Checksum: SHA256(0d5d14ff6b075655f4421038fbde3a5d7b418c26a249a187a4175600d7aecc09)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
@@ -221,7 +221,8 @@ SplitOff: <<
 		postgresql95-dev,
 		postgresql96-dev,
 		postgresql10-dev,
-		postgresql11-dev
+		postgresql11-dev,
+		postgresql12-dev
 	<<
 	Replaces: <<
 		postgresql92-dev,
@@ -230,7 +231,8 @@ SplitOff: <<
 		postgresql95-dev,
 		postgresql96-dev,
 		postgresql10-dev,
-		postgresql11-dev
+		postgresql11-dev,
+		postgresql12-dev
 	<<
 	BuildDependsOnly: true
 	Files: <<

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql11.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql11.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 11.5
+Version: 11.6
 Revision: 1
 Type: postgresql 11
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 580da94f6d85046ff2a228785ab2cc89
-Source-Checksum: SHA256(7fdf23060bfc715144cbf2696cf05b0fa284ad3eb21f0c378591c6bca99ad180)
+Source-MD5: 8e3462b342caf6f2265126674dde26da
+Source-Checksum: SHA256(49924f7ff92965fdb20c86e0696f2dc9f8553e1563124ead7beedf8910c13170)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
@@ -221,7 +221,8 @@ SplitOff: <<
 		postgresql95-dev,
 		postgresql96-dev,
 		postgresql10-dev,
-		postgresql11-dev
+		postgresql11-dev,
+		postgresql12-dev
 	<<
 	Replaces: <<
 		postgresql92-dev,
@@ -230,7 +231,8 @@ SplitOff: <<
 		postgresql95-dev,
 		postgresql96-dev,
 		postgresql10-dev,
-		postgresql11-dev
+		postgresql11-dev,
+		postgresql12-dev
 	<<
 	BuildDependsOnly: true
 	Files: <<

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.4.24
+Version: 9.4.25
 Revision: 1
 Epoch: 1
 Type: postgresql 9.4
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 5ba0ffe7cb9b97a7d39a2ab7bab9e86c
-Source-Checksum: SHA256(52253d67dd46a7463a9d7c5e82bf959931fa4c11ec56293150210fa82a0f9429)
+Source-MD5: 5b8270dfd9a074088d3508836584260e
+Source-Checksum: SHA256(cb98afaef4748de76c13202c14198e3e4717adde49fd9c90fdc81da877520928)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
@@ -216,7 +216,8 @@ SplitOff: <<
 		postgresql95-dev,
 		postgresql96-dev,
 		postgresql10-dev,
-		postgresql11-dev
+		postgresql11-dev,
+		postgresql12-dev
 	<<
 	Replaces: <<
 		postgresql92-dev,
@@ -225,7 +226,8 @@ SplitOff: <<
 		postgresql95-dev,
 		postgresql96-dev,
 		postgresql10-dev,
-		postgresql11-dev
+		postgresql11-dev,
+		postgresql12-dev
 	<<
 	BuildDependsOnly: true
 	Files: <<

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.5.19
+Version: 9.5.20
 Revision: 1
 Epoch: 1
 Type: postgresql 9.5
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: a65c32f211e29afbf35442e0babebbeb
-Source-Checksum: SHA256(960caa26612bca8a3791d1c0bdc5c6d24b3d15841becb617470424edbc5e1bb3)
+Source-MD5: 021c821114af69080a0139bd39e63112
+Source-Checksum: SHA256(925751b375cf975bebbe79753fbcb5fe85d7a62abe516d4c56861a6b877dde0d)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
@@ -216,7 +216,8 @@ SplitOff: <<
 		postgresql95-dev,
 		postgresql96-dev,
 		postgresql10-dev,
-		postgresql11-dev
+		postgresql11-dev,
+		postgresql12-dev
 	<<
 	Replaces: <<
 		postgresql92-dev,
@@ -225,7 +226,8 @@ SplitOff: <<
 		postgresql95-dev,
 		postgresql96-dev,
 		postgresql10-dev,
-		postgresql11-dev
+		postgresql11-dev,
+		postgresql12-dev
 	<<
 	BuildDependsOnly: true
 	Files: <<

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.6.15
+Version: 9.6.16
 Revision: 1
 Epoch: 1
 Type: postgresql 9.6
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: efb0bfbd9926f9491543e5cafd30ddd7
-Source-Checksum: SHA256(3cd9fe9af247167f863030842c1a57f58bdf3e5d50a94997d34a802b6032170a)
+Source-MD5: dffa2163d80b47a96c20aee618e90f8a
+Source-Checksum: SHA256(5c6cba9cc0df70ba2b128c4a87d0babfce7c0e2b888f70a9c8485745f66b22e7)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
@@ -216,7 +216,8 @@ SplitOff: <<
 		postgresql95-dev,
 		postgresql96-dev,
 		postgresql10-dev,
-		postgresql11-dev
+		postgresql11-dev,
+		postgresql12-dev
 	<<
 	Replaces: <<
 		postgresql92-dev,
@@ -225,7 +226,8 @@ SplitOff: <<
 		postgresql95-dev,
 		postgresql96-dev,
 		postgresql10-dev,
-		postgresql11-dev
+		postgresql11-dev,
+		postgresql12-dev
 	<<
 	BuildDependsOnly: true
 	Files: <<


### PR DESCRIPTION
PR contains:
- postgresql upstream updates 11.6 10.11 9.6.16 9.5.20 9.4.25
- preparation for next major release  PostgreSQL 12

PostgreSQL 9.4 (postgresql94) goes EOL on February 2020 and PostgreSQL 9.5 (postgresql95) a year later (EOL Feb. 2021), so we should also start for this releases a migration tracker?
