### PR TITLE
New upstream versions

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-amap-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-amap-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: cran-amap-r%type_pkg[rversion]
 Type: rversion (3.6)
-Version: 0.8-17
+Version: 0.8-18
 Revision: 1
 Description: Another Multidimensional Analysis Package
 Homepage: https://cran.r-project.org/package=amap
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:amap_%v.tar.gz
-Source-MD5: 299a98e59bc2bf23b7fdb81567c10f02
+Source-MD5: a8ba9853bf4d4fa1d650698568b0625e
 SourceDirectory: amap
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-analyzefmri-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-analyzefmri-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: cran-analyzefmri-r%type_pkg[rversion]
 Type: rversion (3.6)
-Version: 1.1-20
+Version: 1.1-21
 Revision: 1
 Description: Functions for analysis of fMRI datasets
 Homepage: https://cran.r-project.org/package=AnalyzeFMRI
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:AnalyzeFMRI_%v.tar.gz
-Source-MD5: 366b7795e11c2b8c496f03103a0c1284
+Source-MD5: 1dc96e6507fa7c45c60aca0472ce5634
 SourceDirectory: AnalyzeFMRI
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-arules-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-arules-r.info
@@ -18,14 +18,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 1.6-4
+Version: 1.6-5
 Revision: 1
 Description: Mining Association Rules 
 Homepage: https://cran.r-project.org/package=arules
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:arules_%v.tar.gz
-Source-MD5: fba1e1bb03f9930ab658d7862221bdac
+Source-MD5: 40825fa5d68460c80cfd8e89ea68185e
 SourceDirectory: arules
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -34,7 +34,7 @@ CustomMirror: <<
 Depends: <<
 	fink (>= 0.27.2),
 	r-base%type_pkg[rversion],
-	cran-matrix-r%type_pkg[rversion] (>= 1.2-0),
+	cran-matrix-r%type_pkg[rversion] (>= 1.2-0-1),
 	libgettext8-shlibs
 <<
 BuildDepends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-backports-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-backports-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.1.5
+Version: 1.1.6
 Revision: 1
 Description: Resolving the function names
 Homepage: https://cran.r-project.org/package=backports
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:backports_%v.tar.gz
-Source-MD5: 3e22dd9c53fa5822c14b2d476f86a0ea
+Source-MD5: 72ce2e24d58e06d5706454ffa542bc00
 SourceDirectory: backports
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-bma-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-bma-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 3.18.11
+Version: 3.18.12
 Revision: 1
 Description: Bayesian Model Averaging
 Homepage: https://cran.r-project.org/package=BMA
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:BMA_%v.tar.gz
-Source-MD5: 1dcbc4f7ee1ccc105eede3ec9f336082
+Source-MD5: 7cffcfee253f9dc1c78c581bf806a674
 SourceDirectory: BMA
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-cairo-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-cairo-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.5-11
+Version: 1.5-12
 Revision: 1
 Description: Graphics device using cairo graphics library
 Homepage: https://cran.r-project.org/package=Cairo
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:Cairo_%v.tar.gz
-Source-MD5: 72f72957953026e380252c037eb2f0fa
+Source-MD5: e15d1ec8669f38c6b1969e476bd60a0c
 SourceDirectory: Cairo
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-callr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-callr-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 3.4.2
+Version: 3.4.3
 Revision: 1
 Description: Call R from R
 Homepage: https://cran.r-project.org/package=callr
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:callr_%v.tar.gz
-Source-MD5: f200013d469c0e8309306da6c46f87cc
+Source-MD5: 9b0e11e01a4ec19f066ac6ab7905cfef
 SourceDirectory: callr
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-car-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-car-r.info
@@ -11,14 +11,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5)
-Version: 3.0-6
+Version: 3.0-7
 Revision: 1
 Description: Companion to Applied Regression
 Homepage: https://cran.r-project.org/package=car
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:car_%v.tar.gz
-Source-MD5: 0170752d31d590f723f559ac10e69a07
+Source-MD5: 0d6067320d7e227575b1e16eb3a105b3
 SourceDirectory: car
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-caret-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-caret-r.info
@@ -11,14 +11,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5)
-Version: 6.0-85
+Version: 6.0-86
 Revision: 1
 Description: Classification and Regression Training
 Homepage: https://cran.r-project.org/package=caret
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:caret_%v.tar.gz
-Source-MD5: 2326a6bcc90ce1b43528cc414f3becb6
+Source-MD5: be58a4f3185d1f5138919a250379d1af
 SourceDirectory: caret
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -30,10 +30,11 @@ Depends: <<
 	cran-foreach-r%type_pkg[rversion],
 	cran-ggplot2-r%type_pkg[rversion],
 	cran-lattice-r%type_pkg[rversion] (>= 0.20-1),
-	cran-modelmetrics-r%type_pkg[rversion] (>= 1.1.0-1),
+	cran-modelmetrics-r%type_pkg[rversion] (>= 1.2.2.2-1),
 	cran-nlme-r%type_pkg[rversion],
 	cran-plyr-r%type_pkg[rversion],
-	cran-recipes-r%type_pkg[rversion] (>= 0.1.4-1),
+	cran-proc-r%type_pkg[rversion],
+	cran-recipes-r%type_pkg[rversion] (>= 0.1.10-1),
 	cran-reshape2-r%type_pkg[rversion],
 	cran-withr-r%type_pkg[rversion] (>= 2.0.0-1),
 	libgettext8-shlibs

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-classint-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-classint-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 0.4-2
+Version: 0.4-3
 Revision: 1
 Description: Choose Univariate Class Intervals
 Homepage: https://cran.r-project.org/package=classInt
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:classInt_%v.tar.gz
-Source-MD5: fa0dd031bbaa43e38315c7ff894f5db0
+Source-MD5: 8222cf7fca6b824a51bababc18a86659
 SourceDirectory: classInt
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-clv-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-clv-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 0.3-2.1
+Version: 0.3-2.2
 Revision: 1
 Description: Cluster Validation Techniques
 Homepage: https://cran.r-project.org/package=clv
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:clv_%v.tar.gz
-Source-MD5: 69f20d55febd80fd6daa4762b59c2be2
+Source-MD5: 78c2e9825b9b10ae2597b46dc331e982
 SourceDirectory: clv
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-crosstalk-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-crosstalk-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.0.0
-Revision: 3
+Version: 1.1.0.1
+Revision: 1
 Description: Inter-widget interactivity for HTML widgets
 Homepage: https://cran.r-project.org/package=crosstalk
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:crosstalk_%v.tar.gz
-Source-MD5: c13c21b81af2154be3f08870fd3a7077
+Source-MD5: b70d114f68e638dc6ddc5568d8a592f9
 SourceDirectory: crosstalk
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-daag-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-daag-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.22.1
+Version: 1.24
 Revision: 1
 Description: Data Analysis And Graphics
 Homepage: https://cran.r-project.org/package=DAAG
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:DAAG_%v.tar.gz
-Source-MD5: 03730c052c4f5b21ef864e0c4ec37ead
+Source-MD5: 37638c93e1cc744bd458adb31f91261f
 SourceDirectory: DAAG
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dt-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-dt-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 0.12
+Version: 0.13
 Revision: 1
 Description: Wrapper of JavaScript Library DataTables
 Homepage: https://cran.r-project.org/package=DT
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:DT_%v.tar.gz
-Source-MD5: f87d3f75b8683589d04c1c95a9b4333c
+Source-MD5: 557ab21201b9380080fa48079ccadeeb
 SourceDirectory: DT
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -50,9 +50,9 @@ Depends: <<
 	fink (>=0.32),
 	r-base%type_pkg[rversion],
 	cran-crosstalk-r%type_pkg[rversion],
-	cran-htmltools-r%type_pkg[rversion] (>= 0.3.6), 
-	cran-htmlwidgets-r%type_pkg[rversion] (>= 1.3), 
-	cran-jsonlite-r%type_pkg[rversion] (>= 0.9.16), 
+	cran-htmltools-r%type_pkg[rversion] (>= 0.3.6-1), 
+	cran-htmlwidgets-r%type_pkg[rversion] (>= 1.3-1), 
+	cran-jsonlite-r%type_pkg[rversion] (>= 0.9.16-1), 
 	cran-magrittr-r%type_pkg[rversion],
 	cran-promises-r%type_pkg[rversion]
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-foreach-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-foreach-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.4.8
+Version: 1.5.0
 Revision: 1
 Description: Foreach looping construct for R
 Homepage: https://cran.r-project.org/package=foreach
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:foreach_%v.tar.gz
-Source-MD5: cbe4ac21d8dea0a51f34e83f4d91acad
+Source-MD5: 973c8ba4da54d5384f89a700cc514b8e
 SourceDirectory: foreach
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-forecast-r-8.9.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-forecast-r-8.9.info
@@ -2,42 +2,20 @@ Info2: <<
 
 Package: cran-forecast-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.9,
