### PR TITLE
tcltk update to 8.6.10 with MacOSX headers and Aqua support.

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/tcltk-8.6.10.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/tcltk-8.6.10.info
@@ -1,0 +1,261 @@
+Package: tcltk
+Epoch: 1
+
+# update itcl path-flags in "itk" and versions in "iwidgets" when updating
+Version: 8.6.10
+
+Revision: 1
+BuildDepends: <<
+	fink (>= 0.28),
+	fink-package-precedence,
+	fontconfig2-dev (>= 2.10.0-1),
+	freetype219 (>= 2.6-1),
+	pkgconfig,
+	x11-dev,
+	xft2-dev (>= 2.2.0-1)
+<<
+Depends: <<
+	%N-shlibs (= %e:%v-%r),
+	fontconfig2-shlibs (>= 2.10.0-1),
+	freetype219-shlibs (>= 2.6-1),
+	x11-shlibs,
+	xft2-shlibs (>= 2.2.0-1)
+<<
+Source: mirror:sourceforge:tcl/tcl%v-src.tar.gz
+Source-MD5: 97c55573f8520bcab74e21bfd8d0aadc
+SourceDirectory: tcl%v
+Source2: mirror:sourceforge:tcl/tk%v-src.tar.gz
+Source2-MD5: 602a47ad9ecac7bf655ada729d140a94
+PatchFile: %n-%v.patch
+PatchFile-MD5: 458c0e7ea6996a7e0f1e762791f8269a
+PatchScript: <<
+	%{default_script}
+	# patch *ancient* darwin-ignorant autoconf
+	perl -pi -e 's/(a so sl)/dylib \1/' tk%v/unix/configure
+	# autoconf2.6ish patch for modern XQuartz paths
+	perl -pi -e "s|/usr/lpp/Xamples|/opt/X11|" tk%v/unix/configure
+<<
+NoSourceDirectory: true
+SetCPPFLAGS: -MD -g
+ConfigureParams: --enable-shared --enable-threads --enable-aqua=yes --exec-prefix=%p --mandir=%p/share/man tcl_cv_type_64bit="long long"
+CompileScript: <<
+#!/bin/sh -ev
+
+	pushd tcl%v/unix
+		export COMMAND_MODE=legacy
+		./configure %c
+		make
+	popd
+
+	pushd tk%v/unix
+		export DYLD_FALLBACK_LIBRARY_PATH=%b/tcl%v/unix
+		export ac_cv_path_tclsh=%b/tcl%v/unix/tclsh
+		./configure %c
+#		make genstubs
+		make
+	popd
+	fink-package-precedence --depfile-ext='\.d' --prohibit-bdep=%n-dev .
+<<
+# tcl tests hanging on http11.test, needs to be manually killed; tk tests require display and possibly user interaction
+InfoTest: <<
+	TestScript: <<
+		cd tcl%v/unix; make -k test || exit 2
+		cd tk%v/unix; make -k test || exit 2
+		fink-package-precedence --depfile-ext='\.d' --prohibit-bdep=%n-dev .
+	<<
+<<
+InstallScript: <<
+#!/bin/sh -ev
+	MAJORVER=8.6
+
+	mkdir -p %i/share/doc/%n
+	make -C tcl%v/unix INSTALL_ROOT=%d install
+	make -C tk%v/unix  INSTALL_ROOT=%d install
+
+	ln -s wish${MAJORVER}  %i/bin/wish
+	ln -s tclsh${MAJORVER} %i/bin/tclsh
+
+	ln -s tk${MAJORVER} %i/lib/tk
+	ln -s libtk${MAJORVER}.dylib %i/lib/libtk.dylib
+	ln -s libtkstub${MAJORVER}.a %i/lib/libtkstub.a
+	/usr/bin/ranlib %i/lib/libtclstub${MAJORVER}.a
+
+	ln -s tcl${MAJORVER} %i/lib/tcl
+	ln -s libtcl${MAJORVER}.dylib %i/lib/libtcl.dylib
+	ln -s libtclstub${MAJORVER}.a %i/lib/libtclstub.a
+	/usr/bin/ranlib %i/lib/libtkstub${MAJORVER}.a
+
+	for pkg in tcl tk; do
+		mkdir -p %i/include/tcltk-private/${pkg}${MAJORVER}
+		cp ${pkg}%v/unix/*.h ${pkg}%v/generic/*.h %i/include/tcltk-private/${pkg}${MAJORVER}
+		[ ${pkg} == "tk" ] && cp ${pkg}%v/macosx/*.h  %i/include/tcltk-private/${pkg}${MAJORVER}
+
+		pushd %i/include
+			for hdr in *.h ; do
+				if [ -f tcltk-private/${pkg}${MAJORVER}/${hdr} ]; then
+					ln -sf ../../${hdr} tcltk-private/${pkg}${MAJORVER}
+				fi
+			done
+		popd
+
+		perl -pi -e "s,%b/${pkg}%v/unix,%p/lib,; s,%b,%p/include/tcltk-private,; s,/${pkg}%v,/${pkg}${MAJORVER},g" %i/lib/*Config.sh %i/lib/*/*Config.sh
+	done
+
+	# manually fix install names (fink wants full path even though
+	# private and dlopen'ed). Why are these .dylib not .so ?
+	for modulepath in \
+		itcl4.2.0/libitcl4.2.0.dylib \
+		sqlite3.30.1.2/libsqlite3.30.1.2.dylib \
+		tdbc1.1.1/libtdbc1.1.1.dylib \
+		tdbcmysql1.1.1/libtdbcmysql1.1.1.dylib \
+		tdbcodbc1.1.1/libtdbcodbc1.1.1.dylib \
+		tdbcpostgres1.1.1/libtdbcpostgres1.1.1.dylib \
+		thread2.8.5/libthread2.8.5.dylib \
+	; do
+		install_name_tool -id %p/lib/$modulepath %i/lib/$modulepath
+	done
+<<
+DocFiles: <<
+	tcl%v/license.terms:LICENSE.tcl
+	tcl%v/README.md:README.tcl
+	tcl%v/ChangeLog:ChangeLog.tcl
+	tcl%v/changes:changes.tcl
+	tk%v/license.terms:LICENSE.tk
+	tk%v/README.md:README.tk
+	tk%v/ChangeLog:ChangeLog.tk 
+	tk%v/changes:changes.tk 
+<<
+SplitOff: <<
+	Package: %N-shlibs
+	Depends: <<
+		fontconfig2-shlibs (>= 2.10.0-1),
+		freetype219-shlibs (>= 2.6-1),
+		x11-shlibs,
+		xft2-shlibs (>= 2.2.0-1)
+	<<
+	Files: <<
+		lib/libtcl8.6.dylib
+		lib/libtk8.6.dylib
+		lib/itcl4.2.0/libitcl4.2.0.dylib
+		lib/sqlite3.30.1.2/libsqlite3.30.1.2.dylib
+		lib/tdbc1.1.1/libtdbc1.1.1.dylib
+		lib/tdbcmysql1.1.1/libtdbcmysql1.1.1.dylib
+		lib/tdbcodbc1.1.1/libtdbcodbc1.1.1.dylib
+		lib/tdbcpostgres1.1.1/libtdbcpostgres1.1.1.dylib
+		lib/thread2.8.5/libthread2.8.5.dylib
+	<<
+	Shlibs: <<
+		%p/lib/libtcl8.6.dylib 8.6.0 %n (>= 8.6.0-1)
+		%p/lib/libtk8.6.dylib 8.6.0 %n (>= 8.6.0-1)
+		!%p/lib/itcl4.2.0/libitcl4.2.0.dylib
+		!%p/lib/sqlite3.30.1.2/libsqlite3.30.1.2.dylib
+		!%p/lib/tdbc1.1.1/libtdbc1.1.1.dylib
+		!%p/lib/tdbcmysql1.1.1/libtdbcmysql1.1.1.dylib
+		!%p/lib/tdbcodbc1.1.1/libtdbcodbc1.1.1.dylib
+		!%p/lib/tdbcpostgres1.1.1/libtdbcpostgres1.1.1.dylib
+		!%p/lib/thread2.8.5/libthread2.8.5.dylib
+	<<
+	DocFiles: <<
+		tcl%v/license.terms:LICENSE.tcl
+		tcl%v/README.md:README.tcl
+		tcl%v/ChangeLog:ChangeLog.tcl
+		tk%v/license.terms:LICENSE.tk
+		tk%v/README.md:README.tk
+		tk%v/ChangeLog:ChangeLog.tk 
+	<<
+<<
+SplitOff2: <<
+	Package: %N-dev
+	BuildDependsOnly: True
+	Depends: %N (= %e:%v-%r), %N-shlibs (= %e:%v-%r)
+	Conflicts: system-tcltk-dev
+	Replaces: %N (<< 1:8.6.5-1), system-tcltk-dev
+	Files: <<
+		lib/*Config.sh
+		include
+		lib/libtcl*
+		lib/libtk*
+		lib/pkgconfig
+		share/man/man3
+		share/man/mann
+	<<
+	DocFiles: <<
+		tcl%v/license.terms:LICENSE.tcl
+		tcl%v/README.md:README.tcl
+		tcl%v/ChangeLog:ChangeLog.tcl
+		tcl%v/changes:changes.tcl
+		tk%v/license.terms:LICENSE.tk
+		tk%v/README.md:README.tk
+		tk%v/ChangeLog:ChangeLog.tk 
+		tk%v/changes:changes.tk 
+	<<
+	DescUsage: <<
+Packages that want to use the supplied internal-interface headers
+should BuildDepends on %n of at least epoch 1 or higher.
+	<<
+<<
+Description: Tool Command Language and the Tk toolkit
+DescPort: <<
+	We add /System/Library/Tcl and /usr/lib to TCL_PACKAGE_PATH so
+	that Tcl packages (such as darwinports) installed in the
+	standard system locations will be found.
+
+	What is COMMAND_MODE?
+
+	Pass CPPFLAGS so it works as everyone expects (*after* local
+	flags), despite how build system incorrectly reimplements it
+	differently.
+<<
+DescPackaging: <<
+	tcl and tk are built in separate/parallel dirs. Clearer to do
+	NoSourceDirectory and have them both subdirs of %b than to
+	have one be %b and keep having to 'cd ..'
+
+	Make sure tk build finds tclsh from current build rather than
+	different-version one from installed fink package or different
+	arch and build-options one from OS X. Thanks pogma for helping
+	make sure tclsh finds its libtcl
+
+	Don't try xft's older detection method. And fink's (newer) xft
+	detection publishes x11 flags, so don't also pass them
+	explicitly (unix/Makefile mis-orders them before fink's)
+
+	Installed *Config.sh scripts encode build-dir paths as well as
+	runtime paths, which other packages may read and then try to
+	access. We cannot allow that (no guarantee that they exist, or
+	where they exist, or that they are the correct arch or build-
+	options, etc), so adjust to point to the installed locations.
+
+	Building extensions sometimes needs access to internal
+	headers, so install them in a private location. Point
+	*Config.sh vars accordingly. Thanks fedora!
+
+	As of 1:8.6.5-1, some build-time config files moved %N->%N-dev
+
+	1:8.6.10-1: include tkMacOSX* headers and enable Aqua windowingsystem
+	as both are required by dependent package (vtk82); collected all
+	private headers (generic + unix + macosx) in one subdirectory.
+	Note this means include paths now have to be set to
+	%p/include/tcltk-private/tcl8.6
+	(without the + "generic").
+<<
+DescDetail: <<
+Tcl provides a portable scripting environment for Unix, Windows,
+and Macintosh that supports string processing and pattern matching,
+native file system access, shell-like control over other programs,
+TCP/IP networking, timers, and event-driven I/O.
+
+Tcl has traditional programming constructs like variables, loops,
+procedures, namespaces, error handling, script packages, 
+and dynamic loading of DLLs.
+
+Tk provides portable GUIs on UNIX, Windows, and Macintosh.
+A powerful widget set and the concise scripting interface to Tk make
+it a breeze to develop sophisticated user interfaces.
+<<
+PostInstScript: <<
+	update-alternatives --remove Object.3 %p/share/man/man3/Object.3.tcltk
+<<
+License: BSD
+Homepage: http://www.tcl.tk
+Maintainer: Daniel Macks <dmacks@netspace.org>

--- a/10.9-libcxx/stable/main/finkinfo/languages/tcltk-8.6.10.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/tcltk-8.6.10.patch
@@ -1,0 +1,235 @@
+diff -uNr tcltk-8.6.10.orig/tcl8.6.10/generic/tclInt.h tcltk-8.6.10/tcl8.6.10/generic/tclInt.h
+--- tcltk-8.6.10.orig/tcl8.6.10/generic/tclInt.h	2017-07-18 08:51:45.000000000 -0400
++++ tcltk-8.6.10/tcl8.6.10/generic/tclInt.h	2017-08-17 19:56:13.000000000 -0400
+@@ -3277,7 +3277,7 @@
+ MODULE_SCOPE int	TclClockOldscanObjCmd(
+ 			    ClientData clientData, Tcl_Interp *interp,
+ 			    int objc, Tcl_Obj *const objv[]);
+-MODULE_SCOPE int	Tcl_CloseObjCmd(ClientData clientData,
++extern int	Tcl_CloseObjCmd(ClientData clientData,
+ 			    Tcl_Interp *interp, int objc,
+ 			    Tcl_Obj *const objv[]);
+ MODULE_SCOPE int	Tcl_ConcatObjCmd(ClientData clientData,
+@@ -3458,7 +3458,7 @@
+ MODULE_SCOPE int	Tcl_RepresentationCmd(ClientData clientData,
+ 			    Tcl_Interp *interp, int objc,
+ 			    Tcl_Obj *const objv[]);
+-MODULE_SCOPE int	Tcl_ReturnObjCmd(ClientData clientData,
++extern int	Tcl_ReturnObjCmd(ClientData clientData,
+ 			    Tcl_Interp *interp, int objc,
+ 			    Tcl_Obj *const objv[]);
+ MODULE_SCOPE int	Tcl_ScanObjCmd(ClientData clientData,
+diff -uNr tcltk-8.6.10.orig/tcl8.6.10/unix/configure tcltk-8.6.10/tcl8.6.10/unix/configure
+--- tcltk-8.6.10.orig/tcl8.6.10/unix/configure	2017-08-09 10:45:58.000000000 -0400
++++ tcltk-8.6.10/tcl8.6.10/unix/configure	2017-08-17 19:56:13.000000000 -0400
+@@ -18820,7 +18820,7 @@
+     else
+         TCL_LIB_FLAG="-ltcl`echo ${TCL_VERSION} | tr -d .`"
+     fi
+-    TCL_BUILD_LIB_SPEC="-L`pwd | sed -e 's/ /\\\\ /g'` ${TCL_LIB_FLAG}"
++    TCL_BUILD_LIB_SPEC="`pwd`/${TCL_LIB_FILE}"
+     TCL_LIB_SPEC="-L${libdir} ${TCL_LIB_FLAG}"
+ fi
+ VERSION='${VERSION}'
+@@ -18864,7 +18864,7 @@
+     TCL_STUB_LIB_FLAG="-ltclstub`echo ${TCL_VERSION} | tr -d .`"
+ fi
+ 
+-TCL_BUILD_STUB_LIB_SPEC="-L`pwd | sed -e 's/ /\\\\ /g'` ${TCL_STUB_LIB_FLAG}"
++TCL_BUILD_STUB_LIB_SPEC="`pwd`/${TCL_STUB_LIB_FILE}"
+ TCL_STUB_LIB_SPEC="-L${TCL_STUB_LIB_DIR} ${TCL_STUB_LIB_FLAG}"
+ TCL_BUILD_STUB_LIB_PATH="`pwd`/${TCL_STUB_LIB_FILE}"
+ TCL_STUB_LIB_PATH="${TCL_STUB_LIB_DIR}/${TCL_STUB_LIB_FILE}"
+@@ -19048,7 +19048,7 @@
+ 
+ 
+ 
+-CFLAGS="${CFLAGS} ${CPPFLAGS}"; CPPFLAGS=""
++EXTRA_CC_SWITCHES="${EXTRA_CC_SWITCHES} ${CPPFLAGS}"; CPPFLAGS=""
+ 
+ : ${CONFIG_STATUS=./config.status}
+ ac_clean_files_save=$ac_clean_files
+diff -uNr tcltk-8.6.10.orig/tk8.6.10/unix/Makefile.in tcltk-8.6.10/tk8.6.10/unix/Makefile.in
+--- tcltk-8.6.10.orig/tk8.6.10/unix/Makefile.in	2017-08-09 10:46:03.000000000 -0400
++++ tcltk-8.6.10/tk8.6.10/unix/Makefile.in	2017-08-17 19:56:13.000000000 -0400
+@@ -149,7 +149,7 @@
+ # X11 include files accessible (the configure script will try to
+ # set this value, and will cause it to be an empty string if the
+ # include files are accessible via /usr/include).
+-X11_INCLUDES		= @XINCLUDES@
++X11_INCLUDES		= $(XFT_CFLAGS) @XINCLUDES@
+ 
+ AQUA_INCLUDES		= -I$(MAC_OSX_DIR) -I$(XLIB_DIR)
+ 
+@@ -266,6 +266,9 @@
+ LIBS = @LIBS@ $(X11_LIB_SWITCHES) @TCL_LIBS@
+ WISH_LIBS = $(TCL_LIB_SPEC) @LIBS@ $(X11_LIB_SWITCHES) @TCL_LIBS@ @EXTRA_WISH_LIBS@
+ 
++# support for embedded libraries on Darwin / Mac OS X
++DYLIB_INSTALL_DIR       = ${libdir}
++
+ # The symbols below provide support for dynamic loading and shared
+ # libraries.  See configure.in for a description of what the
+ # symbols mean.  The values of the symbols are normally set by the
+@@ -283,9 +283,6 @@
+ CC_SEARCH_FLAGS	= @CC_SEARCH_FLAGS@
+ LD_SEARCH_FLAGS	= @LD_SEARCH_FLAGS@
+ 
+-# support for embedded libraries on Darwin / Mac OS X
+-DYLIB_INSTALL_DIR	= ${LIB_RUNTIME_DIR}
+-
+ # support for building the Aqua resource file
+ TK_RSRC_FILE		= @TK_RSRC_FILE@
+ WISH_RSRC_FILE		= @WISH_RSRC_FILE@
+@@ -330,18 +330,18 @@
+ 
+ CC_SWITCHES_NO_STUBS = ${CFLAGS} ${CFLAGS_WARNING} ${SHLIB_CFLAGS} \
+ -I${UNIX_DIR} -I${GENERIC_DIR} -I${BMAP_DIR} -I${TCL_GENERIC_DIR} \
+--I${TCL_PLATFORM_DIR} ${@TK_WINDOWINGSYSTEM@_INCLUDES} ${AC_FLAGS} \
+-${PROTO_FLAGS} ${SECURITY_FLAGS} ${MEM_DEBUG_FLAGS} ${KEYSYM_FLAGS} \
+-${NO_DEPRECATED_FLAGS} @EXTRA_CC_SWITCHES@
++-I${TCL_PLATFORM_DIR} ${AC_FLAGS} ${PROTO_FLAGS} ${SECURITY_FLAGS} \
++${MEM_DEBUG_FLAGS} ${KEYSYM_FLAGS} ${NO_DEPRECATED_FLAGS} \
++@EXTRA_CC_SWITCHES@ ${@TK_WINDOWINGSYSTEM@_INCLUDES}
+ 
+ CC_SWITCHES = $(CC_SWITCHES_NO_STUBS) @TCL_STUB_FLAGS@
+ 
+ APP_CC_SWITCHES = $(CC_SWITCHES_NO_STUBS) @EXTRA_APP_CC_SWITCHES@
+ 
+ DEPEND_SWITCHES = ${CFLAGS} -I${UNIX_DIR} -I${GENERIC_DIR} -I${BMAP_DIR} \
+--I${TCL_GENERIC_DIR} -I${TCL_PLATFORM_DIR} ${@TK_WINDOWINGSYSTEM@_INCLUDES} \
+-${AC_FLAGS} ${PROTO_FLAGS} ${SECURITY_FLAGS} ${MEM_DEBUG_FLAGS} \
+-${KEYSYM_FLAGS} @EXTRA_CC_SWITCHES@
++-I${TCL_GENERIC_DIR} -I${TCL_PLATFORM_DIR} ${AC_FLAGS} ${PROTO_FLAGS} \
++${SECURITY_FLAGS} ${MEM_DEBUG_FLAGS} ${KEYSYM_FLAGS} @EXTRA_CC_SWITCHES@ \
++${@TK_WINDOWINGSYSTEM@_INCLUDES}
+ 
+ WISH_OBJS = tkAppInit.o
+ 
+@@ -1202,7 +1202,7 @@
+ 
+ # NB: tkUnixRFont.o uses nondefault CFLAGS
+ tkUnixRFont.o: $(UNIX_DIR)/tkUnixRFont.c
+-	$(CC) -c $(CC_SWITCHES) $(XFT_CFLAGS) $(UNIX_DIR)/tkUnixRFont.c
++	$(CC) -c $(CC_SWITCHES) $(UNIX_DIR)/tkUnixRFont.c
+ 
+ tkUnixInit.o: $(UNIX_DIR)/tkUnixInit.c tkConfig.sh
+ 	$(CC) -c $(CC_SWITCHES) -DTK_LIBRARY=\"${TK_LIBRARY}\" \
+diff -uNr tcltk-8.6.10.orig/tcl8.6.10/unix/configure tcltk-8.6.10/tcl8.6.10/unix/configure
+--- tcltk-8.6.10.orig/tcl8.6.10/unix/configure	2019-11-20 20:10:12.000000000 +0100
++++ tcltk-8.6.10/tcl8.6.10/unix/configure	2020-04-13 17:19:28.000000000 +0200
+@@ -7895,7 +7895,7 @@
+ 			done
+ fi
+ 
+-		    LIBS="$LIBS -framework CoreFoundation"
++		    LIBS="$LIBS -Wl,-framework,CoreFoundation"
+ 		    cat >conftest.$ac_ext <<_ACEOF
+ /* confdefs.h.  */
+ _ACEOF
+@@ -7955,7 +7955,7 @@
+ echo "${ECHO_T}$tcl_cv_lib_corefoundation" >&6
+ 		if test $tcl_cv_lib_corefoundation = yes; then
+ 
+-		    LIBS="$LIBS -framework CoreFoundation"
++		    LIBS="$LIBS -Wl,-framework,CoreFoundation"
+ 
+ cat >>confdefs.h <<\_ACEOF
+ #define HAVE_COREFOUNDATION 1
+diff -uNr tcltk-8.6.10.orig/tk8.6.10/unix/configure tcltk-8.6.10/tk8.6.10/unix/configure
+--- tcltk-8.6.10.orig/tk8.6.10/unix/configure	2019-11-20 20:56:52.000000000 +0100
++++ tcltk-8.6.10/tk8.6.10/unix/configure	2020-04-13 17:21:28.000000000 +0200
+@@ -5801,7 +5801,7 @@
+ 			done
+ fi
+ 
+-		    LIBS="$LIBS -framework CoreFoundation"
++		    LIBS="$LIBS -Wl,-framework,CoreFoundation"
+ 		    cat >conftest.$ac_ext <<_ACEOF
+ /* confdefs.h.  */
+ _ACEOF
+@@ -5861,7 +5861,7 @@
+ echo "${ECHO_T}$tcl_cv_lib_corefoundation" >&6
+ 		if test $tcl_cv_lib_corefoundation = yes; then
+ 
+-		    LIBS="$LIBS -framework CoreFoundation"
++		    LIBS="$LIBS -Wl,-framework,CoreFoundation"
+ 
+ cat >>confdefs.h <<\_ACEOF
+ #define HAVE_COREFOUNDATION 1
+@@ -10002,21 +10002,16 @@
+     XFT_LIBS=""
+     if test "$enable_xft" = "no" ; then
+ 	echo "$as_me:$LINENO: result: $enable_xft" >&5
+-echo "${ECHO_T}$enable_xft" >&6
++	echo "${ECHO_T}$enable_xft" >&6
+     else
+ 	found_xft="yes"
+-			XFT_CFLAGS=`xft-config --cflags 2>/dev/null` || found_xft="no"
+-	XFT_LIBS=`xft-config --libs 2>/dev/null` || found_xft="no"
+-	if test "$found_xft" = "no" ; then
+-	    found_xft=yes
+-	    XFT_CFLAGS=`pkg-config --cflags xft fontconfig 2>/dev/null` || found_xft="no"
+-	    XFT_LIBS=`pkg-config --libs xft fontconfig 2>/dev/null` || found_xft="no"
+-	fi
++	XFT_CFLAGS=`pkg-config --cflags xft 2>/dev/null` || found_xft="no"
++	XFT_LIBS=`pkg-config --libs xft 2>/dev/null` || found_xft="no"
+ 	echo "$as_me:$LINENO: result: $found_xft" >&5
+-echo "${ECHO_T}$found_xft" >&6
+-		if test "$found_xft" = "yes" ; then
++	echo "${ECHO_T}$found_xft" >&6
++	if test "$found_xft" = "yes" ; then
+ 	    tk_oldCFlags=$CFLAGS
+-	    CFLAGS="$CFLAGS $XINCLUDES $XFT_CFLAGS"
++	    CFLAGS="$CFLAGS $XFT_CFLAGS $XINCLUDES"
+ 	    tk_oldLibs=$LIBS
+ 	    LIBS="$tk_oldLIBS $XFT_LIBS $XLIBSW"
+ 	    echo "$as_me:$LINENO: checking for X11/Xft/Xft.h" >&5
+@@ -10081,7 +10081,7 @@
+ 	fi
+ 		if test "$found_xft" = "yes" ; then
+ 	    tk_oldCFlags=$CFLAGS
+-	    CFLAGS="$CFLAGS $XINCLUDES $XFT_CFLAGS"
++	    CFLAGS="$CFLAGS $XFT_CFLAGS $XINCLUDES"
+ 	    tk_oldLibs=$LIBS
+ 	    LIBS="$tk_oldLIBS $XFT_LIBS $XLIBSW"
+ 
+@@ -11059,7 +11059,7 @@
+ 	else
+ 	    TK_LIB_FLAG="-ltk`echo ${TK_VERSION} | tr -d .`"
+ 	fi
+-	TK_BUILD_LIB_SPEC="-L`pwd | sed -e 's/ /\\\\ /g'` ${TK_LIB_FLAG}"
++	TK_BUILD_LIB_SPEC="`pwd`/${TK_LIB_FILE}"
+     fi
+     TK_LIB_SPEC="-L${libdir} ${TK_LIB_FLAG}"
+ fi
+@@ -11079,7 +11079,7 @@
+     TK_STUB_LIB_FLAG="-ltkstub`echo ${TK_VERSION} | tr -d .`"
+ fi
+ 
+-TK_BUILD_STUB_LIB_SPEC="-L`pwd | sed -e 's/ /\\\\ /g'` ${TK_STUB_LIB_FLAG}"
++TK_BUILD_STUB_LIB_SPEC="`pwd`/${TK_STUB_LIB_FILE}"
+ TK_STUB_LIB_SPEC="-L${TK_STUB_LIB_DIR} ${TK_STUB_LIB_FLAG}"
+ TK_BUILD_STUB_LIB_PATH="`pwd`/${TK_STUB_LIB_FILE}"
+ TK_STUB_LIB_PATH="${TK_STUB_LIB_DIR}/${TK_STUB_LIB_FILE}"
+@@ -11268,7 +11268,7 @@
+ LTLIBOBJS=$ac_ltlibobjs
+ 
+ 
+-CFLAGS="${CFLAGS} ${CPPFLAGS}"; CPPFLAGS=""
++EXTRA_CC_SWITCHES="${EXTRA_CC_SWITCHES} ${CPPFLAGS}"; CPPFLAGS=""
+ 
+ : ${CONFIG_STATUS=./config.status}
+ ac_clean_files_save=$ac_clean_files
+diff -uNr tcltk-8.6.10.orig/tk8.6.10/unix/tkConfig.sh.in tcltk-8.6.10/tk8.6.10/unix/tkConfig.sh.in
+--- tcltk-8.6.10.orig/tk8.6.10/unix/tkConfig.sh.in	2017-08-09 10:46:03.000000000 -0400
++++ tcltk-8.6.10/tk8.6.10/unix/tkConfig.sh.in	2017-08-17 19:56:13.000000000 -0400
+@@ -32,7 +32,7 @@
+ TK_LIB_FILE='@TK_LIB_FILE@'
+ 
+ # Additional libraries to use when linking Tk.
+-TK_LIBS='@XLIBSW@ @XFT_LIBS@ @LIBS@ @TCL_LIBS@'
++TK_LIBS='@XFT_LIBS@ @XLIBSW@ @LIBS@ @TCL_LIBS@'
+ 
+ # Top-level directory in which Tk's platform-independent files are
+ # installed.

