### PR TITLE
SDL2 versions of sdl-image, sdl-mixer, and sdl-ttf

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/games/sdl2-image.info
+++ b/10.9-libcxx/stable/main/finkinfo/games/sdl2-image.info
@@ -1,0 +1,67 @@
+# DISCLAIMER: Max Horn is the sole maintainer of this package.
+# Please DO NOT MAKE MODIFICATIONS without informing the maintainer.
+# Preferably, send a patch to me instead of making changes yourself!
+# If that is not possible due to extra urgency, at least send me a mail.
+#
+# Explanation: I am sick and tired of getting back to my packages and
+# discovering that people have messed with it. I am then forced to
+# retrace their steps, find out who, when and why did make a certain
+# change etc. -- i.e. it makes my life as maintainer harder.
+# Furthermore, as maintainer I am responsible for problems caused by my
+# packages. But I am not willing to take responsibility for something I
+# did not do. In particular, for changes that other people introduced
+# behind my back, no matter how good and noble their intentions were. As
+# such, I may see myself forced to drop responsibility for (and hence,
+# maintainership of) the affected package.
+
+Package: sdl2-image
+Version: 2.0.5
+Revision: 1
+Maintainer: Max Horn <max@quendi.de>
+BuildDepends: <<
+  fink-package-precedence,
+  sdl2 (>= 2.0.10-1),
+  libjpeg9,
+  libpng16,
+  libtiff5,
+  libwebp7,
+  pkgconfig
+<<
+Depends: %N-shlibs (= %v-%r)
+BuildDependsOnly: True
+Source: https://www.libsdl.org/projects/SDL_image/release/SDL2_image-%v.tar.gz
+Source-MD5: f26f3a153360a8f09ed5220ef7b07aea
+ConfigureParams: <<
+ --disable-jpg-shared \
+ --disable-png-shared \
+ --disable-tif-shared \
+ --disable-webp-shared \
+ --disable-sdltest \
+ --enable-dependency-tracking
+<<
+CompileScript: <<
+  ./configure %c
+  make
+  fink-package-precedence .
+<<
+InstallScript: make install DESTDIR=%d
+SplitOff: <<
+  Package: %N-shlibs
+  Depends: <<
+    sdl2-shlibs (>= 2.0.10-1),
+    libjpeg9-shlibs,
+    libpng16-shlibs,
+    libtiff5-shlibs,
+    libwebp7-shlibs
+  <<
+  Files: lib/libSDL2_image-*.dylib
+  Shlibs: %p/lib/libSDL2_image-2.0.0.dylib 3.0.0 %n (>= 2.0.5-1)
+  Docfiles: CHANGES.txt COPYING.txt README.txt
+<<
+Docfiles: CHANGES.txt COPYING.txt README.txt
+Description: SDL image file loading library
+DescPackaging: <<
+ Use --disable-sdltest to allow building on headless systems.
+<<
+Homepage: http://www.libsdl.org/projects/SDL_image/
+License: OSI-Approved

--- a/10.9-libcxx/stable/main/finkinfo/games/sdl2-image.info
+++ b/10.9-libcxx/stable/main/finkinfo/games/sdl2-image.info
@@ -1,23 +1,10 @@
-# DISCLAIMER: Max Horn is the sole maintainer of this package.
-# Please DO NOT MAKE MODIFICATIONS without informing the maintainer.
-# Preferably, send a patch to me instead of making changes yourself!
-# If that is not possible due to extra urgency, at least send me a mail.
-#
-# Explanation: I am sick and tired of getting back to my packages and
-# discovering that people have messed with it. I am then forced to
-# retrace their steps, find out who, when and why did make a certain
-# change etc. -- i.e. it makes my life as maintainer harder.
-# Furthermore, as maintainer I am responsible for problems caused by my
-# packages. But I am not willing to take responsibility for something I
-# did not do. In particular, for changes that other people introduced
-# behind my back, no matter how good and noble their intentions were. As
-# such, I may see myself forced to drop responsibility for (and hence,
-# maintainership of) the affected package.
-
 Package: sdl2-image
 Version: 2.0.5
 Revision: 1
-Maintainer: Max Horn <max@quendi.de>
+Description: SDL image file loading library
+License: OSI-Approved
+# Free to take over
+Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
 BuildDepends: <<
   fink-package-precedence,
   sdl2 (>= 2.0.10-1),
@@ -32,12 +19,12 @@ BuildDependsOnly: True
 Source: https://www.libsdl.org/projects/SDL_image/release/SDL2_image-%v.tar.gz
 Source-MD5: f26f3a153360a8f09ed5220ef7b07aea
 ConfigureParams: <<
