### PR TITLE
ENH: Python3 updates and test suite fixes

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/python27.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python27.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: python%type_pkg[python]
 Version: 2.7.18
-Revision: 1
+Revision: 2
 Epoch: 1
 Type: python 2.7
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>

--- a/10.9-libcxx/stable/main/finkinfo/languages/python27.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python27.info
@@ -103,17 +103,31 @@ CompileScript: <<
 InfoTest: <<
 	TestConflicts: pyxml-py%type_pkg[python], gnome-applets, apple-gdb
 	TestScript: <<
-		# Change install_name of lib during tests since DYLD_LIBRARY_PATH doesn't work on 10.11+.
-		install_name_tool -change %p/lib/python%type_raw[python]/config/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib python.exe
+		#!/bin/sh -ex
+		# Change install_name of lib during tests since DYLD_LIBRARY_PATH is not exported to test_subprocess on 10.11+.
+		if [ -x python.exe ]; then
+			python_exe=python.exe
+		else
+			python_exe=python
+		fi
+		install_name_tool -change %p/lib/python%type_raw[python]/config/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib $python_exe
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/python%type_raw[python]/config/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib {} \;
 		install_name_tool -id %b/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
-		
-		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS='-w -x test_distutils test_argparse test_httpservers test_gdb test_ssl test_httplib test_urllib2_localnet' || exit 2
-		
+
+		# test_socket can fail with some DNS settings.
+		# multiprocessing_spawn fails on "KeyboardInterrupt not raised by wait",
+		# the other 4 hang indefinitely
+		EXTRATESTOPTS='-w -x test_socket test_distutils test_ssl test_multiprocessing_spawn test_asyncio test_httpservers test_logging test_xmlrpc'
+		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
+
 		# Put install_name back.
-		install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/python%type_raw[python]/config/libpython%type_raw[python].dylib python.exe
+		install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/python%type_raw[python]/config/libpython%type_raw[python].dylib $python_exe
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/python%type_raw[python]/config/libpython%type_raw[python].dylib {} \;
 		install_name_tool -id %p/lib/python%type_raw[python]/config/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
+
+		# Remove stray .pyc that get made during tests to keep validator happy.
+		find ./Tools -name "*.pyc" -delete
+		exit $TESTRETURN
 	<<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/python27.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python27.info
@@ -269,6 +269,9 @@ DescPort: <<
 	
 	Upstream patch from https://bugs.python.org/issue27369 to fix tests
 	with expat 2.2.0.
+
+	Call build executable by correct filename in test suite
+	(python on case-sensitive, python.exe on -insensitive file systems).
 <<
 License: OSI-Approved
 Homepage: http://www.python.org

--- a/10.9-libcxx/stable/main/finkinfo/languages/python27.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python27.info
@@ -18,7 +18,7 @@ Depends: <<
 	libgettext8-shlibs,
 	libncursesw5-shlibs,
 	openssl110-shlibs (>= 1.1.1d-1),
-	readline6-shlibs,
+	readline7-shlibs,
 	sqlite3-shlibs  (>= 3.23.1-1),
 	tcltk (>= 8.4.1-1),
 	x11
@@ -35,7 +35,7 @@ BuildDepends: <<
 	libffi6,
 	libgettext8-dev,
 	libncursesw5,
-	readline6,
+	readline7,
 	sqlite3-dev (>= 3.23.1-1),
 	openssl110-dev (>= 1.1.1d-1),
 	tcltk-dev (>= 8.4.1-1),
@@ -51,10 +51,9 @@ Source2: http://www.python.org/ftp/python/doc/%v/python-%v-docs-html.tar.bz2
 Source2-Checksum: SHA256(20445e9a571cacdd350f702f0980e4dc559b6ff81f1d69affe9b0a862fef2f0e)
 
 PatchFile: %n.patch
-PatchFile-MD5: 84983fcb7eb4677be2ff56ccfcf12671
+PatchFile-MD5: 828380d012fe11d6fc03dea8647bec99
 PatchScript: <<
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
-	perl -pi -e 's|/usr/local|%p|' setup.py
 	# /tmp and /var/tmp are symlinks to /private/tmp and /private/var/tmp
 	# on OS X. That's fine except it can cause tests in some packages to
 	# fail since '/tmp' != '/private/tmp'. Default to using /private/tmp.
@@ -84,7 +83,6 @@ CompileScript: <<
 		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
 		export CFLAGS="-Wno-nullability-completeness"
 		export CPPFLAGS="-I%p/include -I%p/include/ncursesw -I$SDK_PATH/usr/include"
-		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi
 
 	# https://bugs.python.org/issue28456 and radar://28372390

--- a/10.9-libcxx/stable/main/finkinfo/languages/python27.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python27.patch
@@ -233,6 +233,19 @@ diff -ruN Python-2.7.17.orig/setup.py Python-2.7.17/setup.py
  
      def build_extension(self, ext):
  
+@@ -501,9 +506,9 @@
+
+     def detect_modules(self):
+         # Ensure that /usr/local is always used
+-        if not cross_compiling:
+-            add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+-            add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
++        # if not cross_compiling:
++        #     add_dir_to_list(self.compiler.library_dirs, '/usr/lib')
++        #     add_dir_to_list(self.compiler.include_dirs, '/usr/include')
+         if cross_compiling:
+             self.add_gcc_paths()
+         self.add_multiarch_paths()
 @@ -991,53 +996,8 @@
          # construct a list of paths to look for the header file in on
          # top of the normal inc_dirs.

--- a/10.9-libcxx/stable/main/finkinfo/languages/python34.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python34.info
@@ -110,27 +110,37 @@ CompileScript: <<
 <<
 
 # Tests have started hanging for me.