--- a/10.9-libcxx/stable/main/finkinfo/utils/expect.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/expect.info
@@ -1,20 +1,20 @@
 Package: expect
-Version: 5.45
-Revision: 205
+Version: 5.45.4
+Revision: 1
 Maintainer: None <fink-devel@lists.sourceforge.net>
 BuildDepends: <<
 	fink-buildenv-modules (>= 0.1.3-1),
-	tcltk-dev (>= 8.6.1-1),
+	tcltk-dev (>= 8.6.10-1),
 	x11-dev
 <<
 Depends: <<
-	tcltk (>= 8.6.1-1)
+	tcltk (>= 8.6.10-1)
 <<
 Source: mirror:sourceforge:%n/Expect/%v/%n%v.tar.gz
-Source-MD5: 44e1a4f4c877e9ddc5a542dfa7ecc92b
+Source-MD5: 00fce8de158422f5ccd2666512329bd2
 PatchFile: %n.patch
-PatchFile-MD5: f0b227a38b679756e9db6ae6a2e2c322
-ConfigureParams: --mandir='$(prefix)/share/man' --with-tcl=%p/lib --with-tk=%p/lib --x-inc=$X11_BASE_DIR/include --x-lib=$X11_BASE_DIR/lib --with-tkinclude=%p/include --with-tclinclude=%p/include/tcltk-private/tcl8.6/generic
+PatchFile-MD5: 50c75db9999be083468aa07e551b8ee1
+ConfigureParams: --mandir='$(prefix)/share/man' --with-tcl=%p/lib --with-tk=%p/lib --x-inc=$X11_BASE_DIR/include --x-lib=$X11_BASE_DIR/lib --with-tkinclude=%p/include --with-tclinclude=%p/include/tcltk-private/tcl8.6
 PatchScript: <<
 	%{default_script}
 	perl -pi -e 's|-Wall|-Wall -Wno-unused-variable -Wno-unused-function -Wno-knr-promoted-parameter -Wno-switch|' configure
