### PR TITLE
nettle7-shlibs 3.5.1 - updated Debian patchfile

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/nettle7-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/nettle7-shlibs.info
@@ -1,6 +1,6 @@
 Package: nettle7-shlibs
 Version: 3.5.1
-Revision: 1
+Revision: 2
 #
 License: GPL
 # Free to update, modify, and take over
@@ -9,8 +9,8 @@ Homepage: http://www.lysator.liu.se/~nisse/nettle/
 #
 Source: mirror:gnu:nettle/nettle-%v.tar.gz
 Source-MD5: 0e5707b418c3826768d41130fbe4ee86
-Source2:mirror:debian:pool/main/n/nettle/nettle_%v-1.debian.tar.xz
-Source2-MD5: 36609c579ce86808786eb291cf10d6d7
+Source2:mirror:debian:pool/main/n/nettle/nettle_%v+really%v-2.debian.tar.xz
+Source2-MD5: 77dc3d6ab31fab9ac407ed58a6bcb8fe
 #
 BuildDepends: <<
 	fink (>= 0.32),


### PR DESCRIPTION
The Debian patchfile in the existing infofile doesn't exist on the server any more, preventing this package from building. The updated patchfile appears to work as expected. As I can't download the old patchfile, I'm not sure what has changed.

Maintainer is @nieder 