### PR TITLE
Add missing dependency on help2man

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/libtool2.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/libtool2.info
@@ -19,6 +19,7 @@ Version: 2.4.6
 Revision: 4
 Maintainer: Max Horn <max@quendi.de>
 Depends: %N-shlibs (= %v-%r)
+BuildDepends: help2man
 BuildDependsOnly: true
 Conflicts: libtool14, libtool, libstroke (<= 0.5.1-2), libstroke-m4
 Replaces: libtool, libtool14


### PR DESCRIPTION
help2man is needed to rebuild doc/libtool.1