-#InfoTest: <<
-#	TestConflicts: apple-gdb
-#	TestScript: <<
-#		# Change install_name of lib during tests since DYLD_LIBRARY_PATH doesn't work on 10.11+.
-#		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib python.exe
-#		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib {} \;
-#		install_name_tool -id %b/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
-#		
-#		# test_socket can fail with some DNS settings.
-#		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS='-w -unone -x test_socket' || exit 2
-#		
-#		# Put install_name back.
-#		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib python.exe
-#		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib {} \;
-#		install_name_tool -id %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
-#		
-#		# Remove stray .pyc that get made during tests to keep validator happy.
-#		find ./Tools -name "*.pyc" -delete
-#		find ./Tools -name "__pycache__" -delete
-#	<<
-#<<
+InfoTest: <<
+	TestConflicts: apple-gdb
+	TestScript: <<
+		#!/bin/sh -ex
+		# Change install_name of lib during tests since DYLD_LIBRARY_PATH is not exported to test_subprocess on 10.11+.
+		if [ -x python.exe ]; then
+			python_exe=python.exe
+		else
+			python_exe=python
+		fi
+		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib $python_exe
+		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib {} \;
+		install_name_tool -id %b/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
+
+		# test_socket can fail with some DNS settings.
+		# multiprocessing_spawn fails on "KeyboardInterrupt not raised by wait",
+		# the other 4 hang indefinitely
+		EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_ssl test_multiprocessing_spawn test_asyncio test_httpservers test_logging test_xmlrpc'
+		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
+
+		# Put install_name back.
+		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib $python_exe
+		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib {} \;
+		install_name_tool -id %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
+
+		# Remove stray .pyc that get made during tests to keep validator happy.
+		find ./Tools -name "*.pyc" -delete
+		find ./Tools -name "__pycache__" -delete
+		exit $TESTRETURN
+	<<
+<<
 
 InstallScript: <<
 #!/bin/sh -ex

--- a/10.9-libcxx/stable/main/finkinfo/languages/python34.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python34.info
@@ -281,6 +281,9 @@ DescPort: <<
 
 	No longer change stack size of interpreter in configure. Causes test
 	failures in 10.14.4. https://bugs.python.org/issue34602
+
+	Call build executable by correct filename in test suite
+	(python on case-sensitive, python.exe on -insensitive file systems).
 <<
 License: OSI-Approved
 Homepage: http://www.python.org

--- a/10.9-libcxx/stable/main/finkinfo/languages/python35.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python35.info
@@ -83,7 +83,8 @@ ConfigureParams: <<
 	--with-system-ffi \
 	--with-tcltk-includes="-I%p/include -I/opt/X11/include" \
 	--with-tcltk-libs="-L%p/lib -ltcl -ltk" \
-	--without-ensurepip
+	--without-ensurepip \
+	--with-suffix=.exe
 <<
 
 CompileScript: <<
@@ -107,27 +108,27 @@ CompileScript: <<
 <<
 
 # Tests have started hanging for me.
-#InfoTest: <<
-#	TestConflicts: apple-gdb
-#	TestScript: <<
-#		# Change install_name of lib during tests since DYLD_LIBRARY_PATH doesn't work on 10.11+.
-#		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib python.exe
-#		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib {} \;
-#		install_name_tool -id %b/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
-#		
-#		# test_socket can fail with some DNS settings.
-#		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_asyncio' || exit 2
-#		
-#		# Put install_name back.
-#		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib python.exe
-#		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib {} \;
-#		install_name_tool -id %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
-#		
-#		# Remove stray .pyc that get made during tests to keep validator happy.
-#		find ./Tools -name "*.pyc" -delete
-#		find ./Tools -name "__pycache__" -delete
-#	<<
-#<<
+InfoTest: <<
+	TestConflicts: apple-gdb
+	TestScript: <<
+		# Change install_name of lib during tests since DYLD_LIBRARY_PATH doesn't work on 10.11+.
+		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib python.exe
+		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib {} \;
+		install_name_tool -id %b/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
+
+		# test_socket can fail with some DNS settings.
+		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_asyncio' || exit 2
+
+		# Put install_name back.
+		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib python.exe
+		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib {} \;
+		install_name_tool -id %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
+
+		# Remove stray .pyc that get made during tests to keep validator happy.
+		find ./Tools -name "*.pyc" -delete
+		find ./Tools -name "__pycache__" -delete
+	<<
+<<
 
 InstallScript: <<
 #!/bin/sh -ex
@@ -149,6 +150,10 @@ InstallScript: <<
 	# fix all main things to be python-versioned filenames with
 	# unversioned symlinks to them
 	pushd %i/bin
+		rm python3.exe python%type_raw[python].exe
+		mv python%type_raw[python]m.exe python%type_raw[python]m
+		ln -s python%type_raw[python]m python%type_raw[python]
+		ln -s python%type_raw[python] python3
 		for f in idle3 pydoc3; do
 			mv ${f} ${f}-%type_raw[python]
 			ln -s ${f}-%type_raw[python] %i/bin/${f}
@@ -156,7 +161,7 @@ InstallScript: <<
 		#Remove this for now to avoid conflicting with 'python' package.
 		rm 2to3
 	popd
-	
+
 	# Add symlinks to %p/lib.
 	ln -s %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib %i/lib/libpython%type_raw[python].dylib
 	ln -s %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib %i/lib/libpython%type_raw[python]m.dylib
@@ -242,13 +247,13 @@ DescPackaging: <<
 	package series. Why would they be in different places? Patch
 	-config script to continue this tradition (bug in previous
 	versions accidentally did the Right Thing here).
-	
+
 	New in 3.2, .pyc files are saved in the __pycache__ directory
 	at the same level as the matching .py file. Any packages that
 	expect the .pyc file to be next to the .py file will need adjustment.
-	
+
 	The .pyc and .so files also include the python version in the name.
-	
+
 	Don't run ensurepip since it installs files that conflict with
 	the pip and setuptools packages.
 <<
@@ -260,7 +265,7 @@ DescPort: <<
 	bsddb is gone so drop db* patch and dep.
 	Patch setup.py to find ncursesw headers and drop libncurses5 dep.
 	Ensure $(LDFLAGS) is used linking libpython or else it can't find libintl.
-	
+
 	Patch ctypes to look in %p/lib for libraries.
 
 	Upstream patch from https://bugs.python.org/issue27369 to fix tests
@@ -268,6 +273,9 @@ DescPort: <<
 
 	No longer change stack size of interpreter in configure. Causes test
 	failures in 10.14.4. https://bugs.python.org/issue34602
+
+	Enforce .exe suffix for executable to ensure consistent build on
+	case-[in]sensitive file systems.
 <<
 License: OSI-Approved
 Homepage: http://www.python.org

--- a/10.9-libcxx/stable/main/finkinfo/languages/python35.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python35.info
@@ -83,8 +83,7 @@ ConfigureParams: <<
 	--with-system-ffi \
 	--with-tcltk-includes="-I%p/include -I/opt/X11/include" \
 	--with-tcltk-libs="-L%p/lib -ltcl -ltk" \
