### PR TITLE
mp3diags: dep updates

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sound/mp3diags.info
+++ b/10.9-libcxx/stable/main/finkinfo/sound/mp3diags.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: mp3diags-%type_pkg[qt]
 Version: 1.3.04
-Revision: 1
+Revision: 2
 Type: qt (mac x11)
 Description: Fix problems with mp3 files
 License: GPL2
@@ -16,9 +16,8 @@ PatchFile: mp3diags.patch
 PatchFile-MD5: 8266948899e2528a299b03bad048307e
 
 Depends: <<
-	boost1.58-nopython-shlibs,
-	libiconv,
-	libpng16-shlibs,
+	boost1.68-nopython-shlibs,
+	( %type_pkg[qt] = x11) libiconv,
 	qt4-base-%type_pkg[qt]-qtcore-shlibs (>= 4.7.3-1),
 	qt4-base-%type_pkg[qt]-qtgui-shlibs (>= 4.7.3-1),
 	qt4-base-%type_pkg[qt]-qtxml-shlibs (>= 4.7.3-1),
@@ -26,20 +25,21 @@ Depends: <<
 <<
 
 BuildDepends: <<
-	boost1.58-nopython,
+	boost1.68-nopython,
 	fink-package-precedence,
-	libiconv-dev,
-	libpng16,
+	( %type_pkg[qt] = x11) libiconv-dev,
 	qt4-base-%type_pkg[qt] (>= 4.7.3-1),
-	( %type_pkg[qt] = mac) openssl100-dev (>= 1.0.2h-1)
+	( %type_pkg[qt] = mac) openssl110-dev
 <<
 
 GCC: 4.0
 
 CompileScript: <<
-	%p/lib/qt4-%type_pkg[qt]/bin/qmake "LIBS+=-lz -L%p/lib -L%p/opt/boost-1_58/lib"
-	make CXX="g++ -I%p/include -I%p/opt/boost-1_58/include -w"
-	fink-package-precedence --no-h .
+	%p/lib/qt4-%type_pkg[qt]/bin/qmake "LIBS+=-lz -L%p/lib -L%p/opt/boost-1_68/lib"
+	make CXX="g++ -I%p/include -I%p/opt/boost-1_68/include -w -MD"
+	# NB: f-p-p doesn't always understand relative -I that go to to
+    # higher levels than %b
+	fink-package-precedence --depfile-ext='\.d' .
 <<
 
 InstallScript: <<


### PR DESCRIPTION
Switch to openssl110 (though doesn't seem to be used anyway. maybe obsolete IBD?) and misc other dep cleanups.