- --disable-jpg-shared \
- --disable-png-shared \
- --disable-tif-shared \
- --disable-webp-shared \
- --disable-sdltest \
- --enable-dependency-tracking
+	--disable-jpg-shared \
+	--disable-png-shared \
+	--disable-tif-shared \
+	--disable-webp-shared \
+	--disable-sdltest \
+	--enable-dependency-tracking
 <<
 CompileScript: <<
   ./configure %c
@@ -46,22 +33,20 @@ CompileScript: <<
 <<
 InstallScript: make install DESTDIR=%d
 SplitOff: <<
-  Package: %N-shlibs
-  Depends: <<
-    sdl2-shlibs (>= 2.0.10-1),
-    libjpeg9-shlibs,
-    libpng16-shlibs,
-    libtiff5-shlibs,
-    libwebp7-shlibs
-  <<
-  Files: lib/libSDL2_image-*.dylib
-  Shlibs: %p/lib/libSDL2_image-2.0.0.dylib 3.0.0 %n (>= 2.0.5-1)
-  Docfiles: CHANGES.txt COPYING.txt README.txt
+	Package: %N-shlibs
+	Depends: <<
+		sdl2-shlibs (>= 2.0.10-1),
+		libjpeg9-shlibs,
+		libpng16-shlibs,
+		libtiff5-shlibs,
+		libwebp7-shlibs
+	<<
+	Files: lib/libSDL2_image-*.dylib
+	Shlibs: %p/lib/libSDL2_image-2.0.0.dylib 3.0.0 %n (>= 2.0.5-1)
+	Docfiles: CHANGES.txt COPYING.txt README.txt
 <<
 Docfiles: CHANGES.txt COPYING.txt README.txt
-Description: SDL image file loading library
-DescPackaging: <<
- Use --disable-sdltest to allow building on headless systems.
-<<
 Homepage: http://www.libsdl.org/projects/SDL_image/
-License: OSI-Approved
+DescPackaging: <<
+Use --disable-sdltest to allow building on headless systems.
+<<

--- a/10.9-libcxx/stable/main/finkinfo/games/sdl2-mixer.info
+++ b/10.9-libcxx/stable/main/finkinfo/games/sdl2-mixer.info
@@ -1,23 +1,10 @@
-# DISCLAIMER: Max Horn is the sole maintainer of this package.
-# Please DO NOT MAKE MODIFICATIONS without informing the maintainer.
-# Preferably, send a patch to me instead of making changes yourself!
-# If that is not possible due to extra urgency, at least send me a mail.
-#
-# Explanation: I am sick and tired of getting back to my packages and
-# discovering that people have messed with it. I am then forced to
-# retrace their steps, find out who, when and why did make a certain
-# change etc. -- i.e. it makes my life as maintainer harder.
-# Furthermore, as maintainer I am responsible for problems caused by my
-# packages. But I am not willing to take responsibility for something I
-# did not do. In particular, for changes that other people introduced
-# behind my back, no matter how good and noble their intentions were. As
-# such, I may see myself forced to drop responsibility for (and hence,
-# maintainership of) the affected package.
-
 Package: sdl2-mixer
 Version: 2.0.4
 Revision: 1
-Maintainer: Max Horn <max@quendi.de>
+Description: SDL multi-channel audio mixer library
+License: OSI-Approved
+# Free to take over
+Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
 Depends: %N-shlibs (= %v-%r)
 BuildDependsOnly: true
 BuildDepends: <<
@@ -47,20 +34,18 @@ CompileScript: <<
 <<
 InstallScript: make install DESTDIR=%d
 SplitOff: <<
-  Package: %N-shlibs
-  Depends: <<
-  	libmikmod3-shlibs,
-  	libvorbis0-shlibs,
-  	sdl2-shlibs (>= 2.0.10-1)
-  <<
-  Files: lib/libSDL2_mixer-*.dylib
-  Shlibs: %p/lib/libSDL2_mixer-2.0.0.dylib 3.0.0 %n (>= 2.0.4-1)
-  Docfiles: CHANGES.txt COPYING.txt README.txt
+	Package: %N-shlibs
+	Depends: <<
+		libmikmod3-shlibs,
+		libvorbis0-shlibs,
+		sdl2-shlibs (>= 2.0.10-1)
+	<<
+	Files: lib/libSDL2_mixer-*.dylib
+	Shlibs: %p/lib/libSDL2_mixer-2.0.0.dylib 3.0.0 %n (>= 2.0.4-1)
+	Docfiles: CHANGES.txt COPYING.txt README.txt
 <<
 Docfiles: CHANGES.txt COPYING.txt README.txt
