### PR TITLE
Fix exuberant-ctags build on 10.14 with __unused macro issues.

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/editors/exuberant-ctags.info
+++ b/10.9-libcxx/stable/main/finkinfo/editors/exuberant-ctags.info
@@ -1,8 +1,11 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Package: exuberant-ctags
 Version: 5.8
-Revision: 1
+Revision: 2
 Source: mirror:sourceforge:ctags/ctags-%v.tar.gz
+PatchFile: %n_unused_namespace.patch
+PatchFile-MD5: 2464d39d6553512ce553397714f9baaa
+PatchScript: patch -p0 < %{PatchFile}
 SetCFlags: -Os
 ConfigureParams: --mandir=%i/share/man --disable-etags
 Description: Reimplementation of ctags(1) 

--- a/10.9-libcxx/stable/main/finkinfo/editors/exuberant-ctags.info
+++ b/10.9-libcxx/stable/main/finkinfo/editors/exuberant-ctags.info
@@ -23,6 +23,9 @@ You may have to run
    sudo update-alternatives --config ctags
 to make sure you are using this package.
 <<
+DescPort: <<
+Use MacPorts patch to deal with namespacing of __unused__ macro.
+<<
 InstallScript: <<
 make prefix=%i mandir=%i/share/man install
 mv %i/bin/ctags %i/bin/ctags-exuberant

