### PR TITLE
New upstream tcpflow

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/net/tcpflow.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/tcpflow.info
@@ -1,10 +1,10 @@
 Package: tcpflow
-Version: 1.4.4
-Revision: 4
+Version: 1.5.0
+Revision: 1
 Description: Captures data transmitted in TCP connections
 License: GPL/OpenSSL
 BuildDepends: <<
-	boost1.58-nopython,
+	boost1.68-nopython,
 	bzip2-dev,
 	cairo (>= 1.12.14-1),
 	expat1,
@@ -29,21 +29,10 @@ Depends: <<
 	sqlite3-shlibs
 <<
 Source: http://www.digitalcorpora.org/downloads/tcpflow/%n-%v.tar.gz
-Source-MD5: f395fea6f5fe136543f4c982beff9cba
-# dmacks migrated to openssl110...
-# Debian version of upstream patch:
-#  https://sources.debian.org/src/tcpflow/1.4.5+repack1-4/debian/patches/update-dfxml-for-openssl-1.1.patch
-# and fix to configure comparable to their configure.ac:
-# https://sources.debian.org/src/tcpflow/1.4.5+repack1-4/debian/patches/update-configure-for-openssl-1.1.patch
-# but hardcoded for openssl110 since that's what we use.
-PatchFile: %n.patch
-PatchFile-MD5: a9a1ddc47b978021e2be24563e77e003
-PatchScript: <<
-	%{default_script}
-	perl -pi -e 's/SSL_library_init/OPENSSL_init_ssl/g' configure
-<<
+Source-MD5: 5978b112a899f2099e98cef6d9a0ece9
+Source-Checksum: SHA256(20abe3353a49a13dcde17ad318d839df6312aa6e958203ea710b37bede33d988)
 GCC: 4.0
-SetCPPFLAGS: -I%p/opt/boost-1_58/include
+SetCPPFLAGS: -I%p/opt/boost-1_68/include
 CompileScript: <<
 	%{default_script}
 	fink-package-precedence .
@@ -53,7 +42,7 @@ InfoTest: <<
 <<
 InstallScript: make install DESTDIR=%d
 Homepage: http://github.com/simsong/tcpflow/wiki
-Maintainer: Nick Siripipat <nsiripip+fink@gmail.com>
+Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 DescDetail: <<
 tcpflow is a program that captures data transmitted as part of TCP
 connections (flows), and stores the data in a way that is convenient for
@@ -67,4 +56,19 @@ streams regardless of retransmissions or out-of-order delivery. However,
 it currently does not understand IP fragments; flows containing IP fragments
 will not be recorded properly. 
 <<
-DocFiles: README AUTHORS COPYING NEWS
+DescPackaging: <<
+Formerly maintained by Nick Siripipat:  version 1.4.4-4
+<<
+DescPort: <<
+Only appears to use boost at compile time, so we leave it out of the Depends.
+
+dmacks migrated to openssl110...
+
+Debian version of upstream patch:
+https://sources.debian.org/src/tcpflow/1.4.5+repack1-4/debian/patches/update-dfxml-for-openssl-1.1.patch
+and fix to configure comparable to their configure.ac:
+
+https://sources.debian.org/src/tcpflow/1.4.5+repack1-4/debian/patches/update-configure-for-openssl-1.1.patch
+but hardcoded for openssl110 since that's what we use.
+<<
+DocFiles: AUTHORS COPYING NEWS


### PR DESCRIPTION
Assume maintainership since current listed maintainer can't do it anymore: https://sourceforge.net/p/fink/package-submissions/4977/
Use newest boost.
Move notes from dmacks into DescPort.