### PR TITLE
migrate wgscott packages to gcc9

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/clipper.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/clipper.info
@@ -1,21 +1,21 @@
 Package: clipper
 Epoch: 2
 Version: 2.1.20160708
-Revision: 1
+Revision: 3
 GCC:4.0
 BuildDepends: <<
 fftw (>= 2.1.5-1010) | fftw-mpi (>= 2.1.5-1010), 
 mmdb2-dev (>= 2.0.1-1), 
 ssm-dev (>= 1.4.0-6), 
-libccp4-dev (>= 1:6.4.0-2), 
-gcc5,
-gcc5-compiler
+libccp4-dev (>= 1:6.4.0-5), 
+gcc9,
+gcc9-compiler
 <<
 Depends: <<
 %n-shlibs (>= %e:%v-%r)
 <<
 Maintainer: W. G. Scott <wgscott@users.sourceforge.net> 
-Homepage: http://www.ysbl.york.ac.uk/~cowtan/clipper/clipper.html 
+Homepage: http://www.ysbl.york.ac.uk/~cowtan/clipper/clipper.html
 Source: ftp://ftp.ccp4.ac.uk/opensource/%n-%v.tar.gz
 Source-MD5: 57a2feadf2e1f13f4b6418fe4922012a
 SourceDirectory: %n-%v
@@ -34,7 +34,7 @@ License: LGPL
 CompileScript: <<
 #!/bin/bash -evf
 autoreconf -fi  
-LDFLAGS="-L%p/lib -L/usr/lib" F77="%p/bin/gfortran-fsf-5" FFLAGS="-L%p/lib/gcc5/lib -lgfortran " \
+LDFLAGS="-L%p/lib -L/usr/lib" F77="%p/bin/gfortran-fsf-9" FFLAGS="-L%p/lib/gcc9/lib -lgfortran " \
   ./configure  --prefix=%p --enable-shared --enable-ccp4    --enable-fortran --with-ccp4=%p --with-mmdb=%p --with-fftw=%p --enable-mmdb --enable-minimol --enable-cif --enable-cns 
   perl -pi -e 's|examples||g' Makefile  
   make  
@@ -48,8 +48,8 @@ SplitOff: <<
 	fftw-shlibs (>= 2.1.5-1010) | fftw-mpi-shlibs (>= 2.1.5-1010),
 	mmdb2-shlibs (>= 2.0.1-1),
 	ssm-shlibs (>= 1.4.0-6), 
-	libccp4-shlibs (>= 1:6.4.0-2),
-	gcc5-shlibs 
+	libccp4-shlibs (>= 1:6.4.0-5),
+	gcc9-shlibs 
   <<
   Files: <<
 	lib/libclipper-ccp4.2.*dylib

--- a/10.9-libcxx/stable/main/finkinfo/sci/coot.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/coot.info
@@ -1,6 +1,6 @@
 Package: coot
 Version: 0.8.9
-Revision: 2
+Revision: 3
 SourceDirectory: %n-%v
 GCC: 4.0 
 Source: http://www2.mrc-lmb.cam.ac.uk/Personal/pemsley/coot/source/releases/%n-%v.tar.gz
@@ -40,12 +40,11 @@ Recommends:  povray, ccp4, raster3d
 Replaces: coot-pre             
 BuildDepends: <<
  automake1.15                            ,
- fink (>= 0.24.12)                       ,
- fink-buildenv-modules  (>= 0.1.3-1)     ,
+ fink-buildenv-modules (>= 0.1.3-1)      ,
  fink-package-precedence                 ,
- boost1.63-python27 (>= 1.63.0-1)        , 
- clipper-dev (>= 2:2.1.20160708-1)       ,
- libccp4-dev (>= 1:6.4.0-3)              ,
+ boost1.68-python27 (>= 1.68.0-1)        , 
+ clipper-dev (>= 2:2.1.20160708-3)       ,
+ libccp4-dev (>= 1:6.4.0-5)              ,
  mmdb2-dev (>= 2.0.1-1)                  ,
  ssm-dev (>= 1.4.0-6)                    ,
  atk1 (>= 1.32.0-1)                      ,
@@ -85,11 +84,11 @@ BuildDepends: <<
 #           
 Depends: <<
  %N-shlibs (= %v-%r)                     ,
- boost1.63-python27-shlibs (>= 1.63.0-1) , 
+ boost1.68-python27-shlibs (>= 1.68.0-1) , 
  ccp4srs-shlibs (>= 1.0-1)               ,