-	(%type_pkg[rversion] = 33 ) 10.10,
-	(%type_pkg[rversion] = 33 ) 10.11,
-	(%type_pkg[rversion] = 33 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.13,
-	(%type_pkg[rversion] = 33 ) 10.14,
-	(%type_pkg[rversion] = 33 ) 10.14.5,
-	(%type_pkg[rversion] = 34 ) 10.9,
-	(%type_pkg[rversion] = 34 ) 10.10,
-	(%type_pkg[rversion] = 34 ) 10.11,
-	(%type_pkg[rversion] = 34 ) 10.12,
-	(%type_pkg[rversion] = 34 ) 10.13,
-	(%type_pkg[rversion] = 34 ) 10.14,
-	(%type_pkg[rversion] = 34 ) 10.14.5,
-	(%type_pkg[rversion] = 35 ) 10.9,
-	(%type_pkg[rversion] = 35 ) 10.10,
-	(%type_pkg[rversion] = 35 ) 10.11,
-	(%type_pkg[rversion] = 35 ) 10.12,
-	(%type_pkg[rversion] = 35 ) 10.13,
-	(%type_pkg[rversion] = 35 ) 10.14,
-	(%type_pkg[rversion] = 35 ) 10.14.5
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12
 <<
-# See DescPackaging
-Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 8.12
-Revision: 1
+Type: rversion (3.1)
+Version: 8.9
+Revision: 2
 Description: Forecasting functions 
 Homepage: https://cran.r-project.org/package=forecast
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:forecast_%v.tar.gz
-Source-MD5: 54f86210d2284e798fb42704d6b7d6e7
+Source-MD5: 204b744dcee466fa82f502d3cfd3370c
 SourceDirectory: forecast
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -45,17 +23,15 @@ CustomMirror: <<
 <<
 Depends: <<
 	fink (>= 0.27.2), 
-	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion],
-	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.0-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-3),
 	cran-colorspace-r%type_pkg[rversion],
 	cran-fracdiff-r%type_pkg[rversion],
-	cran-ggplot2-r%type_pkg[rversion] (>= 2.2.1-1),
+	cran-ggplot2-r%type_pkg[rversion] (>= 2.2.1),
 	cran-lmtest-r%type_pkg[rversion],
 	cran-magrittr-r%type_pkg[rversion],
 	cran-nnet-r%type_pkg[rversion],
 	cran-rcpp-r%type_pkg[rversion] (>= 0.11.0-1),
-	cran-rcpparmadillo-r%type_pkg[rversion] (>= 0.2.35-1),
+	cran-rcpparmadillo-r%type_pkg[rversion] (>= 0.2.35),
 	cran-timedate-r%type_pkg[rversion],
 	cran-tseries-r%type_pkg[rversion],
 	cran-urca-r%type_pkg[rversion],
@@ -65,8 +41,6 @@ Depends: <<
 <<
 BuildDepends: <<
 	fink (>= 0.27.2), 
-	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion]-dev,
-	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3),
 	cran-rcpp-r%type_pkg[rversion]-dev,
 	cran-rcpparmadillo-r%type_pkg[rversion]-dev,
@@ -103,8 +77,7 @@ forecasts including exponential smoothing via state space models and
 automatic ARIMA modelling.
 <<
 DescPackaging: <<
-  The homepage says the packages depends on R >= 3.0.2, but it uses a R-3.2 function
-  during the build process.
+  R (>= 3.0.2)
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-ggally-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-ggally-r.info
@@ -25,14 +25,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3)
-Version: 1.4.0
+Version: 1.5.0
 Revision: 1
 Description: Extension to ggplot2
 Homepage: https://cran.r-project.org/package=GGally
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:GGally_%v.tar.gz
-Source-MD5: 59bfd42d0f1fd270ba8647970acda4fd
+Source-MD5: ce6473ce8d1800b7cb69eeef497071bf
 SourceDirectory: GGally
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -41,12 +41,12 @@ CustomMirror: <<
 Depends: <<
 	fink (>=0.32),
 	r-base%type_pkg[rversion],
-	cran-ggplot2-r%type_pkg[rversion] (>=2.2.0),
-	cran-gtable-r%type_pkg[rversion] (>=0.2.0),
-	cran-plyr-r%type_pkg[rversion] (>=1.8.3),
+	cran-ggplot2-r%type_pkg[rversion] (>= 2.2.0-1),
+	cran-gtable-r%type_pkg[rversion] (>= 0.2.0-1),
+	cran-plyr-r%type_pkg[rversion] (>= 1.8.3-1),
 	cran-progress-r%type_pkg[rversion],
 	cran-rcolorbrewer-r%type_pkg[rversion],
-	cran-reshape-r%type_pkg[rversion] (>=0.8.5),
+	cran-reshape-r%type_pkg[rversion] (>= 0.8.5-1),
 	cran-rlang-r%type_pkg[rversion]
 <<
 BuildDepends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-glue-r-1.3.1.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-glue-r-1.3.1.info
@@ -2,42 +2,20 @@ Info2: <<
 
 Package: cran-glue-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.9,
-	(%type_pkg[rversion] = 33 ) 10.10,
-	(%type_pkg[rversion] = 33 ) 10.11,
-	(%type_pkg[rversion] = 33 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.13,
-	(%type_pkg[rversion] = 33 ) 10.14,
-	(%type_pkg[rversion] = 33 ) 10.14.5,
-	(%type_pkg[rversion] = 34 ) 10.9,
-	(%type_pkg[rversion] = 34 ) 10.10,
-	(%type_pkg[rversion] = 34 ) 10.11,
-	(%type_pkg[rversion] = 34 ) 10.12,
-	(%type_pkg[rversion] = 34 ) 10.13,
-	(%type_pkg[rversion] = 34 ) 10.14,
-	(%type_pkg[rversion] = 34 ) 10.14.5,
-	(%type_pkg[rversion] = 35 ) 10.9,
-	(%type_pkg[rversion] = 35 ) 10.10,
-	(%type_pkg[rversion] = 35 ) 10.11,
-	(%type_pkg[rversion] = 35 ) 10.12,
-	(%type_pkg[rversion] = 35 ) 10.13,
-	(%type_pkg[rversion] = 35 ) 10.14,
-	(%type_pkg[rversion] = 35 ) 10.14.5
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12
 <<
-# See DescPackaging
-Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 1.4.0
+Type: rversion (3.1)
+Version: 1.3.1
 Revision: 1
 Description: Interpreted String Literals
 Homepage: https://cran.r-project.org/package=glue
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:glue_%v.tar.gz
-Source-MD5: 74c3779648eb24f6644816971ae23db1
+Source-MD5: 242edf3ba74c928b434c8cee138aa16e
 SourceDirectory: glue
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -81,10 +59,6 @@ DescDetail: <<
 An implementation of interpreted string literals, inspired by Python's 
 Literal String Interpolation and Docstrings and Julia's Triple-Quoted 
 String Literals.
-<<
-DescPackaging: <<
-  As of 1.40, the homepage says the packages depends on R (>= 3.1.0),
-  but buildprocess uses a R-3.2 function (isNamespaceLoaded).
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gpairs-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gpairs-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.2
+Version: 1.3.3
 Revision: 1
 Description: Generalized Pairs Plot
 Homepage: https://cran.r-project.org/package=gpairs
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:gpairs_%v.tar.gz
-Source-MD5: 6f3852e5520e98323862f18144aa987b
+Source-MD5: 6fe8863fb930a60f948bb12dee624a10
 SourceDirectory: gpairs
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gtools-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gtools-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 3.8.1
+Version: 3.8.2
 Revision: 1
 Description: Various R programming tools
 Homepage: http://cran.r-project.org/web/packages/gtools/index.html
-License: LGPL
+License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:gtools_%v.tar.gz
-Source-MD5: df4bee0a17bc18d00660b81ce9365426
+Source-MD5: bba2f02cb357b4e817abbe9009f2dabb
 SourceDirectory: gtools
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-hmisc-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-hmisc-r.info
@@ -19,14 +19,14 @@ Distribution: <<
 <<
 # See DescPackaging
 Type: rversion (3.6 3.5 3.4)
-Version: 4.3-1
+Version: 4.4-0
 Revision: 1
 Description: Harrell Miscellaneous
 Homepage: https://cran.r-project.org/package=Hmisc
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:Hmisc_%v.tar.gz
-Source-MD5: e832b908f48a0e1f10bb52d4f1dc6aa1
+Source-MD5: c323fbc70a96c78be46aa13a79c48048
 SourceDirectory: Hmisc
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-hyperspec-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-hyperspec-r.info
@@ -2,14 +2,14 @@ Info2: <<
 
 Package: cran-hyperspec-r%type_pkg[rversion]
 Type: rversion (3.6)
-Version: 0.99-20200213
+Version: 0.99-20200213.1
 Revision: 1
 Description: Interface for hyperspectral data
 Homepage: https://cran.r-project.org/package=hyperSpec
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:hyperSpec_%v.tar.gz
-Source-MD5: 3dc1400b7c703f517336826a9c734449
+Source-MD5: 2b93a30221d8cd82968c9b4ec4d84506
 SourceDirectory: hyperSpec
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-igraph-r-1.2.4.1.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-igraph-r-1.2.4.1.info
@@ -2,41 +2,20 @@ Info2: <<
 
 Package: cran-igraph-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.9,
-	(%type_pkg[rversion] = 33 ) 10.10,
-	(%type_pkg[rversion] = 33 ) 10.11,
-	(%type_pkg[rversion] = 33 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.13,
-	(%type_pkg[rversion] = 33 ) 10.14,
-	(%type_pkg[rversion] = 33 ) 10.14.5,
-	(%type_pkg[rversion] = 34 ) 10.9,
-	(%type_pkg[rversion] = 34 ) 10.10,
-	(%type_pkg[rversion] = 34 ) 10.11,
-	(%type_pkg[rversion] = 34 ) 10.12,
-	(%type_pkg[rversion] = 34 ) 10.13,
-	(%type_pkg[rversion] = 34 ) 10.14,
-	(%type_pkg[rversion] = 34 ) 10.14.5,
-	(%type_pkg[rversion] = 35 ) 10.9,
-	(%type_pkg[rversion] = 35 ) 10.10,
-	(%type_pkg[rversion] = 35 ) 10.11,
-	(%type_pkg[rversion] = 35 ) 10.12,
-	(%type_pkg[rversion] = 35 ) 10.13,
-	(%type_pkg[rversion] = 35 ) 10.14,
-	(%type_pkg[rversion] = 35 ) 10.14.5
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12
 <<
-Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 1.2.5
-Revision: 1
+Type: rversion (3.1)
+Version: 1.2.4.1
+Revision: 2
 Description: Network analysis and visualization
 Homepage: https://cran.r-project.org/package=igraph
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:igraph_%v.tar.gz
-Source-MD5: 7a36934755ea936f9601b52db8d59e1f
+Source-MD5: eabac29603d0db7c4ad302f839cfefca
 SourceDirectory: igraph
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -44,9 +23,8 @@ CustomMirror: <<
 <<
 Depends: <<
 	fink (>= 0.27.2), 
-	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion],
-	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.0-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-3),
+	cran-irlba-r%type_pkg[rversion],
 	cran-magrittr-r%type_pkg[rversion],
 	cran-matrix-r%type_pkg[rversion],
 	cran-pkgconfig-r%type_pkg[rversion] (>= 2.0.0-1),
