### PR TITLE
Fix assumptions from internal time::local about 2-digit years.

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5162-timelocal-y2020.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5162-timelocal-y2020.patch
@@ -1,0 +1,46 @@
+--- a/cpan/Time-Local/t/Local.t	2014-01-31 15:55:51.000000000 -0600
++++ a/cpan/Time-Local/t/Local.t	2020-02-23 05:19:01.000000000 -0600
+@@ -91,7 +91,7 @@
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal($sec,$min,$hour,$mday,$mon,$year_in);
+ 
+             my($s,$m,$h,$D,$M,$Y) = localtime($time);
+@@ -107,7 +107,7 @@
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm($sec,$min,$hour,$mday,$mon,$year_in);
+ 
+             my($s,$m,$h,$D,$M,$Y) = gmtime($time);
+@@ -125,7 +125,6 @@
+ 
+ for (@bad_time) {
+     my($year, $mon, $mday, $hour, $min, $sec) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm($sec,$min,$hour,$mday,$mon,$year) };
+@@ -134,14 +133,14 @@
+ }
+ 
+ {
+-    is(timelocal(0,0,1,1,0,90) - timelocal(0,0,0,1,0,90), 3600,
++    is(timelocal(0,0,1,1,0,1990) - timelocal(0,0,0,1,0,1990), 3600,
+        'one hour difference between two calls to timelocal');
+ 
+-    is(timelocal(1,2,3,1,0,100) - timelocal(1,2,3,31,11,99), 24 * 3600,
++    is(timelocal(1,2,3,1,0,2000) - timelocal(1,2,3,31,11,1999), 24 * 3600,
+        'one day difference between two calls to timelocal');
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+-    is(timegm(0,0,0, 1, 2, 80) - timegm(0,0,0, 1, 0, 80), 60 * 24 * 3600,
++    is(timegm(0,0,0, 1, 2, 1980) - timegm(0,0,0, 1, 0, 1980), 60 * 24 * 3600,
+        '60 day difference between two calls to timegm');
+ }
+ 

--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5162.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5162.info
@@ -3,6 +3,7 @@ Version: 5.16.2
 Revision: 103
 # sync changes from here into texi2html-perl5162 pkg if appropriate
 Distribution: 10.10, 10.11, 10.12, 10.13, 10.14
+BuildDepends: fink (>= 0.30.0)
 Depends: %n-core (>= %v-%r)
 Conflicts: perl5123, perl5124, perl5162, perl5182, perl5184
 Replaces: perl5123, perl5124, perl5162, perl5182, perl5184
@@ -38,6 +39,10 @@ disable testing them.
 http://grokbase.com/t/perl/perl5-porters/1289z1msea/whats-blocking-5-14-3
 perl bug #35895
 radar://4139653 (?)
+
+Included Time::Local does bad assumptions for 2 digit years, which broke
+starting in 2020. Patch adapted for perl5.1x from here:
+https://rt.cpan.org/Public/Bug/Display.html?id=124787
 <<
 DescUsage: <<
 Most perl scripts start with #!/usr/bin/perl which will invoke Apple's
@@ -49,6 +54,8 @@ Source: mirror:cpan:src/5.0/perl-%v.tar.bz2
 Source-MD5: 2818ab01672f005a4e552a713aa27b08
 PatchFile: %n.patch
 PatchFile-MD5: a3486815c04c6618e7cc1c18eb2b6999
+PatchFile3: perl5184-timelocal-y2020.patch
+PatchFile3-MD5: 8a97c37daec434dfcc673b6e3c74fe7c
 CompileScript: <<
 #!/bin/sh -ev
  sh Configure -desr -Dcc="gcc" -Dcpp="-gcc -E" -Dprefix=%p -Dccflags=-I%p/include -Dldflags=-L%p/lib -Dperladmin=none -Uinstallusrbinperl -Dprivlib="%p/lib/perl5-core/5.16.2" -Darchlib="%p/lib/perl5-core/5.16.2/darwin-thread-multi-2level" -Dman3dir="%p/lib/perl5-core/5.16.2/man/man3" -Dman3ext=3pm -Dscriptdir="%p/bin" -Duseithreads -Dinc_version_list=none -Adefine:startperl="#!%p/bin/perl5.16.2" -Adefine:perlpath="%p/bin/perl5.16.2"

--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5182-timelocal-y2020.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5182-timelocal-y2020.patch
@@ -1,0 +1,46 @@
+--- a/cpan/Time-Local/t/Local.t	2014-01-31 15:55:51.000000000 -0600
++++ a/cpan/Time-Local/t/Local.t	2020-02-23 05:19:01.000000000 -0600
+@@ -91,7 +91,7 @@
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal($sec,$min,$hour,$mday,$mon,$year_in);
+ 
+             my($s,$m,$h,$D,$M,$Y) = localtime($time);
+@@ -107,7 +107,7 @@
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm($sec,$min,$hour,$mday,$mon,$year_in);
+ 
+             my($s,$m,$h,$D,$M,$Y) = gmtime($time);
+@@ -125,7 +125,6 @@
+ 
+ for (@bad_time) {
+     my($year, $mon, $mday, $hour, $min, $sec) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm($sec,$min,$hour,$mday,$mon,$year) };
+@@ -134,14 +133,14 @@
+ }
+ 
+ {
+-    is(timelocal(0,0,1,1,0,90) - timelocal(0,0,0,1,0,90), 3600,
++    is(timelocal(0,0,1,1,0,1990) - timelocal(0,0,0,1,0,1990), 3600,
+        'one hour difference between two calls to timelocal');
+ 
+-    is(timelocal(1,2,3,1,0,100) - timelocal(1,2,3,31,11,99), 24 * 3600,
++    is(timelocal(1,2,3,1,0,2000) - timelocal(1,2,3,31,11,1999), 24 * 3600,
+        'one day difference between two calls to timelocal');
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+-    is(timegm(0,0,0, 1, 2, 80) - timegm(0,0,0, 1, 0, 80), 60 * 24 * 3600,
++    is(timegm(0,0,0, 1, 2, 1980) - timegm(0,0,0, 1, 0, 1980), 60 * 24 * 3600,
+        '60 day difference between two calls to timegm');
+ }
+ 

--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5182.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5182.info
@@ -38,6 +38,10 @@ disable testing them.
 http://grokbase.com/t/perl/perl5-porters/1289z1msea/whats-blocking-5-14-3
 perl bug #35895
 radar://4139653 (?)
+
+Included Time::Local does bad assumptions for 2 digit years, which broke
+starting in 2020. Patch adapted for perl5.1x from here:
+https://rt.cpan.org/Public/Bug/Display.html?id=124787
 <<
 DescUsage: <<
 Most perl scripts start with #!/usr/bin/perl which will invoke Apple's
@@ -51,6 +55,13 @@ PatchFile: %n.patch
 PatchFile-MD5: 82c99ae1c164a33e98d85095ab3a630c
 PatchFile2: perl5182-remove-10.3-target-PR126360.patch
 PatchFile2-MD5: 413da23b6aeac6c33a0d296d2710aff9
+PatchFile3: perl5182-timelocal-y2020.patch
+PatchFile3-MD5: 8a97c37daec434dfcc673b6e3c74fe7c
+PatchScript: <<
+    sed -e 's|@FINK_PREFIX@|%p|g' <  %{PatchFile} | patch -p1
+    patch -p1 < %{PatchFile2}
+    patch -p1 < %{PatchFile3}
+<<
 CompileScript: <<
 #!/bin/sh -ev
     sh Configure \

--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5184-timelocal-y2020.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5184-timelocal-y2020.patch
@@ -1,0 +1,46 @@
+--- a/cpan/Time-Local/t/Local.t	2014-01-31 15:55:51.000000000 -0600
++++ a/cpan/Time-Local/t/Local.t	2020-02-23 05:19:01.000000000 -0600
+@@ -91,7 +91,7 @@
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal($sec,$min,$hour,$mday,$mon,$year_in);
+ 
+             my($s,$m,$h,$D,$M,$Y) = localtime($time);
+@@ -107,7 +107,7 @@
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm($sec,$min,$hour,$mday,$mon,$year_in);
+ 
+             my($s,$m,$h,$D,$M,$Y) = gmtime($time);
+@@ -125,7 +125,6 @@
+ 
+ for (@bad_time) {
+     my($year, $mon, $mday, $hour, $min, $sec) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm($sec,$min,$hour,$mday,$mon,$year) };
+@@ -134,14 +133,14 @@
+ }
+ 
+ {
+-    is(timelocal(0,0,1,1,0,90) - timelocal(0,0,0,1,0,90), 3600,
++    is(timelocal(0,0,1,1,0,1990) - timelocal(0,0,0,1,0,1990), 3600,
+        'one hour difference between two calls to timelocal');
+ 
+-    is(timelocal(1,2,3,1,0,100) - timelocal(1,2,3,31,11,99), 24 * 3600,
++    is(timelocal(1,2,3,1,0,2000) - timelocal(1,2,3,31,11,1999), 24 * 3600,
+        'one day difference between two calls to timelocal');
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+-    is(timegm(0,0,0, 1, 2, 80) - timegm(0,0,0, 1, 0, 80), 60 * 24 * 3600,
++    is(timegm(0,0,0, 1, 2, 1980) - timegm(0,0,0, 1, 0, 1980), 60 * 24 * 3600,
+        '60 day difference between two calls to timegm');
+ }
+ 

--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5184.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5184.info
@@ -38,6 +38,10 @@ disable testing them.
 http://grokbase.com/t/perl/perl5-porters/1289z1msea/whats-blocking-5-14-3
 perl bug #35895
 radar://4139653 (?)
+
+Included Time::Local does bad assumptions for 2 digit years, which broke
+starting in 2020. Patch adapted for perl5.1x from here:
+https://rt.cpan.org/Public/Bug/Display.html?id=124787
 <<
 DescUsage: <<
 Most perl scripts start with #!/usr/bin/perl which will invoke Apple's
@@ -51,9 +55,12 @@ PatchFile: %n.patch
 PatchFile-MD5: 82c99ae1c164a33e98d85095ab3a630c
 PatchFile2: perl5184-remove-10.3-target-PR126360.patch
 PatchFile2-MD5: 413da23b6aeac6c33a0d296d2710aff9
+PatchFile3: perl5184-timelocal-y2020.patch
+PatchFile3-MD5: 8a97c37daec434dfcc673b6e3c74fe7c
 PatchScript: <<
     sed -e 's|@FINK_PREFIX@|%p|g' <  %{PatchFile} | patch -p1
     patch -p1 < %{PatchFile2}
+    patch -p1 < %{PatchFile3}
 <<
 CompileScript: <<
 #!/bin/sh -ev

--- a/10.9-libcxx/stable/main/finkinfo/text/texi2html-perl5162-timelocal-y2020.patch
+++ b/10.9-libcxx/stable/main/finkinfo/text/texi2html-perl5162-timelocal-y2020.patch
@@ -1,0 +1,46 @@
+--- a/cpan/Time-Local/t/Local.t	2014-01-31 15:55:51.000000000 -0600
++++ a/cpan/Time-Local/t/Local.t	2020-02-23 05:19:01.000000000 -0600
+@@ -91,7 +91,7 @@
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal($sec,$min,$hour,$mday,$mon,$year_in);
+ 
+             my($s,$m,$h,$D,$M,$Y) = localtime($time);
+@@ -107,7 +107,7 @@
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm($sec,$min,$hour,$mday,$mon,$year_in);
+ 
+             my($s,$m,$h,$D,$M,$Y) = gmtime($time);
+@@ -125,7 +125,6 @@
+ 
+ for (@bad_time) {
+     my($year, $mon, $mday, $hour, $min, $sec) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm($sec,$min,$hour,$mday,$mon,$year) };
+@@ -134,14 +133,14 @@
+ }
+ 
+ {
+-    is(timelocal(0,0,1,1,0,90) - timelocal(0,0,0,1,0,90), 3600,
++    is(timelocal(0,0,1,1,0,1990) - timelocal(0,0,0,1,0,1990), 3600,
+        'one hour difference between two calls to timelocal');
+ 
+-    is(timelocal(1,2,3,1,0,100) - timelocal(1,2,3,31,11,99), 24 * 3600,
++    is(timelocal(1,2,3,1,0,2000) - timelocal(1,2,3,31,11,1999), 24 * 3600,
+        'one day difference between two calls to timelocal');
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+-    is(timegm(0,0,0, 1, 2, 80) - timegm(0,0,0, 1, 0, 80), 60 * 24 * 3600,
++    is(timegm(0,0,0, 1, 2, 1980) - timegm(0,0,0, 1, 0, 1980), 60 * 24 * 3600,
+        '60 day difference between two calls to timegm');
+ }
+ 

--- a/10.9-libcxx/stable/main/finkinfo/text/texi2html-perl5162.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/texi2html-perl5162.info
@@ -36,6 +36,10 @@ Remove M_D_T=10.3 using upstream patch
 https://rt.perl.org/Ticket/Display.html?id=126360
 https://rt.perl.org/Ticket/Display.html?id=128980
 http://perl5.git.perl.org/perl.git/commit/53d1d41c81e1de9cc6416dcae828c13d4c5a470a
+
+Included Time::Local does bad assumptions for 2 digit years, which broke
+starting in 2020. Patch adapted for perl5.1x from here:
+https://rt.cpan.org/Public/Bug/Display.html?id=124787
 <<
 DescUsage: <<
 This package is for private use of the texi2html package only! It is
@@ -50,6 +54,8 @@ PatchFile: %n.patch
 PatchFile-MD5: a3486815c04c6618e7cc1c18eb2b6999
 PatchFile2: %n-deployment_target.patch
 PatchFile2-MD5: cba18c557d30c80966b2d8f8d75bdc46
+PatchFile3: %n-timelocal-y2020.patch
+PatchFile3-MD5: 8a97c37daec434dfcc673b6e3c74fe7c
 CompileScript: <<
 #!/bin/sh -ev
  sh Configure -desr -Dcc="gcc" -Dcpp="-gcc -E" -Dprefix=%p/lib/texi2html -Dccflags=-I%p/include -Dldflags=-L%p/lib -Dperladmin=none -Uinstallusrbinperl -Dprivlib="%p/lib/texi2html/lib/perl5-core/5.16.2" -Darchlib="%p/lib/texi2html/lib/perl5-core/5.16.2/darwin-thread-multi-2level" -Dman3dir="%p/lib/texi2html/lib/perl5-core/5.16.2/man/man3" -Dman3ext=3pm -Dscriptdir="%p/lib/texi2html/bin" -Duseithreads -Dinc_version_list=none -Adefine:startperl="#!%p/lib/texi2html/bin/perl5.16.2" -Adefine:perlpath="%p/lib/texi2html/bin/perl5.16.2"


### PR DESCRIPTION
Closes #579
Tested on 10.13 and 10.15 for relevant perl51X packages