- clipper-shlibs (>= 2:2.1.20160708-1)    ,
- libccp4-shlibs (>= 1:6.4.0-3)           ,
- libccp4-lib (>= 1:6.4.0-2)              ,
+ clipper-shlibs (>= 2:2.1.20160708-3)    ,
+ libccp4-shlibs (>= 1:6.4.0-5)           ,
+ libccp4-lib (>= 1:6.4.0-5)              ,
  mmdb2-shlibs (>= 2.0.1-1)               ,
  refmac (>= 5.8-5)                       ,
  ssm-shlibs (>= 1.4.0-6)                 ,
@@ -158,21 +157,21 @@ CompileScript: <<
 #!/bin/bash -efv
 # autoreconf -fi # Run-time errors occur when we do this.  I am working on it.
 export GUILE=%p/bin/guile-1.8
-export PATH=%p/var/lib/fink/path-prefix-10.6:%p/share/guile/1.8/scripts/binoverride:%p/bin:$PWD/bin:$PATH
+export PATH=%p/var/lib/fink/path-prefix-libcxx:%p/share/guile/1.8/scripts/binoverride:%p/bin:$PWD/bin:$PATH
 export X11_BASE_DIR=/opt/X11
 export SED=/usr/bin/sed
 export GDK_USE_XFT='1'
 export COOT_REFMAC_LIB_DIR=%p/share/coot/lib
 export PKG_CONFIG_PATH=%p/lib/glib-2.0/pkgconfig-strict:${PKG_CONFIG_PATH}
   FLIBS="-L%p/lib -L%p/lib/rdkit" \
-  CPPFLAGS="-I%b/ccp4mg-utils -I%p/include/rdkit -I%b/lidia-core -I%p/include/libglade-2.0/glade -I%p/include/libglade-2.0 -I%p/include/python2.7  -I%p/include/mmdb2 -I%p/include/ssm -I%p/include/ccp4 -I%p/include/clipper -I%p/include -I$X11_BASE_DIR/include -I%p/opt/boost-1_63/include" \
-  LDFLAGS="-Wl,-dylib_file,%p/lib/libboost_python.dylib:%p/lib/python2.7/site-packages/libboost_python-1_63.dylib:%p/lib/python2.7/config/libpython2.7.dylib:%p/lib/libsfftw.2.0.7.dylib:%p/lib/libsrfftw.2.0.7.dylib:%p/lib/pango-ft219/lib/libpango-1.0.dylib:%p/lib/pango-ft219/lib/libpangocairo-1.0.dylib:%p/lib/pango-ft219/lib/libpangoft2-1.0.dylib:%p/lib/pango-ft219/lib/libpangox-1.0.dylib:%p/lib/pango-ft219/lib/libpangoxft-1.0.dylib -L%p/lib -L$X11_BASE_DIR/lib -L%p/opt/boost-1_63/lib -L/usr/lib -L/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries" \
+  CPPFLAGS="-I%b/ccp4mg-utils -I%p/include/rdkit -I%b/lidia-core -I%p/include/libglade-2.0/glade -I%p/include/libglade-2.0 -I%p/include/python2.7 -I%p/include/mmdb2 -I%p/include/ssm -I%p/include/ccp4 -I%p/include/clipper -I%p/include -I$X11_BASE_DIR/include -I%p/opt/boost-1_68/include" \
+  LDFLAGS="-Wl,-dylib_file,%p/lib/python2.7/site-packages/libboost_python27-1_68.dylib:%p/lib/python2.7/config/libpython2.7.dylib:%p/lib/libsfftw.2.0.7.dylib:%p/lib/libsrfftw.2.0.7.dylib:%p/lib/pango-ft219/lib/libpango-1.0.dylib:%p/lib/pango-ft219/lib/libpangocairo-1.0.dylib:%p/lib/pango-ft219/lib/libpangoft2-1.0.dylib:%p/lib/pango-ft219/lib/libpangox-1.0.dylib:%p/lib/pango-ft219/lib/libpangoxft-1.0.dylib -L%p/lib -L$X11_BASE_DIR/lib -L%p/opt/boost-1_68/lib -L/usr/lib -L/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries" \
   DYLD_LIBRARY_PATH="" \
   RDKIT_CXXFLAGS=-I%p/include/rdkit \
   RDKIT_LIBS="-L%p/lib/rdkit -lRDKitMolChemicalFeatures -lRDKitDescriptors -lRDKitSubgraphs -lRDKitPartialCharges \
-   -lRDKitForceFieldHelpers -lRDKitForceField -lRDKitSubstructMatch -lRDKitOptimizer -lRDKitDistGeomHelpers \
-   -lRDKitDistGeometry -lRDKitAlignment -lRDKitEigenSolvers -lRDKitDepictor -lRDKitFileParsers \
-    -lRDKitRDGeometryLib -lRDKitGraphMol -lRDKitSmilesParse -lRDKitDataStructs -lRDKitRDGeneral -lboost_python" \
+  -lRDKitForceFieldHelpers -lRDKitForceField -lRDKitSubstructMatch -lRDKitOptimizer -lRDKitDistGeomHelpers \
+  -lRDKitDistGeometry -lRDKitAlignment -lRDKitEigenSolvers -lRDKitDepictor -lRDKitFileParsers \
+  -lRDKitRDGeometryLib -lRDKitGraphMol -lRDKitSmilesParse -lRDKitDataStructs -lRDKitRDGeneral -lboost_python27" \
   PYTHON=%p/bin/python2.7  PYTHON_CONFIG=%p/bin/python2.7-config ./configure %c
 #
  NUMPROC="$(sysctl -n hw.ncpu)"