-Description: SDL multi-channel audio mixer library
-DescPackaging: <<
- Use --disable-sdltest to allow building on headless systems.
-<<
 Homepage: http://www.libsdl.org/projects/SDL_mixer/
-License: OSI-Approved
+DescPackaging: <<
+Use --disable-sdltest to allow building on headless systems.
+<<

--- a/10.9-libcxx/stable/main/finkinfo/games/sdl2-mixer.info
+++ b/10.9-libcxx/stable/main/finkinfo/games/sdl2-mixer.info
@@ -1,0 +1,66 @@
+# DISCLAIMER: Max Horn is the sole maintainer of this package.
+# Please DO NOT MAKE MODIFICATIONS without informing the maintainer.
+# Preferably, send a patch to me instead of making changes yourself!
+# If that is not possible due to extra urgency, at least send me a mail.
+#
+# Explanation: I am sick and tired of getting back to my packages and
+# discovering that people have messed with it. I am then forced to
+# retrace their steps, find out who, when and why did make a certain
+# change etc. -- i.e. it makes my life as maintainer harder.
+# Furthermore, as maintainer I am responsible for problems caused by my
+# packages. But I am not willing to take responsibility for something I
+# did not do. In particular, for changes that other people introduced
+# behind my back, no matter how good and noble their intentions were. As
+# such, I may see myself forced to drop responsibility for (and hence,
+# maintainership of) the affected package.
+
+Package: sdl2-mixer
+Version: 2.0.4
+Revision: 1
+Maintainer: Max Horn <max@quendi.de>
+Depends: %N-shlibs (= %v-%r)
+BuildDependsOnly: true
+BuildDepends: <<
+	fink-package-precedence,
+	libflac8-dev,
+	libmikmod3 (>= 3.2.0-beta2-4),
+	libmodplug1,
+	libmpg123,
+	libogg,
+	libvorbis0,
+	pkgconfig,
+	sdl2 (>= 2.0.10-1)
+<<
+Source: https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-%v.tar.gz
+Source-MD5: a36e8410cac46b00a4d01752b32c3eb1
+ConfigureParams: <<
+	--disable-music-ogg-shared \
+	--enable-music-mod-mikmod \
+	--disable-music-opus-shared \
+	--disable-music-midi-fluidsynth \
+	--disable-sdltest \
+	--enable-dependency-tracking
+<<
+CompileScript: <<
+	%{default_script}
+	fink-package-precedence --prohibit-bdep=%n --depfile-ext='\.d' .
+<<
+InstallScript: make install DESTDIR=%d
+SplitOff: <<
+  Package: %N-shlibs
+  Depends: <<
+  	libmikmod3-shlibs,
+  	libvorbis0-shlibs,
+  	sdl2-shlibs (>= 2.0.10-1)
+  <<
+  Files: lib/libSDL2_mixer-*.dylib
+  Shlibs: %p/lib/libSDL2_mixer-2.0.0.dylib 3.0.0 %n (>= 2.0.4-1)
+  Docfiles: CHANGES.txt COPYING.txt README.txt
+<<
+Docfiles: CHANGES.txt COPYING.txt README.txt
+Description: SDL multi-channel audio mixer library
+DescPackaging: <<
+ Use --disable-sdltest to allow building on headless systems.
+<<
+Homepage: http://www.libsdl.org/projects/SDL_mixer/
+License: OSI-Approved

--- a/10.9-libcxx/stable/main/finkinfo/games/sdl2-ttf.info
+++ b/10.9-libcxx/stable/main/finkinfo/games/sdl2-ttf.info
@@ -1,23 +1,10 @@
-# DISCLAIMER: Max Horn is the sole maintainer of this package.
-# Please DO NOT MAKE MODIFICATIONS without informing the maintainer.
-# Preferably, send a patch to me instead of making changes yourself!
-# If that is not possible due to extra urgency, at least send me a mail.
-#
-# Explanation: I am sick and tired of getting back to my packages and
-# discovering that people have messed with it. I am then forced to
-# retrace their steps, find out who, when and why did make a certain
-# change etc. -- i.e. it makes my life as maintainer harder.
-# Furthermore, as maintainer I am responsible for problems caused by my
-# packages. But I am not willing to take responsibility for something I
-# did not do. In particular, for changes that other people introduced
-# behind my back, no matter how good and noble their intentions were. As
-# such, I may see myself forced to drop responsibility for (and hence,
-# maintainership of) the affected package.
-
 Package: sdl2-ttf
 Version: 2.0.15
 Revision: 1