@@ -36,7 +36,7 @@ InstallScript: <<
 	install_name_tool -id %p/lib/%n%v/libexpect%v.dylib %i/lib/%n%v/libexpect%v.dylib
 <<
 # is a tcl runtime-loadable module and also a dynamic-linker library
-Shlibs:%p/lib/expect5.45/libexpect5.45.dylib 5.45.0 %n (>= 5.45-200)
+Shlibs: %p/lib/expect5.45.4/libexpect5.45.4.dylib 5.45.4 %n (>= 5.45-200)
 SplitOff: <<
 	Package: %N-dev
 	BuildDependsOnly: true
@@ -47,7 +47,7 @@ SplitOff: <<
 	<<
 	DocFiles: README
 <<
-DocFiles: FAQ HISTORY NEWS README
+DocFiles: FAQ HISTORY NEWS README example
 Description: Tool for automatic interactive applications
 DescDetail: <<
 Expect is a tool for automating interactive applications such as
@@ -61,4 +61,5 @@ distribution during build (This should not require an extra download
 since the source should still be around from the tcltk dependency).
 <<
 License: Public Domain
-Homepage: http://expect.nist.gov
+#  Homepage: http://expect.nist.gov  # Server no longer exists
+Homepage: https://sourceforge.net/projects/expect