--- a/10.9-libcxx/stable/main/finkinfo/sci/coot.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/coot.info
@@ -1,11 +1,11 @@
 Package: coot
-Version: 0.8.9
-Revision: 3
+Version: 0.8.9.1
+Revision: 1
 SourceDirectory: %n-%v
 GCC: 4.0 
 Source: http://www2.mrc-lmb.cam.ac.uk/Personal/pemsley/coot/source/releases/%n-%v.tar.gz
 # Source: http://www2.mrc-lmb.cam.ac.uk/Personal/pemsley/coot/source/pre-releases/%n-%v-revision-%r.tar.gz
-Source-MD5: 866e18da280a855ac50279cb9ad852f7
+Source-MD5: fee68a8b92b4b6f92ecf52fc656a9ec4
 Source2: http://www2.mrc-lmb.cam.ac.uk/personal/pemsley/coot/dependencies/reference-structures.tar.gz
 Source2-MD5: 257ab90d44f1c877ada96720dbb87c13
 Description: Crystallographic molecular graphics
@@ -105,6 +105,7 @@ Depends: <<
  gtkglext1-shlibs (>= 1.2.0-4)           ,
  libart2-shlibs                          ,
  libcurl4-shlibs                         ,
+ libidn2.0-shlibs (>= 2.0.4-1)           ,
  libgettext8-shlibs                      ,
  libgnomecanvas2-shlibs (>= 2.20.0)      ,
  libpng16-shlibs                         ,

--- a/10.9-libcxx/stable/main/finkinfo/sci/coot.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/coot.info
@@ -35,6 +35,10 @@ stereo on OS X.
 This package actually requires a flat namespace build, according to the primary
 author.
 <<
+DescPackaging: <<
+coot stack uses fftw-2, not fftw3
+https://www.mail-archive.com/coot@jiscmail.ac.uk/msg00336.html
+<<
 ###############################################################################
 Recommends:  povray, ccp4, raster3d        
 Replaces: coot-pre             

--- a/10.9-libcxx/stable/main/finkinfo/sci/libccp4.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/libccp4.info
@@ -1,6 +1,6 @@
 Package: libccp4
 Version: 6.4.0
-Revision: 4
+Revision: 5
 Epoch: 1
 Maintainer: W. G. Scott <wgscott@users.sourceforge.net> 
 DescPackaging: <<
@@ -18,8 +18,8 @@ Source3: ftp://ftp.ccp4.ac.uk/opensource/ccp4srs-data-20120621.tar.gz
 Source3-MD5: f8b62642f313ae1342cd13ea8699eca7
 NoSourceDirectory: false
 SourceDirectory: %n-%v
-Depends: %N-shlibs (= %e:%v-%r), gcc5-shlibs 
-BuildDepends: mmdb2-dev (>= 2.0.1-1), ssm-dev (>= 1.4.0-6), gcc5, pkgconfig
+Depends: %N-shlibs (= %e:%v-%r), gcc9-shlibs 
+BuildDepends: mmdb2-dev (>= 2.0.1-1), ssm-dev (>= 1.4.0-6), gcc9, pkgconfig
 BuildConflicts: g77, fort77, g95
 Conflicts: gpp4 
 Replaces: gpp4 