-	--without-ensurepip \
-	--with-suffix=.exe
+	--without-ensurepip
 <<
 
 CompileScript: <<
@@ -111,22 +110,32 @@ CompileScript: <<
 InfoTest: <<
 	TestConflicts: apple-gdb
 	TestScript: <<
-		# Change install_name of lib during tests since DYLD_LIBRARY_PATH doesn't work on 10.11+.
-		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib python.exe
+		#!/bin/sh -ex
+		# Change install_name of lib during tests since DYLD_LIBRARY_PATH is not exported to test_subprocess on 10.11+.
+		if [ -x python.exe ]; then
+			python_exe=python.exe
+		else
+			python_exe=python
+		fi
+		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib $python_exe
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib {} \;
 		install_name_tool -id %b/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
 
 		# test_socket can fail with some DNS settings.
-		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_asyncio' || exit 2
+		# multiprocessing_spawn fails on "KeyboardInterrupt not raised by wait",
+		# the other 4 hang indefinitely
+		EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_ssl test_multiprocessing_spawn test_asyncio test_httpservers test_logging test_xmlrpc'
+		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
 
 		# Put install_name back.
-		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib python.exe
+		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib $python_exe
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib {} \;
 		install_name_tool -id %p/lib/python%type_raw[python]/config-%type_raw[python]m/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
 
 		# Remove stray .pyc that get made during tests to keep validator happy.
 		find ./Tools -name "*.pyc" -delete
 		find ./Tools -name "__pycache__" -delete
+		exit $TESTRETURN
 	<<
 <<
 
@@ -150,10 +159,6 @@ InstallScript: <<
 	# fix all main things to be python-versioned filenames with
 	# unversioned symlinks to them
 	pushd %i/bin
-		rm python3.exe python%type_raw[python].exe
-		mv python%type_raw[python]m.exe python%type_raw[python]m
-		ln -s python%type_raw[python]m python%type_raw[python]
-		ln -s python%type_raw[python] python3
 		for f in idle3 pydoc3; do
 			mv ${f} ${f}-%type_raw[python]
 			ln -s ${f}-%type_raw[python] %i/bin/${f}

--- a/10.9-libcxx/stable/main/finkinfo/languages/python35.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python35.info
@@ -279,8 +279,8 @@ DescPort: <<
 	No longer change stack size of interpreter in configure. Causes test
 	failures in 10.14.4. https://bugs.python.org/issue34602
 
-	Enforce .exe suffix for executable to ensure consistent build on
-	case-[in]sensitive file systems.
+	Call build executable by correct filename in test suite
+	(python on case-sensitive, python.exe on -insensitive file systems).
 <<
 License: OSI-Approved
 Homepage: http://www.python.org

--- a/10.9-libcxx/stable/main/finkinfo/languages/python36.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python36.info
@@ -275,8 +275,8 @@ DescPort: <<
 	No longer change stack size of interpreter in configure. Causes test
 	failures in 10.14.4. https://bugs.python.org/issue34602
 
-	Enforce .exe suffix for executable to ensure consistent build on
-	case-[in]sensitive file systems.
+	Call build executable by correct filename in test suite
+	(python on case-sensitive, python.exe on -insensitive file systems).
 <<
 License: OSI-Approved
 Homepage: http://www.python.org

--- a/10.9-libcxx/stable/main/finkinfo/languages/python36.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python36.info
@@ -82,7 +82,8 @@ ConfigureParams: <<
 	--with-tcltk-includes="-I%p/include -I/opt/X11/include" \
 	--with-tcltk-libs="-L%p/lib -ltcl -ltk" \
 	--with-dtrace \
-	--without-ensurepip
+	--without-ensurepip \
+	--with-suffix=.exe
 <<
 
 CompileScript: <<
@@ -109,18 +110,18 @@ InfoTest: <<
 	TestConflicts: apple-gdb
 	TestScript: <<
 		# Change install_name of lib during tests since DYLD_LIBRARY_PATH doesn't work on 10.11+.
-		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib python
+		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib python.exe
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib {} \;
 		install_name_tool -id %b/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
-		
+
 		# test_socket can fail with some DNS settings.
 		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_ssl' || exit 2
-		
+
 		# Put install_name back.
-		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib python
+		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib python.exe
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib {} \;
 		install_name_tool -id %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
-		
+
 		# Remove stray .pyc that get made during tests to keep validator happy.
 		find ./Tools -name "*.pyc" -delete
 		find ./Tools -name "__pycache__" -delete
@@ -147,6 +148,10 @@ InstallScript: <<
 	# fix all main things to be python-versioned filenames with
 	# unversioned symlinks to them
 	pushd %i/bin
+		rm python3.exe python%type_raw[python].exe
+		mv python%type_raw[python]m.exe python%type_raw[python]m
+		ln -s python%type_raw[python]m python%type_raw[python]
+		ln -s python%type_raw[python] python3
 		for f in idle3 pydoc3; do
 			mv ${f} ${f}-%type_raw[python]
 			ln -s ${f}-%type_raw[python] %i/bin/${f}
@@ -263,6 +268,9 @@ DescPort: <<
 
 	No longer change stack size of interpreter in configure. Causes test
 	failures in 10.14.4. https://bugs.python.org/issue34602
+
+	Enforce .exe suffix for executable to ensure consistent build on
+	case-[in]sensitive file systems.
 <<
 License: OSI-Approved
 Homepage: http://www.python.org

--- a/10.9-libcxx/stable/main/finkinfo/languages/python36.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python36.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: python36.patch -*-
 Info2: <<
 Package: python%type_pkg[python]
-Version: 3.6.9
+Version: 3.6.10
 Revision: 1
 Type: python 3.6
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
@@ -46,7 +46,7 @@ Recommends: pip-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
 Provides: argparse-py%type_pkg[python], futures-py%type_pkg[python], enum34-py%type_pkg[python], pathlib-py%type_pkg[python]
 
 Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
-Source-Checksum: SHA256(5e2f5f554e3f8f7f0296f7e73d8600c4e9acbaee6b2555b83206edf5153870da)
+Source-Checksum: SHA256(0a833c398ac8cd7c5538f7232d8531afef943c60495c504484f308dac3af40de)
 
 PatchFile: %n.patch
 PatchFile-MD5: d1f5d23c7ee06375a290374404552ecb
@@ -109,7 +109,7 @@ InfoTest: <<
 	TestConflicts: apple-gdb
 	TestScript: <<
 		# Change install_name of lib during tests since DYLD_LIBRARY_PATH doesn't work on 10.11+.
