### PR TITLE
fortune-mod: new upstream version

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/games/fortune-mod.info
+++ b/10.9-libcxx/stable/main/finkinfo/games/fortune-mod.info
@@ -39,32 +39,37 @@ PatchFile: %n.patch
 PatchFile-MD5: f5b82d985e48bb3a308af3615f6be6fb
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 CompileScript: <<
+	#!/bin/sh -ev
 	. %p/sbin/fink-buildenv-cmake.sh
 	mkdir build
-	cd build && cmake -D CMAKE_C_FLAGS=-I%p/include \
-		-D CMAKE_INSTALL_PREFIX=%i \
-		-D COOKIEDIR=%i/share/fortunes \
-		-D LOCALDIR=%i/share/fortunes ..
-	perl -pi -e 's|%i|%p|g' build/config.h
-	cd build && make all
+	cd build
+	cmake $FINK_CMAKE_ARGS \
+		-D CMAKE_C_FLAGS=-I%p/include \
+		-D COOKIEDIR=%p/share/fortunes \
+		-D LOCALDIR=%p/share/fortunes ..
+	make all
+	cd ..
 	perl fortune/gen-fortune-man-page.pl --cookiedir %p/share/fortunes --ocookiedir %p/share/fortunes/off --output fortune/fortune.6
 <<
 InfoTest: <<
 	TestDepends: <<
 		path-tiny-pm5184 | path-tiny-pm5182,
-		file-find-object-pm5182 | file-find-object-pm5184,
+		file-find-object-pm5184 | file-find-object-pm5182,
 		test-differences-pm
 	<<
 	TestScript: <<
-	#. %p/sbin/fink-buildenv-cmake.sh
+	#!/bin/sh -ev
 	rm tests/t/valgrind.t 
 	# Valgrind not yet available through Fink...
-	cd build && make check || exit 2
+	cd build
+	make check || exit 2
 <<
 <<
 InstallScript: <<
- cd build && make install
- cd %i/share/man/man1; gzip -6 strfile.1
+	#!/bin/sh -ev
+	cd build
+	make install DESTDIR=%d
+	cd %i/share/man/man1; gzip -6 strfile.1
 <<
 Maintainer: None <fink-devel@lists.sourceforge.net>
 PostInstScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/games/fortune-mod.info
+++ b/10.9-libcxx/stable/main/finkinfo/games/fortune-mod.info
@@ -1,6 +1,6 @@
 Package: fortune-mod
-Version: 1.99.1
-Revision: 4003
+Version: 2.12.0
+Revision: 1
 Epoch: 1
 Description: Fortune cookies on demand
 DescDetail: <<
@@ -19,82 +19,54 @@ DescUsage: <<
 
  %p/bin/fortune
 <<
-HomePage: http://www.redellipse.net/code/fortune
+HomePage: https://www.shlomifish.org/open-source/projects/fortune-mod/
 License: BSD
 BuildDepends: <<
-	fink (>= 0.24.12),
-	recode,
-	recode-dev
+	cmake,
+	fink (>= 0.32),
+	fink-buildenv-modules,
+	recode3-dev,
+	rinutils
 <<
-Depends: recode-shlibs
+Depends: recode3-shlibs
 Recommends: fortunes-min, fortunes
 Suggests: fortune-cookie-db
 #Replaces: %n (<= 9708-3)
-Source: mirror:debian:pool/main/f/%n/%n_%v.orig.tar.gz
-Source-MD5: f208805b3b712e32997d7667e0ec52d8
+Source: https://www.shlomifish.org/open-source/projects/fortune-mod/arcs/%n-%v.tar.xz
+Source-MD5: b35c6052e3a5f595c12350968bb454f1
 SourceDirectory: %n-%v
-Source2: mirror:debian:pool/main/f/%n/%n_%v-7.debian.tar.bz2
-Source2-MD5: 1bcabbd308c0f9a00929b6c5a1bf77f6
 PatchFile: %n.patch