--- a/10.9-libcxx/stable/main/finkinfo/utils/expect.patch
+++ b/10.9-libcxx/stable/main/finkinfo/utils/expect.patch
@@ -40,16 +40,16 @@ diff -uNr expect5.45.orig/Dbg.c expect5.45/Dbg.c
 diff -Nurd -x'*~' expect5.45.orig/configure expect5.45/configure
 --- expect5.45.orig/configure	2010-09-16 16:46:47.000000000 -0400
 +++ expect5.45/configure	2019-03-04 17:34:41.091738377 +0100
-@@ -6288,7 +6288,7 @@
-     echo "$as_me:$LINENO: checking for Tcl private include files" >&5
- echo $ECHO_N "checking for Tcl private include files... $ECHO_C" >&6
+@@ -5093,7 +5093,7 @@
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Tcl private include files" >&5
+ $as_echo_n "checking for Tcl private include files... " >&6; }
 
 -    TCL_SRC_DIR_NATIVE=`${CYGPATH} ${TCL_SRC_DIR}`
 +    TCL_SRC_DIR_NATIVE=`${CYGPATH} ${TCL_SRC_DIR}|sed s:/private::g`
      TCL_TOP_DIR_NATIVE=\"${TCL_SRC_DIR_NATIVE}\"
 
      # Check to see if tcl<Plat>Port.h isn't already with the public headers
