### PR TITLE
json-c version 0.13.1 with new library version

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/json-c.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/json-c.info
@@ -1,13 +1,14 @@
 Package: json-c
 Version: 0.12.1
-Revision: 1
+Revision: 2
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Homepage: https://github.com/json-c/json-c/wiki
 ###
 Depends: %N-shlibs (= %v-%r)
 BuildDependsOnly: true
-Conflicts: libjson
+Replaces:  json-c4-dev
+Conflicts: libjson, json-c4-dev
 ###
 Source: https://github.com/%n/%n/archive/%n-%v-20160607.tar.gz
 Source-MD5: 0a2a49a1e89044fdac414f984f3f81a6

--- a/10.9-libcxx/stable/main/finkinfo/libs/json-c4-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/json-c4-shlibs.info
@@ -1,0 +1,62 @@
+### json-c 0.13 bumps to libN=5
+Package: json-c4-shlibs
+Version: 0.13.1
+Revision: 1
+License: BSD
+Maintainer: Wolfgang Fischer <wodev@users.sourceforge.net>
+Homepage: https://github.com/json-c/json-c/wiki
+###
+BuildDepends: <<
+        fink-package-precedence (>= 0.7-1)
+<<
+###
+Source: https://github.com/json-c/json-c/archive/json-c-%v-20180305.tar.gz
+Source-MD5: 20dba7bf773599a0842745a2fe5b7cd3
+Source-Checksum: SHA256(5d867baeb7f540abe8f3265ac18ed7a24f91fe3c5f4fd99ac3caba0708511b90)
+SourceDirectory: json-c-json-c-%v-20180305
+ConfigureParams: <<
+	--disable-static \
+	--enable-threading
+<<
+CompileScript: <<
+        %{default_script}
+        fink-package-precedence --prohibit-bdep json-c4-dev .
+<<
+InfoTest: <<
+	TestScript: make check || exit 2
+<<
+InstallScript: <<
+        make install DESTDIR="%d"
+<<
+Shlibs: <<
+	%p/lib/libjson-c.4.dylib 5.0.0 %n (>= 0.13-1)
+<<
+DocFiles: AUTHORS COPYING ChangeLog README.md README.html
+###
+Splitoff: <<
+	Package: json-c4-dev
+	Depends: %N (>= %v-%r)
+	Conflicts: <<
+ 		libjson,
+		json-c
+        <<
+        Replaces: <<
+                json-c
+        <<
+        BuildDependsOnly: true
+	Files: <<
+		include
+		lib/libjson-c.{dylib,la}
+		lib/pkgconfig
+	<<
+	DocFiles: AUTHORS COPYING ChangeLog INSTALL NEWS README README.md README.html doc/html
+<<
+###
+Description: JSON implementation in C
+DescDetail: <<
+JSON-C implements a reference counting object model that allows you
+to easily construct JSON objects in C, output them as JSON formatted
+strings and parse JSON formatted strings back into the C
+representation of JSON objects.
+<<
+###

--- a/10.9-libcxx/stable/main/finkinfo/libs/libjson.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libjson.info
@@ -1,8 +1,8 @@
 Package: libjson
 Version: 7.6.1
-Revision: 1
+Revision: 2
 
-Conflicts: json-c
+Conflicts: json-c, json-c4-dev
 BuildDependsOnly: true
 
 Source: mirror:sourceforge:%n/%n_%v.zip


### PR DESCRIPTION
New package json-c4-shlibs for json-c .

json-c version 0.13 bumps a new library version. I created a new package json-c4-shlibs to keep alive the old library version .