-		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib python.exe
+		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib python
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib {} \;
 		install_name_tool -id %b/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
 		
@@ -117,7 +117,7 @@ InfoTest: <<
 		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_ssl' || exit 2
 		
 		# Put install_name back.
-		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib python.exe
+		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib python
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib {} \;
 		install_name_tool -id %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
 		

--- a/10.9-libcxx/stable/main/finkinfo/languages/python36.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python36.info
@@ -82,8 +82,7 @@ ConfigureParams: <<
 	--with-tcltk-includes="-I%p/include -I/opt/X11/include" \
 	--with-tcltk-libs="-L%p/lib -ltcl -ltk" \
 	--with-dtrace \
-	--without-ensurepip \
-	--with-suffix=.exe
+	--without-ensurepip
 <<
 
 CompileScript: <<
@@ -109,22 +108,33 @@ CompileScript: <<
 InfoTest: <<
 	TestConflicts: apple-gdb
 	TestScript: <<
-		# Change install_name of lib during tests since DYLD_LIBRARY_PATH doesn't work on 10.11+.
-		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib python.exe
+		#!/bin/sh -ex
+		# Change install_name of lib during tests since DYLD_LIBRARY_PATH is not exported to test_subprocess on 10.11+.
+		if [ -x python.exe ]; then
+			python_exe=python.exe
+		else
+			python_exe=python
+		fi
+		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib $python_exe
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib {} \;
 		install_name_tool -id %b/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
 
 		# test_socket can fail with some DNS settings.
-		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_ssl' || exit 2
+		# EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_ssl'
+		# multiprocessing_span can fail on "KeyboardInterrupt not raised by wait",
+		# the other 4 hang indefinitely
+		EXTRATESTOPTS='-w -unone -x test_asyncio test_httpservers test_logging test_xmlrpc'
+		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
 
 		# Put install_name back.
-		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib python.exe
+		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib $python_exe
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib {} \;
 		install_name_tool -id %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
 
 		# Remove stray .pyc that get made during tests to keep validator happy.
 		find ./Tools -name "*.pyc" -delete
 		find ./Tools -name "__pycache__" -delete
+		exit $TESTRETURN
 	<<
 <<
 
@@ -148,10 +158,6 @@ InstallScript: <<
 	# fix all main things to be python-versioned filenames with
 	# unversioned symlinks to them
 	pushd %i/bin
-		rm python3.exe python%type_raw[python].exe
-		mv python%type_raw[python]m.exe python%type_raw[python]m
-		ln -s python%type_raw[python]m python%type_raw[python]
-		ln -s python%type_raw[python] python3
 		for f in idle3 pydoc3; do
 			mv ${f} ${f}-%type_raw[python]
 			ln -s ${f}-%type_raw[python] %i/bin/${f}

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -85,7 +85,8 @@ ConfigureParams: <<
 	--with-tcltk-includes="-I%p/include -I/opt/X11/include" \
 	--with-tcltk-libs="-L%p/lib -ltcl -ltk" \
 	--with-dtrace \
-	--without-ensurepip
+	--without-ensurepip \
+	--with-suffix=.exe
 <<
 
 CompileScript: <<
@@ -112,19 +113,19 @@ InfoTest: <<
 	TestConflicts: apple-gdb
 	TestScript: <<
 		# Change install_name of lib during tests since DYLD_LIBRARY_PATH doesn't work on 10.11+.
-		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib python
+		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib python.exe
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib {} \;
 		install_name_tool -id %b/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
-		
+
 		# test_socket can fail with some DNS settings.
 		# test.test_asyncio.test_sslproto.SelectorStartTLSTests fails intermittently with a timeout.
 		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_asyncio' || exit 2
-		
+
 		# Put install_name back.
-		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib python
+		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib python.exe
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib {} \;
 		install_name_tool -id %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
-		
+
 		# Remove stray .pyc that get made during tests to keep validator happy.
 		find ./Tools -name "*.pyc" -delete
 		find ./Tools -name "__pycache__" -delete
@@ -151,6 +152,10 @@ InstallScript: <<
 	# fix all main things to be python-versioned filenames with
 	# unversioned symlinks to them
 	pushd %i/bin
+		rm python3.exe python%type_raw[python].exe
+		mv python%type_raw[python]m.exe python%type_raw[python]m
+		ln -s python%type_raw[python]m python%type_raw[python]
+		ln -s python%type_raw[python] python3
 		for f in idle3 pydoc3; do
 			mv ${f} ${f}-%type_raw[python]
 			ln -s ${f}-%type_raw[python] %i/bin/${f}
@@ -158,7 +163,7 @@ InstallScript: <<
 		#Remove this for now to avoid conflicting with 'python' package.
 		rm 2to3
 	popd
-	
+
 	# Add symlinks to %p/lib.
 	ln -s %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %i/lib/libpython%type_raw[python].dylib
 	ln -s %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %i/lib/libpython%type_raw[python]m.dylib
@@ -244,13 +249,13 @@ DescPackaging: <<
 	package series. Why would they be in different places? Patch
 	-config script to continue this tradition (bug in previous
 	versions accidentally did the Right Thing here).
-	
+
 	New in 3.2, .pyc files are saved in the __pycache__ directory
 	at the same level as the matching .py file. Any packages that
 	expect the .pyc file to be next to the .py file will need adjustment.
-	
+
 	The .pyc and .so files also include the python version in the name.
-	
+
 	Don't run ensurepip since it installs files that conflict with
 	the pip and setuptools packages.
 <<
@@ -262,11 +267,14 @@ DescPort: <<
 	bsddb is gone so drop db* patch and dep.
 	Patch setup.py to find ncursesw headers and drop libncurses5 dep.
 	Ensure $(LDFLAGS) is used linking libpython or else it can't find libintl.
-	
+
 	Patch ctypes to look in %p/lib for libraries.
-	
+
 	No longer change stack size of interpreter in configure. Causes test
 	failures in 10.14.4. https://bugs.python.org/issue34602
+
+	Enforce .exe suffix for executable to ensure consistent build on
+	case-[in]sensitive file systems.
 <<
 License: OSI-Approved
 Homepage: http://www.python.org

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -157,8 +157,7 @@ InstallScript: <<
 	# we don't want -lintl to appear in LIBS otherwise python-config will propagate it
 	perl -pi -e 's/-lintl //' %i/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/Makefile
 	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin,' %i/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/Makefile	
