### PR TITLE
Add 10.14.5 to available distributions

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
@@ -3,7 +3,7 @@ Package: cernlib2006
 Type: gcc (9)
 Version: 2006b
 Revision: 30
-Distribution: 10.9, 10.10, 10.11, 10.12, 10.13, 10.14
+Distribution: 10.9, 10.10, 10.11, 10.12, 10.13, 10.14, 10.14.5
 Description: Paw and other basic executables
 Depends: <<
   gcc%type_pkg[gcc]-shlibs,


### PR DESCRIPTION
xmkmf is available for distribution 10.14.5, which allows building cernlib on this platform, too.