@@ -58,8 +36,6 @@ Depends: <<
 <<
 BuildDepends: <<
 	fink (>= 0.27.2), 
-	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion]-dev,
-	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3),
 	(%type_raw[rversion] << 3.6) gcc5-compiler | (%type_raw[rversion] >= 3.6) gcc9-compiler,
 	gmp5,

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-isoband-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-isoband-r.info
@@ -29,14 +29,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 0.2.0
+Version: 0.2.1
 Revision: 1
 Description: Isolines and Isobands from Elevation Grids
 Homepage: https://cran.r-project.org/package=isoband
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:isoband_%v.tar.gz
-Source-MD5: d7e56f9a0ec28581171ab3927f0975c8
+Source-MD5: 2766692dec6ae8d497b59352764d9dfb
 SourceDirectory: isoband
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-jade-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-jade-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 2.0-2
-Revision: 2
+Version: 2.0-3
+Revision: 1
 Description: JADE and other BSS methods
 Homepage: https://cran.r-project.org/package=JADE
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:JADE_%v.tar.gz
-Source-MD5: f862ba0f45a06d253af1e39c2a47a041
+Source-MD5: 5d835eafe44e2360efb8bb0e29c2b8f6
 SourceDirectory: JADE
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-lme4-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-lme4-r.info
@@ -29,14 +29,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 1.1-21
+Version: 1.1-23
 Revision: 1
 Description: Various R programming tools
 Homepage: https://cran.r-project.org/package=lme4
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:lme4_%v.tar.gz
-Source-MD5: 80a9e68927bace7c7b45294c506de8b7
+Source-MD5: cd3963f34f1efaf7b8075766fa6f8f1b
 SourceDirectory: lme4
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -44,35 +44,32 @@ CustomMirror: <<
 <<
 Depends: <<
 	r-base%type_pkg[rversion],
+	cran-boot-r%type_pkg[rversion],
 	cran-lattice-r%type_pkg[rversion],
 	cran-mass-r%type_pkg[rversion],
-	cran-matrix-r%type_pkg[rversion] (>= 1.2-1),
-	cran-minqa-r%type_pkg[rversion] (>= 1.1.15),
-	cran-nlme-r%type_pkg[rversion] (>= 3.1-123),
-	cran-nloptr-r%type_pkg[rversion] (>=1.0.4),
-	cran-rcpp-r%type_pkg[rversion] (>= 0.10.5),
+	cran-matrix-r%type_pkg[rversion] (>= 1.2-1-1),
+	cran-minqa-r%type_pkg[rversion] (>= 1.1.15-1),
+	cran-nlme-r%type_pkg[rversion] (>= 3.1-123-1),
+	cran-nloptr-r%type_pkg[rversion] (>= 1.0.4-1),
+	cran-rcpp-r%type_pkg[rversion] (>= 0.10.5-1),
 	cran-rcppeigen-r%type_pkg[rversion],
+	cran-statmod-r%type_pkg[rversion],
 	libgettext8-shlibs
 <<
 BuildDepends: <<
 	fink (>= 0.27.2),
 	r-base%type_pkg[rversion]-dev,
-	cran-rcpp-r%type_pkg[rversion]-dev (>= 0.10.5),
+	cran-rcpp-r%type_pkg[rversion]-dev (>= 0.10.5-1),
 	cran-rcppeigen-r%type_pkg[rversion]-dev,
 	libgettext8-dev
 <<
 GCC: 4.0
 CompileScript: <<
   #!/bin/bash -ev
-  export TMPDIR=%b/tmp
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
-  if [[ %type_raw[rversion] > 2.15 ]]; then
-    $BIN_R --verbose CMD build --no-build-vignettes lme4
-  else
-    $BIN_R --verbose CMD build --no-vignettes lme4
-  fi
+  $BIN_R --verbose CMD build --no-build-vignettes lme4
 <<
 InstallScript: <<
   #!/bin/sh -ev

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-locfit-r-1.5-9.1.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-locfit-r-1.5-9.1.info
@@ -1,6 +1,6 @@
 Info2: <<
 
-Package: cran-fs-r%type_pkg[rversion]
+Package: cran-locfit-r%type_pkg[rversion]
 Distribution: <<
 	(%type_pkg[rversion] = 31 ) 10.9,
 	(%type_pkg[rversion] = 31 ) 10.10,
@@ -23,71 +23,61 @@ Distribution: <<
 	(%type_pkg[rversion] = 34 ) 10.12,
 	(%type_pkg[rversion] = 34 ) 10.13,
 	(%type_pkg[rversion] = 34 ) 10.14,
-	(%type_pkg[rversion] = 34 ) 10.14.5,
-	(%type_pkg[rversion] = 35 ) 10.9,
-	(%type_pkg[rversion] = 35 ) 10.10,
-	(%type_pkg[rversion] = 35 ) 10.11,
-	(%type_pkg[rversion] = 35 ) 10.12,
-	(%type_pkg[rversion] = 35 ) 10.13,
-	(%type_pkg[rversion] = 35 ) 10.14,
-	(%type_pkg[rversion] = 35 ) 10.14.5
+	(%type_pkg[rversion] = 34 ) 10.14.5
 <<
-Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.4.1
-Revision: 1
-Description: Cross-Platform File System Operations
-Homepage: https://cran.r-project.org/package=fs
+Type: rversion (3.4 3.3 3.2 3.1)
+Version: 1.5-9.1
+Revision: 2
+Description: Local Regression/Likelihood/Density Estimtion
+Homepage: https://cran.r-project.org/package=locfit
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: mirror:custom:fs_%v.tar.gz
-Source-MD5: fa176594fe282dbc067d10e493a8b023
-SourceDirectory: fs
+Source: mirror:custom:locfit_%v.tar.gz
+Source-MD5: 38af7791c9cda78e2804020e65ac7fb4
+SourceDirectory: locfit
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
-	Secondary: https://cran.r-project.org/src/contrib/00Archive/fs
+	Secondary: https://cran.r-project.org/src/contrib/00Archive/locfit
 <<
 Depends: <<
 	r-base%type_pkg[rversion],
-	cran-rcpp-r%type_pkg[rversion],
+	cran-lattice-r%type_pkg[rversion],
 	libgettext8-shlibs
 <<
 BuildDepends: <<
 	fink (>= 0.27.2),
 	r-base%type_pkg[rversion]-dev,
-	cran-rcpp-r%type_pkg[rversion]-dev,
 	libgettext8-dev
 <<
-GCC: 4.0
 CompileScript: <<
   #!/bin/bash -ev
   export TMPDIR=%b/tmp
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
-  $BIN_R --verbose CMD build --no-build-vignettes fs
+  $BIN_R --verbose CMD build --no-build-vignettes locfit
 <<
 InstallScript: <<
   #!/bin/sh -ev
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   mkdir -p %i/lib/R/%type_raw[rversion]/site-library
-  pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library fs
+  pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library locfit
   if [ "%type_num[rversion]" -lt "34" ]; then
-	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/fs/libs/fs.dylib %i/lib/R/%type_raw[rversion]/site-library/fs/libs/fs.dylib
+	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/locfit/libs/locfit.dylib %i/lib/R/%type_raw[rversion]/site-library/locfit/libs/locfit.dylib
   else
-	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/fs/libs/fs.so %i/lib/R/%type_raw[rversion]/site-library/fs/libs/fs.so
+	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/locfit/libs/locfit.so %i/lib/R/%type_raw[rversion]/site-library/locfit/libs/locfit.so
   fi
 <<
 Shlibs: <<
-  ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/fs/libs/fs.so 0.0.0 %n (>= 1.17-1-1)
-  ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/fs/libs/fs.dylib 0.0.0 %n (>= 1.17-1-1)
+  ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/locfit/libs/locfit.so 0.0.0 %n (>=-1.5-9-1)
+  ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/locfit/libs/locfit.dylib 0.0.0 %n (>=-1.5-9-1)
 <<
 DescDetail: <<
-A cross-platform interface to file system operations, built on top of
-the 'libuv' C library.
+Local regression, likelihood and density estimation.
 <<
 DescPackaging: <<
-  R (>= 3.1)
+  R (>= 2.0.1)
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-locfit-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-locfit-r.info
@@ -2,28 +2,6 @@ Info2: <<
 
 Package: cran-locfit-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 31 ) 10.9,