-	# Fix all main things to be python-versioned filenames with
-	# unversioned symlinks to them; strip .exe suffix.
+	# Fix all main things to be python-versioned filenames with unversioned symlinks to them.
 	pushd %i/bin
 		for f in idle3 pydoc3; do
 			mv ${f} ${f}-%type_raw[python]
@@ -277,8 +276,8 @@ DescPort: <<
 	No longer change stack size of interpreter in configure. Causes test
 	failures in 10.14.4. https://bugs.python.org/issue34602
 
-	Enforce .exe suffix for executable to ensure consistent build on
-	case-[in]sensitive file systems.
+	Call build executable by correct filename in test suite
+	(python on case-sensitive, python.exe on -insensitive file systems).
 <<
 License: OSI-Approved
 Homepage: http://www.python.org

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: python37.patch -*-
 Info2: <<
 Package: python%type_pkg[python]
-Version: 3.7.6
+Version: 3.7.7
 Revision: 1
 Type: python 3.7
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
@@ -49,7 +49,7 @@ Recommends: pip-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
 Provides: argparse-py%type_pkg[python], futures-py%type_pkg[python], enum34-py%type_pkg[python], pathlib-py%type_pkg[python]
 
 Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
-Source-Checksum: SHA256(55a2cce72049f0794e9a11a84862e9039af9183603b78bc60d89539f82cf533f)
+Source-Checksum: SHA256(06a0a9f1bf0d8cd1e4121194d666c4e28ddae4dd54346de6c343206599f02136)
 
 PatchFile: %n.patch
 PatchFile-MD5: 2d47c28843a13238bbe9495c42c8b910
@@ -150,8 +150,9 @@ InstallScript: <<
 	perl -pi -e 's/-lintl //' %i/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/Makefile
 	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin,' %i/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/Makefile	
 	# fix all main things to be python-versioned filenames with
-	# unversioned symlinks to them
+	# unversioned symlinks to them; strip .exe suffix.
 	pushd %i/bin
+		perl -pi -e 's,(%p/bin/python%type_raw[python]m*)(.exe),$1,' *3 *%type_raw[python] *config
 		rm python3.exe python%type_raw[python].exe
 		mv python%type_raw[python]m.exe python%type_raw[python]m
 		ln -s python%type_raw[python]m python%type_raw[python]

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -85,8 +85,7 @@ ConfigureParams: <<
 	--with-tcltk-includes="-I%p/include -I/opt/X11/include" \
 	--with-tcltk-libs="-L%p/lib -ltcl -ltk" \
 	--with-dtrace \
-	--without-ensurepip \
-	--with-suffix=.exe
+	--without-ensurepip
 <<
 
 CompileScript: <<
@@ -112,23 +111,32 @@ CompileScript: <<
 InfoTest: <<
 	TestConflicts: apple-gdb
 	TestScript: <<
-		# Change install_name of lib during tests since DYLD_LIBRARY_PATH doesn't work on 10.11+.
-		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib python.exe
+		#!/bin/sh -ex
+		# Change install_name of lib during tests since DYLD_LIBRARY_PATH is not exported to test_subprocess on 10.11+.
+		if [ -x python.exe ]; then
+			python_exe=python.exe
+		else
+			python_exe=python
+		fi
+		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib $python_exe
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib {} \;
 		install_name_tool -id %b/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
 
 		# test_socket can fail with some DNS settings.
-		# test.test_asyncio.test_sslproto.SelectorStartTLSTests fails intermittently with a timeout.
-		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_asyncio' || exit 2
+		# multiprocessing_spawn fails on "KeyboardInterrupt not raised by wait",
+		# the other 4 hang indefinitely
+		EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_ssl test_multiprocessing_spawn test_asyncio test_httpservers test_logging test_xmlrpc'
+		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
 
 		# Put install_name back.
-		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib python.exe
+		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib $python_exe
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib {} \;
 		install_name_tool -id %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
 
 		# Remove stray .pyc that get made during tests to keep validator happy.
 		find ./Tools -name "*.pyc" -delete
 		find ./Tools -name "__pycache__" -delete
+		exit $TESTRETURN
 	<<
 <<
 
@@ -149,14 +157,9 @@ InstallScript: <<
 	# we don't want -lintl to appear in LIBS otherwise python-config will propagate it
 	perl -pi -e 's/-lintl //' %i/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/Makefile
 	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin,' %i/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/Makefile	
-	# fix all main things to be python-versioned filenames with
+	# Fix all main things to be python-versioned filenames with
 	# unversioned symlinks to them; strip .exe suffix.
 	pushd %i/bin
-		perl -pi -e 's,(%p/bin/python%type_raw[python]m*)(.exe),$1,' *3 *%type_raw[python] *config
-		rm python3.exe python%type_raw[python].exe
-		mv python%type_raw[python]m.exe python%type_raw[python]m
-		ln -s python%type_raw[python]m python%type_raw[python]
-		ln -s python%type_raw[python] python3
 		for f in idle3 pydoc3; do
 			mv ${f} ${f}-%type_raw[python]
 			ln -s ${f}-%type_raw[python] %i/bin/${f}

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: python37.patch -*-
 Info2: <<
 Package: python%type_pkg[python]
-Version: 3.7.5
+Version: 3.7.6
 Revision: 1
 Type: python 3.7
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
@@ -49,7 +49,7 @@ Recommends: pip-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
 Provides: argparse-py%type_pkg[python], futures-py%type_pkg[python], enum34-py%type_pkg[python], pathlib-py%type_pkg[python]
 
 Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
-Source-Checksum: SHA256(e85a76ea9f3d6c485ec1780fca4e500725a4a7bbc63c78ebc44170de9b619d94)
+Source-Checksum: SHA256(55a2cce72049f0794e9a11a84862e9039af9183603b78bc60d89539f82cf533f)
 
 PatchFile: %n.patch
 PatchFile-MD5: 2d47c28843a13238bbe9495c42c8b910
@@ -112,7 +112,7 @@ InfoTest: <<
 	TestConflicts: apple-gdb
 	TestScript: <<
 		# Change install_name of lib during tests since DYLD_LIBRARY_PATH doesn't work on 10.11+.
-		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib python.exe
+		install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib python
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib %b/libpython%type_raw[python]m.dylib {} \;
 		install_name_tool -id %b/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
 		
