### PR TITLE
ESS update to 18.10.2 + emacs26 compatibility

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/editors/ess.info
+++ b/10.9-libcxx/stable/main/finkinfo/editors/ess.info
@@ -1,24 +1,37 @@
 Package: ess
-Version: 17.11
-Revision: 2
+Version: 18.10.2
+Revision: 1
 Description: Emacs Speaks Statistics
 License: GPL
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
-BuildDepends: fink (>= 0.24.12)
-Depends: emacs25 | emacs25-nox | emacs24 | emacs24-nox
-Suggests: r-base34 | r-base33 | r-base32 | r-base31
+BuildDepends: fink (>= 0.32)
+Depends: emacs26 | emacs26-nox | emacs25 | emacs25-nox | emacs24 (>= 24.5) | emacs24-nox (>= 24.5)
+Suggests: r-base36 | r-base35 | r-base34 | r-base33 | r-base32 | r-base31
 Source: http://ess.r-project.org/downloads/%n/%n-%v.tgz
-Source-MD5: 26cbbd358334ab6d480a5dcf3b3665dd
+Source-MD5: 5cc3cb67fbaaeb506e00100640674056
+Source2: mirror:debian:pool/main/e/%n/%n_%v-1.debian.tar.xz
+Source2-MD5: a2ae24055e1f30b2a6bb1323e6446653
 
+# ess-set-working-directory test apparently tries to write to root dir; replace with %b
 PatchScript: <<
  perl -pi.bak -e 's|("../../etc/ess/") ("./etc/")|$1 "../../../emacs/etc/" "../../../emacs/etc/ess/"|g;' lisp/ess-utils.el
  perl -pi -e 's|( ../../etc/ess/) (or ./etc/")|$1, ../../../emacs/etc/ or ../../../emacs/etc/ess/"|g;' lisp/ess-utils.el
  perl -pi.bak -e 's|(expand-file-name) ("icons")|$1 "ess/icons"|g;' lisp/ess-toolbar.el
- perl -pi.bak -e 's|/usr/s|%p/s|g' debian/emacsen-*
- perl -pi -e 's|/usr/lib|%p/lib|g' debian/emacsen-*
- perl -pi -e 's|^#rm -f .*.el|find . -name ess-rd.el -prune -o -type l -exec rm {} \\;|;' debian/emacsen-install
- perl -pi -e 's|(debian-)([ep].*)|fink-$2|g;' debian/emacsen-startup
- perl -pi -e 's|(Adapted for .*)|$1\n;; Translated to fink-startup setup by Derek Homeier <dhomeie\@gwdg.de>|;' debian/emacsen-startup
+ perl -pi.bak -e 's|(INSTALL.*)(ELC)|${1}ELS|;' lisp/Makefile
+ perl -pi.bak -e 's|/usr/s|%p/s|g' ../debian/emacsen-* ../debian/old/emacsen-*
+ perl -pi -e 's|/usr/lib|%p/lib|g' ../debian/emacsen-* ../debian/old/emacsen-*
+ perl -pi -e 's/(FLAVOR. in xemacs.|)(emacs2)/${1}emacs|${2}/;' ../debian/old/emacsen-install
+ perl -pi -e 's|(^#)([df ][o ])|$2|g;' ../debian/old/emacsen-install
+ #perl -pi -e 's|(^cat .. EOF . path.el)|rm -f path.el && $1|g;' ../debian/old/emacsen-install
+ perl -pi -e 's|(^FLAGS=.*)( -l ess-comp.el)|$1|;' ../debian/old/emacsen-install
+ perl -pi -e 's|^#rm -f .*.el|find . -name ess-rd.el -prune -o -type l -exec rm {} \\;|;' ../debian/old/emacsen-install
+ perl -pi -e 's|(debian-)([ep].*)|fink-$2|g;' ../debian/old/emacsen-startup
+ perl -pi -e 's|(/elpa.*/ess-18.10)|/ess|g;' ../debian/old/emacsen-startup
+ perl -pi -e 's|(Adapted for .*)|$1\n;; Translated to fink-startup setup by Derek Homeier <dhomeie\@gwdg.de>|;' ../debian/old/emacsen-startup
+ perl -pi.bak -e 's|(set-working-directory ")/(")|${1}%b/${2}|;' test/ess-r-tests.el
+ perl -pi -e 's|(setwd..)/(.*")/|${1}%b/${2}%b|;' test/ess-r-tests.el
+ perl -pi -e 's|(string= default-directory ")/(")|${1}%b/${2}|;' test/ess-r-tests.el
+ perl -pi -e 's|(;; )(.skip-unless..member..roxygen2)|${2}|;' test/ess-r-tests.el
 <<
 
 CompileScript: <<