-Maintainer: Max Horn <max@quendi.de>
+Description: SDL TrueType font library
+License: OSI-Approved
+# Free to take over
+Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
 Depends: %N-shlibs (= %v-%r)
 BuildDependsOnly: true
 BuildDepends: <<
@@ -36,20 +23,18 @@ CompileScript: <<
 <<
 InstallScript: make install DESTDIR=%d
 SplitOff: <<
-  Package: %N-shlibs
-  Depends: <<
-  	sdl2-shlibs (>= 2.0.10-1),
-  	freetype219-shlibs (>= 2.6-1)
-  <<
-  Files: lib/libSDL2_ttf-*.dylib
-  Shlibs: %p/lib/libSDL2_ttf-2.0.0.dylib 15.0.0 %n (>= 2.0.15-1)
-  Docfiles: CHANGES.txt COPYING.txt README.txt
+	Package: %N-shlibs
+	Depends: <<
+		sdl2-shlibs (>= 2.0.10-1),
+		freetype219-shlibs (>= 2.6-1)
+	<<
+	Files: lib/libSDL2_ttf-*.dylib
+	Shlibs: %p/lib/libSDL2_ttf-2.0.0.dylib 15.0.0 %n (>= 2.0.15-1)
+	Docfiles: CHANGES.txt COPYING.txt README.txt
 <<
 DocFiles: CHANGES.txt COPYING.txt README.txt
-Description: SDL TrueType font library
+Homepage: http://www.libsdl.org/projects/SDL_ttf/
 DescDetail: <<
 Sample library which allows you to use TrueType fonts in your SDL applications.  
 <<
 DescPackaging:  Uses freetype219 so that non-X11 apps can partake of this
-Homepage: http://www.libsdl.org/projects/SDL_ttf/
-License: OSI-Approved

--- a/10.9-libcxx/stable/main/finkinfo/games/sdl2-ttf.info
+++ b/10.9-libcxx/stable/main/finkinfo/games/sdl2-ttf.info
@@ -1,0 +1,55 @@
+# DISCLAIMER: Max Horn is the sole maintainer of this package.
+# Please DO NOT MAKE MODIFICATIONS without informing the maintainer.
+# Preferably, send a patch to me instead of making changes yourself!
+# If that is not possible due to extra urgency, at least send me a mail.
+#
+# Explanation: I am sick and tired of getting back to my packages and
+# discovering that people have messed with it. I am then forced to
+# retrace their steps, find out who, when and why did make a certain
+# change etc. -- i.e. it makes my life as maintainer harder.
+# Furthermore, as maintainer I am responsible for problems caused by my
+# packages. But I am not willing to take responsibility for something I
+# did not do. In particular, for changes that other people introduced
+# behind my back, no matter how good and noble their intentions were. As
+# such, I may see myself forced to drop responsibility for (and hence,
+# maintainership of) the affected package.
+
+Package: sdl2-ttf
+Version: 2.0.15
+Revision: 1
+Maintainer: Max Horn <max@quendi.de>
+Depends: %N-shlibs (= %v-%r)
+BuildDependsOnly: true
+BuildDepends: <<
+	fink-package-precedence,
+	freetype219 (>= 2.6-1),
+	pkgconfig,
+	sdl2 (>= 2.0.10-1)
+<<
+Source: https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-%v.tar.gz
+Source-MD5: 04fe06ff7623d7bdcb704e82f5f88391
+NoSetCPPFLAGS: true
+ConfigureParams: --disable-sdltest
+CompileScript: <<
+	%{default_script}
+	fink-package-precedence --prohibit-bdep=%n .
+<<
+InstallScript: make install DESTDIR=%d
+SplitOff: <<
+  Package: %N-shlibs
+  Depends: <<
+  	sdl2-shlibs (>= 2.0.10-1),
+  	freetype219-shlibs (>= 2.6-1)
+  <<
+  Files: lib/libSDL2_ttf-*.dylib
+  Shlibs: %p/lib/libSDL2_ttf-2.0.0.dylib 15.0.0 %n (>= 2.0.15-1)
+  Docfiles: CHANGES.txt COPYING.txt README.txt
+<<
+DocFiles: CHANGES.txt COPYING.txt README.txt
+Description: SDL TrueType font library
+DescDetail: <<
+Sample library which allows you to use TrueType fonts in your SDL applications.  
+<<
+DescPackaging:  Uses freetype219 so that non-X11 apps can partake of this
+Homepage: http://www.libsdl.org/projects/SDL_ttf/
+License: OSI-Approved


### PR DESCRIPTION
SDL2 versions of sdl-image, sdl-mixer, and sdl-ttf. Based on the current SDL1 packages.
I can take them over if desired.