### PR TITLE
Ruby updates

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/ruby24.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/ruby24.info
@@ -1,6 +1,6 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Package: ruby24
-Version: 2.4.6
+Version: 2.4.10
 Revision: 1
 Description: Interpreted, object-oriented language
 License: BSD
@@ -30,8 +30,9 @@ BuildDepends: <<
 
 # Unpack Phase.
 Source: http://ftp.ruby-lang.org/pub/ruby/2.4/ruby-%v.tar.xz
-Source-Checksum: SHA256(25da31b9815bfa9bba9f9b793c055a40a35c43c6adfb1fdbd81a09099f9b529c)
-
+Source-Checksum: SHA256(d5668ed11544db034f70aec37d11e157538d639ed0d0a968e2f587191fc530df)
+PatchFile: %n.patch
+PatchFile-MD5: bcbdef900f1328b4b5f414d7a9fbe9e8
 # Patch Phase.
 PatchScript: <<
   %{default_script}
@@ -52,7 +53,7 @@ PatchScript: <<
   rm test/net/http/test_https.rb
   rm test/rubygems/test_gem_remote_fetcher.rb
   rm test/rinda/test_rinda.rb
-  perl -pi -e 's/timeout: 60/timeout: 240/' test/ruby/test_io.rb
+  perl -pi -e 's/timeout: 60/timeout: 600/' test/ruby/test_io.rb
   # Fix library install_name
   perl -pi -e 's/\@RUBY_SO_NAME\@/ruby.2.4.0/' Makefile.in
 <<
@@ -163,4 +164,7 @@ always link with Fink's to get consistent results.
 
 Move mkmf script into -dev to make extension configuration error out
 instead of failing all tests.
+
+test_io.rb patch is change implemented in ruby25 to allow
+TestIO#test_select_leak test to consistently pass.
 <<

--- a/10.9-libcxx/stable/main/finkinfo/languages/ruby24.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/ruby24.patch
@@ -1,0 +1,10 @@
+diff -u ruby-2.4.10/test/ruby/test_io.rb ruby-2.5.8/test/ruby/test_io.rb --- ruby-2.4.10/test/ruby/test_io.rb	2020-03-31 06:42:18.000000000 -0500
++++ ruby-2.5.8/test/ruby/test_io.rb	2020-03-31 07:15:56.000000000 -0500
+@@ -3575,6 +3768,7 @@
+         Thread.pass until th.stop?
+         th.kill
+         th.join
++        GC.start
+       end
+     end;
+   end

--- a/10.9-libcxx/stable/main/finkinfo/languages/ruby25.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/ruby25.info
@@ -1,6 +1,6 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Package: ruby25
-Version: 2.5.5
+Version: 2.5.8
 Revision: 1
 Description: Interpreted, object-oriented language
 License: BSD
@@ -30,7 +30,7 @@ BuildDepends: <<
 
 # Unpack Phase.
 Source: http://ftp.ruby-lang.org/pub/ruby/2.5/ruby-%v.tar.xz
-Source-Checksum: SHA256(9bf6370aaa82c284f193264cc7ca56f202171c32367deceb3599a4f354175d7d)
+Source-Checksum: SHA256(0391b2ffad3133e274469f9953ebfd0c9f7c186238968cbdeeb0651aa02a4d6d)
 
 # Patch Phase.
 PatchScript: <<
@@ -83,7 +83,7 @@ InfoTest: <<
 		# Change install_name of lib during tests since DYLD_LIBRARY_PATH doesn't work on 10.11+.
 		install_name_tool -change %p/lib/libruby.2.5.dylib %b/libruby.2.5.dylib ruby2.5
 		/usr/bin/find .ext/x86_64-darwin -name *.bundle -exec install_name_tool -change %p/lib/libruby.2.5.dylib %b/libruby.2.5.dylib {} \;
-		install_name_tool -id %b/libruby.2.5.dylib libruby.2.5.5.dylib
+		install_name_tool -id %b/libruby.2.5.dylib libruby.2.5.8.dylib
 		
 		export LANG=en_US.UTF-8
 		export PATH="%b:$PATH"
@@ -92,7 +92,7 @@ InfoTest: <<
 		# Put install_name back.
 		install_name_tool -change %b/libruby.2.5.dylib %p/lib/libruby.2.5.dylib ruby2.5
 		/usr/bin/find .ext/x86_64-darwin -name *.bundle -exec install_name_tool -change %b/libruby.2.5.dylib %p/lib/libruby.2.5.dylib {} \;
-		install_name_tool -id %p/lib/libruby.2.5.dylib libruby.2.5.5.dylib
+		install_name_tool -id %p/lib/libruby.2.5.dylib libruby.2.5.8.dylib
 	<<
 <<
 
@@ -132,7 +132,7 @@ SplitOff4: <<
   Package: %N-shlibs
   Shlibs: %p/lib/libruby.2.5.dylib 2.5.0 %n (>= 2.5.0-1)
   Description: Ruby 2.5 shared libraries
-  Files: lib/libruby.2.5.5.dylib lib/libruby.2.5.dylib
+  Files: lib/libruby.2.5.8.dylib lib/libruby.2.5.dylib
   DocFiles: BSDL COPYING COPYING.ja ChangeLog GPL LEGAL NEWS README*
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/ruby26.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/ruby26.info
@@ -1,6 +1,6 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Package: ruby26
-Version: 2.6.3
+Version: 2.6.6
 Revision: 1
 Description: Interpreted, object-oriented language
 License: BSD
@@ -30,7 +30,7 @@ BuildDepends: <<
 
 # Unpack Phase.
 Source: http://ftp.ruby-lang.org/pub/ruby/2.6/ruby-%v.tar.xz
-Source-Checksum: SHA256(11a83f85c03d3f0fc9b8a9b6cad1b2674f26c5aaa43ba858d4b0fcc2b54171e1)
+Source-Checksum: SHA256(5db187882b7ac34016cd48d7032e197f07e4968f406b0690e20193b9b424841f)
 
 # Patch Phase.
 PatchScript: <<


### PR DESCRIPTION
Updates for the ruby packages that are still maintained upstream. Simple %v bumps. ruby24 has a little extra change added one test that consistently failed w/out that change. With the change, that test consistently passes on my system.

Tested on 10.13/Xcode10.1