@@ -31,11 +44,12 @@ InstallScript: <<
  make DESTDIR=%i install
  cd ../lisp
  make DESTDIR=%i install
- find %i -name "*.elc" -exec rm {} \;
+ #find %i -name "*.elc" -exec rm {} \;
+ ln -s %p/share/emacs/site-lisp/ess/ess-site.el %i/share/emacs/site-lisp/ess-site.el
  cd ../doc
  make DESTDIR=%i install-info
 
- cd ../debian
+ cd ../../debian/old
  install -m 755 -d              %i/etc/emacs/site-start.d
  install -m 644 emacsen-startup %i/etc/emacs/site-start.d/50%n.el
 
@@ -45,7 +59,7 @@ InstallScript: <<
 <<
 
 InfoTest: <<
- TestDepends: r-base
+ TestDepends: r-base, cran-roxygen2-r36 | cran-roxygen2-r35 | cran-roxygen2-r34
  TestScript: <<
   #!/bin/bash -ev
   cd test
@@ -55,15 +69,17 @@ InfoTest: <<
   else
    # probably last test in rstats failed; just disable it and run again:
    perl -pi -e 's|"Error: unexpected symbol"|""|;' ess-r-tests.el
+   # might not work even with cran-roxygen2 installed...
+   perl -pi -e 's|(.skip-unless..member..roxygen)(2)|${1}0|;' test/ess-r-tests.el
    make EMACS=%p/bin/emacs
-   echo "Warning: disabled ess-r-namespaced-eval-no-srcref-in-errors test!"
+   echo "Warning: disabled ess-r-namespaced-eval-no-srcref-in-errors and ess-roxy-preview-Rd tests!"
    exit 1
   fi
  <<
  TestSuiteSize: small
 <<
 
-DocFiles: ANNOUNCE COPYING ChangeLog NEWS ONEWS OONEWS README VERSION doc/html doc/images doc/{readme,ess,ess-intro-graphs}.pdf doc/refcard/refcard.pdf
+DocFiles: ANNOUNCE COPYING ChangeLog NEWS ONEWS OONEWS README VERSION doc/html doc/images doc/{readme,ess,archive/ess-intro-graphs}.pdf doc/refcard/refcard.pdf
 InfoDocs: %n.info
 ConfFiles: %p/etc/emacs/site-start.d/50%n.el
 
@@ -108,8 +124,9 @@ directory of your Emacs version %e (likely 25, 24 or 23) to your load path:
 <<
 DescPort: <<
 Last test in tests/ess-r-tests.el failing; removed expected err-msg.
-Hacked packages/install/ and -/remove/ files for byte-compiling .elc files
-on installation from ./debian subdir.
+Hacked packages/install/ and -/remove/ files for byte-compiling .elc files on
+installation from ../debian subdir (now downloaded separately from debian.org),
+and to restore installation to flavour-specific site-lisp only (as in 17.11).
 Adapted etc configuration dir search path, icons path and load file to fink's
 emacsen-common setup.
 <<

--- a/10.9-libcxx/stable/main/finkinfo/editors/ess.info
+++ b/10.9-libcxx/stable/main/finkinfo/editors/ess.info
@@ -12,25 +12,31 @@ Source-MD5: 5cc3cb67fbaaeb506e00100640674056
 Source2: mirror:debian:pool/main/e/%n/%n_%v-1.debian.tar.xz
 Source2-MD5: a2ae24055e1f30b2a6bb1323e6446653
 