-PatchFile-MD5: 29cdf78e277bc94ededda0fbc0e9ac9a
-PatchScript: <<
-	#!/bin/sh -ev
-	for PATCH in `cat ../debian/patches/series`; do
-		patch -p1 < ../debian/patches/$PATCH
-	done
-	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
-	# allow lines longer than 72
-	perl -pi -e 's|72|1000|g' datfiles/Makefile
-	# fix datafiles
-	echo "%%" >> datfiles/computers
-	echo "%%" >> datfiles/law
-	echo "%%" >> datfiles/people
-	echo "%%" >> datfiles/pratchett
-	echo "%%" >> datfiles/wisdom
-<<
+PatchFile-MD5: 0262d0bbcc54d71eb14bf09af0b45c63
+PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 CompileScript: <<
-	make \
-		FORTDIR=%p/bin \
-		COOKIEDIR=%p/share/fortunes \
-		LOCALDIR=%p/share/fortunes \
-		BINDIR=%p/bin \
-		BINMANDIR=%p/share/man/man1 \
-		FORTMANDIR=%p/share/man/man6 \
-		LDFLAGS='-L%p/lib' \
-		REGEXDEFS='-DHAVE_REGEX_H -DPOSIX_REGEX' \
-		all fortune/fortune.man
+	. %p/sbin/fink-buildenv-cmake.sh
+	mkdir build
+	cd build && cmake -D CMAKE_C_FLAGS=-I%p/include \
+		-D CMAKE_INSTALL_PREFIX=%i \
+		-D COOKIEDIR=%i/share/fortunes \
+		-D LOCALDIR=%i/share/fortunes ..
+	perl -pi -e 's|%i|%p|g' build/config.h
+	cd build && make all
+	perl fortune/gen-fortune-man-page.pl --cookiedir %p/share/fortunes --ocookiedir %p/share/fortunes/off --output fortune/fortune.6
 <<
 InfoTest: <<
-	TestScript: make -C datfiles check || exit 2
+	TestDepends: <<
+		path-tiny-pm5184 | path-tiny-pm5182,
+		file-find-object-pm5182 | file-find-object-pm5184,
+		test-differences-pm
+	<<
+	TestScript: <<
+	#. %p/sbin/fink-buildenv-cmake.sh
+	rm tests/t/valgrind.t 
+	# Valgrind not yet available through Fink...
+	cd build && make check || exit 2
+<<
 <<
 InstallScript: <<
- make FORTDIR=%i/bin COOKIEDIR=%i/share/fortunes LOCALDIR=%p/share/fortunes BINDIR=%i/bin BINMANDIR=%i/share/man/man1 FORTMANDIR=%i/share/man/man6 install
+ cd build && make FORTDIR=%i/bin COOKIEDIR=%i/share/fortunes LOCALDIR=%p/share/fortunes BINDIR=%i/bin BINMANDIR=%i/share/man/man1 FORTMANDIR=%i/share/man/man6 install
  cd %i/share/man/man1; gzip -6 strfile.1
 <<
 Maintainer: None <fink-devel@lists.sourceforge.net>