@@ -121,7 +121,7 @@ InfoTest: <<
 		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_asyncio' || exit 2
 		
 		# Put install_name back.
-		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib python.exe
+		install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib python
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python]m.dylib %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib {} \;
 		install_name_tool -id %p/lib/python%type_raw[python]/config-%type_raw[python]m-darwin/libpython%type_raw[python]m.dylib libpython%type_raw[python]m.dylib
 		

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.info
@@ -52,7 +52,7 @@ Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
 Source-Checksum: SHA256(dfab5ec723c218082fe3d5d7ae17ecbdebffa9a1aea4d64aa3a2ecdd2e795864)
 
 PatchFile: %n.patch
-PatchFile-MD5: 385c9da231cfd77ff810af1298712f46
+PatchFile-MD5: 25181b340fc83818ea6d910b64481f0b
 PatchScript: <<
 	#!/bin/sh -ex
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.info
@@ -1,7 +1,7 @@
-# -*- coding: ascii; tab-width: 4; x-counterpart: python37.patch -*-
+# -*- coding: ascii; tab-width: 4; x-counterpart: python38.patch -*-
 Info2: <<
 Package: python%type_pkg[python]
-Version: 3.8.0
+Version: 3.8.1
 Revision: 1
 Type: python 3.8
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
@@ -49,10 +49,10 @@ Recommends: pip-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
 Provides: argparse-py%type_pkg[python], futures-py%type_pkg[python], enum34-py%type_pkg[python], pathlib-py%type_pkg[python]
 
 Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
-Source-Checksum: SHA256(b356244e13fb5491da890b35b13b2118c3122977c2cd825e3eb6e7d462030d84)
+Source-Checksum: SHA256(75894117f6db7051c1b34f37410168844bbb357c139a8a10a352e9bf8be594e8)
 
 PatchFile: %n.patch
-PatchFile-MD5: 539728f3f9d9d07c05346450b9fa7110
+PatchFile-MD5: bd770f2fb72d2c223030ac2cc49ec384
 PatchScript: <<
 	#!/bin/sh -ex
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
@@ -112,14 +112,14 @@ InfoTest: <<
 	TestConflicts: apple-gdb
 	TestScript: <<
 		# Change install_name of lib during tests since DYLD_LIBRARY_PATH doesn't work on 10.11+.
-		install_name_tool -change %p/lib/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib python.exe
+		install_name_tool -change %p/lib/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib python
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib {} \;
 		install_name_tool -id %b/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
 		
 		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS='-w -unone' || exit 2
 		
 		# Put install_name back.
-		install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib python.exe
+		install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib python
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib {} \;
 		install_name_tool -id %p/lib/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
 		

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: python38.patch -*-
 Info2: <<
 Package: python%type_pkg[python]
-Version: 3.8.2
+Version: 3.8.3
 Revision: 1
 Type: python 3.8
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
@@ -49,10 +49,10 @@ Recommends: pip-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
 Provides: argparse-py%type_pkg[python], futures-py%type_pkg[python], enum34-py%type_pkg[python], pathlib-py%type_pkg[python]
 
 Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
-Source-Checksum: SHA256(2646e7dc233362f59714c6193017bb2d6f7b38d6ab4a0cb5fbac5c36c4d845df)
+Source-Checksum: SHA256(dfab5ec723c218082fe3d5d7ae17ecbdebffa9a1aea4d64aa3a2ecdd2e795864)
 
 PatchFile: %n.patch
-PatchFile-MD5: f34a610c4ebd0b12dc64615a6ea72d49
+PatchFile-MD5: 385c9da231cfd77ff810af1298712f46
 PatchScript: <<
 	#!/bin/sh -ex
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
@@ -158,8 +158,7 @@ InstallScript: <<
 	# we don't want -lintl to appear in LIBS otherwise python-config will propagate it
 	perl -pi -e 's/-lintl //' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile
 	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile	
-	# fix all main things to be python-versioned filenames with
-	# unversioned symlinks to them
+	# Fix all main things to be python-versioned filenames with unversioned symlinks to them.
 	pushd %i/bin
 		for f in idle3 pydoc3; do
 			mv ${f} ${f}-%type_raw[python]
@@ -259,8 +258,8 @@ DescPort: <<
 
 	Patch ctypes to look in %p/lib for libraries.
 
-	Enforce .exe suffix for executable to ensure consistent build on
-	case-[in]sensitive file systems.
+	Call build executable by correct filename in test suite
+	(python on case-sensitive, python.exe on -insensitive file systems).
 <<
 License: OSI-Approved
 Homepage: http://www.python.org

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: python38.patch -*-
 Info2: <<
 Package: python%type_pkg[python]
-Version: 3.8.1
+Version: 3.8.2
 Revision: 1
 Type: python 3.8
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
@@ -49,10 +49,10 @@ Recommends: pip-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
 Provides: argparse-py%type_pkg[python], futures-py%type_pkg[python], enum34-py%type_pkg[python], pathlib-py%type_pkg[python]
 
 Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
-Source-Checksum: SHA256(75894117f6db7051c1b34f37410168844bbb357c139a8a10a352e9bf8be594e8)
+Source-Checksum: SHA256(2646e7dc233362f59714c6193017bb2d6f7b38d6ab4a0cb5fbac5c36c4d845df)
 
 PatchFile: %n.patch
-PatchFile-MD5: 711229d21faa1912d1bc22e5778eba7b
+PatchFile-MD5: f34a610c4ebd0b12dc64615a6ea72d49
 PatchScript: <<
 	#!/bin/sh -ex
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
@@ -148,9 +148,10 @@ InstallScript: <<
 	# we don't want -lintl to appear in LIBS otherwise python-config will propagate it
 	perl -pi -e 's/-lintl //' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile
 	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile	
-	# fix all main things to be python-versioned filenames with
-	# unversioned symlinks to them
+	# fix all main things to be python-versioned filenames with unversioned
+	# symlinks to them; calling python%type_raw[python] without .exe suffix
 	pushd %i/bin
+		perl -pi -e 's,(%p/bin/python%type_raw[python])(.exe),$1,' *3 *%type_raw[python] *config
 		mv python%type_raw[python].exe python%type_raw[python]
 		rm python3.exe
 		ln -s python%type_raw[python] python3

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.info
@@ -86,8 +86,7 @@ ConfigureParams: <<
 	--with-tcltk-includes="-I%p/include -I/opt/X11/include" \
 	--with-tcltk-libs="-L%p/lib -ltcl -ltk" \
 	--with-dtrace \