-# ess-set-working-directory test apparently tries to write to root dir; replace with %b
 PatchScript: <<
  perl -pi.bak -e 's|("../../etc/ess/") ("./etc/")|$1 "../../../emacs/etc/" "../../../emacs/etc/ess/"|g;' lisp/ess-utils.el
  perl -pi -e 's|( ../../etc/ess/) (or ./etc/")|$1, ../../../emacs/etc/ or ../../../emacs/etc/ess/"|g;' lisp/ess-utils.el
  perl -pi.bak -e 's|(expand-file-name) ("icons")|$1 "ess/icons"|g;' lisp/ess-toolbar.el
+ # Install .el files (to be byte-compiled in Emacs-version-specific site-lisp by emacsen-install)
  perl -pi.bak -e 's|(INSTALL.*)(ELC)|${1}ELS|;' lisp/Makefile
  perl -pi.bak -e 's|/usr/s|%p/s|g' ../debian/emacsen-* ../debian/old/emacsen-*
  perl -pi -e 's|/usr/lib|%p/lib|g' ../debian/emacsen-* ../debian/old/emacsen-*
- perl -pi -e 's/(FLAVOR. in xemacs.|)(emacs2)/${1}emacs|${2}/;' ../debian/old/emacsen-install
+ # Bypass generic emacsen (always install byte-compiled files under version-specific site-lisp ${ELCDIR})
+ perl -pi -e 's/(FLAVOR. in xemacs.\|)(emacs2)/${1}emacs|${2}/;' ../debian/old/emacsen-install
+ # Uncomment loop "for f in ${ELDIR}/*.el" to create links into ${ELCDIR}
  perl -pi -e 's|(^#)([df ][o ])|$2|g;' ../debian/old/emacsen-install
- #perl -pi -e 's|(^cat .. EOF . path.el)|rm -f path.el && $1|g;' ../debian/old/emacsen-install
  perl -pi -e 's|(^FLAGS=.*)( -l ess-comp.el)|$1|;' ../debian/old/emacsen-install
+ #perl -pi -e 's|(^cat .. EOF . path.el)|rm -f path.el && $1|g;' ../debian/old/emacsen-install
+ # Remove links to .el files in ${ELCDIR} again after byte-compiling
  perl -pi -e 's|^#rm -f .*.el|find . -name ess-rd.el -prune -o -type l -exec rm {} \\;|;' ../debian/old/emacsen-install
+ # We have installed into "ess" site-lisp subdir, unlike Debian's elpa-ess package.
  perl -pi -e 's|(debian-)([ep].*)|fink-$2|g;' ../debian/old/emacsen-startup
  perl -pi -e 's|(/elpa.*/ess-18.10)|/ess|g;' ../debian/old/emacsen-startup
  perl -pi -e 's|(Adapted for .*)|$1\n;; Translated to fink-startup setup by Derek Homeier <dhomeie\@gwdg.de>|;' ../debian/old/emacsen-startup
+ # ess-set-working-directory test apparently tries to write to root dir; replace with %b
  perl -pi.bak -e 's|(set-working-directory ")/(")|${1}%b/${2}|;' test/ess-r-tests.el
  perl -pi -e 's|(setwd..)/(.*")/|${1}%b/${2}%b|;' test/ess-r-tests.el
  perl -pi -e 's|(string= default-directory ")/(")|${1}%b/${2}|;' test/ess-r-tests.el
+ # Disable ess-roxy-preview-Rd if roxygen2 not available (cran-roxygen2-rNN might not be detected)
  perl -pi -e 's|(;; )(.skip-unless..member..roxygen2)|${2}|;' test/ess-r-tests.el
 <<
 


### PR DESCRIPTION
The updated `emacs26` package (thanks!) is not in the dependency options of `ess`. This version adds the new emacsen and is updated to the latest upstream, with the emacsen-common install voodoo now pulled separately from Debian. Tested on 10.12.6.