### PR TITLE
Atlas 3.10.3

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/atlas-xcode7.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/atlas-xcode7.patch
@@ -1,24 +1,22 @@
---- ATLAS/CONFIG/include/atlconf.h.orig	2015-09-19 12:04:08.000000000 -0400
-+++ ATLAS/CONFIG/include/atlconf.h	2015-09-19 12:20:35.000000000 -0400
-@@ -76,12 +76,12 @@
- enum F2CINT {f2c_IntErr=0, FintCint, FintClong, FintClonglong, FintCshort};
- enum F2CSTRING {f2c_StrErr=0, fstrSun, fstrCray, fstrStructVal, fstrStructPtr};
- 
--#define NISA 11
-+#define NISA 8
+--- ATLAS/CONFIG/include/atlconf.h.orig	2016-07-28 14:43:00.000000000 -0500
++++ ATLAS/CONFIG/include/atlconf.h	2020-01-13 19:56:58.000000000 -0600
+@@ -99,11 +99,11 @@
+ #define NISA 15
  static char *ISAXNAM[NISA] =
--   {"", "VSX", "AltiVec", "AVXMAC", "AVXFMA4", "AVX", "SSE3", "SSE2", "SSE1",
-+   {"", "VSX", "AltiVec", "SSE3", "SSE2", "SSE1",
-     "3DNow", "NEON"};
+    {"", "VSX", "VXZ", "AltiVec",
+-    "AVXMAC", "AVXFMA4", "AVX", "SSE3", "SSE2", "SSE1", "3DNow",
++    "SSE3", "SSE2", "SSE1", "3DNow",
+     "FPV3D2MACNEON", "FPV3D16MACNEON", "FPV3D32MAC", "FPV3D16MAC"};
  enum ISAEXT
--   {ISA_None=0, ISA_VSX, ISA_AV, ISA_AVXMAC, ISA_AVXFMA4, ISA_AVX,
-+   {ISA_None=0, ISA_VSX, ISA_AV,
-     ISA_SSE3, ISA_SSE2, ISA_SSE1, ISA_3DNow, ISA_NEON};
+    {ISA_None=0, ISA_VSX, ISA_VXZ, ISA_AV,
+-    ISA_AVXMAC, ISA_AVXFMA4, ISA_AVX, ISA_SSE3, ISA_SSE2, ISA_SSE1, ISA_3DNow,
++    ISA_SSE3, ISA_SSE2, ISA_SSE1, ISA_3DNow,
+     ISA_NEON, ISA_NEON16, ISA_VFP3D32MAC, ISA_VFP3D16MAC};
  
- #define NASMD 9
+ #define NASMD 11
 --- ATLAS/CONFIG/src/probe_comp.c.orig	2015-09-19 13:41:43.000000000 -0400
-+++ ATLAS/CONFIG/src/probe_comp.c	2015-09-19 13:42:30.000000000 -0400
-@@ -444,18 +444,10 @@
++++ ATLAS/CONFIG/src/probe_comp.c	2020-01-13 19:59:31.000000000 -0600
+@@ -444,20 +444,12 @@
     char *vp=NULL;
     int i;
  
@@ -31,6 +29,8 @@
 -   else if (vecexts & (1<<ISA_VSX))
 +   if (vecexts & (1<<ISA_VSX))
        vp = "-mvsx";
+    else if (vecexts & (1<<ISA_VXZ))
+       vp = "-mvx -mzvector";
     else if (vecexts & (1<<ISA_AV))
        vp = "-maltivec";
 -   else if (vecexts & (1<<ISA_AVX))

--- a/10.9-libcxx/stable/main/finkinfo/sci/atlas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/atlas.info
@@ -246,6 +246,10 @@ InstallScript: <<
  find %i/lib -type f -name '*.a' -exec ranlib \{\} \;
  chmod -R a-x %i/lib/*
  chmod -R a+rX %i/share
+
+ # rm manpage causing a conflict on case-insensitive FS (actually just a reference to Cintface.c.3)
+ cd %i/share/man/man3
+ [ -f C_INTFACE.3 ] && [ ! C_INTFACE.3 -ef c_intface.3 ] && rm C_INTFACE.3 || echo "no file to remove"
 <<
 Splitoff: <<
 	Package: %N-shlibs

--- a/10.9-libcxx/stable/main/finkinfo/sci/atlas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/atlas.info
@@ -1,6 +1,6 @@
 Package: atlas
-Version: 3.10.2
-Revision: 5
+Version: 3.10.3
+Revision: 1
 Description: Portable optimal linear algebra software
 DescDetail: <<
 The current version provides a complete BLAS and LAPACK API.
@@ -48,13 +48,13 @@ or
 Also decide carefully whether you want to link to static or to shared libs.
 <<
 Source: mirror:sourceforge:math-atlas/files/%n%v.tar.bz2
-Source-MD5: a4e21f343dec8f22e7415e339f09f6da
-Source2: http://www.netlib.org/lapack/lapack-3.5.0.tgz
-Source2-MD5: b1d3e3e425b2e44a06760ff173104bdf
+Source-MD5: d6ce4f16c2ad301837cfb3dade2f7cef
+Source2: http://www.netlib.org/lapack/lapack-3.6.1.tgz
+Source2-MD5: 421b2cb72e15f237e144428f9c460ee0
 PatchFile: %n.patch
 PatchFile-MD5: 6085b07dd1803882776cf0008c38d787
 PatchFile2: %n-xcode7.patch
-PatchFile2-MD5: 2db7a1ffa2a9145e1a04e87c3858bc79
+PatchFile2-MD5: d58bb72a0fb1adad3109a5de580ce9e2
 
 SourceDirectory: ATLAS 
 License: BSD
@@ -74,7 +74,6 @@ Depends: <<
 	%N-shlibs (=%v-%r)
 <<
 
-# The whole previous patchscript is in the srcs for %v 3.9.4
 PatchScript: <<
 #!/bin/bash -ev
 sed -e 's|@COMPILER_PATH@|%b/../opt-bin|g' -e 's|@F77LIB_PATH@|%p/lib/gcc9/lib|g' < %{PatchFile} | patch -p1
@@ -94,7 +93,7 @@ fi
 
 cd ..
 if [ -e LAPACK ] ; then mv LAPACK LAPACK-strange; fi
-mv lapack-3.5.0 LAPACK
+mv lapack-3.6.1 LAPACK
 # first need the tarball of lapack (and no % will give the path to the original;
 # not worth to check the user's fink.conf for a FetchAltDir entry etc)
 tar -czf lapack.tgz LAPACK
@@ -160,7 +159,7 @@ BLD () {
  else   ../ATLAS/configure %c -C ac $GCCADDR/opt-bin/gcc -C if `which gfortran-fsf-9` -F alg "$mflags" $confflags --dylibs
  fi
 
- make
+ make -w
 
 ### Static Libs
  cd lib
@@ -182,7 +181,7 @@ BLD () {
 
 ### LAPACK-DOCS
  cd %b/../LAPACK
- make man html
+ make -w man html
 <<
 InfoTest: <<
 TestSuiteSize: large

--- a/10.9-libcxx/stable/main/finkinfo/sci/atlas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/atlas.info
@@ -117,9 +117,9 @@ perl -pi -e "s|GOODGCC =.*|GOODGCC = gcc-fsf-9\");|" CONFIG/src/SpewMakeInc.c
 cd ..
 cd LAPACK
 sed -e 's,\.\./.\./librefblas\.a,%b/../bld/lib/libf77blas.a %b/../bld/lib/libcblas.a %b/../bld/lib/libatlas.a,' \
-    -e 's,lapack\.a,%b/../bld/lib/liblapack.a,' \
-    -e 's, -g$,,' -e '/LOADOPTS/s,=,= $(OPTS),' \
-    -e 's,libtmglib.a,%b/../bld/src/lapack/reference/libtmglib.a,' < make.inc.example > make.inc.proto
+    -e 's,liblapack\.a,../darwin_bld/lib/liblapack.a,' \
+    -e 's,libtmglib.a,../darwin_bld/src/lapack/reference/libtmglib.a,' \
+    -e 's, -g$,,' -e '/LOADOPTS/s,=,= $(OPTS),' < make.inc.example > make.inc.proto
 path=`which perl`
 sed -i'' -e "s,/s./bin/perl,$path," DOCS/Doxyfile*
 <<


### PR DESCRIPTION
Update atlas to latest stable 3.10.3.
Also bumps internal LAPACK. There are newer LAPACK releases, but 3.6.1 was the latest available when 3.10.3 was released, so most likely to not introduce any issues.