-DescPort: <<
- * ld: Undefined symbols: _program_name: added program_name
-   http://www.delorie.com/gnu/docs/recode/recode_17.html
- * implicit declaration of function `exit': added #include <stdlib.h>
- * Force build of fortune/fortune.man during CompileScript for correct
-   Fink path insertion into man file.
- * gzip strfile.1 during packaging for the unstr man file symlink.
- * Splitoff as Debian does, to allow for future localized fortune
-   packages or simply other fortune packages in Fink.
- * Depends: fortunes-min | fortunes | fortune-cookie-db to ensure the
-   default choice is not the offensive set, does not work if
-   fortunes-de is selected during building, because Fink incorrrectly
-   sees it as a circular dependency, when really fortune-mod only
-   depends on fortune-cookie-db [virtual] RUNTIME, while the building
-   of any fortune-cookie-db DOES require fortune-mod as a
-   BuildDepends (to parse the datafiles during their creation).
- * Also, Fink currently does NOT handle virtual package selection,
-   such as: 'fink install fortune-cookie-db' (does not work) so the
-   PostInstScript here should be updated whenever a new localized
-   fortunes package is added in the future.
- * ld: warning prebinding disabled because dependent library:
-   %p/lib/librecode.0.dylib is not prebound
-<<
 PostInstScript: <<
  echo
  echo " * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *"
@@ -111,8 +83,8 @@ PostInstScript: <<
  echo " * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *"
 <<
 DocFiles: <<
- ChangeLog cookie-files ../debian/copyright INDEX Notes Offensive README
- ../debian/README.Debian ../debian/README.Debian.offensive TODO
+ ChangeLog cookie-files COPYING.txt INDEX INSTALL Notes Offensive README
+  TODO
 <<
 Splitoff: <<
  Package: fortunes-off
@@ -127,8 +99,8 @@ Splitoff: <<
  Recommends: %N
  Files: share/fortunes/off
  DocFiles: <<
-  ChangeLog cookie-files ../debian/copyright INDEX Notes Offensive README
-  ../debian/README.Debian ../debian/README.Debian.offensive TODO
+ ChangeLog cookie-files COPYING.txt INDEX INSTALL Notes Offensive README
+  TODO
  <<
 <<
 Splitoff2: <<
@@ -154,8 +126,8 @@ Splitoff2: <<
   share/fortunes/riddles.u8
   <<
  DocFiles: <<
-  ChangeLog cookie-files ../debian/copyright INDEX Notes Offensive README
-  ../debian/README.Debian ../debian/README.Debian.offensive TODO
+ ChangeLog cookie-files COPYING.txt INDEX INSTALL Notes Offensive README
+  TODO
  <<
 <<
 Splitoff3: <<
@@ -169,8 +141,8 @@ Splitoff3: <<
  Recommends: %N
  Files: share/fortunes
  DocFiles: <<
-  ChangeLog cookie-files ../debian/copyright INDEX Notes Offensive README
-  ../debian/README.Debian ../debian/README.Debian.offensive TODO
+ ChangeLog cookie-files COPYING.txt INDEX INSTALL Notes Offensive README
+  TODO
  <<
 <<
 DescPackaging: <<

--- a/10.9-libcxx/stable/main/finkinfo/games/fortune-mod.info
+++ b/10.9-libcxx/stable/main/finkinfo/games/fortune-mod.info
@@ -36,7 +36,7 @@ Source: https://www.shlomifish.org/open-source/projects/fortune-mod/arcs/%n-%v.t
 Source-MD5: b35c6052e3a5f595c12350968bb454f1
 SourceDirectory: %n-%v
 PatchFile: %n.patch
-PatchFile-MD5: 0262d0bbcc54d71eb14bf09af0b45c63
+PatchFile-MD5: f5b82d985e48bb3a308af3615f6be6fb
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 CompileScript: <<
 	. %p/sbin/fink-buildenv-cmake.sh

--- a/10.9-libcxx/stable/main/finkinfo/games/fortune-mod.info
+++ b/10.9-libcxx/stable/main/finkinfo/games/fortune-mod.info
@@ -63,7 +63,7 @@ InfoTest: <<
 <<
 <<
 InstallScript: <<
- cd build && make FORTDIR=%i/bin COOKIEDIR=%i/share/fortunes LOCALDIR=%p/share/fortunes BINDIR=%i/bin BINMANDIR=%i/share/man/man1 FORTMANDIR=%i/share/man/man6 install
+ cd build && make install
  cd %i/share/man/man1; gzip -6 strfile.1
 <<
 Maintainer: None <fink-devel@lists.sourceforge.net>

--- a/10.9-libcxx/stable/main/finkinfo/games/fortune-mod.patch
+++ b/10.9-libcxx/stable/main/finkinfo/games/fortune-mod.patch
@@ -1,72 +1,118 @@
-diff -ru2N --exclude=.DS_Store fortune-mod-1.99.1/Notes fortune-mod-1.99.1-patched/Notes
---- fortune-mod-1.99.1/Notes	Fri Mar  5 08:29:56 2004
-+++ fortune-mod-1.99.1-patched/Notes	Fri Dec 10 18:32:28 2004
-@@ -17,7 +17,7 @@
+diff -ur fortune-mod-2.12.0.orig/CMakeLists.txt fortune-mod-2.12.0/CMakeLists.txt
+--- fortune-mod-2.12.0.orig/CMakeLists.txt	2019-12-18 11:01:26.000000000 +0000
++++ fortune-mod-2.12.0/CMakeLists.txt	2019-12-19 17:50:38.000000000 +0000
+@@ -158,7 +158,7 @@
+ my_exe(
+     "fortune"
+     "fortune/fortune.c"
+-    "games"
++    "bin"
+ )
+ 
+ my_exe(
+diff -ur fortune-mod-2.12.0.orig/Notes fortune-mod-2.12.0/Notes
+--- fortune-mod-2.12.0.orig/Notes	2019-03-12 13:58:14.000000000 +0000
++++ fortune-mod-2.12.0/Notes	2019-12-19 17:51:13.000000000 +0000
+@@ -16,7 +16,7 @@
+ 
  ==> GENERAL INFORMATION
  	By default, fortune retrieves its fortune files from the directory
 -/usr/local/share/games/fortune.  A fortune file has two parts: the source file
 +@PREFIX@/share/fortunes.  A fortune file has two parts: the source file
  (which contains the fortunes themselves) and the data file which describes
--the fortunes.  The data fil always has the same name as the fortune file
-+the fortunes.  The data file always has the same name as the fortune file
+ the fortunes.  The data fil always has the same name as the fortune file
  with the string ".dat" concatenated, e.g. if "fort" is a standard fortune
- database, then "fort.dat" is the data file which describes it.  See
-@@ -26,5 +26,5 @@
+@@ -25,7 +25,7 @@
+ 	Fortunes are split into potentially offensive and not potentially
  offensive parts.  The offensive version of a file has the same name as the
- non-offensive version but exists in the offensive fortunes directory 
+ non-offensive version but exists in the offensive fortunes directory
 -(/usr/local/share/games/fortune/off by default).  The fortune program
 +(@PREFIX@/share/fortunes/off by default).  The fortune program
  automatically assumes that any file in the offensive fortune directory
  is potentially offensive, and should therefore only be displayed if
-diff -ru2N --exclude=.DS_Store fortune-mod-1.99.1/fortune/fortune.c fortune-mod-1.99.1-patched/fortune/fortune.c
---- fortune-mod-1.99.1/fortune/fortune.c	Fri Mar  5 08:29:56 2004
-+++ fortune-mod-1.99.1-patched/fortune/fortune.c	Fri Dec 10 16:22:22 2004
-@@ -98,5 +98,5 @@
+ explicitly requested, either with the -o option, by specifying a file name
+diff -ur fortune-mod-2.12.0.orig/tests/fortune-m-test.py fortune-mod-2.12.0/tests/fortune-m-test.py
+--- fortune-mod-2.12.0.orig/tests/fortune-m-test.py	2019-06-24 20:02:33.000000000 +0100
++++ fortune-mod-2.12.0/tests/fortune-m-test.py	2019-12-19 17:50:38.000000000 +0000
+@@ -6,6 +6,6 @@
+ from os.path import join
+ inst_dir = join(os.getcwd(), "fortune-m-INST_DIR")
  
- #define		PROGRAM_NAME		"fortune-mod"
--#define		PROGRAM_VERSION		"9708"
-+#define		PROGRAM_VERSION		"1.99.1"
- 
- #ifdef HAVE_STDBOOL_H
-@@ -258,4 +258,5 @@
- int add_dir(register FILEDESC *);
- 
-+const char *program_name;
- char *program_version(void)
+-exe = glob.glob(join(inst_dir, "games", "fortune")+'*')[0]
++exe = glob.glob(join(inst_dir, "bin", "fortune")+'*')[0]
+ subprocess.call(["objdump", "-p", exe])
+ subprocess.check_call([exe, "-m", "giants"])
+diff -ur fortune-mod-2.12.0.orig/tests/t/lib/FortTestInst.pm fortune-mod-2.12.0/tests/t/lib/FortTestInst.pm
+--- fortune-mod-2.12.0.orig/tests/t/lib/FortTestInst.pm	2019-06-30 12:16:55.000000000 +0100
++++ fortune-mod-2.12.0/tests/t/lib/FortTestInst.pm	2019-12-19 17:52:54.000000000 +0000
+@@ -43,6 +43,7 @@
+                     ? "-DCMAKE_MAKE_PROGRAM=$ENV{CMAKE_MAKE_PROGRAM}"
+                     : ()
+                 ),
++                "-DCMAKE_C_FLAGS=-I@PREFIX@/include",
+                 "-DCMAKE_INSTALL_PREFIX=$inst_dir",
+                 $ENV{SRC_DIR}
+             ]
+Only in fortune-mod-2.12.0/tests/t/lib: FortTestInst.pm~
+diff -ur fortune-mod-2.12.0.orig/tests/t/test-fortune-m.t fortune-mod-2.12.0/tests/t/test-fortune-m.t
+--- fortune-mod-2.12.0.orig/tests/t/test-fortune-m.t	2019-06-30 12:16:14.000000000 +0100
++++ fortune-mod-2.12.0/tests/t/test-fortune-m.t	2019-12-19 17:50:38.000000000 +0000
+@@ -11,7 +11,7 @@
  {
-@@ -1676,4 +1677,5 @@
-     char *ctype, *crequest;
-     getargs(ac, av);
-+    program_name = (char *const) av[0];
+     my $inst_dir = FortTestInst::install("fortune-m");
  
-     outer = recode_new_outer(true);
-@@ -1682,6 +1682,9 @@
-     setlocale(LC_ALL,"");
-     ctype = nl_langinfo(CODESET);
--    if(strcmp(ctype,"ANSI_X3.4-1968") == 0)
--        ctype="ISO-8859-1";
-+    if (!ctype || !*ctype)
-+        ctype="C"; /* revert to C if no valid envvars! */
-+    else
-+        if(strcmp(ctype,"ANSI_X3.4-1968") == 0)
-+            ctype="ISO-8859-1";
- 	
-     crequest = malloc(strlen(ctype) + 7 + 1);
-diff -ru2N --exclude=.DS_Store fortune-mod-1.99.1/util/rot.c fortune-mod-1.99.1-patched/util/rot.c
---- fortune-mod-1.99.1/util/rot.c	Fri Mar  5 08:29:57 2004
-+++ fortune-mod-1.99.1-patched/util/rot.c	Fri Dec 10 13:29:00 2004
-@@ -6,4 +6,5 @@
- #include <stdio.h>
- #include <ctype.h>
-+#include <stdlib.h>
+-    my $text = `$inst_dir/games/fortune -m giants`;
++    my $text = `$inst_dir/bin/fortune -m giants`;
  
- int main(void)
-diff -ru2N --exclude=.DS_Store fortune-mod-1.99.1/util/unstr.c fortune-mod-1.99.1-patched/util/unstr.c
---- fortune-mod-1.99.1/util/unstr.c	Fri Mar  5 08:29:57 2004
-+++ fortune-mod-1.99.1-patched/util/unstr.c	Fri Dec 10 13:28:45 2004
-@@ -97,4 +97,5 @@
- #include	<string.h>
- #include	<unistd.h>
-+#include	<stdlib.h>
+     # TEST
+     like( $text, qr/Newton/, 'fortune -m matched' );
+diff -ur fortune-mod-2.12.0.orig/tests/t/test-fortune-o-rot.t fortune-mod-2.12.0/tests/t/test-fortune-o-rot.t
+--- fortune-mod-2.12.0.orig/tests/t/test-fortune-o-rot.t	2019-06-30 12:16:19.000000000 +0100
++++ fortune-mod-2.12.0/tests/t/test-fortune-o-rot.t	2019-12-19 17:50:38.000000000 +0000
+@@ -15,7 +15,7 @@
+ {
+     my $inst_dir = FortTestInst::install("fortune-o-rot");
+     local $ENV{FORTUNE_MOD_RAND_HARD_CODED_VALS} = 240;
+-    my $text = `$inst_dir/games/fortune -o`;
++    my $text = `$inst_dir/bin/fortune -o`;
  
- #ifndef MAXPATHLEN
+     # TEST
+     like( $text, qr/\A"Prayer/, 'fortune -o was not rotated' );
+diff -ur fortune-mod-2.12.0.orig/tests/t/trailing-space-and-CRs.t fortune-mod-2.12.0/tests/t/trailing-space-and-CRs.t
+--- fortune-mod-2.12.0.orig/tests/t/trailing-space-and-CRs.t	2019-06-24 21:50:51.000000000 +0100
++++ fortune-mod-2.12.0/tests/t/trailing-space-and-CRs.t	2019-12-19 18:30:45.000000000 +0000
+@@ -13,10 +13,11 @@
+ my %do_not_check = (
+     map { $_ => 1 }
+         qw(
+-        fortune/fortune
+-        util/rot
+-        util/strfile
+-        util/unstr
++        fortune
++        rot
++        strfile
++        unstr
++        randstr
+         )
+ );
+ 
+@@ -32,7 +33,7 @@
+             not(   $r->basename =~ /\A\..*?\.swp\z/
+                 or $r->basename =~ /\.(o|dat|valgrind-log)\z/
+                 or
+-                exists( $do_not_check{ join '/', @{ $r->full_components } } ) )
++                exists( $do_not_check{ $r->basename } ) )
+             )
+         {
+             my $contents = path($fn)->slurp_raw;
+@@ -53,7 +54,8 @@
+     }
+     else
+     {
+-        if ( ( $r->dir_components->[-1] // '' ) eq '.git' )
++        if ( ( $r->dir_components->[-1] // '' ) eq '.git' or
++	     ( $r->dir_components->[-1] // '' ) eq 'CMakeFiles' )
+         {
+             $tree->prune;
+         }

--- a/10.9-libcxx/stable/main/finkinfo/games/fortune-mod.patch
+++ b/10.9-libcxx/stable/main/finkinfo/games/fortune-mod.patch
@@ -12,17 +12,19 @@ diff -ur fortune-mod-2.12.0.orig/CMakeLists.txt fortune-mod-2.12.0/CMakeLists.tx
  my_exe(
 diff -ur fortune-mod-2.12.0.orig/Notes fortune-mod-2.12.0/Notes
 --- fortune-mod-2.12.0.orig/Notes	2019-03-12 13:58:14.000000000 +0000
-+++ fortune-mod-2.12.0/Notes	2019-12-19 17:51:13.000000000 +0000
-@@ -16,7 +16,7 @@
++++ fortune-mod-2.12.0/Notes	2019-12-19 18:56:05.000000000 +0000
+@@ -16,16 +16,16 @@
  
  ==> GENERAL INFORMATION
  	By default, fortune retrieves its fortune files from the directory
 -/usr/local/share/games/fortune.  A fortune file has two parts: the source file
 +@PREFIX@/share/fortunes.  A fortune file has two parts: the source file
  (which contains the fortunes themselves) and the data file which describes
- the fortunes.  The data fil always has the same name as the fortune file
+-the fortunes.  The data fil always has the same name as the fortune file
++the fortunes.  The data file always has the same name as the fortune file
  with the string ".dat" concatenated, e.g. if "fort" is a standard fortune
-@@ -25,7 +25,7 @@
+ database, then "fort.dat" is the data file which describes it.  See
+ strfile(8) for more information on creating the data files.
  	Fortunes are split into potentially offensive and not potentially
  offensive parts.  The offensive version of a file has the same name as the
  non-offensive version but exists in the offensive fortunes directory

--- a/10.9-libcxx/stable/main/finkinfo/libs/rinutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rinutils.info
@@ -1,0 +1,30 @@
+Package: rinutils
+Version: 0.1.4
+Revision: 1
+Description: C11 / gnu11 utilities C library
+BuildDependsOnly: true
+Source: https://github.com/shlomif/rinutils/releases/download/%v/%n-%v.tar.xz
+Source-MD5: 63e74f531f6fd8c91d3c9c526d730455
+BuildDepends: <<
+	fink (>= 0.32),
+	cmake
+<<
+CompileScript: <<
+cmake -D CMAKE_INSTALL_PREFIX=%i .
+perl -pi -e 's|%i|%p|g' librinutils.pc
+make 
+<<
+DocFiles: LICENSE NEWS.asciidoc README.asciidoc
+DescDetail: <<
+This is a set of C headers containing macros and static functions that are 
+expected to work on Unix-like systems and MS Windows that have been extracted 
+from Shlomi Fish's projects.
+
+They are quite random and task specific and may not work for you.
+
+Note: we only support the -std=gnu11 dialect as supported by GCC, clang and 
+compatible compilers. Other compilers are not supported.
+<<
+License: BSD
+Maintainer: None <fink-devel@lists.sourceforge.net>
+Homepage: https://github.com/shlomif/rinutils


### PR DESCRIPTION
Changes:
- new version with new upstream repository
- uses recode3 instead of recode
- uses cmake
- uses "rinutils" headers (which have been added as a separate package in libs as part of this PR)

Tested on 10.15.2, including with "-m"