-	(%type_pkg[rversion] = 31 ) 10.10,
-	(%type_pkg[rversion] = 31 ) 10.11,
-	(%type_pkg[rversion] = 31 ) 10.12,
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.9,
-	(%type_pkg[rversion] = 33 ) 10.10,
-	(%type_pkg[rversion] = 33 ) 10.11,
-	(%type_pkg[rversion] = 33 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.13,
-	(%type_pkg[rversion] = 33 ) 10.14,
-	(%type_pkg[rversion] = 33 ) 10.14.5,
-	(%type_pkg[rversion] = 34 ) 10.9,
-	(%type_pkg[rversion] = 34 ) 10.10,
-	(%type_pkg[rversion] = 34 ) 10.11,
-	(%type_pkg[rversion] = 34 ) 10.12,
-	(%type_pkg[rversion] = 34 ) 10.13,
-	(%type_pkg[rversion] = 34 ) 10.14,
-	(%type_pkg[rversion] = 34 ) 10.14.5,
 	(%type_pkg[rversion] = 35 ) 10.9,
 	(%type_pkg[rversion] = 35 ) 10.10,
 	(%type_pkg[rversion] = 35 ) 10.11,
@@ -32,15 +10,15 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14,
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
-Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.5-9.1
-Revision: 2
+Type: rversion (3.6 3.5)
+Version: 1.5-9.4
+Revision: 1
 Description: Local Regression/Likelihood/Density Estimtion
 Homepage: https://cran.r-project.org/package=locfit
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:locfit_%v.tar.gz
-Source-MD5: 38af7791c9cda78e2804020e65ac7fb4
+Source-MD5: 00549c79e43bea01276a74a0e2b8d158
 SourceDirectory: locfit
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -70,15 +48,10 @@ InstallScript: <<
   
   mkdir -p %i/lib/R/%type_raw[rversion]/site-library
   pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library locfit
-  if [ "%type_num[rversion]" -lt "34" ]; then
-	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/locfit/libs/locfit.dylib %i/lib/R/%type_raw[rversion]/site-library/locfit/libs/locfit.dylib
-  else
-	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/locfit/libs/locfit.so %i/lib/R/%type_raw[rversion]/site-library/locfit/libs/locfit.so
-  fi
+  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/locfit/libs/locfit.so %i/lib/R/%type_raw[rversion]/site-library/locfit/libs/locfit.so
 <<
 Shlibs: <<
-  ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/locfit/libs/locfit.so 0.0.0 %n (>=-1.5-9-1)
-  ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/locfit/libs/locfit.dylib 0.0.0 %n (>=-1.5-9-1)
+  %p/lib/R/%type_raw[rversion]/site-library/locfit/libs/locfit.so 0.0.0 %n (>=-1.5-9-1)
 <<
 DescDetail: <<
 Local regression, likelihood and density estimation.

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-lubridate-r-1.7.4.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-lubridate-r-1.7.4.info
@@ -2,41 +2,20 @@ Info2: <<
 
 Package: cran-lubridate-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.9,
-	(%type_pkg[rversion] = 33 ) 10.10,
-	(%type_pkg[rversion] = 33 ) 10.11,
-	(%type_pkg[rversion] = 33 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.13,
-	(%type_pkg[rversion] = 33 ) 10.14,
-	(%type_pkg[rversion] = 33 ) 10.14.5,
-	(%type_pkg[rversion] = 34 ) 10.9,
-	(%type_pkg[rversion] = 34 ) 10.10,
-	(%type_pkg[rversion] = 34 ) 10.11,
-	(%type_pkg[rversion] = 34 ) 10.12,
-	(%type_pkg[rversion] = 34 ) 10.13,
-	(%type_pkg[rversion] = 34 ) 10.14,
-	(%type_pkg[rversion] = 34 ) 10.14.5,
-	(%type_pkg[rversion] = 35 ) 10.9,
-	(%type_pkg[rversion] = 35 ) 10.10,
-	(%type_pkg[rversion] = 35 ) 10.11,
-	(%type_pkg[rversion] = 35 ) 10.12,
-	(%type_pkg[rversion] = 35 ) 10.13,
-	(%type_pkg[rversion] = 35 ) 10.14,
-	(%type_pkg[rversion] = 35 ) 10.14.5
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12
 <<
-Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 1.7.8
+Type: rversion (3.1)
+Version: 1.7.4
 Revision: 1
 Description: Make Dealing with Dates a Little Easier
 Homepage: https://cran.r-project.org/package=lubridate
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:lubridate_%v.tar.gz
-Source-MD5: 3502e7945185d4159eca9957a1bccbf1
+Source-MD5: 34d49a18996dfca7c9117b4ff101f460
 SourceDirectory: lubridate
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -44,18 +23,15 @@ CustomMirror: <<
 <<
 Depends: <<
 	fink (>= 0.27.2), 
-	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion],
-	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.0-2),
-	cran-generics-r%type_pkg[rversion],
-	cran-rcpp-r%type_pkg[rversion] (>= 0.12.13-1),
+	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-3),
+	cran-rcpp-r%type_pkg[rversion] (>= 0.12.13),
 	cran-stringr-r%type_pkg[rversion],
 	libgettext8-shlibs
 <<
 BuildDepends: <<
 	fink (>= 0.27.2), 
-	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion]-dev,
-	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
-	cran-rcpp-r%type_pkg[rversion]-dev (>= 0.12.13-1),
+	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3),
+	cran-rcpp-r%type_pkg[rversion]-dev (>= 0.12.13),
 	libgettext8-dev
 <<
 CompileScript: <<
@@ -89,7 +65,7 @@ date-time (years, months, days, hours, minutes, and seconds), algebraic
 manipulation on date-time and time-span objects. The 'lubridate' package
 has a consistent and memorable syntax that makes working with dates easy
 and fun. Parts of the 'CCTZ' source code, released under the Apache 2.0
-License: GPL
+License, are included in this package. See
 <https://github.com/google/cctz> for more details.
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-lubridate-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-lubridate-r.info
@@ -89,7 +89,7 @@ date-time (years, months, days, hours, minutes, and seconds), algebraic
 manipulation on date-time and time-span objects. The 'lubridate' package
 has a consistent and memorable syntax that makes working with dates easy
 and fun. Parts of the 'CCTZ' source code, released under the Apache 2.0
-License: GPL
+License, are included in this package. See
 <https://github.com/google/cctz> for more details.
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-matrixstats-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-matrixstats-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 0.55.0
+Version: 0.56.0
 Revision: 1
 Description: Functions for Rows and Columns of Matrices
 Homepage: https://cran.r-project.org/package=matrixStats
 License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:matrixStats_%v.tar.gz
-Source-MD5: 860aa7af56ddb598268cbca7921e2d4c
+Source-MD5: 27aa52de739cfdbfb01f5fc9fe9df71c
 SourceDirectory: matrixStats
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mclust-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mclust-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 5.4.5
-Revision: 2
+Version: 5.4.6
+Revision: 1
 Description: Normal Mixture Modeling
 Homepage: https://cran.r-project.org/package=mclust
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:mclust_%v.tar.gz
-Source-MD5: 7450afbf6c741672070f323c79a0208f
+Source-MD5: ab9f0309e9f6efecf3dba0059b41440e
 SourceDirectory: mclust
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mcmc-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mcmc-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 0.9-6.1
+Version: 0.9-7
 Revision: 1
 Description: Markov Chain Monte Carlo
 Homepage: https://cran.r-project.org/package=mcmc
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:mcmc_%v.tar.gz
-Source-MD5: 44af7c90e76baecbfe74ea6290a77684
+Source-MD5: d97284aef5ec8152fb06de49ce308b80
 SourceDirectory: mcmc
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-metafor-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-metafor-r.info
@@ -11,14 +11,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5)
-Version: 2.1-0
+Version: 2.4-0
 Revision: 1
 Description: Meta-Analysis Package for R
 Homepage: https://cran.r-project.org/package=metafor
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:metafor_%v.tar.gz
-Source-MD5: 686fb670a23c5f279be03c5d5b3057dd
+Source-MD5: 751cb240a6c1bd0bc473fb5e839536da
 SourceDirectory: metafor
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mkin-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-mkin-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 0.9.49.8
+Version: 0.9.49.10
 Revision: 1
 Description: Routines for fitting kinetic models
 Homepage: https://cran.r-project.org/package=mkin
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:mkin_%v.tar.gz
-Source-MD5: 89cc7db656a379bbef90f71432f9835e
+Source-MD5: 55d652bba48648810b26ac3a28109ba8
 SourceDirectory: mkin
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -49,9 +49,12 @@ CustomMirror: <<
 Depends: <<
 	r-base%type_pkg[rversion],
 	cran-desolve-r%type_pkg[rversion],
-	cran-lmtest-r%type_pkg[rversion],
 	cran-inline-r%type_pkg[rversion],
+	cran-lmtest-r%type_pkg[rversion],
+	cran-nlme-r%type_pkg[rversion],
 	cran-numderiv-r%type_pkg[rversion],