@@ -53,10 +53,10 @@ The library contains several subcomponents:
 <<
 CompileScript: <<
 #!/bin/bash -evf
-LDFLAGS="-L%p/lib/gcc5/lib -L%p/lib -L/usr/lib" \
+LDFLAGS="-L%p/lib/gcc9/lib -L%p/lib -L/usr/lib" \
 MMDB_CFLAGS="-I%p/include/mmdb2" MMDB_LIBS="-L%p/lib"  \
-FC="%p/bin/gfortran-fsf-5"  \
-  ./configure --enable-shared F77="%p/bin/gfortran-fsf-5" FFLAGS="-L%p/lib/gcc5/lib -lgfortran " --prefix=%p 
+FC="%p/bin/gfortran-fsf-9"  \
+  ./configure --enable-shared F77="%p/bin/gfortran-fsf-9" FFLAGS="-L%p/lib/gcc9/lib -lgfortran " --prefix=%p 
   make
 <<
 InstallScript: <<
@@ -82,7 +82,7 @@ SplitOff: <<
 	%p/lib/libccp4c.0.dylib 1.0.0 %n (>= 6.4.0-1)
     %p/lib/libccp4f.0.dylib 1.0.0 %n (>= 6.4.0-1)
   <<
-	Depends: gcc5-shlibs, mmdb2-shlibs (>= 2.0.1-1), ssm-shlibs (>= 1.4.0-6)
+	Depends: gcc9-shlibs, mmdb2-shlibs (>= 2.0.1-1), ssm-shlibs (>= 1.4.0-6)
 <<
 SplitOff2: <<
 Package: %N-dev

--- a/10.9-libcxx/stable/main/finkinfo/sci/phaser-mpi.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/phaser-mpi.info
@@ -1,24 +1,24 @@
 Package: phaser-mpi
 Version: 2.5.5
-Revision: 2
+Revision: 3
 # Distribution: 10.6, 10.7, 10.8, 10.9
 Source: ftp://ftp.ccp4.ac.uk/ccp4/6.4.0/ccp4-src-6.4.0.tar.gz
 Source-MD5: a7e8784f7e67fa262ea73f20c40928ca  
 SourceDirectory: ccp4-src-6.4.0
 NoSetCPPFLAGS: true
 NoSetLDFLAGS: true
-Depends: gcc5-shlibs
-BuildDepends: gcc5-compiler, gcc5
+Depends: gcc9-shlibs
+BuildDepends: gcc9-compiler, gcc9
 BuildDependsOnly: false
-PatchScript:  perl -pi.orig -e "s|cxx \= cc.replace\(\"gcc\", \"g\+\+\"\)|cxx \= cc.replace\(\"%p/bin/gcc-5\", \"%p/bin/g\+\+-5\"\)|g" checkout/cctbx-phaser-2013-09-30/libtbx/SConscript
+PatchScript:  perl -pi.orig -e "s|cxx \= cc.replace\(\"gcc\", \"g\+\+\"\)|cxx \= cc.replace\(\"%p/bin/gcc-9\", \"%p/bin/g\+\+-9\"\)|g" checkout/cctbx-phaser-2013-09-30/libtbx/SConscript
 CompileScript: << 
 #!/bin/bash -efv
 CCP4=""
-export CXXFLAGS="-L%p/lib/gcc5/lib"
-export CFLAGS="-I%p/lib/gcc5/include"
+export CXXFLAGS="-L%p/lib/gcc9/lib"
+export CFLAGS="-I%p/lib/gcc9/include"
 export CPPFLAGS="$CFLAGS"
-export CC=%p/bin/gcc-5
-export CXX=%p/bin/g++-5
+export CC=%p/bin/gcc-9
+export CXX=%p/bin/g++-9
 NUMPROC="$(sysctl -n hw.ncpu)"
 cd checkout/cctbx-phaser-2013-09-30/phaser/src
 /usr/bin/python \
@@ -30,7 +30,7 @@ InstallScript: <<
 #!/bin/bash -efv
  mkdir -p %i/bin
  cd checkout/cctbx-phaser-2013-09-30/phaser/src
- install_name_tool -change /usr/lib/libstdc++.6.dylib   %p/lib/gcc5/lib/libstdc++.6.dylib   exe/phaser
+ install_name_tool -change /usr/lib/libstdc++.6.dylib   %p/lib/gcc9/lib/libstdc++.6.dylib   exe/phaser
  cp exe/phaser  %i/bin/phaser_omp
 <<
 Description: CCP4 automated molecular replacement program

