### PR TITLE
Fix circular dependencies

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-prettyunits-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-prettyunits-r.info
@@ -34,7 +34,7 @@ Distribution: <<
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
 Version: 1.1.1
-Revision: 1
+Revision: 2
 Description: Human Readable Formatting of Quantities
 Homepage: https://cran.r-project.org/package=prettyunits
 License: BSD
@@ -47,10 +47,7 @@ CustomMirror: <<
 	Secondary: https://cran.r-project.org/src/contrib/00Archive/prettyunits
 <<
 Depends: <<
-	r-base%type_pkg[rversion],
-	cran-codetools-r%type_pkg[rversion],
-	cran-covr-r%type_pkg[rversion],
-	cran-testthat-r%type_pkg[rversion]
+	r-base%type_pkg[rversion]
 <<
 BuildDepends: <<
 	fink (>=0.32),

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-testthat-r-2.2.1.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-testthat-r-2.2.1.info
@@ -2,42 +2,20 @@ Info2: <<
 
 Package: cran-testthat-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.9,
-	(%type_pkg[rversion] = 33 ) 10.10,
-	(%type_pkg[rversion] = 33 ) 10.11,
-	(%type_pkg[rversion] = 33 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.13,
-	(%type_pkg[rversion] = 33 ) 10.14,
-	(%type_pkg[rversion] = 33 ) 10.14.5,
-	(%type_pkg[rversion] = 34 ) 10.9,
-	(%type_pkg[rversion] = 34 ) 10.10,
-	(%type_pkg[rversion] = 34 ) 10.11,
-	(%type_pkg[rversion] = 34 ) 10.12,
-	(%type_pkg[rversion] = 34 ) 10.13,
-	(%type_pkg[rversion] = 34 ) 10.14,
-	(%type_pkg[rversion] = 34 ) 10.14.5,
-	(%type_pkg[rversion] = 35 ) 10.9,
-	(%type_pkg[rversion] = 35 ) 10.10,
-	(%type_pkg[rversion] = 35 ) 10.11,
-	(%type_pkg[rversion] = 35 ) 10.12,
-	(%type_pkg[rversion] = 35 ) 10.13,
-	(%type_pkg[rversion] = 35 ) 10.14,
-	(%type_pkg[rversion] = 35 ) 10.14.5
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12
 <<
-# See DescPackaging
-Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 2.3.2
+Type: rversion (3.1)
+Version: 2.2.1
 Revision: 1
 Description: Testthat code
 Homepage: https://cran.r-project.org/package=testthat
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:testthat_%v.tar.gz
-Source-MD5: 0e9ed62b4d94f9b7fa1ad353a5372690
+Source-MD5: b0ee8c0485ccf7b9e68108c87d8d1b16
 SourceDirectory: testthat
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -48,16 +26,14 @@ Depends: <<
 	cran-prettyunits-r%type_pkg[rversion] (>= 1.1.1-2),
 	r-base%type_pkg[rversion], 
 	cran-cli-r%type_pkg[rversion],
-	cran-crayon-r%type_pkg[rversion] (>= 1.3.4-1),
+	cran-crayon-r%type_pkg[rversion] (>=1.3.4),
 	cran-digest-r%type_pkg[rversion],
-	cran-ellipsis-r%type_pkg[rversion],
 	cran-evaluate-r%type_pkg[rversion],
 	cran-magrittr-r%type_pkg[rversion],
-	cran-pkgload-r%type_pkg[rversion],
 	cran-praise-r%type_pkg[rversion],
-	cran-r6-r%type_pkg[rversion] (>= 2.2.0-1),
-	cran-rlang-r%type_pkg[rversion] (>= 0.4.1-1),
-	cran-withr-r%type_pkg[rversion] (>= 2.0.0-1)
+	cran-r6-r%type_pkg[rversion] (>=2.2.0),
+	cran-rlang-r%type_pkg[rversion] (>=0.3.0),
+	cran-withr-r%type_pkg[rversion] (>=2.0.0)
 <<
 BuildDepends: <<
 	fink (>= 0.27.2),
@@ -102,8 +78,8 @@ A testing package specifically tailored for R that's fun,
 flexible and easy to set up.
 <<
 DescPackaging: <<
-  cran-rlang-r%type_pkg[rversion] (>= 0.4.1-1) is not available for r-base31.
-  
+  R (>= 3.1.0)
+
   cran-prettyunits-r%type_pkg[rversion] (= 1.1.1-1) wrongly depended on testthat, which caused circular dependencies.
 <<
 


### PR DESCRIPTION
CRAN testthat and prettyunits depend on each other, causing a circular dependency conflict.

testthat:
Added 
DEP: cran-prettyunits-r%type_pkg[rversion] (>= 1.1.1-2),
CONFLICTS: cran-prettyunits-r%type_pkg[rversion] (= 1.1.1-1)

prettyunits:
Removed the dependencies (which were only "suggested").