+	cran-pkgbuild-r%type_pkg[rversion],
+	cran-purrr-r%type_pkg[rversion],
 	cran-r6-r%type_pkg[rversion]
 <<
 BuildDepends: r-base%type_pkg[rversion]-dev

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-modelmetrics-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-modelmetrics-r.info
@@ -29,14 +29,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 1.2.2.1
+Version: 1.2.2.2
 Revision: 1
 Description: Rapid Calculation of Model Metrics
 Homepage: https://cran.r-project.org/package=ModelMetrics
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:ModelMetrics_%v.tar.gz
-Source-MD5: 6dbbb0a6e4cc96b1f38a8e70b0acbd88
+Source-MD5: 3f3d10e443dab1a0e8e399bcd6be6d1b
 SourceDirectory: ModelMetrics
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-multcomp-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-multcomp-r.info
@@ -11,14 +11,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5)
-Version: 1.4-12
+Version: 1.4-13
 Revision: 1
 Description: Simultaneous Inference in Parametric Models
 Homepage: https://cran.r-project.org/package=multcomp
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:multcomp_%v.tar.gz
-Source-MD5: 1c6f66cbcae685f8f97355eea30ad203
+Source-MD5: 333196ff40484dcab27ef77e62be193a
 SourceDirectory: multcomp
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-nada-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-nada-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.6-1
+Version: 1.6-1.1
 Revision: 1
 Description: Analysis for Environmental Data
 Homepage: https://cran.r-project.org/package=NADA
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:NADA_%v.tar.gz
-Source-MD5: 5d407d9d2d85ba807d08ef47a4c289e1
+Source-MD5: 387fc10823dd93bdfced5adeb7b9d710
 SourceDirectory: NADA
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-nloptr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-nloptr-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.2.2
+Version: 1.2.2.1
 Revision: 1
 Description: R interface to NLopt
 Homepage: http://cran.r-project.org/web/packages/nloptr/index.html
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:nloptr_%v.tar.gz
-Source-MD5: 47590eabd1beb757867b34f068950ca5
+Source-MD5: 5e732439fa489f35ae1b32b1fd6a6cdd
 SourceDirectory: nloptr
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-optimx-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-optimx-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 2020-2.2
+Version: 2020-4.2
 Revision: 1
 Description: Replacement optmin function
 Homepage: https://cran.r-project.org/package=optimx
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:optimx_%v.tar.gz
-Source-MD5: ce03bedab7afa2293f2db4a745f0fc09
+Source-MD5: ddcda8be7dfdb586bf88c581c814c9c7
 SourceDirectory: optimx
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pkgmaker-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pkgmaker-r.info
@@ -30,14 +30,14 @@ Distribution: <<
 <<
 # See DescPackageing
 Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 0.31
+Version: 0.31.1
 Revision: 1
 Description: Package development utilities
 Homepage: https://cran.r-project.org/package=pkgmaker
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:pkgmaker_%v.tar.gz
-Source-MD5: fb521e30e2f635bea2a299f60b0fff64
+Source-MD5: 32766df13e8a90caee3eeee354366a02
 SourceDirectory: pkgmaker
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-plotly-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-plotly-r.info
@@ -29,14 +29,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 4.9.2
+Version: 4.9.2.1
 Revision: 1
 Description: Various plotting functions
 Homepage: https://cran.r-project.org/package=plotly
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:plotly_%v.tar.gz
-Source-MD5: 46b79bba0bee44b1b02b9cadf2696c98
+Source-MD5: ccb4e5b917d9f327a8dc7bb647bfcd7f
 SourceDirectory: plotly
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-plotmo-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-plotmo-r.info
@@ -2,20 +2,6 @@ Info2: <<
 
 Package: cran-plotmo-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 31 ) 10.9,
-	(%type_pkg[rversion] = 31 ) 10.10,
-	(%type_pkg[rversion] = 31 ) 10.11,
-	(%type_pkg[rversion] = 31 ) 10.12,
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.9,
-	(%type_pkg[rversion] = 33 ) 10.10,
-	(%type_pkg[rversion] = 33 ) 10.11,
-	(%type_pkg[rversion] = 33 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.13,
-	(%type_pkg[rversion] = 33 ) 10.14,
 	(%type_pkg[rversion] = 33 ) 10.14.5,
 	(%type_pkg[rversion] = 34 ) 10.9,
 	(%type_pkg[rversion] = 34 ) 10.10,
@@ -33,14 +19,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 3.5.6
+Version: 3.5.7
 Revision: 1
 Description: Plot a model's response
 Homepage: https://cran.r-project.org/package=plotmo
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:plotmo_%v.tar.gz
-Source-MD5: bfbdf02833a3713b58d839fba55b09d0
+Source-MD5: b93413644a0a3e92576a6cdb3214a214
 SourceDirectory: plotmo
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-plotrix-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-plotrix-r.info
@@ -11,14 +11,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5)
-Version: 3.7-7
+Version: 3.7-8
 Revision: 1
 Description: Various plotting functions
 Homepage: https://cran.r-project.org/package=plotrix
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:plotrix_%v.tar.gz
-Source-MD5: 7929793096a28b6b21e5811b48d221cf
+Source-MD5: b7239bb52867eb3f3bf1ef9631512c38
 SourceDirectory: plotrix
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pmml-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pmml-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 2.2.0
+Version: 2.3.0
 Revision: 1
 Description: Generate PMML for various models
 Homepage: https://cran.r-project.org/package=pmml
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:pmml_%v.tar.gz
-Source-MD5: 5cc1b2317a90abaca5fcc9a37d8ebada
+Source-MD5: c6a0be9b5949214b7e432ca4b5259af2
 SourceDirectory: pmml
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -48,7 +48,7 @@ CustomMirror: <<
 <<
 Depends: <<
 	r-base%type_pkg[rversion],
-	cran-stringr-r%type_pkg[rversion] (>= 1.2.0),
+	cran-stringr-r%type_pkg[rversion],
 	cran-xml-r%type_pkg[rversion]
 <<
 BuildDepends: r-base%type_pkg[rversion]-dev

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pomp-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pomp-r.info
@@ -11,14 +11,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5)
-Version: 2.7
+Version: 2.8
 Revision: 1
 Description: Partially observed Markov processes methods
 Homepage: https://cran.r-project.org/package=pomp
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:pomp_%v.tar.gz
-Source-MD5: 9e6cffa46a09232fe7eb73c256541a55
+Source-MD5: 2d97d5e7cafd0e57bf57d4ed881b0af1
 SourceDirectory: pomp
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-prim-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-prim-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.0.16
+Version: 1.0.17
 Revision: 1
 Description: Patient Rule Induction Method
 Homepage: https://cran.r-project.org/package=prim
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:prim_%v.tar.gz
-Source-MD5: fcc84bf7d4efaa2dea58ba027e54d88f
+Source-MD5: cb1a8bb583b25b3a166147eec2a8ae54
 SourceDirectory: prim
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-proc-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-proc-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.16.1
+Version: 1.16.2
 Revision: 1
 Description: Display and analyze ROC curves
 Homepage: http://expasy.org/tools/pROC/
 License: GPL
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
 Source: mirror:custom:pROC_%v.tar.gz
-Source-MD5: 9b70044fb48d866973df0740eacfda81
+Source-MD5: 6c9dfc6c91dcbb48c209535a989d5f83
 SourceDirectory: pROC
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-proj4-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-proj4-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.0-9
-Revision: 102
+Version: 1.0-10
+Revision: 1
 Description: PROJ.4 cartographic projections library for R
 Homepage: http://www.rforge.net/proj4/
 License: GPL
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
 Source: http://www.rforge.net/proj4/snapshot/proj4_%v.tar.gz
-Source-MD5: de103b030101e001e9a8a9a91200faa8
+Source-MD5: 8265fb8e11b359a2334974adadb45951
 SourceDirectory: proj4
 Depends: <<
 	fink (>= 0.27.2),

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-prospectr-r-0.1.3.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-prospectr-r-0.1.3.info
@@ -1,6 +1,6 @@
 Info2: <<
 
-Package: cran-quantreg-r%type_pkg[rversion]
+Package: cran-prospectr-r%type_pkg[rversion]
 Distribution: <<
 	(%type_pkg[rversion] = 31 ) 10.9,
 	(%type_pkg[rversion] = 31 ) 10.10,
@@ -23,44 +23,41 @@ Distribution: <<
 	(%type_pkg[rversion] = 34 ) 10.12,
 	(%type_pkg[rversion] = 34 ) 10.13,
 	(%type_pkg[rversion] = 34 ) 10.14,
-	(%type_pkg[rversion] = 34 ) 10.14.5,
-	(%type_pkg[rversion] = 35 ) 10.9,
-	(%type_pkg[rversion] = 35 ) 10.10,
-	(%type_pkg[rversion] = 35 ) 10.11,
-	(%type_pkg[rversion] = 35 ) 10.12,
-	(%type_pkg[rversion] = 35 ) 10.13,
-	(%type_pkg[rversion] = 35 ) 10.14,
-	(%type_pkg[rversion] = 35 ) 10.14.5
+	(%type_pkg[rversion] = 34 ) 10.14.5
 <<
-Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 5.55
-Revision: 1
-Description: Quantile Regression
-Homepage: https://cran.r-project.org/package=quantreg
+Type: rversion (3.4 3.3 3.2 3.1)
+Version: 0.1.3
+Revision: 4
+Description: Processing and sample selection of vis-NIR
+Homepage: http://cran.r-project.org/web/packages/prospectr/index.html
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: mirror:custom:quantreg_%v.tar.gz
-Source-MD5: 7e5391460f1cdacfcaaed14c74607f6f
-SourceDirectory: quantreg
+Source: mirror:custom:prospectr_%v.tar.gz
+Source-MD5: f4bed91a86fb050e603b403e34f69cc4
+SourceDirectory: prospectr
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
-	Secondary: https://cran.r-project.org/src/contrib/00Archive/quantreg
+	Secondary: https://cran.r-project.org/src/contrib/00Archive/prospectr
 <<
 Depends: <<
+	fink (>= 0.27.2), 
 	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion],
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.0-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-3),
-	cran-matrix-r%type_pkg[rversion],
-	cran-matrixmodels-r%type_pkg[rversion],
-	cran-sparsem-r%type_pkg[rversion],
+	cran-foreach-r%type_pkg[rversion],
+	cran-iterators-r%type_pkg[rversion],
+	cran-rcpp-r%type_pkg[rversion] (>= 0.11.0),
+	cran-rcpparmadillo-r%type_pkg[rversion] (>= 0.4.00),
 	(%type_raw[rversion] << 3.6) gcc5-shlibs | (%type_raw[rversion] >= 3.6) gcc9-shlibs,
 	libgettext8-shlibs
 <<
 BuildDepends: <<