-	--without-ensurepip \
-	--with-suffix=.exe
+	--without-ensurepip
 <<
 
 CompileScript: <<
@@ -113,21 +112,32 @@ CompileScript: <<
 InfoTest: <<
 	TestConflicts: apple-gdb
 	TestScript: <<
-		# Change install_name of lib during tests since DYLD_LIBRARY_PATH doesn't work on 10.11+.
-		install_name_tool -change %p/lib/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib python.exe || exit 2
+		#!/bin/sh -ex
+		# Change install_name of lib during tests since DYLD_LIBRARY_PATH is not exported to test_subprocess on 10.11+.
+		if [ -x python.exe ]; then
+			python_exe=python.exe
+		else
+			python_exe=python
+		fi
+		install_name_tool -change %p/lib/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib $python_exe
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib {} \;
 		install_name_tool -id %b/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
 
-		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS='-w -unone' || exit 2
+		# test_socket can fail with some DNS settings.
+		# multiprocessing_spawn fails on "KeyboardInterrupt not raised by wait",
+		# the other 4 hang indefinitely
+		EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_ssl test_multiprocessing_spawn test_asyncio test_httpservers test_logging test_xmlrpc'
+		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
 
 		# Put install_name back.
-		install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib python.exe
+		install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib $python_exe
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib {} \;
 		install_name_tool -id %p/lib/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
 
 		# Remove stray .pyc that get made during tests to keep validator happy.
 		find ./Tools -name "*.pyc" -delete
 		find ./Tools -name "__pycache__" -delete
+		exit $TESTRETURN
 	<<
 <<
 
@@ -148,13 +158,9 @@ InstallScript: <<
 	# we don't want -lintl to appear in LIBS otherwise python-config will propagate it
 	perl -pi -e 's/-lintl //' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile
 	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile	
-	# fix all main things to be python-versioned filenames with unversioned
-	# symlinks to them; calling python%type_raw[python] without .exe suffix
+	# fix all main things to be python-versioned filenames with
+	# unversioned symlinks to them
 	pushd %i/bin
-		perl -pi -e 's,(%p/bin/python%type_raw[python])(.exe),$1,' *3 *%type_raw[python] *config
-		mv python%type_raw[python].exe python%type_raw[python]
-		rm python3.exe
-		ln -s python%type_raw[python] python3
 		for f in idle3 pydoc3; do
 			mv ${f} ${f}-%type_raw[python]
 			ln -s ${f}-%type_raw[python] %i/bin/${f}

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.info
@@ -52,7 +52,7 @@ Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
 Source-Checksum: SHA256(75894117f6db7051c1b34f37410168844bbb357c139a8a10a352e9bf8be594e8)
 
 PatchFile: %n.patch
-PatchFile-MD5: bd770f2fb72d2c223030ac2cc49ec384
+PatchFile-MD5: 711229d21faa1912d1bc22e5778eba7b
 PatchScript: <<
 	#!/bin/sh -ex
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
@@ -79,13 +79,15 @@ SetCXX: g++
 ConfigureParams: <<
 	--enable-shared \
 	--enable-loadable-sqlite-extensions \
+	--enable-optimizations \
 	--with-dbmliborder=gdbm \
 	--with-system-expat \
 	--with-system-ffi \
 	--with-tcltk-includes="-I%p/include -I/opt/X11/include" \
 	--with-tcltk-libs="-L%p/lib -ltcl -ltk" \
 	--with-dtrace \
-	--without-ensurepip
+	--without-ensurepip \
+	--with-suffix=.exe
 <<
 
 CompileScript: <<
@@ -112,17 +114,17 @@ InfoTest: <<
 	TestConflicts: apple-gdb
 	TestScript: <<
 		# Change install_name of lib during tests since DYLD_LIBRARY_PATH doesn't work on 10.11+.
-		install_name_tool -change %p/lib/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib python
+		install_name_tool -change %p/lib/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib python.exe || exit 2
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib {} \;
 		install_name_tool -id %b/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
-		
+
 		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS='-w -unone' || exit 2
-		
+
 		# Put install_name back.
-		install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib python
+		install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib python.exe
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib {} \;
 		install_name_tool -id %p/lib/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
-		
+
 		# Remove stray .pyc that get made during tests to keep validator happy.
 		find ./Tools -name "*.pyc" -delete
 		find ./Tools -name "__pycache__" -delete
@@ -149,6 +151,9 @@ InstallScript: <<
 	# fix all main things to be python-versioned filenames with
 	# unversioned symlinks to them
 	pushd %i/bin
+		mv python%type_raw[python].exe python%type_raw[python]
+		rm python3.exe
+		ln -s python%type_raw[python] python3
 		for f in idle3 pydoc3; do
 			mv ${f} ${f}-%type_raw[python]
 			ln -s ${f}-%type_raw[python] %i/bin/${f}
@@ -156,7 +161,7 @@ InstallScript: <<
 		#Remove this for now to avoid conflicting with 'python' package.
 		rm 2to3
 	popd
-	
+
 	# Add symlink to %p/lib/python%type_raw[python]/config-%type_raw[python]-darwin.
 	ln -s %p/lib/libpython%type_raw[python].dylib %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/libpython%type_raw[python].dylib
 
@@ -221,17 +226,17 @@ DescPackaging: <<
 	New in 3.2, .pyc files are saved in the __pycache__ directory
 	at the same level as the matching .py file. Any packages that
 	expect the .pyc file to be next to the .py file will need adjustment.
-	
+
 	The .pyc and .so files also include the python version in the name.
-	
+
 	Don't run ensurepip since it installs files that conflict with
 	the pip and setuptools packages.
-	
+
 	Previous python packages went to great lengths to patch to use
 	%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin
 	for libpython instead of %p/lib. Revert to using default library
 	location but make symlink in config dir.
-	
+
 	Upstream no longer links extensions to libpython and use of 
 	-undefined dynamic_lookup is recommended instead so remove those
 	patches.
@@ -244,8 +249,11 @@ DescPort: <<
 	bsddb is gone so drop db* patch and dep.
 	Patch setup.py to find ncursesw headers and drop libncurses5 dep.
 	Ensure $(LDFLAGS) is used linking libpython or else it can't find libintl.
-	
+
 	Patch ctypes to look in %p/lib for libraries.
