### PR TITLE
pandas-py 0.25.3

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/pandas-py-0.19.2.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/pandas-py-0.19.2.info
@@ -1,0 +1,57 @@
+Info3: <<
+Package: pandas-py%type_pkg[python]
+Version: 0.19.2
+Revision: 1
+Type: python (2.7 3.4 3.5 3.6)
+Description: Data analysis, time series,and statistics
+DescDetail: <<
+Providing fast, flexible, and expressive data structures designed to
+make working with structured (tabular, multidimensional, potentially
+heterogeneous) and time series data both easy and intuitive. It aims
+to be the fundamental high-level building block for doing practical,
+real world data analysis in Python.
+<<
+Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
+License: BSD
+Homepage: http://pypi.python.org/pypi/pandas/
+
+Source: https://files.pythonhosted.org/packages/source/p/pandas/pandas-%v.tar.gz
+Source-MD5: 26df3ef7cd5686fa284321f4f48b38cd
+
+# matplotlib, scipy and pytables are not strictly required
+# Recommends: scikits.statsmodels-py%type_pkg[python]
+Depends: <<
+  python%type_pkg[python],
+  dateutil-py%type_pkg[python],
+  matplotlib-py%type_pkg[python],
+  numpy-py%type_pkg[python],
+  pytables-py%type_pkg[python],
+  scipy-py%type_pkg[python],
+<<
+# TODO: openpyxl-py%type_pkg[python]
+BuildDepends: <<
+  fink (>= 0.33.3.2),
+  dateutil-py%type_pkg[python],
+  setuptools-tng-py%type_pkg[python]
+<<
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build
+
+InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
+
+# TODO: from . import hashtable failure.
+# InfoTest: <<
+#  TestDepends: nose-py%type_pkg[python]
+#  TestScript: <<
+#   #!/bin/bash -ev
+#   export PYTHONPATH=$(ls -d %b/build/lib.macosx-*-%type_raw[python])
+#   %p/bin/nosetests-%type_raw[python] pandas
+#   #find %b/build/lib.macosx-*-%type_raw[python] -name '*.py[oc]' -exec rm {} \;
+#  <<
+#  TestSuiteSize: large
+# <<
+
+# DocFiles:
+
+# Info3
+<<

--- a/10.9-libcxx/stable/main/finkinfo/sci/pandas-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/pandas-py.info
@@ -1,8 +1,8 @@
 Info3: <<
 Package: pandas-py%type_pkg[python]
-Version: 0.19.2
+Version: 0.25.3
 Revision: 1
-Type: python (2.7 3.4 3.5 3.6)
+Type: python (3.5 3.6 3.7)
 Description: Data analysis, time series,and statistics
 DescDetail: <<
 Providing fast, flexible, and expressive data structures designed to
@@ -15,43 +15,64 @@ Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 License: BSD
 Homepage: http://pypi.python.org/pypi/pandas/
 
-Source: https://pypi.python.org/packages/08/9d/31ec596099f14528fc6ad39428248ac5360f0bb5205a3ee79a5d1cf260fb/pandas-%v.tar.gz
-Source-MD5: 26df3ef7cd5686fa284321f4f48b38cd
+Source: https://files.pythonhosted.org/packages/source/p/pandas/pandas-%v.tar.gz
+Source-MD5: c70bbdfed7f1b9807a738f85fcdd9767
 
-# matplotlib, scipy and pytables are not strictly required
-# Recommends: scikits.statsmodels-py%type_pkg[python]
-Depends: <<
-  python%type_pkg[python],
-  dateutil-py%type_pkg[python],
-  matplotlib-py%type_pkg[python],
-  numpy-py%type_pkg[python],
-  pytables-py%type_pkg[python],
-  scipy-py%type_pkg[python],
+# matplotlib, numexpr, scipy, and pytables are not strictly required
+
+Recommends: <<
+    beautifulsoup-py%type_pkg[python],
+    bottleneck-py%type_pkg[python],
+    html5lib-py%type_pkg[python],
+    jinja2-py%type_pkg[python],
+    lxml-py%type_pkg[python],
+    openpyxl-py%type_pkg[python],
+    psycopg2-py%type_pkg[python],
+    qtpy-py%type_pkg[python],
+    scikits.statsmodels-py%type_pkg[python],
+    sqlalchemy-py%type_pkg[python],
+    xlrd-py%type_pkg[python]
 <<
+Depends: <<
+    python%type_pkg[python],
+    dateutil-py%type_pkg[python] (>= 2.6.1),
+    matplotlib-py%type_pkg[python],
+    numexpr-py%type_pkg[python] (>= 2.6.2),
+    numpy-py%type_pkg[python] (>= 1.13.3),
+    pytables-py%type_pkg[python],
+    pytz-py%type_pkg[python] (>= 2017.2),
+    scipy-py%type_pkg[python],
+<<
+
 # TODO: openpyxl-py%type_pkg[python]
 BuildDepends: <<
-  fink (>= 0.33.3.2),
-  dateutil-py%type_pkg[python],
-  setuptools-tng-py%type_pkg[python]
+    fink (>= 0.33.3.2),
+    setuptools-tng-py%type_pkg[python]
 <<
 
-CompileScript: %p/bin/python%type_raw[python] setup.py build
+CompileScript: <<
+    %p/bin/python%type_raw[python] setup.py build_ext --inplace
+    %p/bin/python%type_raw[python] setup.py build
+<<
 
 InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
 
-# TODO: from . import hashtable failure.
-# InfoTest: <<
-#  TestDepends: nose-py%type_pkg[python]
-#  TestScript: <<
-#   #!/bin/bash -ev
-#   export PYTHONPATH=$(ls -d %b/build/lib.macosx-*-%type_raw[python])
-#   %p/bin/nosetests-%type_raw[python] pandas
-#   #find %b/build/lib.macosx-*-%type_raw[python] -name '*.py[oc]' -exec rm {} \;
-#  <<
-#  TestSuiteSize: large
-# <<
+# Release tarball is missing multiple test data files so lots of tests error and/or fail.
+#InfoTest: <<
+#    TestDepends: <<
+#        hypothesis-py%type_pkg[python] (>= 3.58),
+#        pytest-py%type_pkg[python] (>= 4.0.2)
+#    <<
+#    TestScript: <<
+#        #!/bin/bash -ev
+#        export PYTHONPATH=$(ls -d %b/build/lib.macosx-*-%type_raw[python])
+#        %p/bin/python%type_raw[python] -B -c "import pandas; pandas.test()" || exit 2
+#        #find %b/build/lib.macosx-*-%type_raw[python] -name '*.py[oc]' -exec rm {} \;
+#    <<
+#    TestSuiteSize: large
+#<<
 
-# DocFiles:
+DocFiles: LICENSE README.md RELEASE.md
 
 # Info3
 <<


### PR DESCRIPTION
Update to pandas-py 0.25.3
Only works with python35 and up, so copy the existing old version .info for older pythons.
Many tests fail or error out with missing data files that are in Git but not in the tarball, so I disabled tests (which were already disabled in our older version).