### PR TITLE
GnuTLS 3.6.13

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-shlibs.info
@@ -1,8 +1,8 @@
 Package: gnutls30-shlibs
-Version: 3.6.10
+Version: 3.6.13
 Revision: 1
 Source: https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-%v.tar.xz
-Source-MD5: 254e756d882a38ce9ad6f47589330d87
+Source-MD5: bb1fe696a11543433785b4fc70ca225f
 GCC: 4.0
 Depends: <<
 	gmp5-shlibs,
@@ -27,9 +27,17 @@ BuildDepends: <<
 	nettle7,
 	pkgconfig
 <<
+PatchFile: gnutls30-xcode11.4.patch
+PatchFile-MD5: e486231c88c44082fe75a7d0984fc06d
 PatchScript: <<
 	#!/bin/bash -ev
-	%{default_script}
+	XCODE_VERSION=`xcodebuild -version 2>/dev/null | head -n 1 | cut -f 2 -d ' '`
+	if `dpkg --compare-versions $XCODE_VERSION ge 11.4`; then
+		# -no_weak_imports causes failure with Xcode11.4
+		# https://gitlab.com/gnutls/gnutls/-/issues/966
+		%{default_script}
+		autoreconf -vfi
+	fi
 	#strip unnecessary lines from .pc
 	perl -pi -e "s|^Libs\.private.*\n||g" lib/gnutls.pc.in
 	perl -pi -e "s|\@GNUTLS_REQUIRES_PRIVATE\@\n||g" lib/gnutls.pc.in
@@ -54,6 +62,7 @@ ConfigureParams: <<
 	--disable-guile \
 	--disable-libdane \
 	--with-system-priority-file="%p/etc/gnutls/default-priorities" \
+	ac_cv_func_nettle_cfb8_encrypt=no \
 	ac_cv_prog_AWK=/usr/bin/awk \
 	ac_cv_path_GREP=/usr/bin/grep \
 	ac_cv_path_SED=/usr/bin/sed
@@ -75,7 +84,7 @@ InfoTest: <<
   <<
 <<
 Shlibs: <<
-	%p/lib/gnutls30/libgnutls.30.dylib         57.0.0 %n (>= 3.6.10-1)
+	%p/lib/gnutls30/libgnutls.30.dylib         58.0.0 %n (>= 3.6.10-1)
 	%p/lib/gnutls30/libgnutls-openssl.27.dylib 28.0.0 %n (>= 3.6.10-1)
 	%p/lib/gnutls30/libgnutlsxx.28.dylib       30.0.0 %n (>= 3.6.10-1)
 <<
@@ -141,6 +150,10 @@ DescPackaging: <<
    dep. Most users probably didn't have it installed, so we disable
    libdane (the feature that is enabled by libunbound being detected)
    for consistent results. Alt would be to enable it an add deps.
+   
+   ac_cv_func_nettle_cfb8_encrypt=no because 3.6.13 checks for 
+   nettle-3.5 but needs unreleased v3.6 to pass some tests.
+   https://gitlab.com/gnutls/gnutls/-/issues/974
 <<
 License: GPL/LGPL
 Maintainer: Dave Reiser <dbreiser@users.sourceforge.net>

--- a/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-xcode11.4.patch
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-xcode11.4.patch
@@ -1,0 +1,17 @@
+--- a/configure.ac	2020-03-30 13:50:54.000000000 -0500
++++ b/configure.ac	2020-03-31 09:59:19.000000000 -0500
+@@ -126,10 +126,10 @@
+     dnl Try to use -no_weak_imports if available. This makes sure we
+     dnl error out when linking to a function that doesn't exist in the
+     dnl intended minimum runtime version.
+-    LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"
+-    AC_MSG_CHECKING([whether the linker supports -Wl,-no_weak_imports])
+-    AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+-      [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no); LDFLAGS="$save_LDFLAGS"])
++#     LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"
++#     AC_MSG_CHECKING([whether the linker supports -Wl,-no_weak_imports])
++#     AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
++#       [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no); LDFLAGS="$save_LDFLAGS"])
+   ;;
+   *solaris*)
+     have_elf=yes


### PR DESCRIPTION
Fix build failure with Xcode11.4
Fix test failure from code that expects (but forgets to check for) not-yet-released version of nettle library.