### PR TITLE
OpenBLAS updated to 0.3.8 and fixed smallscaling build on 10.11 and lower

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
@@ -14,7 +14,7 @@ Source: https://github.com/xianyi/OpenBLAS/archive/v%v.tar.gz
 Source-MD5: a3cb780c2d79e3fe13af58a261308fdf
 SourceRename: OpenBLAS-%v.tar.gz
 PatchFile: %n.patch
-PatchFile-MD5: f4ab9508a7d4bde8e28ba4e84707056e
+PatchFile-MD5: 3aefa8256082dd2c2edf04e4d25c6a7d
 
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 
@@ -132,9 +132,10 @@ actually all tuning options from skylake to icelake appear to generate
 identical assembler and object code.)
 0.3.8: patched in https://github.com/xianyi/OpenBLAS/pull/2424
   to resolve gcc-9 build failure (#2421).
-  Patched `smallscaling` benchmark to work around missing CLOCK_MONOTONIC macro
-  on 10.11 and lower, from https://github.com/sysown/proxysql/issues/1571.
-  (Build failure: https://sourceforge.net/p/fink/mailman/message/36927850/).
+  Patched `smallscaling` benchmark to substitute CLOCK_MONOTONIC + clock_gettime
+  on 10.11 and lower (https://sourceforge.net/p/fink/mailman/message/36927850/),
+  based on https://github.com/sysown/proxysql/issues/1571 and
+  https://stackoverflow.com/a/11709413 .
   Including, but not using patches for build with clang without -fopenmp option;
   for that FOPENMP needs to be set instead to
   "-I$(ls -d %p/lib/gcc%type_raw[gcc]/lib/gcc/x86_64-*/%type_raw[gcc]*/include) -L%p/lib/gcc%type_raw[gcc]/lib -lgomp"

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: openblas
-Version: 0.3.7
+Version: 0.3.8
 Revision: 1
 Type: gcc (9)
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
@@ -11,10 +11,10 @@ BuildDepends: fink (>= 0.30.0), gcc%type_raw[gcc]-compiler
 Depends: %N-shlibs (= %v-%r)
 
 Source: https://github.com/xianyi/OpenBLAS/archive/v%v.tar.gz
-Source-MD5: 5cd4ff3891b66a59e47af2d14cde4056
+Source-MD5: a3cb780c2d79e3fe13af58a261308fdf
 SourceRename: OpenBLAS-%v.tar.gz
 PatchFile: %n.patch
-PatchFile-MD5: 94c9a2955bd88d3e5e0c28be9b7c1cf2
+PatchFile-MD5: 588741129832a336fc9ae29d2bf64ee4
 
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 
@@ -25,15 +25,19 @@ CompileScript: <<
 	# set arch to minimum model supported in OS version
 	darwin_vers=$(uname -r | cut -d. -f1)
 	if [ "$darwin_vers" -ge 18 ]; then
-			perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=intel -march=ivybridge|g;" Makefile.system
+		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=cascadelake -march=ivybridge|g;" Makefile.system
 	else
-			perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=intel -march=core2|g;" Makefile.system
+		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=cascadelake -march=core2|g;" Makefile.system
 	fi
 	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 libs netlib shared
 	cd benchmark
-	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 smallscaling veclib goto
 	mkdir -m 755 bin
-	mv smallscaling *.veclib *.goto bin
+	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 veclib goto
+	mv *.veclib *.goto bin
+	if [ "$darwin_vers" -gt 15 ]; then
+		make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp smallscaling
+		mv smallscaling bin
+	fi
 <<
 
 InstallScript: <<
@@ -46,11 +50,12 @@ InfoTest: <<
 	TestDepends: atlas
 	TestScript: <<
 		#!/bin/sh -ev
+		darwin_vers=$(uname -r | cut -d. -f1)
 		make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 tests | tee tests.log
 		grep -i fail tests.log
 		grep -c PASSED tests.log
 		cd benchmark
-		make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 atlas
+		make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp atlas
 		# created a ton of *.veclib, *.goto, *.atlas executables to be compared in performance...
 		# just filter largest matrix results and run a little suite of comparisons of threaded vs. openmp speedup
 		echo ATLAS
@@ -69,7 +74,7 @@ InfoTest: <<
 			echo -n $x
 			./$x 2>&1 | tail -1
 		done
-		./smallscaling
+		[ -x smallscaling ] && ./smallscaling
 	<<
 <<
 
@@ -114,14 +119,28 @@ Thus this project was created to continue developing OpenBLAS/GotoBLAS.
 DescPackaging: <<
 Setup with architecture-independent version and some patches from MacPorts
 https://github.com/macports/macports-ports/blob/master/math/OpenBLAS/Portfile
-Build with FSF gcc8 to ensure optimum compatibility with gfortran.
+Build with FSF gcc9 to ensure optimum compatibility with gfortran.
 cblas.h conflicts with header from atlas.
 Also builds executables for comparison with VecLib [+Atlas] in benchmark/bin,
 TestScript does not run them all (producing ~200 lines of timing output each);
 adding benchmark scripts and binaries to docs.
 Optimisation flags chosen to create binary packages that should work on
-anything from Pentium with SSE upwards, with tuning up to Haswell & Silvermont
-CPUs with AVX2 (most recent supported by gcc8).
+anything from Pentium with SSE upwards, with tuning up to Cascadelake CPUs with
+AVX512 support.
+(Note: gcc9 manual states `-mtune=intel` includes "Haswell & Silvermont" as
+"most recent supported" by that gcc version, but I found the intel tuning
+option to create different assembly output than haswell or skylake upwards.
+Chose cascadelake for 0.3.8 as newest generation available in the 2019 Mac Pro;
+actually all tuning options from skylake to icelake appear to generate
+identical assembler and object code.)
+0.3.8: patched in https://github.com/xianyi/OpenBLAS/pull/2424
+  to resolve gcc-9 build failure (#2421).
+  Disabled build of `smallscaling` benchmark on 10.11 and lower to avoid failure
+  on missing CLOCK_MONOTONIC macro
+  (https://sourceforge.net/p/fink/mailman/message/36927850/).
+  Including, but not using patches for build with clang without -fopenmp option;
+  for that FOPENMP needs to be set instead to
+  "-I$(ls -d %p/lib/gcc%type_raw[gcc]/lib/gcc/x86_64-*/%type_raw[gcc]*/include) -L%p/lib/gcc%type_raw[gcc]/lib -lgomp"
 <<
 # Info2
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
@@ -14,7 +14,7 @@ Source: https://github.com/xianyi/OpenBLAS/archive/v%v.tar.gz
 Source-MD5: a3cb780c2d79e3fe13af58a261308fdf
 SourceRename: OpenBLAS-%v.tar.gz
 PatchFile: %n.patch
-PatchFile-MD5: 588741129832a336fc9ae29d2bf64ee4
+PatchFile-MD5: f4ab9508a7d4bde8e28ba4e84707056e
 
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 
@@ -32,12 +32,8 @@ CompileScript: <<
 	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 libs netlib shared
 	cd benchmark
 	mkdir -m 755 bin
-	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 veclib goto
-	mv *.veclib *.goto bin
-	if [ "$darwin_vers" -gt 15 ]; then
-		make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp smallscaling
-		mv smallscaling bin
-	fi
+	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp veclib goto smallscaling
+	mv *.veclib *.goto smallscaling bin
 <<
 
 InstallScript: <<
@@ -50,31 +46,32 @@ InfoTest: <<
 	TestDepends: atlas
 	TestScript: <<
 		#!/bin/sh -ev
-		darwin_vers=$(uname -r | cut -d. -f1)
 		make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 tests | tee tests.log
 		grep -i fail tests.log
 		grep -c PASSED tests.log
 		cd benchmark
 		make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp atlas
+		# use hw.physicalcpu to run without hyperthreading
+		ncore=$(sysctl -n hw.logicalcpu)
 		# created a ton of *.veclib, *.goto, *.atlas executables to be compared in performance...
-		# just filter largest matrix results and run a little suite of comparisons of threaded vs. openmp speedup
+		# just filter results for a sample of matrix sizes and run a little suite of comparisons of threaded vs. openmp speedup
 		echo ATLAS
 		for x in *.atlas; do
-			echo -n $x
-			./$x 2>&1 | tail -1
+			echo OPENBLAS_NUM_THREADS=$ncore OMP_NUM_THREADS=1 $x
+			OPENBLAS_NUM_THREADS=$ncore OMP_NUM_THREADS=1 ./$x 2>&1 | awk '(NR < 4)||((NR-2)%%20 == 0)'
 		done
 		cd bin
 		echo VecLib
 		for x in *.veclib; do
-			echo -n $x
-			./$x 2>&1 | tail -1
+			echo OPENBLAS_NUM_THREADS=$ncore OMP_NUM_THREADS=1 $x
+			OPENBLAS_NUM_THREADS=$ncore OMP_NUM_THREADS=1 ./$x 2>&1 | awk '(NR < 4)||((NR-2)%%20 == 0)'
 		done
 		echo OpenBLAS
 		for x in *.goto; do
-			echo -n $x
-			./$x 2>&1 | tail -1
+			echo OPENBLAS_NUM_THREADS=$ncore OMP_NUM_THREADS=1 $x
+			OPENBLAS_NUM_THREADS=$ncore OMP_NUM_THREADS=1 ./$x 2>&1 | awk '(NR < 4)||((NR-2)%%20 == 0)'
 		done
-		[ -x smallscaling ] && ./smallscaling
+		OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=$ncore ./smallscaling
 	<<
 <<
 
@@ -135,9 +132,9 @@ actually all tuning options from skylake to icelake appear to generate
 identical assembler and object code.)
 0.3.8: patched in https://github.com/xianyi/OpenBLAS/pull/2424
   to resolve gcc-9 build failure (#2421).
-  Disabled build of `smallscaling` benchmark on 10.11 and lower to avoid failure
-  on missing CLOCK_MONOTONIC macro
-  (https://sourceforge.net/p/fink/mailman/message/36927850/).
+  Patched `smallscaling` benchmark to work around missing CLOCK_MONOTONIC macro
+  on 10.11 and lower, from https://github.com/sysown/proxysql/issues/1571.
+  (Build failure: https://sourceforge.net/p/fink/mailman/message/36927850/).
   Including, but not using patches for build with clang without -fopenmp option;
   for that FOPENMP needs to be set instead to
   "-I$(ls -d %p/lib/gcc%type_raw[gcc]/lib/gcc/x86_64-*/%type_raw[gcc]*/include) -L%p/lib/gcc%type_raw[gcc]/lib -lgomp"

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
@@ -22,8 +22,8 @@ diff -uNr a/Makefile.system b/Makefile.system
 
  ifeq ($(DEBUG), 1)
  COMMON_OPT += -g
-@@ -1272,11 +1274,11 @@
-
+@@ -1274,19 +1274,19 @@
+ 
  ifneq ($(DYNAMIC_ARCH), 1)
  ifndef SMP
 -LIBNAME		= $(LIBPREFIX)_$(LIBCORE)$(REVISION).$(LIBSUFFIX)
@@ -38,6 +38,17 @@ diff -uNr a/Makefile.system b/Makefile.system
  endif
  else
  ifndef SMP
+ LIBNAME		= $(LIBPREFIX)$(REVISION).$(LIBSUFFIX)
+-LIBNAME_P	= $(LIBPREFIX)$(REVISION)_p.$(LIBSUFFIX)
++LIBNAME_P	= $(LIBPREFIX)_p$(REVISION).$(LIBSUFFIX)
+ else
+-LIBNAME		= $(LIBPREFIX)p$(REVISION).$(LIBSUFFIX)
+-LIBNAME_P	= $(LIBPREFIX)p$(REVISION)_p.$(LIBSUFFIX)
++LIBNAME		= $(LIBPREFIX)$(REVISION).$(LIBSUFFIX)
++LIBNAME_P	= $(LIBPREFIX)_p$(REVISION).$(LIBSUFFIX)
+ endif
+ endif
+
 diff -uNr a/benchmark/Makefile b/benchmark/Makefile
 --- a/benchmark/Makefile   2020-02-09 23:16:28.000000000 +0100
 +++ b/benchmark/Makefile   2020-02-20 19:15:33.000000000 +0100
@@ -67,20 +78,50 @@ diff -uNr a/benchmark/Makefile b/benchmark/Makefile
  	@rm -f *.goto *.mkl *.acml *.atlas *.veclib *.essl smallscaling
 diff -uNr a/benchmark/smallscaling.c b/benchmark/smallscaling.c
 --- a/benchmark/smallscaling.c   2020-02-09 23:16:28.000000000 +0100
-+++ b/benchmark/smallscaling.c   2020-02-25 14:05:03.000000000 +0100
-@@ -10,6 +10,12 @@
++++ b/benchmark/smallscaling.c   2020-02-25 22:29:50.000000000 +0100
+@@ -10,6 +10,32 @@
  #define MAX_SIZE 60
  #define NB_SIZE 10
  
 +// Workaround for missing CLOCK_MONOTONIC on OS X El Capitan & earlier
 +#ifndef CLOCK_MONOTONIC
 +#include <mach/clock_types.h>
++#include <mach/mach_time.h>
 +#define CLOCK_MONOTONIC SYSTEM_CLOCK
++#define MACH_CLOCK_NEEDS_INIT 1
++
++double sec_factor;
++double nsec_factor;
++
++void clock_gett_init() {
++    mach_timebase_info_data_t timebase;
++    mach_timebase_info(&timebase);
++    nsec_factor = ((double)timebase.numer)/((double)timebase.denom);
++    sec_factor = ((double)timebase.numer)/((double)timebase.denom * 1e-9);
++}
++
++int clock_gettime(clock_id_t clk_id, struct timespec *tp) {
++    uint64_t time;
++    time = mach_absolute_time();
++    tp->tv_sec = (double)time * sec_factor;
++    tp->tv_nsec = (double)time * nsec_factor;
++    return 0;
++}
 +#endif // CLOCK_MONOTONIC
 +
  // number of loop for a 1x1 matrix. Lower it if the test is
  // too slow on you computer.
  #define NLOOP 2e7
+@@ -169,6 +194,9 @@
+ }
+ 
+ int main(int argc, char * argv[]) {
++#ifdef MACH_CLOCK_NEEDS_INIT
++    clock_gett_init();
++#endif
+     double inc_factor = exp(log((double)MAX_SIZE / MIN_SIZE) / NB_SIZE);
+     BenchParam param;
+     int test_id;
 diff -uNr a/Makefile b/Makefile
 --- a/Makefile		2019-08-11 23:23:27.000000000 +0100
 +++ b/Makefile		2019-11-06 19:18:15.000000000 +0100

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
@@ -56,14 +56,6 @@ diff -uNr a/benchmark/Makefile b/benchmark/Makefile
  
  # Intel standard
  # MKL=/opt/intel/mkl/lib/intel64
-@@ -183,7 +183,6 @@
-        cher2k.goto zher2k.goto \
-        sgemv.goto dgemv.goto cgemv.goto zgemv.goto \
-        ssymm.goto dsymm.goto csymm.goto zsymm.goto \
--       smallscaling \
-        isamax.goto idamax.goto icamax.goto izamax.goto \
-        snrm2.goto dnrm2.goto scnrm2.goto dznrm2.goto $(GOTO_LAPACK_TARGETS)
-
 @@ -2338,7 +2342,7 @@
  
  
@@ -73,6 +65,22 @@ diff -uNr a/benchmark/Makefile b/benchmark/Makefile
  
  clean ::
  	@rm -f *.goto *.mkl *.acml *.atlas *.veclib *.essl smallscaling
+diff -uNr a/benchmark/smallscaling.c b/benchmark/smallscaling.c
+--- a/benchmark/smallscaling.c   2020-02-09 23:16:28.000000000 +0100
++++ b/benchmark/smallscaling.c   2020-02-25 14:05:03.000000000 +0100
+@@ -10,6 +10,12 @@
+ #define MAX_SIZE 60
+ #define NB_SIZE 10
+ 
++// Workaround for missing CLOCK_MONOTONIC on OS X El Capitan & earlier
++#ifndef CLOCK_MONOTONIC
++#include <mach/clock_types.h>
++#define CLOCK_MONOTONIC SYSTEM_CLOCK
++#endif // CLOCK_MONOTONIC
++
+ // number of loop for a 1x1 matrix. Lower it if the test is
+ // too slow on you computer.
+ #define NLOOP 2e7
 diff -uNr a/Makefile b/Makefile
 --- a/Makefile		2019-08-11 23:23:27.000000000 +0100
 +++ b/Makefile		2019-11-06 19:18:15.000000000 +0100

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
@@ -1,7 +1,18 @@
 diff -uNr a/Makefile.system b/Makefile.system
---- a/Makefile.system	2019-04-29 19:21:59.000000000 +0200
-+++ b/Makefile.system	2019-05-03 02:07:52.000000000 +0200
-@@ -1173,8 +1173,8 @@
+--- a/Makefile.system	2020-02-09 23:16:28.000000000 +0100
++++ b/Makefile.system	2020-02-20 18:06:14.000000000 +0100
+@@ -486,8 +486,10 @@
+ endif
+ 
+ ifeq ($(C_COMPILER), CLANG)
++ifneq ($(OSNAME), Darwin)
+ CCOMMON_OPT    += -fopenmp
+ endif
++endif
+ 
+ ifeq ($(C_COMPILER), INTEL)
+ CCOMMON_OPT    += -fopenmp
+@@ -1201,8 +1203,8 @@
  endif
 
 
@@ -11,7 +22,7 @@ diff -uNr a/Makefile.system b/Makefile.system
 
  ifeq ($(DEBUG), 1)
  COMMON_OPT += -g
-@@ -1244,11 +1244,11 @@
+@@ -1272,11 +1274,11 @@
 
  ifneq ($(DYNAMIC_ARCH), 1)
  ifndef SMP
@@ -28,18 +39,40 @@ diff -uNr a/Makefile.system b/Makefile.system
  else
  ifndef SMP
 diff -uNr a/benchmark/Makefile b/benchmark/Makefile
---- a/benchmark/Makefile   2019-04-29 19:21:59.000000000 +0200
-+++ b/benchmark/Makefile   2019-05-03 02:08:58.000000000 +0200
-@@ -19,7 +19,8 @@
+--- a/benchmark/Makefile   2020-02-09 23:16:28.000000000 +0100
++++ b/benchmark/Makefile   2020-02-20 19:15:33.000000000 +0100
+@@ -19,8 +19,12 @@
  #LIBATLAS = -fopenmp $(ATLAS)/liblapack_atlas.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
  
  # Atlas RHEL and Fedora
 -ATLAS=/usr/lib64/atlas
-+# Atlas MacOS X Fink
+-LIBATLAS = -fopenmp $(ATLAS)/liblapack.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
++#ATLAS=/usr/lib64/atlas
++#LIBATLAS = -fopenmp $(ATLAS)/liblapack.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
++
++# Atlas MacOS X Fink (Xcode clang does not support -fopenmp)
 +ATLAS=@PREFIX@/lib
- LIBATLAS = -fopenmp $(ATLAS)/liblapack.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
++LIBATLAS = $(FOPENMP) $(ATLAS)/liblapack.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
  
  # Intel standard
+ # MKL=/opt/intel/mkl/lib/intel64
+@@ -183,7 +183,6 @@
+        cher2k.goto zher2k.goto \
+        sgemv.goto dgemv.goto cgemv.goto zgemv.goto \
+        ssymm.goto dsymm.goto csymm.goto zsymm.goto \
+-       smallscaling \
+        isamax.goto idamax.goto icamax.goto izamax.goto \
+        snrm2.goto dnrm2.goto scnrm2.goto dznrm2.goto $(GOTO_LAPACK_TARGETS)
+
+@@ -2338,7 +2342,7 @@
+ 
+ 
+ smallscaling: smallscaling.c ../$(LIBNAME)
+-	$(CC) $(CFLAGS) -o $(@F) $^ $(EXTRALIB) -fopenmp -lm -lpthread
++	$(CC) $(CFLAGS) -o $(@F) $^ $(EXTRALIB) $(FOPENMP) -lm -lpthread
+ 
+ clean ::
+ 	@rm -f *.goto *.mkl *.acml *.atlas *.veclib *.essl smallscaling
 diff -uNr a/Makefile b/Makefile
 --- a/Makefile		2019-08-11 23:23:27.000000000 +0100
 +++ b/Makefile		2019-11-06 19:18:15.000000000 +0100
@@ -57,7 +90,7 @@ diff -uNr a/Makefile b/Makefile
 diff -uNr a/Makefile.install b/Makefile.install
 --- a/Makefile.install	2019-08-11 23:23:27.000000000 +0100
 +++ b/Makefile.install	2019-11-06 2019-11-06 20:13:02.000000000 +0100
-@@ -83,8 +83,7 @@
+@@ -84,8 +84,7 @@
 	@-cp $(LIBDYNNAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
 	@-install_name_tool -id "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)/$(LIBDYNNAME)" "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)/$(LIBDYNNAME)"
 	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
@@ -67,3 +100,142 @@ diff -uNr a/Makefile.install b/Makefile.install
  endif
  ifeq ($(OSNAME), WINNT)
 	@-cp $(LIBDLLNAME) "$(DESTDIR)$(OPENBLAS_BINARY_DIR)"
+diff --git a/.travis.yml b/.travis.yml
+index 9e18412e8..0f20aef5c 100644
+--- a/.travis.yml
++++ b/.travis.yml
+@@ -176,7 +176,7 @@ matrix:
+     - <<: *test-macos
+       osx_image: xcode10.1
+       env:
+-        - CC="/Applications/Xcode-10.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -isysroot /Applications/Xcode-10.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.1.sdk"
++        - CC="/Applications/Xcode-10.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
+         - CFLAGS="-O2 -Wno-macro-redefined -isysroot /Applications/Xcode-10.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.1.sdk -arch arm64 -miphoneos-version-min=10.0"
+         - BTYPE="TARGET=ARMV8 BINARY=64 HOSTCC=clang NOFORTRAN=1"
+ 
+diff --git a/Makefile.prebuild b/Makefile.prebuild
+index a366004a1..b00f13368 100644
+--- a/Makefile.prebuild
++++ b/Makefile.prebuild
+@@ -42,7 +42,7 @@ all: getarch_2nd
+ 	./getarch_2nd  1 >> $(TARGET_CONF)
+ 
+ config.h : c_check f_check getarch
+-	perl ./c_check $(TARGET_MAKE) $(TARGET_CONF) $(CC) $(TARGET_FLAGS)
++	perl ./c_check $(TARGET_MAKE) $(TARGET_CONF) $(CC) $(TARGET_FLAGS) $(CFLAGS)
+ ifneq ($(ONLY_CBLAS), 1)
+ 	perl ./f_check $(TARGET_MAKE) $(TARGET_CONF) $(FC) $(TARGET_FLAGS)
+ else
+@@ -59,13 +59,13 @@ endif
+ 
+ 
+ getarch : getarch.c cpuid.S dummy $(CPUIDEMU)
+-	$(HOSTCC) $(CFLAGS) $(EXFLAGS) -o $(@F) getarch.c cpuid.S $(CPUIDEMU)
++	$(HOSTCC) $(HOST_CFLAGS) $(EXFLAGS) -o $(@F) getarch.c cpuid.S $(CPUIDEMU)
+ 
+ getarch_2nd : getarch_2nd.c config.h dummy
+ ifndef TARGET_CORE
+-	$(HOSTCC) -I. $(CFLAGS) -o $(@F) getarch_2nd.c
++	$(HOSTCC) -I. $(HOST_CFLAGS) -o $(@F) getarch_2nd.c
+ else
+-	$(HOSTCC) -I. $(CFLAGS) -DBUILD_KERNEL -o $(@F) getarch_2nd.c
++	$(HOSTCC) -I. $(HOST_CFLAGS) -DBUILD_KERNEL -o $(@F) getarch_2nd.c
+ endif
+ 
+ dummy:
+diff --git a/Makefile.system b/Makefile.system
+index c0e45515f..cf9e9bafa 100644
+--- a/Makefile.system
++++ b/Makefile.system
+@@ -214,7 +214,7 @@ ifndef GOTOBLAS_MAKEFILE
+ export GOTOBLAS_MAKEFILE = 1
+ 
+ # Generating Makefile.conf and config.h
+-DUMMY := $(shell $(MAKE) -C $(TOPDIR) -f Makefile.prebuild CC="$(CC)" FC="$(FC)" HOSTCC="$(HOSTCC)" CFLAGS="$(GETARCH_FLAGS)" BINARY=$(BINARY) USE_OPENMP=$(USE_OPENMP) TARGET_CORE=$(TARGET_CORE) ONLY_CBLAS=$(ONLY_CBLAS) TARGET=$(TARGET) all)
++DUMMY := $(shell $(MAKE) -C $(TOPDIR) -f Makefile.prebuild CC="$(CC)" FC="$(FC)" HOSTCC="$(HOSTCC)" HOST_CFLAGS="$(GETARCH_FLAGS)" CFLAGS="$(CFLAGS)" BINARY=$(BINARY) USE_OPENMP=$(USE_OPENMP) TARGET_CORE=$(TARGET_CORE) ONLY_CBLAS=$(ONLY_CBLAS) TARGET=$(TARGET) all)
+ 
+ ifndef TARGET_CORE
+ include $(TOPDIR)/Makefile.conf
+diff --git a/c_check b/c_check
+index 555b2eccf..c7899c84f 100644
+--- a/c_check
++++ b/c_check
+@@ -18,11 +18,12 @@ $binary = $ENV{"BINARY"};
+ $makefile = shift(@ARGV);
+ $config   = shift(@ARGV);
+ 
+-$compiler_name = join(" ", @ARGV);
++$compiler_name = shift(@ARGV);
++$flags = join(" ", @ARGV);
+ 
+ # First, we need to know the target OS and compiler name
+ 
+-$data = `$compiler_name -E ctest.c`;
++$data = `$compiler_name $flags -E ctest.c`;
+ 
+ if ($?) {
+     printf STDERR "C Compiler ($compiler_name) is something wrong.\n";
+@@ -175,7 +176,7 @@ if ($defined == 0) {
+ 
+ # Do again
+ 
+-$data = `$compiler_name -E ctest.c`;
++$data = `$compiler_name $flags -E ctest.c`;
+ 
+ if ($?) {
+     printf STDERR "C Compiler ($compiler_name) is something wrong.\n";
+@@ -195,7 +196,7 @@ if (($architecture eq "mips") || ($architecture eq "mips64")) {
+ 	print $tmpf "void main(void){ __asm__ volatile($code); }\n";
+ 
+ 	$args = "$msa_flags -o $tmpf.o $tmpf";
+-	my @cmd = ("$compiler_name $args");
++	my @cmd = ("$compiler_name $flags $args >/dev/null 2>/dev/null");
+ 	system(@cmd) == 0;
+ 	if ($? != 0) {
+ 	    $have_msa = 0;
+@@ -236,7 +237,7 @@ if (($architecture eq "x86") || ($architecture eq "x86_64")) {
+ 	if ($compiler eq "PGI") {
+ 	    $args = " -tp skylake -c -o $tmpf.o $tmpf";
+ 	}
+-	my @cmd = ("$compiler_name $args >/dev/null 2>/dev/null");
++	my @cmd = ("$compiler_name $flags $args >/dev/null 2>/dev/null");
+ 	system(@cmd) == 0;
+ 	if ($? != 0) {
+ 	    $no_avx512 = 1;
+@@ -247,7 +248,7 @@ if (($architecture eq "x86") || ($architecture eq "x86_64")) {
+     }
+ }
+ 
+-$data = `$compiler_name -S ctest1.c && grep globl ctest1.s | head -n 1 && rm -f ctest1.s`;
++$data = `$compiler_name $flags -S ctest1.c && grep globl ctest1.s | head -n 1 && rm -f ctest1.s`;
+ 
+ $data =~ /globl\s([_\.]*)(.*)/;
+ 
+@@ -263,19 +264,6 @@ if ($architecture ne $hostarch) {
+ 
+ $cross = 1 if ($os ne $hostos);
+ 
+-# rework cross suffix and architecture if we are on OSX cross-compiling for ARMV8-based IOS
+-# the initial autodetection will have been confused by the command-line arguments to clang
+-# and the cross-compiler apparently still claims to build for x86_64 in its CC -E output
+-if (($os eq "Darwin") && ($cross_suffix ne "")) {
+-  my $tmpnam = `xcrun --sdk iphoneos --find clang`;
+-  $cross_suffix = substr($tmpnam, 0, rindex($tmpnam, "/")+1 ); 
+-# this should produce something like $cross_suffix="/Applications/Xcode-10.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/";
+-  $cross =1;
+-  $architecture = arm64;
+-}
+-
+-
+-
+ $openmp = "" if $ENV{USE_OPENMP} != 1;
+ 
+ $linker_L = "";
+@@ -283,7 +271,7 @@ $linker_l = "";
+ $linker_a = "";
+ 
+ {
+-    $link = `$compiler_name -c ctest2.c -o ctest2.o 2>&1 && $compiler_name $openmp -v ctest2.o -o ctest2 2>&1 && rm -f ctest2.o ctest2 ctest2.exe`;
++    $link = `$compiler_name $flags -c ctest2.c -o ctest2.o 2>&1 && $compiler_name $flags $openmp -v ctest2.o -o ctest2 2>&1 && rm -f ctest2.o ctest2 ctest2.exe`;
+ 
+     $link =~ s/\-Y\sP\,/\-Y/g;


### PR DESCRIPTION
Updated the `openblas` package to latest upstream and worked around a failure on compilation of the `smallscaling` benchmark program on OS X 10.11 (and presumably earlier) due to missing `CLOCK_MONOTONIC` reported [here](https://sourceforge.net/p/fink/mailman/message/36927850).
Also modified the `-mtune` option - see discussion in `DescPackaging`, as the `intel` option did not seem to enable all optimisations for the latest CPUs supported with gcc9 - might see some performance improvement on the latest iMac Pro or Mac Pro.