### PR TITLE
libnc-dap3: gcc upgrade, resolve some warnings, etc

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/libnc-dap3.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/libnc-dap3.info
@@ -1,11 +1,11 @@
 Info2:<<
 Package: libnc-dap3
 Version: 3.7.4
-Revision: 1
+Revision: 2
 Epoch: 1
 BuildDependsOnly: true
 GCC: 4.0
-Type: gcc (5)
+Type: gcc (9)
 
 Description: OpenDAP netCDF Client Library
 License: LGPL
@@ -20,7 +20,12 @@ BuildDepends: <<
 # Unpack Phase:
 Source: http://opendap.org/pub/source/libnc-dap-%v.tar.gz
 Source-MD5: 671bf7ad07e00ed0be6518a80792c587
+# Fix -I order (local before external-global)
+# Fix implicit declarations
+PatchFile: %n.patch
+PatchFile-MD5: 4f24162df889a54b6feee16470a97ff0
 PatchScript:  <<
+	%{default_script}
 	perl -pi -e 's|ncdump|dncdump|g' ncdump/ncdump.1
  	perl -pi -e  's/is_array/my_is_array/g' NCConnect.cc
  	perl -pi -e  's/HAVE_STRLCAT/HAVE_MY_STRLCAT/g ; s/strlcat/my_strlcat/g' ncdump/ncdump.c
@@ -33,6 +38,9 @@ PatchScript:  <<
 
 	perl -pi -e 's/(-version-info)/-no-undefined \1/' Makefile.in
 	perl -ni -e 'print unless /Requires.private:/' libnc-dap.pc.in
+
+	# printf format-string security fix
+	perl -pi -e 's/Printf\(sout\)/Printf("%%s",sout)/' ncdump/vardata.c
 <<
 
 # Compile Phase

--- a/10.9-libcxx/stable/main/finkinfo/sci/libnc-dap3.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/libnc-dap3.patch
@@ -1,0 +1,60 @@
+diff -Nurd -x'*~' libnc-dap-3.7.4.orig/Dputget.cc libnc-dap-3.7.4/Dputget.cc
+--- libnc-dap-3.7.4.orig/Dputget.cc	2008-09-08 15:26:40.000000000 -0400
++++ libnc-dap-3.7.4/Dputget.cc	2019-12-07 23:18:52.000000000 -0500
+@@ -68,6 +68,7 @@
+ #include "Dv2i.h"
+ #include "nc_util.h"
+ 
++#include "Dputget.h"
+ 
+ // Used for the netCDF 2 interface emulation. See lv2i.c.
+ extern "C" int
+diff -Nurd -x'*~' libnc-dap-3.7.4.orig/Dputget.h libnc-dap-3.7.4/Dputget.h
+--- libnc-dap-3.7.4.orig/Dputget.h	1969-12-31 19:00:00.000000000 -0500
++++ libnc-dap-3.7.4/Dputget.h	2019-12-07 23:18:52.000000000 -0500
+@@ -0,0 +1,11 @@
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++int nc_get_rec(int cdfid, size_t recnum, void **datap);
++int nc_inq_rec(int cdfid, size_t *nrecvars, int *recvarids, size_t *recsizes);
++int nc_put_rec(int cdfid, size_t recnum, void * const *datap);
++
++#ifdef __cplusplus
++}
++#endif
+diff -Nurd -x'*~' libnc-dap-3.7.4.orig/Makefile.in libnc-dap-3.7.4/Makefile.in
+--- libnc-dap-3.7.4.orig/Makefile.in	2009-07-22 22:10:39.000000000 -0400
++++ libnc-dap-3.7.4/Makefile.in	2019-12-07 22:56:21.000000000 -0500
+@@ -308,7 +308,7 @@
+ # the sources for the localized netcdf library (lnetcdf) and fortran jackets
+ # are in subdirecttories. 
+ AM_CPPFLAGS = -Df2cFortran -DLOCAL -I$(top_srcdir)/lnetcdf \
+-$(DAP_CLIENT_CFLAGS) -I$(top_srcdir)/fortran
++-I$(top_srcdir)/fortran $(DAP_CLIENT_CFLAGS)
+ 
+ 
+ # These are not used by automake but are often useful for certain types of
+diff -Nurd -x'*~' libnc-dap-3.7.4.orig/lnetcdf/lv2i.c libnc-dap-3.7.4/lnetcdf/lv2i.c
+--- libnc-dap-3.7.4.orig/lnetcdf/lv2i.c	2006-11-21 18:12:00.000000000 -0500
++++ libnc-dap-3.7.4/lnetcdf/lv2i.c	2019-12-07 23:19:25.000000000 -0500
+@@ -11,6 +11,7 @@
+ #if 0
+ #include "lnc.h"		/* nc.h --> lnc.h 03/05/04 jhrg */
+ #endif
++#include "Dputget.h"
+ 
+ #ifndef NO_NETCDF_2
+ 
+diff -Nurd -x'*~' libnc-dap-3.7.4.orig/ncdump/ncdump.c libnc-dap-3.7.4/ncdump/ncdump.c
+--- libnc-dap-3.7.4.orig/ncdump/ncdump.c	2006-11-02 10:22:25.000000000 -0500
++++ libnc-dap-3.7.4/ncdump/ncdump.c	2019-12-07 23:07:40.000000000 -0500
+@@ -10,6 +10,7 @@
+ #include <string.h>
+ #include <ctype.h>
+ #include <stdlib.h>
++#include <unistd.h>
+ 
+ #include <netcdf.h>
+ #include "ncdump.h"


### PR DESCRIPTION
* -I ordering (put local before external/global
* resolve implicit-declaration warnings
* fix printf string security