-	fink (>= 0.27.2),
+	fink (>= 0.27.2), 
 	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion]-dev,
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3),
+	cran-rcpp-r%type_pkg[rversion]-dev (>= 0.11.0),
+	cran-rcpparmadillo-r%type_pkg[rversion]-dev (>= 0.4.00),
 	(%type_raw[rversion] << 3.6) gcc5-compiler | (%type_raw[rversion] >= 3.6) gcc9-compiler,
 	libgettext8-dev
 <<
@@ -70,29 +67,30 @@ CompileScript: <<
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
-  $BIN_R --verbose CMD build --no-build-vignettes quantreg
+  $BIN_R --verbose CMD build --no-build-vignettes prospectr
 <<
 InstallScript: <<
   #!/bin/sh -ev
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   mkdir -p %i/lib/R/%type_raw[rversion]/site-library
-  pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library quantreg
-  if [ "%type_num[rversion]" -lt "34" ]; then
-	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/quantreg/libs/quantreg.dylib %i/lib/R/%type_raw[rversion]/site-library/quantreg/libs/quantreg.dylib
+  pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library prospectr
+  if (( $(echo "%type_raw[rversion] > 3.3" |bc -l) )); then
+  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/prospectr/libs/prospectr.so %i/lib/R/%type_raw[rversion]/site-library/prospectr/libs/prospectr.so
   else
-	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/quantreg/libs/quantreg.so %i/lib/R/%type_raw[rversion]/site-library/quantreg/libs/quantreg.so
+  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/prospectr/libs/prospectr.dylib %i/lib/R/%type_raw[rversion]/site-library/prospectr/libs/prospectr.dylib
   fi
 <<
 Shlibs: <<
-  ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/quantreg/libs/quantreg.so 0.0.0 %n (>= 5.11-1)
-  ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/quantreg/libs/quantreg.dylib 0.0.0 %n (>= 5.11-1)
+  ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/prospectr/libs/prospectr.so 0.0.0 %n (>= 0.1.3-1)
+  ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/prospectr/libs/prospectr.dylib 0.0.0 %n (>= 0.1.3-1)
 <<
 DescDetail: <<
-Quantile regression and related methods.
+The package provides functions for pretreatment and sample selection
+of visible and near infrared diffuse reflectance spectra
 <<
 DescPackaging: <<
-  R (>= 2.6.0)
+  R (>= 3.0.0)
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-prospectr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-prospectr-r.info
@@ -2,28 +2,6 @@ Info2: <<
 
 Package: cran-prospectr-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 31 ) 10.9,
-	(%type_pkg[rversion] = 31 ) 10.10,
-	(%type_pkg[rversion] = 31 ) 10.11,
-	(%type_pkg[rversion] = 31 ) 10.12,
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.9,
-	(%type_pkg[rversion] = 33 ) 10.10,
-	(%type_pkg[rversion] = 33 ) 10.11,
-	(%type_pkg[rversion] = 33 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.13,
-	(%type_pkg[rversion] = 33 ) 10.14,
-	(%type_pkg[rversion] = 33 ) 10.14.5,
-	(%type_pkg[rversion] = 34 ) 10.9,
-	(%type_pkg[rversion] = 34 ) 10.10,
-	(%type_pkg[rversion] = 34 ) 10.11,
-	(%type_pkg[rversion] = 34 ) 10.12,
-	(%type_pkg[rversion] = 34 ) 10.13,
-	(%type_pkg[rversion] = 34 ) 10.14,
-	(%type_pkg[rversion] = 34 ) 10.14.5,
 	(%type_pkg[rversion] = 35 ) 10.9,
 	(%type_pkg[rversion] = 35 ) 10.10,
 	(%type_pkg[rversion] = 35 ) 10.11,
@@ -32,15 +10,15 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14,
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
-Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 0.1.3
-Revision: 4
+Type: rversion (3.6 3.5)
+Version: 0.2.0
+Revision: 1
 Description: Processing and sample selection of vis-NIR
-Homepage: http://cran.r-project.org/web/packages/prospectr/index.html
+Homepage: https://CRAN.R-project.org/package=prospectr
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:prospectr_%v.tar.gz
-Source-MD5: f4bed91a86fb050e603b403e34f69cc4
+Source-MD5: 82702f50133335f9bc39088c2f95787b
 SourceDirectory: prospectr
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -53,8 +31,8 @@ Depends: <<
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-3),
 	cran-foreach-r%type_pkg[rversion],
 	cran-iterators-r%type_pkg[rversion],
-	cran-rcpp-r%type_pkg[rversion] (>= 0.11.0),
-	cran-rcpparmadillo-r%type_pkg[rversion] (>= 0.4.00),
+	cran-rcpp-r%type_pkg[rversion] (>= 1.0.1-1),
+	cran-rcpparmadillo-r%type_pkg[rversion],
 	(%type_raw[rversion] << 3.6) gcc5-shlibs | (%type_raw[rversion] >= 3.6) gcc9-shlibs,
 	libgettext8-shlibs
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-purrr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-purrr-r.info
@@ -29,14 +29,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 0.3.3
+Version: 0.3.4
 Revision: 1
 Description: Functional Programming Tools
 Homepage: https://cran.r-project.org/package=purrr
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:purrr_%v.tar.gz
-Source-MD5: c8eb681161e566440cae83b36d84704a
+Source-MD5: e5800da22652606547ab14b7ae38058e
 SourceDirectory: purrr
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-qtl-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-qtl-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.45-11
+Version: 1.46-2
 Revision: 1
 Description: Quantitative trait loci
 Homepage: https://cran.r-project.org/package=qtl
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:qtl_%v.tar.gz
-Source-MD5: 55172fa7aa7b10e424e07342890d2228
+Source-MD5: 54165309f32871eed747848886f18b79
 SourceDirectory: qtl
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-quantmod-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-quantmod-r.info
@@ -29,14 +29,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 0.4-16
+Version: 0.4.17
 Revision: 1
 Description: Quantitative Financial Modelling Framework
 Homepage: https://cran.r-project.org/package=quantmod
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:quantmod_%v.tar.gz
-Source-MD5: 956c7a8a3fc839c2e33dd94326f84508
+Source-MD5: ccdf848e8d5964ea07354b3a8de477af
 SourceDirectory: quantmod
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcpp-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcpp-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.0.3
+Version: 1.0.4.6
 Revision: 1
 Description: Seamless R and C++ Integration
 Homepage: https://cran.r-project.org/package=Rcpp
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:Rcpp_%v.tar.gz
-Source-MD5: 0171ac73ab1635df72395dcc5450d48d
+Source-MD5: 59c45d80a5dc8dc3b5635ffd3fec64e9
 SourceDirectory: Rcpp
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -90,7 +90,7 @@ SplitOff: <<
   Description: Headers for CRAN Rcpp
   BuildDependsOnly: true
   Depends: %N (=%v-%r)
-  Files: lib/R/%type_raw[rversion]/site-library/Rcpp/include
+  Files: lib/R/%type_raw[rversion]/site-library/Rcpp/include lib/R/%type_raw[rversion]/site-library/Rcpp/tinytest/testRcppInterfaceExporter/inst/include
 <<
 Shlibs: <<
   ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/Rcpp/libs/Rcpp.so 0.0.0 %n (>=0.12.11-1)
@@ -102,6 +102,8 @@ facilitate the integration of R and C++.
 <<
 DescPackaging: <<
   R (>= 3.0.0)
+  
+  1.0.4.6: Add to -dev: lib/R/%type_raw[rversion]/site-library/Rcpp/tinytest/testRcppInterfaceExporter/inst/include
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcpparmadillo-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcpparmadillo-r.info
@@ -25,14 +25,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3)
-Version: 0.9.850.1.0
+Version: 0.9.860.2.0
 Revision: 1
 Description: Rcpp integration for Armadillo
 Homepage: https://cran.r-project.org/package=RcppArmadillo 
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:RcppArmadillo_%v.tar.gz
-Source-MD5: d0abe2c245e3d99dd16dcfd62a660368
+Source-MD5: 9c7679ca473c740a4c4b539f446f23a0
 SourceDirectory: RcppArmadillo
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcurl-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rcurl-r.info
@@ -18,14 +18,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 1.98-1.1
+Version: 1.98-1.2
 Revision: 1
 Description: Network client (HTTP/FTP/...) R interface
 Homepage: https://cran.r-project.org/package=RCurl
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:RCurl_%v.tar.gz
-Source-MD5: f009eae167bf115209bb531a72aeea24
+Source-MD5: 8a65643fd6e55f0917e11b4b0009993e
 SourceDirectory: RCurl
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-recipes-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-recipes-r.info
@@ -29,14 +29,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 0.1.9
+Version: 0.1.10
 Revision: 1
 Description: Preprocessing Tools to Create Design Matrices
 Homepage: https://cran.r-project.org/package=recipes
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:recipes_%v.tar.gz
-Source-MD5: 68bf20830e13fae4364e9e8e8c9927e4
+Source-MD5: 27a314365350304dbc24327e7ead88e6
 SourceDirectory: recipes
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -53,7 +53,6 @@ Depends: <<
 	cran-magrittr-r%type_pkg[rversion],
 	cran-matrix-r%type_pkg[rversion],
 	cran-purrr-r%type_pkg[rversion] (>= 0.2.3-1),