--- a/10.9-libcxx/stable/main/finkinfo/sci/refmac.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/refmac.info
@@ -1,23 +1,23 @@
 Package: refmac
 Version: 5.8
-Revision: 6
+Revision: 7
 Source: http://www.chem.ucsc.edu/~wgscott/%n/%n%v.tar.gz
 Source-MD5: 4a80b5fe22527047fb0e1abb87d42d39
 Source2: http://www2.mrc-lmb.cam.ac.uk/groups/murshudov/content/%n/Dictionary/%n_dictionary_v5.41.tar.gz
 Source2-MD5: e7acb760fcbbe663147f5245b6c523c4
-Depends: gcc5-shlibs, libccp4-shlibs (>= 1:6.4.0-2),  libccp4-lib (>= 1:6.4.0-2), fftw-shlibs (>= 2.1.5-1121)
-BuildDepends: gcc5, gcc5-compiler, libccp4-dev (>= 1:6.4.0-2), fftw (>= 2.1.5-1121)
+Depends: gcc9-shlibs, libccp4-shlibs (>= 1:6.4.0-5), libccp4-lib (>= 1:6.4.0-5), fftw-shlibs (>= 2.1.5-1121)
+BuildDepends: gcc9, gcc9-compiler, libccp4-dev (>= 1:6.4.0-5), fftw (>= 2.1.5-1121)
 NoSetCPPFLAGS: true
 NoSetLDFLAGS: true
 PatchFile: refmac.patch
-PatchFile-MD5: 8467f6c8d5b0b0b9195e37a3b357312f
+PatchFile-MD5: f25f99abde908b8affdc6e108bc41dc6
 PatchScript: sed 's|@FINKPREFIX@|%p|g' < %{PatchFile} | patch -p1
 CompileScript: << 
 #!/bin/bash -efv
 export PREFIX_SW=%p
 export CLIB=%p/lib
 export CBIN=$PWD/old_5.8
-export FC=%p/lib/gcc5/bin/gfortran
+export FC=%p/lib/gcc9/bin/gfortran
 cp subvag.f subvag1.f
 make -j 1 refmac
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/refmac.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/refmac.patch
@@ -1,3 +1,24 @@
+diff -ruN refmac5.8-orig/gibbs_gm_sampler.f90 refmac5.8/gibbs_gm_sampler.f90
+--- refmac5.8-orig/gibbs_gm_sampler.f90	2014-10-06 16:19:13.000000000 -0500
++++ refmac5.8/gibbs_gm_sampler.f90	2020-01-17 05:57:26.000000000 -0600
+@@ -53,7 +53,7 @@
+     integer, allocatable :: iuniform(:)
+     real runiform
+     integer isize,clock
+-    integer vals(8),puts(12)
++    integer vals(8),puts(33)
+     logical first
+     !
+     !  More locals
+@@ -100,7 +100,7 @@
+     !call date_and_time(values=vals)
+     !call random_seed(put=vals(8:8))
+     call system_clock(count=clock)
+-    puts = clock + 37*(/(i - 1, i = 1, 12) /)
++    puts = clock + 37*(/(i - 1, i = 1, 33) /)
+     call random_seed(put=puts)
+ !    call random_seed(size=isize)
+ !    write(*,*)isize
 diff -ruN refmac5.8-orig/makefile refmac5.8/makefile
 --- refmac5.8-orig/makefile	2014-10-06 16:47:05.000000000 -0700
 +++ refmac5.8/makefile	2014-10-06 17:44:18.000000000 -0700
@@ -17,10 +38,10 @@ diff -ruN refmac5.8-orig/makefile refmac5.8/makefile
 -FFLAGS = $(FOPTIM) $(XFFLAGS) 
 -CFLAGS = $(COPTIM) $(XCFLAGS)
 +VERSION = 5 
-+# FC      = @FINKPREFIX@/lib/gcc5/bin/gfortran
-+# CC      = @FINKPREFIX@/lib/gcc5/bin/gcc-4
-+# CXX     = @FINKPREFIX@/lib/gcc5/bin/g++-4
-+# CPP     = @FINKPREFIX@/lib/gcc5/bin/g++-4
++# FC      = @FINKPREFIX@/lib/gcc9/bin/gfortran
++# CC      = @FINKPREFIX@/lib/gcc9/bin/gcc-4
++# CXX     = @FINKPREFIX@/lib/gcc9/bin/g++-4
++# CPP     = @FINKPREFIX@/lib/gcc9/bin/g++-4
 +FOPTIM  = -O3 
 +COPTIM  = -O 
 +XFFLAGS = -m64 -fno-second-underscore 