-@@ -16026,7 +16026,7 @@
+@@ -9664,7 +9664,7 @@
      else
          EXP_LIB_FLAG="-lexpect`echo ${EXP_LIB_VERSION} | tr -d .`"
      fi
@@ -69,7 +69,7 @@ diff -uNr expect5.45.orig/exp_chan.c expect5.45/exp_chan.c
  #include "tcldbg.h" /* Dbg_StdinMode */
  
  extern int		expSetBlockModeProc _ANSI_ARGS_((int fd, int mode));
-@@ -565,7 +566,7 @@
+@@ -598,7 +599,7 @@
  	if (esPtr->user_waited) continue;	/* one wait only! */
  	if (esPtr->sys_waited) break;
        restart:
@@ -78,7 +78,7 @@ diff -uNr expect5.45.orig/exp_chan.c expect5.45/exp_chan.c
  	if (result == esPtr->pid) break;
  	if (result == 0) continue;	/* busy, try next */
  	if (result == -1) {
-@@ -584,7 +585,7 @@
+@@ -632,7 +618,7 @@
      /* should really be recoded using the common wait code in command.c */
      WAIT_STATUS_TYPE status;
  
@@ -301,16 +301,7 @@ diff -uNr expect5.45.orig/expect.c expect5.45/expect.c
  
      if (free_ilist) {
  	ec->i_list->ecount--;
-@@ -1094,7 +1094,7 @@
- 			/* shift remaining elements down */
- 			/* but only if there are any left */
- 			if (i+1 != ecmd->ecd.count) {
--				memcpy(&ecmd->ecd.cases[i],
-+				memmove(&ecmd->ecd.cases[i],
- 				       &ecmd->ecd.cases[i+1],
- 					((ecmd->ecd.count - i) - 1) * 
- 					sizeof(struct exp_cmd_descriptor *));
-@@ -2363,7 +2363,12 @@
+@@ -2359,7 +2359,12 @@
  
  	/* "!e" means no case matched - transfer by default */
  	if (!e || e->transfer) {


### PR DESCRIPTION
When trying to build a package against Tcl/Tk, compilation failed because 8.6.7's private headers `default.h` and `tkPort.h` are including `tkMacOSXDefault.h` and `tkMacOSXPort.h`, respectively, which are not packaged with `tcltk-dev`. The project also needs `_TkMacOSXMakeRealWindowExist` and some other functions that were not compiled in the current library.

This update to 8.6.10 has the required `TkMacOSX*` included by enabling Aqua support. All needed headers are added from the `generic`, `unix` and `macosx` directories; since they all have unique names, I have changed the structure of `%p/include/tcltk-private` to use a single subdirectory for `tcl8.6` and `tk8.6` each. This shortens the paths a bit and avoids additional patches in the likes of
`#	include "../macosx/tkMacOSXPort.h"`

The only  package I found that is building against the private headers is `expect`; I've checked that the existing package still works and passes all tests with the new `tcltk-shlibs` installed, but to build against `tcltk-dev-8.6.10-1` of course the include paths need to be adapted. This is done with the update to `expect-5.45.4`.