-	cran-rcpproll-r%type_pkg[rversion],
 	cran-rlang-r%type_pkg[rversion] (>= 0.4.0-1),
 	cran-tibble-r%type_pkg[rversion],
 	cran-tidyr-r%type_pkg[rversion] (>= 0.8.3-1),

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-reshape2-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-reshape2-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.4.3
+Version: 1.4.4
 Revision: 1
 Description: Flexibly reshape data
 Homepage: https://cran.r-project.org/package=reshape2
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:reshape2_%v.tar.gz
-Source-MD5: 8f35f5a2b7d4f081e9825f1095133288
+Source-MD5: ab6b937ba184817a8f33690b5ed6ffcb
 SourceDirectory: reshape2
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -51,7 +51,7 @@ Depends: <<
 	( %type_raw[rversion] = 3.3 ) r-base%type_pkg[rversion] (>= 3.3.2-2),
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.5-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-5),
-	cran-plyr-r%type_pkg[rversion] (>= 1.8.1),
+	cran-plyr-r%type_pkg[rversion] (>= 1.8.1-1),
 	cran-rcpp-r%type_pkg[rversion],
 	cran-stringr-r%type_pkg[rversion],
 	libgettext8-shlibs

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rgl-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rgl-r.info
@@ -29,14 +29,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 0.100.30
+Version: 0.100.54
 Revision: 1
 Description: 3D visualization device system
 Homepage: https://cran.r-project.org/package=rgl
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:rgl_%v.tar.gz
-Source-MD5: 6eaccdfff3daf586ce0d0d991f2d3270
+Source-MD5: 02bc519bf468df5cd3dcd6b826ede51f
 SourceDirectory: rgl
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -47,10 +47,10 @@ Depends: <<
 	cran-crosstalk-r%type_pkg[rversion], 
 	cran-htmltools-r%type_pkg[rversion], 
 	cran-htmlwidgets-r%type_pkg[rversion], 
-	cran-jsonlite-r%type_pkg[rversion] (>= 0.9.20), 
+	cran-jsonlite-r%type_pkg[rversion] (>= 0.9.20-1), 
 	cran-knitr-r%type_pkg[rversion], 
 	cran-magrittr-r%type_pkg[rversion], 
-	cran-manipulatewidget-r%type_pkg[rversion] (>= 0.9.0), 
+	cran-manipulatewidget-r%type_pkg[rversion] (>= 0.9.0-1), 
 	cran-shiny-r%type_pkg[rversion], 
 	bzip2-shlibs,
 	freetype219-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-robustbase-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-robustbase-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 0.93-5
-Revision: 2
+Version: 0.93-6
+Revision: 1
 Description: GNU R Tools for robust methods
 Homepage: https://cran.r-project.org/package=robustbase
 License: GPL
 Maintainer: David Fang <fangism@users.sourceforge.net>
 Source: mirror:custom:robustbase_%v.tar.gz
-Source-MD5: 539caa30bb62705aba7779214214dfbb
+Source-MD5: cc603acaafb08119734091a8a02e1b9d
 SourceDirectory: robustbase
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-roxygen2-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-roxygen2-r.info
@@ -29,14 +29,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 7.0.2
+Version: 7.1.0
 Revision: 1
 Description: In-source documentation for R
 Homepage: https://cran.r-project.org/package=roxygen2
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:roxygen2_%v.tar.gz
-Source-MD5: 95a793d446f18c00d2e885b2a0d289ea
+Source-MD5: 5de172eee2223d402fbc4f71fe345185
 SourceDirectory: roxygen2
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -48,9 +48,10 @@ Depends: <<
 	cran-commonmark-r%type_pkg[rversion], 
 	cran-desc-r%type_pkg[rversion] (>= 1.2.0-1), 
 	cran-digest-r%type_pkg[rversion], 
+	cran-knitr-r%type_pkg[rversion], 
 	cran-pkgload-r%type_pkg[rversion] (>= 1.0.2-1), 
 	cran-purrr-r%type_pkg[rversion] (>= 0.3.3-1), 
-	cran-r6-r%type_pkg[rversion], 
+	cran-r6-r%type_pkg[rversion] (>= 2.1.2-1), 
 	cran-rcpp-r%type_pkg[rversion] (>= 0.11.0-1),  
 	cran-stringi-r%type_pkg[rversion], 
 	cran-stringr-r%type_pkg[rversion] (>= 1.0.0-1), 

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-sfsmisc-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-sfsmisc-r.info
@@ -29,14 +29,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 1.1-5
+Version: 1.1-6
 Revision: 1
 Description: Utilities from Statistik ETH Zurich seminar
 Homepage: https://cran.r-project.org/package=sfsmisc
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:sfsmisc_%v.tar.gz
-Source-MD5: c71438093ee44b6a31e11d75511e6b14
+Source-MD5: 72e46478bced767a50df05f0ca9263a3
 SourceDirectory: sfsmisc
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-shiny-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-shiny-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.4.0
+Version: 1.4.0.2
 Revision: 1
 Description: Web Application Framework for R
 Homepage: https://cran.r-project.org/package=shiny
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:shiny_%v.tar.gz
-Source-MD5: 89acec799bb23da271a7770b84283844
+Source-MD5: b9f24697906a59e3e3e6bddede129105
 SourceDirectory: shiny
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-sn-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-sn-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.5-5
+Version: 1.6-1
 Revision: 1
 Description: Skew-normal and skew-t distributions
 Homepage: https://cran.r-project.org/package=sn
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:sn_%v.tar.gz
-Source-MD5: 59dec3b8a4ce9f1a4d7d93779712fb42
+Source-MD5: 725f554eff407be52b4d6b6f0ee54874
 SourceDirectory: sn
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -49,7 +49,8 @@ CustomMirror: <<
 Depends: <<
 	r-base%type_pkg[rversion],
 	cran-mnormt-r%type_pkg[rversion] (>= 1.5-4-1),
-	cran-numderiv-r%type_pkg[rversion]
+	cran-numderiv-r%type_pkg[rversion],
+	cran-quantreg-r%type_pkg[rversion]
 <<
 BuildDepends: r-base%type_pkg[rversion]-dev
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-subselect-r-0.14.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-subselect-r-0.14.info
@@ -2,23 +2,38 @@ Info2: <<
 
 Package: cran-subselect-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 35 ) 10.9,
-	(%type_pkg[rversion] = 35 ) 10.10,
-	(%type_pkg[rversion] = 35 ) 10.11,
-	(%type_pkg[rversion] = 35 ) 10.12,
-	(%type_pkg[rversion] = 35 ) 10.13,
-	(%type_pkg[rversion] = 35 ) 10.14,
-	(%type_pkg[rversion] = 35 ) 10.14.5
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12,
+	(%type_pkg[rversion] = 32 ) 10.9,
+	(%type_pkg[rversion] = 32 ) 10.10,
+	(%type_pkg[rversion] = 32 ) 10.11,
+	(%type_pkg[rversion] = 32 ) 10.12,
+	(%type_pkg[rversion] = 33 ) 10.9,
+	(%type_pkg[rversion] = 33 ) 10.10,
+	(%type_pkg[rversion] = 33 ) 10.11,
+	(%type_pkg[rversion] = 33 ) 10.12,
+	(%type_pkg[rversion] = 33 ) 10.13,
+	(%type_pkg[rversion] = 33 ) 10.14,
+	(%type_pkg[rversion] = 33 ) 10.14.5,
+	(%type_pkg[rversion] = 34 ) 10.9,
+	(%type_pkg[rversion] = 34 ) 10.10,
+	(%type_pkg[rversion] = 34 ) 10.11,
+	(%type_pkg[rversion] = 34 ) 10.12,
+	(%type_pkg[rversion] = 34 ) 10.13,
+	(%type_pkg[rversion] = 34 ) 10.14,
+	(%type_pkg[rversion] = 34 ) 10.14.5
 <<
-Type: rversion (3.6 3.5)
-Version: 0.15.2
-Revision: 1
+Type: rversion (3.4 3.3 3.2 3.1)
+Version: 0.14
+Revision: 2
 Description: Selecting variable subsets
 Homepage: https://cran.r-project.org/package=subselect
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:subselect_%v.tar.gz
-Source-MD5: 59efa2c1517aa81f9249a50c48bae388
+Source-MD5: 77a00304b44efde794d1d35f798bd286
 SourceDirectory: subselect
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -44,6 +59,7 @@ BuildDepends: <<
 <<
 CompileScript: <<
   #!/bin/bash -ev
+  export TMPDIR=%b/tmp
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-survey-r-3.37.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-survey-r-3.37.info
@@ -2,41 +2,20 @@ Info2: <<
 
 Package: cran-survey-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.9,