@@ -46,7 +67,7 @@ diff -ruN refmac5.8-orig/makefile refmac5.8/makefile
 +
 +LLIBLAPACK =  
  
-+LLIBOTHERS =  -L/usr/lib -L${CLIB} -L@FINKPREFIX@/lib/gcc5/lib -lgfortran  ${CLIB}/libccp4c.dylib ${CLIB}/libccp4f.dylib -lfftw @FINKPREFIX@/lib/libfftw.dylib @FINKPREFIX@/lib/librfftw.dylib -lstdc++  /usr/lib/libSystem.B.dylib  -lSystem -lm -lc++
++LLIBOTHERS =  -L/usr/lib -L${CLIB} -L@FINKPREFIX@/lib/gcc9/lib -lgfortran  ${CLIB}/libccp4c.dylib ${CLIB}/libccp4f.dylib -lfftw @FINKPREFIX@/lib/libfftw.dylib @FINKPREFIX@/lib/librfftw.dylib -lstdc++  /usr/lib/libSystem.B.dylib  -lSystem -lm -lc++
  
  
 -# per le versioni dei file, modifica il numero e la data nel file makecif_version.fh

--- a/10.9-libcxx/stable/main/finkinfo/sci/tinker.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/tinker.info
@@ -1,20 +1,20 @@
 Package: tinker
 Version: 7.1.3
-Revision: 1
+Revision: 2
 Source: http://dasher.wustl.edu/%n/downloads/%n-%v.tar.gz
 SourceRename: %n-%v.tar.gz 
 SourceDirectory: %n
 Source-MD5: 6cc34f0e582cdddf034bd86034567643
 PatchFile: %n.patch
 PatchFile-MD5: afa803b46a57c3474a3fecf037c5bf18
-BuildDepends: gcc5-compiler, fftw3
-Depends: gcc5-shlibs, fftw3-shlibs
+BuildDepends: gcc9-compiler, fftw3
+Depends: gcc9-shlibs, fftw3-shlibs
 PatchScript: <<
 #!/bin/zsh -efv
 %{default_script}
-perl -pi -e 's|gfortran -c -O3|gfortran-fsf-5 -c -O3 -fno-align-commons -fopenmp|g' macosx/**/*.make
-perl -pi -e 's|gfortran |gfortran-fsf-5 -fopenmp |g' macosx/**/link*.make
-perl -pi -e 's|libtinker.a|libtinker.a -L%p/lib -lfftw3 -lfftw3_omp -L%p/lib/gcc5/lib -lgomp|g' macosx/**/link*.make
+perl -pi -e 's|gfortran -c -O3|gfortran-fsf-9 -c -O3 -fno-align-commons -fopenmp|g' macosx/**/*.make
+perl -pi -e 's|gfortran |gfortran-fsf-9 -fopenmp |g' macosx/**/link*.make
+perl -pi -e 's|libtinker.a|libtinker.a -L%p/lib -lfftw3 -lfftw3_omp -L%p/lib/gcc9/lib -lgomp|g' macosx/**/link*.make
 perl -pi -e 's| libfftw3| %p/lib/libfftw3|g'  macosx/**/link*.make
 <<
 CompileScript: << 

--- a/10.9-libcxx/stable/main/finkinfo/sci/usf.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/usf.info
@@ -1,6 +1,6 @@
 Package: usf
 Version: 1.0
-Revision: 5
+Revision: 6
 Maintainer: W. G. Scott <wgscott@users.sourceforge.net> 
 DescDetail: <<
 Uppsala Software Factory
@@ -10,8 +10,8 @@ and Structural Biology
 Description: Uppsala Crystallography software
 License: Public Domain
 GCC:4.0
-Depends: gcc5-shlibs, libccp4-shlibs (>= 6.3.1-102)
-BuildDepends: gcc5  
+Depends: gcc9-shlibs, libccp4-shlibs (>= 6.4.0-5)
+BuildDepends: gcc9  
 HomePage: http://xray.bmc.uu.se/usf/
 Source: http://xray.bmc.uu.se/markh/usf/usf_distribution_kit.tar.gz
 Source-MD5: 0d01d5e0cb5072822870004bb29e331e


### PR DESCRIPTION
This is for #481 to close down gcc5.

There are upstream bumps for some packages (coot, mmdb2, libccp4), but I didn't follow them.