### PR TITLE
PostgreSQL upstream updates February 2020

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 10.11
+Version: 10.12
 Revision: 1
 Type: postgresql 10
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 01c83ee159bf2a690e75e69e49fe2a1d
-Source-Checksum: SHA256(0d5d14ff6b075655f4421038fbde3a5d7b418c26a249a187a4175600d7aecc09)
+Source-MD5: 50a69fdba082a9edd5598c3afb52bc3c
+Source-Checksum: SHA256(388f7f888c4fbcbdf424ec2bce52535195b426010b720af7bea767e23e594ae7)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql11.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql11.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 11.6
+Version: 11.7
 Revision: 1
 Type: postgresql 11
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 8e3462b342caf6f2265126674dde26da
-Source-Checksum: SHA256(49924f7ff92965fdb20c86e0696f2dc9f8553e1563124ead7beedf8910c13170)
+Source-MD5: 1cf8e7533b103e2aa9de6e76d477f67d
+Source-Checksum: SHA256(324ae93a8846fbb6a25d562d271bc441ffa8794654c5b2839384834de220a313)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql12.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql12.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 12.1
+Version: 12.2
 Revision: 1
 Type: postgresql 12
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 2ee1bd4ec5f49363a3f456f07e599b41
-Source-Checksum: SHA256(a09bf3abbaf6763980d0f8acbb943b7629a8b20073de18d867aecdb7988483ed)
+Source-MD5: a88ceea8ecf2741307f663e4539b58b7
+Source-Checksum: SHA256(ad1dcc4c4fc500786b745635a9e1eba950195ce20b8913f50345bb7d5369b5de)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.4.25
+Version: 9.4.26
 Revision: 1
 Epoch: 1
 Type: postgresql 9.4
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 5b8270dfd9a074088d3508836584260e
-Source-Checksum: SHA256(cb98afaef4748de76c13202c14198e3e4717adde49fd9c90fdc81da877520928)
+Source-MD5: 370648d6ed1c0b0f2cfd1a7ce76c3c04
+Source-Checksum: SHA256(f5c014fc4a5c94e8cf11314cbadcade4d84213cfcc82081c9123e1b8847a20b9)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.5.20
+Version: 9.5.21
 Revision: 1
 Epoch: 1
 Type: postgresql 9.5
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 021c821114af69080a0139bd39e63112
-Source-Checksum: SHA256(925751b375cf975bebbe79753fbcb5fe85d7a62abe516d4c56861a6b877dde0d)
+Source-MD5: ec5c7dc5ade389be5eb0bc7c564e7796
+Source-Checksum: SHA256(7eb56e4fa877243c2df78adc5a0ef02f851060c282682b4bb97b854100fb732c)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.6.16
+Version: 9.6.17
 Revision: 1
 Epoch: 1
 Type: postgresql 9.6
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: dffa2163d80b47a96c20aee618e90f8a
-Source-Checksum: SHA256(5c6cba9cc0df70ba2b128c4a87d0babfce7c0e2b888f70a9c8485745f66b22e7)
+Source-MD5: 4a12dd9e2afe140a8d2d4366471b075f
+Source-Checksum: SHA256(f6e1e32d32545f97c066f3c19f4d58dfab1205c01252cf85c5c92294ace1a0c2)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1


### PR DESCRIPTION
PR contains:

PostgreSQL upstream updates 12.2 11.7 10.12 9.6.17 9.5.21 9.4.26.  The upstream updates fixes the security issue CVE-2020-1720.

This is the last update for the PostgreSQL 9.4 , which is now EOL.