--- a/10.9-libcxx/stable/main/finkinfo/editors/exuberant-ctags_unused_namespace.patch
+++ b/10.9-libcxx/stable/main/finkinfo/editors/exuberant-ctags_unused_namespace.patch
@@ -1,0 +1,267 @@
+diff -Naurp c.c c.c
+--- c.c	2009-07-04 21:02:43.000000000 -0700
++++ c.c	2019-03-30 20:52:42.000000000 -0700
+@@ -619,7 +619,7 @@ static const char *keywordString (const 
+ 	return name;
+ }
+ 
+-static void __unused__ pt (tokenInfo *const token)
++static void __ctags__unused__ pt (tokenInfo *const token)
+ {
+ 	if (isType (token, TOKEN_NAME))
+ 		printf ("type: %-12s: %-13s   line: %lu\n",
+@@ -634,7 +634,7 @@ static void __unused__ pt (tokenInfo *co
+ 			tokenString (token->type), token->lineNumber);
+ }
+ 
+-static void __unused__ ps (statementInfo *const st)
++static void __ctags__unused__ ps (statementInfo *const st)
+ {
+ 	unsigned int i;
+ 	printf ("scope: %s   decl: %s   gotName: %s   gotParenName: %s\n",
+diff -Naurp eiffel.c eiffel.c
+--- eiffel.c	2009-06-28 16:09:31.000000000 -0700
++++ eiffel.c	2019-03-30 20:52:42.000000000 -0700
+@@ -803,7 +803,7 @@ static void findKeyword (tokenInfo *cons
+ 
+ static boolean parseType (tokenInfo *const token);
+ 
+-static void parseGeneric (tokenInfo *const token, boolean declaration __unused__)
++static void parseGeneric (tokenInfo *const token, boolean declaration __ctags__unused__)
+ {
+ 	unsigned int depth = 0;
+ #ifdef TYPE_REFERENCE_TOOL
+diff -Naurp general.h general.h
+--- general.h	2007-05-02 20:21:08.000000000 -0700
++++ general.h	2019-03-30 20:52:42.000000000 -0700
+@@ -57,10 +57,10 @@
+  *  to prevent warnings about unused variables.
+  */
+ #if (__GNUC__ > 2  ||  (__GNUC__ == 2  &&  __GNUC_MINOR__ >= 7)) && !defined (__GNUG__)
+-# define __unused__  __attribute__((unused))
++# define __ctags__unused__  __attribute__((unused))
+ # define __printf__(s,f)  __attribute__((format (printf, s, f)))
+ #else
+-# define __unused__
++# define __ctags__unused__
+ # define __printf__(s,f)
+ #endif
+ 
+diff -Naurp lregex.c lregex.c
+--- lregex.c	2007-09-09 19:36:48.000000000 -0700
++++ lregex.c	2019-03-30 20:52:42.000000000 -0700
+@@ -538,11 +538,11 @@ extern void findRegexTags (void)
+ #endif  /* HAVE_REGEX */
+ 
+ extern void addTagRegex (
+-		const langType language __unused__,
+-		const char* const regex __unused__,
+-		const char* const name __unused__,
+-		const char* const kinds __unused__,
+-		const char* const flags __unused__)
++		const langType language __ctags__unused__,
++		const char* const regex __ctags__unused__,
++		const char* const name __ctags__unused__,
++		const char* const kinds __ctags__unused__,
++		const char* const flags __ctags__unused__)
+ {
+ #ifdef HAVE_REGEX
+ 	Assert (regex != NULL);
+@@ -564,10 +564,10 @@ extern void addTagRegex (
+ }
+ 
+ extern void addCallbackRegex (
+-		const langType language __unused__,
+-		const char* const regex __unused__,
+-		const char* const flags __unused__,
+-		const regexCallback callback __unused__)
++		const langType language __ctags__unused__,
++		const char* const regex __ctags__unused__,
++		const char* const flags __ctags__unused__,
++		const regexCallback callback __ctags__unused__)
+ {
+ #ifdef HAVE_REGEX
+ 	Assert (regex != NULL);
+@@ -581,7 +581,7 @@ extern void addCallbackRegex (
+ }
+ 
+ extern void addLanguageRegex (
+-		const langType language __unused__, const char* const regex __unused__)
++		const langType language __ctags__unused__, const char* const regex __ctags__unused__)
+ {
+ #ifdef HAVE_REGEX
+ 	if (! regexBroken)
+@@ -602,7 +602,7 @@ extern void addLanguageRegex (
+ */
+ 
+ extern boolean processRegexOption (const char *const option,
+-								   const char *const parameter __unused__)
++								   const char *const parameter __ctags__unused__)
+ {
+ 	boolean handled = FALSE;
+ 	const char* const dash = strchr (option, '-');
+@@ -624,7 +624,7 @@ extern boolean processRegexOption (const
+ 	return handled;
+ }
+ 
+-extern void disableRegexKinds (const langType language __unused__)
++extern void disableRegexKinds (const langType language __ctags__unused__)
+ {
+ #ifdef HAVE_REGEX
+ 	if (language <= SetUpper  &&  Sets [language].count > 0)
+@@ -639,8 +639,8 @@ extern void disableRegexKinds (const lan
+ }
+ 
+ extern boolean enableRegexKind (
+-		const langType language __unused__,
+-		const int kind __unused__, const boolean mode __unused__)
++		const langType language __ctags__unused__,
++		const int kind __ctags__unused__, const boolean mode __ctags__unused__)
+ {
+ 	boolean result = FALSE;
+ #ifdef HAVE_REGEX
+@@ -660,7 +660,7 @@ extern boolean enableRegexKind (
+ 	return result;
+ }
+ 
+-extern void printRegexKinds (const langType language __unused__, boolean indent __unused__)
++extern void printRegexKinds (const langType language __ctags__unused__, boolean indent __ctags__unused__)
+ {
+ #ifdef HAVE_REGEX
+ 	if (language <= SetUpper  &&  Sets [language].count > 0)
+diff -Naurp lua.c lua.c
+--- lua.c	2006-10-11 20:26:40.000000000 -0700
++++ lua.c	2019-03-30 20:52:42.000000000 -0700
+@@ -37,7 +37,7 @@ static kindOption LuaKinds [] = {
+ */
+ 
+ /* for debugging purposes */
+-static void __unused__ print_string (char *p, char *q)
++static void __ctags__unused__ print_string (char *p, char *q)
+ {
+ 	for ( ; p != q; p++)
+ 		fprintf (errout, "%c", *p);
+diff -Naurp main.c main.c
+--- main.c	2007-06-06 21:35:21.000000000 -0700
++++ main.c	2019-03-30 20:52:42.000000000 -0700
+@@ -522,7 +522,7 @@ static void makeTags (cookedArgs *args)
+  *		Start up code
+  */
+ 
+-extern int main (int __unused__ argc, char **argv)
++extern int main (int __ctags__unused__ argc, char **argv)
+ {
+ 	cookedArgs *args;
+ #ifdef VMS
+diff -Naurp options.c options.c
+--- options.c	2007-09-04 19:00:44.000000000 -0700
++++ options.c	2019-03-30 20:52:42.000000000 -0700
+@@ -730,7 +730,7 @@ static void processEtagsInclude (
+ }
+ 
+ static void processExcludeOption (
+-		const char *const option __unused__, const char *const parameter)
++		const char *const option __ctags__unused__, const char *const parameter)
+ {
+ 	const char *const fileName = parameter + 1;
+ 	if (parameter [0] == '\0')
+@@ -867,7 +867,7 @@ static void processFieldsOption (
+ }
+ 
+ static void processFilterTerminatorOption (
+-		const char *const option __unused__, const char *const parameter)
++		const char *const option __ctags__unused__, const char *const parameter)
+ {
+ 	freeString (&Option.filterTerminator);
+ 	Option.filterTerminator = stringCopy (parameter);
+@@ -930,8 +930,8 @@ static void printProgramIdentification (
+ }
+ 
+ static void processHelpOption (
+-		const char *const option __unused__,
+-		const char *const parameter __unused__)
++		const char *const option __ctags__unused__,
++		const char *const parameter __ctags__unused__)
+ {
+ 	printProgramIdentification ();
+ 	putchar ('\n');
+@@ -1139,8 +1139,8 @@ static void processLanguagesOption (
+ }
+ 
+ static void processLicenseOption (
+-		const char *const option __unused__,
+-		const char *const parameter __unused__)
++		const char *const option __ctags__unused__,
++		const char *const parameter __ctags__unused__)
+ {
+ 	printProgramIdentification ();
+ 	puts ("");
+@@ -1166,8 +1166,8 @@ static void processListKindsOption (
+ }
+ 
+ static void processListMapsOption (
+-		const char *const __unused__ option,
+-		const char *const __unused__ parameter)
++		const char *const __ctags__unused__ option,
++		const char *const __ctags__unused__ parameter)
+ {
+ 	if (parameter [0] == '\0' || strcasecmp (parameter, "all") == 0)
+ 	    printLanguageMaps (LANG_AUTO);
+@@ -1183,8 +1183,8 @@ static void processListMapsOption (
+ }
+ 
+ static void processListLanguagesOption (
+-		const char *const option __unused__,
+-		const char *const parameter __unused__)
++		const char *const option __ctags__unused__,
++		const char *const parameter __ctags__unused__)
+ {
+ 	printLanguageList ();
+ 	exit (0);
+@@ -1358,8 +1358,8 @@ static void processIgnoreOption (const c
+ }
+ 
+ static void processVersionOption (
+-		const char *const option __unused__,
+-		const char *const parameter __unused__)
++		const char *const option __ctags__unused__,
++		const char *const parameter __ctags__unused__)
+ {
+ 	printProgramIdentification ();
+ 	exit (0);
+diff -Naurp parse.c parse.c
+--- parse.c	2007-07-30 22:35:33.000000000 -0700
++++ parse.c	2019-03-30 20:52:42.000000000 -0700
+@@ -376,7 +376,7 @@ extern void freeParserResources (void)
+ */
+ 
+ extern void processLanguageDefineOption (
+-		const char *const option, const char *const parameter __unused__)
++		const char *const option, const char *const parameter __ctags__unused__)
+ {
+ #ifdef HAVE_REGEX
+ 	if (parameter [0] == '\0')
+diff -Naurp python.c python.c
+--- python.c	2009-07-06 20:55:23.000000000 -0700
++++ python.c	2019-03-30 20:52:42.000000000 -0700
+@@ -135,7 +135,7 @@ static boolean isIdentifierCharacter (in
+  * extract all relevant information and create a tag.
+  */
+ static void makeFunctionTag (vString *const function,
+-	vString *const parent, int is_class_parent, const char *arglist __unused__)
++	vString *const parent, int is_class_parent, const char *arglist __ctags__unused__)
+ {
+ 	tagEntryInfo tag;
+ 	initTagEntry (&tag, vStringValue (function));
+diff -Naurp routines.c routines.c
+--- routines.c	2007-06-06 21:35:21.000000000 -0700
++++ routines.c	2019-03-30 20:52:42.000000000 -0700
+@@ -526,7 +526,7 @@ static boolean isPathSeparator (const in
+ 
+ #if ! defined (HAVE_STAT_ST_INO)
+ 
+-static void canonicalizePath (char *const path __unused__)
++static void canonicalizePath (char *const path __ctags__unused__)
+ {
+ #if defined (MSDOS_STYLE_PATH)
+ 	char *p;


### PR DESCRIPTION
Based of MP fix.
Closes #573.