-	(%type_pkg[rversion] = 33 ) 10.10,
-	(%type_pkg[rversion] = 33 ) 10.11,
-	(%type_pkg[rversion] = 33 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.13,
-	(%type_pkg[rversion] = 33 ) 10.14,
-	(%type_pkg[rversion] = 33 ) 10.14.5,
-	(%type_pkg[rversion] = 34 ) 10.9,
-	(%type_pkg[rversion] = 34 ) 10.10,
-	(%type_pkg[rversion] = 34 ) 10.11,
-	(%type_pkg[rversion] = 34 ) 10.12,
-	(%type_pkg[rversion] = 34 ) 10.13,
-	(%type_pkg[rversion] = 34 ) 10.14,
-	(%type_pkg[rversion] = 34 ) 10.14.5,
-	(%type_pkg[rversion] = 35 ) 10.9,
-	(%type_pkg[rversion] = 35 ) 10.10,
-	(%type_pkg[rversion] = 35 ) 10.11,
-	(%type_pkg[rversion] = 35 ) 10.12,
-	(%type_pkg[rversion] = 35 ) 10.13,
-	(%type_pkg[rversion] = 35 ) 10.14,
-	(%type_pkg[rversion] = 35 ) 10.14.5
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12
 <<
-Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 4.0
+Type: rversion (3.1)
+Version: 3.37
 Revision: 1
 Description: Analysis of complex survey samples
 Homepage: https://cran.r-project.org/package=survey
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:survey_%v.tar.gz
-Source-MD5: 3632df646f5ccfaab284b1a79ca5cf4a
+Source-MD5: 49e09741a9d3d854cc3f13c0bde0f730
 SourceDirectory: survey
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-teachingdemos-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-teachingdemos-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 2.10
-Revision: 2
+Version: 2.12
+Revision: 1
 Description: Demonstrations for Teaching and Learning
 Homepage: https://cran.r-project.org/package=TeachingDemos
 License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:TeachingDemos_%v.tar.gz
-Source-MD5: 7e87e05fd878261927903896cdea801a
+Source-MD5: e8163919b46cd8ea6feaa4b74fbf1dcc
 SourceDirectory: TeachingDemos
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tibble-r-2.1.3.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tibble-r-2.1.3.info
@@ -2,42 +2,20 @@ Info2: <<
 
 Package: cran-tibble-r%type_pkg[rversion]
 Distribution: <<
-	(%type_pkg[rversion] = 32 ) 10.9,
-	(%type_pkg[rversion] = 32 ) 10.10,
-	(%type_pkg[rversion] = 32 ) 10.11,
-	(%type_pkg[rversion] = 32 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.9,
-	(%type_pkg[rversion] = 33 ) 10.10,
-	(%type_pkg[rversion] = 33 ) 10.11,
-	(%type_pkg[rversion] = 33 ) 10.12,
-	(%type_pkg[rversion] = 33 ) 10.13,
-	(%type_pkg[rversion] = 33 ) 10.14,
-	(%type_pkg[rversion] = 33 ) 10.14.5,
-	(%type_pkg[rversion] = 34 ) 10.9,
-	(%type_pkg[rversion] = 34 ) 10.10,
-	(%type_pkg[rversion] = 34 ) 10.11,
-	(%type_pkg[rversion] = 34 ) 10.12,
-	(%type_pkg[rversion] = 34 ) 10.13,
-	(%type_pkg[rversion] = 34 ) 10.14,
-	(%type_pkg[rversion] = 34 ) 10.14.5,
-	(%type_pkg[rversion] = 35 ) 10.9,
-	(%type_pkg[rversion] = 35 ) 10.10,
-	(%type_pkg[rversion] = 35 ) 10.11,
-	(%type_pkg[rversion] = 35 ) 10.12,
-	(%type_pkg[rversion] = 35 ) 10.13,
-	(%type_pkg[rversion] = 35 ) 10.14,
-	(%type_pkg[rversion] = 35 ) 10.14.5
+	(%type_pkg[rversion] = 31 ) 10.9,
+	(%type_pkg[rversion] = 31 ) 10.10,
+	(%type_pkg[rversion] = 31 ) 10.11,
+	(%type_pkg[rversion] = 31 ) 10.12
 <<
-# See DescPackaging
-Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 3.0.0
+Type: rversion (3.1)
+Version: 2.1.3
 Revision: 1
 Description: Simple Data Frames
 Homepage: https://cran.r-project.org/package=tibble
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:tibble_%v.tar.gz
-Source-MD5: 9655439192084e64c1da7259d6db11cd
+Source-MD5: 7e5ed364e6741c7ea2f0fb0caf659094
 SourceDirectory: tibble
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -45,27 +23,17 @@ CustomMirror: <<
 <<
 Depends: <<
 	fink (>= 0.27.2),
-	( %type_raw[rversion] >= 3.4 ) r-base%type_pkg[rversion] (>= 3.4.0-2),
-	( %type_raw[rversion] = 3.3 ) r-base%type_pkg[rversion] (>= 3.3.2-2),
-	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.5-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-5),
-	cran-cli-r%type_pkg[rversion],
-	cran-crayon-r%type_pkg[rversion] (>= 1.3.4-1),
-	cran-ellipsis-r%type_pkg[rversion] (>= 0.2.0-1),
-	cran-fansi-r%type_pkg[rversion] (>= 0.4.0-1),
-	cran-lifecycle-r%type_pkg[rversion] (>= 0.2.0-1),
-	cran-magrittr-r%type_pkg[rversion],
-	cran-pillar-r%type_pkg[rversion] (>= 1.4.3-1),
+	cran-cli-r%type_pkg[rversion] (>= 1.0.1),
+	cran-crayon-r%type_pkg[rversion] (>= 1.3.4),
+	cran-fansi-r%type_pkg[rversion] (>= 0.4.0),
+	cran-pillar-r%type_pkg[rversion] (>= 1.3.1),
 	cran-pkgconfig-r%type_pkg[rversion] (>= 2.0.2),
-	cran-rlang-r%type_pkg[rversion] (>= 0.4.3),
-	cran-vctrs-r%type_pkg[rversion],
+	cran-rlang-r%type_pkg[rversion] (>= 0.3.0),
 	libgettext8-shlibs
 <<
 BuildDepends: <<
 	fink (>= 0.27.2),
-	( %type_raw[rversion] >= 3.4 ) r-base%type_pkg[rversion]-dev (>= 3.4.0-2),
-	( %type_raw[rversion] = 3.3 ) r-base%type_pkg[rversion]-dev (>= 3.3.2-2),
-	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3),
 	libgettext8-dev,
 	texlive-base
@@ -99,8 +67,7 @@ Provides a `tbl_df' class (the `tibble') that provides stricter checking
 and better formatting than the traditional data frame.
 <<
 DescPackaging: <<
-  As of 3.0.0, the homepage says the packages depends on R (>= 3.1.0),
-  but the depending package, lifecycle (>= 0.2.0) is only aviable for R (>= 3.2.0).
+  R (>= 3.1.0)
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tinytex-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tinytex-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 0.20
+Version: 0.22
 Revision: 1
 Description: Functions to Maintain 'TeX Live'
 Homepage: https://cran.r-project.org/package=tinytex
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:tinytex_%v.tar.gz
-Source-MD5: 699bb2b52f9db7f2f1f22b5d698a9f3a
+Source-MD5: d38e2bc8a4f017daa7d4e6cb609b83a7
 SourceDirectory: tinytex
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tsp-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-tsp-r.info
@@ -11,14 +11,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5)
-Version: 1.1-9
+Version: 1.1-10
 Revision: 1
 Description: Traveling Salesperson Problem
 Homepage: https://cran.r-project.org/package=TSP
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:TSP_%v.tar.gz
-Source-MD5: 7325ca348bbb5f361b241b7ee99b29e7
+Source-MD5: ddc8af45d421b2d615eb9befa6485df3
 SourceDirectory: TSP
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-v8-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-v8-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 3.0.1
+Version: 3.0.2
 Revision: 1
 Description: Embedded JavaScript Engine for R
 Homepage: https://cran.r-project.org/package=V8
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:V8_%v.tar.gz
-Source-MD5: 45d437980db89771b7917d3e6b0f2b8c
+Source-MD5: c565d33e3f55dddf23b884feed37c544
 SourceDirectory: V8
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-vcd-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-vcd-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.4-6
+Version: 1.4-7
 Revision: 1
 Description: Visualizing Categorical Data
 Homepage: https://cran.r-project.org/package=vcd
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:vcd_%v.tar.gz
-Source-MD5: f1854de1aea522079f2d9b2570425516
+Source-MD5: 937c6d99f544880ed149a110411de6c6
 SourceDirectory: vcd
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-waveslim-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-waveslim-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.7.5.2
+Version: 1.8.2
 Revision: 1
 Description: Basic wavelet routines
 Homepage: https://cran.r-project.org/package=waveslim
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:waveslim_%v.tar.gz
-Source-MD5: 73f865808dfb0f22fed182bf7f8deb3b
+Source-MD5: 94d6a1affaf5ebc93ad3e8d1a51115ce
 SourceDirectory: waveslim
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-xfun-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-xfun-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 0.12
+Version: 0.13
 Revision: 1
 Description: Misc. functions by Yihui Xie
 Homepage: https://cran.r-project.org/package=xfun
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:xfun_%v.tar.gz
-Source-MD5: 0820c61fc7b7f4305a8b2c54dc9204a4
+Source-MD5: cdc8750fbf7f071fcc15e638c948de46
 SourceDirectory: xfun
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-xml2-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-xml2-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.2.4
+Version: 1.3.1
 Revision: 1
 Description: Parse XML
 Homepage: https://cran.r-project.org/package=xml2
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:xml2_%v.tar.gz
-Source-MD5: b07aa18879034bb886be07906b2129fe
+Source-MD5: 3e70019d9f92e436592f417dfdf24728
 SourceDirectory: xml2
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -50,8 +50,6 @@ Depends: <<
 	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion],
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.0-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-3),
-	cran-bh-r%type_pkg[rversion],
-	cran-rcpp-r%type_pkg[rversion],
 	(%type_raw[rversion] << 3.6) gcc5-shlibs | (%type_raw[rversion] >= 3.6) gcc9-shlibs,
 	libxml2-shlibs,
 	libgettext8-shlibs
@@ -61,11 +59,9 @@ BuildDepends: <<
 	( %type_raw[rversion] >= 3.3 ) r-base%type_pkg[rversion]-dev,
 	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.0-2),
 	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-3),
-	cran-rcpp-r%type_pkg[rversion]-dev,
 	(%type_raw[rversion] << 3.6) gcc5-compiler | (%type_raw[rversion] >= 3.6) gcc9-compiler,
 	libxml2,
-	libgettext8-dev,
-	texlive-base
+	libgettext8-dev
 <<
 GCC: 4.0
 CompileScript: <<


### PR DESCRIPTION
cran-rcpp-r has an include directory in a subdirectory, which is moved to the -dev variant.  I am not sure if this is the best solution.
The blow packages use R-3.2 functions and thus -r31 is left unupdated: glue, locfit, lubridate, prospectr, subselect and tibble.
cran-forecast-r31 does not build since 8.10, so reverted to 8.9.  Similarly, cran-igraph-r31 is reverted to 1.2.4.1.