+
+	Enforce .exe suffix for executable to ensure consistent build on
+	case-[in]sensitive file systems.
 <<
 License: OSI-Approved
 Homepage: http://www.python.org

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.info
@@ -134,9 +134,6 @@ InfoTest: <<
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib {} \;
 		install_name_tool -id %p/lib/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
 
-		# Remove stray .pyc that get made during tests to keep validator happy.
-		find ./Tools -name "*.pyc" -delete
-		find ./Tools -name "__pycache__" -delete
 		exit $TESTRETURN
 	<<
 <<
@@ -151,6 +148,8 @@ InstallScript: <<
 	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' `ls -d %b/build/lib*`/_sysconfigdata__darwin_darwin.py
 	# Don't propagate -lintl to other packages.
 	perl -pi -e 's/-lintl //' `ls -d %b/build/lib*`/_sysconfigdata__darwin_darwin.py
+	# Remove stray .pyc that get made during tests (including preliminary ones in CompileScript) to keep validator happy.
+	find ./Lib ./Parser ./Tools ./build -name '*.pyc' -delete
 	# install fails with -j greater than 1
 	export MAKEFLAGS=-j1
 	make install DESTDIR=%d

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.patch
@@ -63,7 +63,7 @@ diff -ru Python-3.8.2.orig/configure Python-3.8.2/configure
    Darwin/*)
      gcc_version=`gcc -dumpversion`
 -    if test ${gcc_version} '<' 4.0
-+    if test `echo ${gcc_version} | cut -f1 -d.` -lt 4
++    if test ${gcc_version%%.*} -lt 4
          then
              LIBTOOL_CRUFT="-lcc_dynamic"
          else

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.patch
@@ -115,14 +115,16 @@ diff -ru Python-3.8.0.orig/setup.py Python-3.8.0/setup.py
  
          if self.failed_on_import:
              failed = self.failed_on_import[:]
-@@ -649,8 +654,8 @@
+@@ -648,9 +653,9 @@
+         # Ensure that /usr/local is always used, but the local build
          # directories (i.e. '.' and 'Include') must be first.  See issue
          # 10520.
-         if not CROSS_COMPILING:
+-        if not CROSS_COMPILING:
 -            add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
 -            add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
-+            add_dir_to_list(self.compiler.library_dirs, '@PREFIX@/lib')
-+            add_dir_to_list(self.compiler.include_dirs, '@PREFIX@/include')
++        # if not CROSS_COMPILING:
++        #     add_dir_to_list(self.compiler.library_dirs, '/usr/lib')
++        #     add_dir_to_list(self.compiler.include_dirs, '/usr/include')
          # only change this for cross builds for 3.3, issues on Mageia
          if CROSS_COMPILING:
              self.add_cross_compiling_paths()

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.patch
@@ -55,10 +55,19 @@ diff -ru Python-3.8.0.orig/Modules/_dbmmodule.c Python-3.8.0/Modules/_dbmmodule.
  static const char which_dbm[] = "GNU gdbm";
  #elif defined(HAVE_GDBM_DASH_NDBM_H)
  #include <gdbm-ndbm.h>
-diff -ru Python-3.8.0.orig/configure Python-3.8.0/configure
---- Python-3.8.0.orig/configure	2019-10-14 09:34:47.000000000 -0400
-+++ Python-3.8.0/configure	2019-11-11 21:43:34.538736578 -0500
-@@ -15874,7 +15867,7 @@
+diff -ru Python-3.8.2.orig/configure Python-3.8.2/configure
+--- Python-3.8.2.orig/configure	2020-02-24 22:36:47.000000000 -0400
++++ Python-3.8.2/configure	2020-04-21 04:12:43.000000000 -0500
+@@ -9207,7 +9207,7 @@
+     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -compatibility_version $(VERSION) -current_version $(VERSION)';;
+   Darwin/*)
+     gcc_version=`gcc -dumpversion`
+-    if test ${gcc_version} '<' 4.0
++    if test `echo ${gcc_version} | cut -f1 -d.` -lt 4
+         then
+             LIBTOOL_CRUFT="-lcc_dynamic"
+         else
+@@ -15885,7 +15885,7 @@
  # first curses header check
  ac_save_cppflags="$CPPFLAGS"
  if test "$cross_compiling" = no; then
@@ -67,7 +76,7 @@ diff -ru Python-3.8.0.orig/configure Python-3.8.0/configure
  fi
  
  for ac_header in curses.h ncurses.h
-@@ -16384,7 +16377,7 @@
+@@ -16395,7 +16395,7 @@
  
  if test $ac_sys_system = Darwin
  then

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.patch
@@ -122,7 +122,7 @@ diff -ru Python-3.8.0.orig/setup.py Python-3.8.0/setup.py
              curses_defines.append(('HAVE_NCURSESW', '1'))
              if not CROSS_COMPILING:
 -                curses_includes.append('/usr/include/ncursesw')
-+                curses_includes.append('@PREFIX@/ncursesw')
++                curses_includes.append('@PREFIX@/include/ncursesw')
              # Bug 1464056: If _curses.so links with ncursesw,
              # _curses_panel.so must link with panelw.
              panel_library = 'panelw'

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.patch
@@ -58,7 +58,7 @@ diff -ru Python-3.8.0.orig/Modules/_dbmmodule.c Python-3.8.0/Modules/_dbmmodule.
 diff -ru Python-3.8.0.orig/configure Python-3.8.0/configure
 --- Python-3.8.0.orig/configure	2019-10-14 09:34:47.000000000 -0400
 +++ Python-3.8.0/configure	2019-11-11 21:43:34.538736578 -0500
-@@ -15886,7 +15879,7 @@
+@@ -15874,7 +15867,7 @@
  # first curses header check
  ac_save_cppflags="$CPPFLAGS"
  if test "$cross_compiling" = no; then
@@ -67,7 +67,7 @@ diff -ru Python-3.8.0.orig/configure Python-3.8.0/configure
  fi
  
  for ac_header in curses.h ncurses.h
-@@ -16396,7 +16389,7 @@
+@@ -16384,7 +16377,7 @@
  
  if test $ac_sys_system = Darwin
  then


### PR DESCRIPTION
When checking the newer Python 3.x packages, I noticed that the tests are all failing immediately because `install_name_tool` is called on a non-existent `python.exe`.
Changed that to the default executable name and updated to the latest upstream.
3.7.6 and 3.8.1 however are failing with one persistent failure in `test_startup_imports`.

Also fixed #530; tested on 10.12.