### PR TITLE
lazarus: update to new upstream version (2.0.8)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-doc.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-doc.info
@@ -1,12 +1,12 @@
 Package: lazarus-doc
-Version: 2.0.6
+Version: 2.0.8
 Revision: 1
 Enhances: lazarus-aqua, lazarus-cocoa, lazarus-gtk2, lazarus-qt4, lazarus-qt5
 Recommends: xchm
 
 License: GPL/LGPL
 Source: mirror:sourceforge:lazarus/Lazarus%%20Documentation/Lazarus%%20%v/doc-chm-fpc3.0.4-laz%v.zip
-Source-MD5: 048a2765edead5ab1acd4b48378f30d3
+Source-MD5: fefa6ca46de2f9b62bab7059db932d0e
 
 SourceDirectory: chm
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-carbon.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-carbon.info
@@ -1,5 +1,5 @@
 Package: lazarus-lcl-carbon
-Version: 2.0.6
+Version: 2.0.8
 Revision: 1
 License: GPL/LGPL
 
@@ -15,7 +15,7 @@ Replaces:  lazarus-aqua
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 2e7006ae8af2c52f7e4db0039bf1c6af
+Source-MD5: 4479133eb1b3cfa678b9526408c2356f
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-cocoa-32bit.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-cocoa-32bit.info
@@ -1,5 +1,5 @@
 Package: lazarus-lcl-cocoa-32bit
-Version: 2.0.6
+Version: 2.0.8
 Revision: 1
 License: GPL/LGPL
 
@@ -12,7 +12,7 @@ Depends: <<
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 2e7006ae8af2c52f7e4db0039bf1c6af
+Source-MD5: 4479133eb1b3cfa678b9526408c2356f
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-cocoa.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-cocoa.info
@@ -1,5 +1,5 @@
 Package: lazarus-lcl-cocoa
-Version: 2.0.6
+Version: 2.0.8
 Revision: 1
 License: GPL/LGPL
 
@@ -15,7 +15,7 @@ Replaces:  lazarus-cocoa
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 2e7006ae8af2c52f7e4db0039bf1c6af
+Source-MD5: 4479133eb1b3cfa678b9526408c2356f
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-gtk2.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-gtk2.info
@@ -1,5 +1,5 @@
 Package: lazarus-lcl-gtk2
-Version: 2.0.6
+Version: 2.0.8
 Revision: 1
 License: GPL/LGPL
 
@@ -20,7 +20,7 @@ Replaces:  lazarus-gtk2
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 2e7006ae8af2c52f7e4db0039bf1c6af
+Source-MD5: 4479133eb1b3cfa678b9526408c2356f
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-qt4.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-qt4.info
@@ -1,5 +1,5 @@
 Package: lazarus-lcl-qt4
-Version: 2.0.6
+Version: 2.0.8
 Revision: 1
 License: GPL/LGPL
 
@@ -15,7 +15,7 @@ Replaces:  lazarus-qt4
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 2e7006ae8af2c52f7e4db0039bf1c6af
+Source-MD5: 4479133eb1b3cfa678b9526408c2356f
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-qt5.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-qt5.info
@@ -1,5 +1,5 @@
 Package: lazarus-lcl-qt5
-Version: 2.0.6
+Version: 2.0.8
 Revision: 1
 License: GPL/LGPL
 
@@ -15,7 +15,7 @@ Replaces:  lazarus-qt5
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 2e7006ae8af2c52f7e4db0039bf1c6af
+Source-MD5: 4479133eb1b3cfa678b9526408c2356f
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-win32.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-win32.info
@@ -1,5 +1,5 @@
 Package: lazarus-lcl-win32
-Version: 2.0.6
+Version: 2.0.8
 Revision: 1
 License: GPL/LGPL
 
@@ -12,7 +12,7 @@ Depends: <<
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 2e7006ae8af2c52f7e4db0039bf1c6af
+Source-MD5: 4479133eb1b3cfa678b9526408c2356f
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-win64.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-win64.info
@@ -1,5 +1,5 @@
 Package: lazarus-lcl-win64
-Version: 2.0.6
+Version: 2.0.8
 Revision: 1
 License: GPL/LGPL
 
@@ -12,7 +12,7 @@ Depends: <<
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 2e7006ae8af2c52f7e4db0039bf1c6af
+Source-MD5: 4479133eb1b3cfa678b9526408c2356f
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-wince-arm.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-wince-arm.info
@@ -1,5 +1,5 @@
 Package: lazarus-lcl-wince-arm
-Version: 2.0.6
+Version: 2.0.8
 Revision: 1
 License: GPL/LGPL
 
@@ -12,7 +12,7 @@ Depends: <<
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 2e7006ae8af2c52f7e4db0039bf1c6af
+Source-MD5: 4479133eb1b3cfa678b9526408c2356f
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-wince-i386.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-wince-i386.info
@@ -1,5 +1,5 @@
 Package: lazarus-lcl-wince-i386
-Version: 2.0.6
+Version: 2.0.8
 Revision: 1
 License: GPL/LGPL
 
@@ -12,7 +12,7 @@ Depends: <<
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 2e7006ae8af2c52f7e4db0039bf1c6af
+Source-MD5: 4479133eb1b3cfa678b9526408c2356f
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus.info
@@ -1,14 +1,14 @@
 Info2: <<
 Package: lazarus%type_pkg[uitype]
 Type: uitype (-aqua -cocoa -gtk2 -qt4 -qt5)
-Version: 2.0.6
+Version: 2.0.8
 Revision: 1
 License: GPL/LGPL
 
 Recommends: fpc-doc, lazarus-doc, apple-gdb, gdb
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 2e7006ae8af2c52f7e4db0039bf1c6af
+Source-MD5: 4479133eb1b3cfa678b9526408c2356f
 
 SourceDirectory: lazarus
 


### PR DESCRIPTION
lazarus: update to new upstream version (2.0.8). No further change.