### PR TITLE
proper detection of clang-v11 from Xcode 11.4 (python)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/python27.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python27.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: python27.patch -*-
 Info2: <<
 Package: python%type_pkg[python]
-Version: 2.7.17
+Version: 2.7.18
 Revision: 1
 Epoch: 1
 Type: python 2.7
@@ -46,12 +46,12 @@ Recommends: pip-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
 
 Provides: argparse-py%type_pkg[python]
 Source: http://python.org/ftp/python/%v/Python-%v.tar.xz
-Source-Checksum: SHA256(4d43f033cdbd0aa7b7023c81b0e986fd11e653b5248dac9144d508f11812ba41)
+Source-Checksum: SHA256(b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43)
 Source2: http://www.python.org/ftp/python/doc/%v/python-%v-docs-html.tar.bz2
-Source2-Checksum: SHA256(d7388cfcf28591e5ab09932f70d180b1288130942779ead1fb40f750d72c18eb)
+Source2-Checksum: SHA256(20445e9a571cacdd350f702f0980e4dc559b6ff81f1d69affe9b0a862fef2f0e)
 
 PatchFile: %n.patch
-PatchFile-MD5: 7ce67967ae45dbc71f765eb66e44ab48
+PatchFile-MD5: 84983fcb7eb4677be2ff56ccfcf12671
 PatchScript: <<
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 	perl -pi -e 's|/usr/local|%p|' setup.py

--- a/10.9-libcxx/stable/main/finkinfo/languages/python27.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python27.patch
@@ -1,6 +1,6 @@
-diff -ru Python-2.7.15.orig/Lib/ctypes/macholib/dyld.py Python-2.7.15/Lib/ctypes/macholib/dyld.py
---- Python-2.7.15.orig/Lib/ctypes/macholib/dyld.py	2018-04-29 18:47:33.000000000 -0400
-+++ Python-2.7.15/Lib/ctypes/macholib/dyld.py	2018-05-03 20:59:49.000000000 -0400
+diff -ruN Python-2.7.17.orig/Lib/ctypes/macholib/dyld.py Python-2.7.17/Lib/ctypes/macholib/dyld.py
+--- Python-2.7.17.orig/Lib/ctypes/macholib/dyld.py	2019-10-19 13:38:44.000000000 -0500
++++ Python-2.7.17/Lib/ctypes/macholib/dyld.py	2020-04-21 04:12:43.000000000 -0500
 @@ -23,6 +23,7 @@
  
  DEFAULT_LIBRARY_FALLBACK = [
@@ -9,10 +9,10 @@ diff -ru Python-2.7.15.orig/Lib/ctypes/macholib/dyld.py Python-2.7.15/Lib/ctypes
      "/usr/local/lib",
      "/lib",
      "/usr/lib",
-diff -ru Python-2.7.15.orig/Lib/platform.py Python-2.7.15/Lib/platform.py
---- Python-2.7.15.orig/Lib/platform.py	2018-04-29 18:47:33.000000000 -0400
-+++ Python-2.7.15/Lib/platform.py	2018-05-03 20:59:49.000000000 -0400
-@@ -771,6 +771,15 @@
+diff -ruN Python-2.7.17.orig/Lib/platform.py Python-2.7.17/Lib/platform.py
+--- Python-2.7.17.orig/Lib/platform.py	2019-10-19 13:38:44.000000000 -0500
++++ Python-2.7.17/Lib/platform.py	2020-04-21 04:12:43.000000000 -0500
+@@ -804,6 +804,15 @@
      if info is not None:
          return info
  
@@ -28,9 +28,9 @@ diff -ru Python-2.7.15.orig/Lib/platform.py Python-2.7.15/Lib/platform.py
      # If that also doesn't work return the default values
      return release,versioninfo,machine
  
-diff -ru Python-2.7.15.orig/Lib/sysconfig.py Python-2.7.15/Lib/sysconfig.py
---- Python-2.7.15.orig/Lib/sysconfig.py	2018-04-29 18:47:33.000000000 -0400
-+++ Python-2.7.15/Lib/sysconfig.py	2018-05-03 20:59:49.000000000 -0400
+diff -ruN Python-2.7.17.orig/Lib/sysconfig.py Python-2.7.17/Lib/sysconfig.py
+--- Python-2.7.17.orig/Lib/sysconfig.py	2019-10-19 13:38:44.000000000 -0500
++++ Python-2.7.17/Lib/sysconfig.py	2020-04-21 04:12:43.000000000 -0500
 @@ -312,12 +312,6 @@
              msg = msg + " (%s)" % e.strerror
          raise IOError(msg)
@@ -44,10 +44,10 @@ diff -ru Python-2.7.15.orig/Lib/sysconfig.py Python-2.7.15/Lib/sysconfig.py
      # There's a chicken-and-egg situation on OS X with regards to the
      # _sysconfigdata module after the changes introduced by #15298:
      # get_config_vars() is called by get_platform() as part of the
-diff -ru Python-2.7.15.orig/Lib/test/test_uuid.py Python-2.7.15/Lib/test/test_uuid.py
---- Python-2.7.15.orig/Lib/test/test_uuid.py	2018-04-29 18:47:33.000000000 -0400
-+++ Python-2.7.15/Lib/test/test_uuid.py	2018-05-03 22:06:03.000000000 -0400
-@@ -438,7 +438,7 @@
+diff -ruN Python-2.7.17.orig/Lib/test/test_uuid.py Python-2.7.17/Lib/test/test_uuid.py
+--- Python-2.7.17.orig/Lib/test/test_uuid.py	2019-10-19 13:38:44.000000000 -0500
++++ Python-2.7.17/Lib/test/test_uuid.py	2020-04-21 04:12:43.000000000 -0500
+@@ -471,7 +471,7 @@
          self.assertTrue(0 < node < (1L << 48),
                          "%s is not an RFC 4122 node ID" % hex)
  
@@ -56,9 +56,9 @@ diff -ru Python-2.7.15.orig/Lib/test/test_uuid.py Python-2.7.15/Lib/test/test_uu
      def test_ifconfig_getnode(self):
          node = uuid._ifconfig_getnode()
          self.check_node(node, 'ifconfig')
-diff -ru Python-2.7.15.orig/Makefile.pre.in Python-2.7.15/Makefile.pre.in
---- Python-2.7.15.orig/Makefile.pre.in	2018-04-29 18:47:33.000000000 -0400
-+++ Python-2.7.15/Makefile.pre.in	2018-05-03 20:59:49.000000000 -0400
+diff -ruN Python-2.7.17.orig/Makefile.pre.in Python-2.7.17/Makefile.pre.in
+--- Python-2.7.17.orig/Makefile.pre.in	2019-10-19 13:38:44.000000000 -0500
++++ Python-2.7.17/Makefile.pre.in	2020-04-21 04:12:43.000000000 -0500
 @@ -548,7 +548,7 @@
  	fi
  
@@ -68,7 +68,7 @@ diff -ru Python-2.7.15.orig/Makefile.pre.in Python-2.7.15/Makefile.pre.in
  
  
  libpython$(VERSION).sl: $(LIBRARY_OBJS)
-@@ -992,7 +992,7 @@
+@@ -998,7 +998,7 @@
  # Install the interpreter with $(VERSION) affixed
  # This goes into $(exec_prefix)
  altbininstall:	$(BUILDPYTHON)
@@ -77,7 +77,7 @@ diff -ru Python-2.7.15.orig/Makefile.pre.in Python-2.7.15/Makefile.pre.in
  	do \
  		if test ! -d $(DESTDIR)$$i; then \
  			echo "Creating directory $$i"; \
-@@ -1005,9 +1005,9 @@
+@@ -1011,9 +1011,9 @@
  		if test -n "$(DLLLIBRARY)" ; then \
  			$(INSTALL_SHARED) $(DLLLIBRARY) $(DESTDIR)$(BINDIR); \
  		else \
@@ -89,9 +89,9 @@ diff -ru Python-2.7.15.orig/Makefile.pre.in Python-2.7.15/Makefile.pre.in
  			fi \
  		fi; \
  	else	true; \
-diff -ru Python-2.7.15.orig/Misc/python-config.in Python-2.7.15/Misc/python-config.in
---- Python-2.7.15.orig/Misc/python-config.in	2018-04-29 18:47:33.000000000 -0400
-+++ Python-2.7.15/Misc/python-config.in	2018-05-03 20:59:49.000000000 -0400
+diff -ruN Python-2.7.17.orig/Misc/python-config.in Python-2.7.17/Misc/python-config.in
+--- Python-2.7.17.orig/Misc/python-config.in	2019-10-19 13:38:44.000000000 -0500
++++ Python-2.7.17/Misc/python-config.in	2020-04-21 04:12:43.000000000 -0500
 @@ -47,12 +47,10 @@
          libs = ['-lpython' + pyver]
          libs += getvar('LIBS').split()
@@ -109,9 +109,9 @@ diff -ru Python-2.7.15.orig/Misc/python-config.in Python-2.7.15/Misc/python-conf
 +            libs.extend(getvar('LINKFORSHARED').split())
          print ' '.join(libs)
  
-diff -ru Python-2.7.15.orig/Misc/python.pc.in Python-2.7.15/Misc/python.pc.in
---- Python-2.7.15.orig/Misc/python.pc.in	2018-04-29 18:47:33.000000000 -0400
-+++ Python-2.7.15/Misc/python.pc.in	2018-05-03 20:59:49.000000000 -0400
+diff -ruN Python-2.7.17.orig/Misc/python.pc.in Python-2.7.17/Misc/python.pc.in
+--- Python-2.7.17.orig/Misc/python.pc.in	2019-10-19 13:38:44.000000000 -0500
++++ Python-2.7.17/Misc/python.pc.in	2020-04-21 04:12:43.000000000 -0500
 @@ -1,6 +1,6 @@
  prefix=@prefix@
  exec_prefix=@exec_prefix@
@@ -120,9 +120,9 @@ diff -ru Python-2.7.15.orig/Misc/python.pc.in Python-2.7.15/Misc/python.pc.in
  includedir=@includedir@
  
  Name: Python
-diff -ru Python-2.7.15.orig/Modules/dbmmodule.c Python-2.7.15/Modules/dbmmodule.c
---- Python-2.7.15.orig/Modules/dbmmodule.c	2018-04-29 18:47:33.000000000 -0400
-+++ Python-2.7.15/Modules/dbmmodule.c	2018-05-03 20:59:49.000000000 -0400
+diff -ruN Python-2.7.17.orig/Modules/dbmmodule.c Python-2.7.17/Modules/dbmmodule.c
+--- Python-2.7.17.orig/Modules/dbmmodule.c	2019-10-19 13:38:44.000000000 -0500
++++ Python-2.7.17/Modules/dbmmodule.c	2020-04-21 04:12:43.000000000 -0500
 @@ -19,7 +19,7 @@
  static char *which_dbm = "GNU gdbm";  /* EMX port of GDBM */
  #endif
@@ -132,9 +132,9 @@ diff -ru Python-2.7.15.orig/Modules/dbmmodule.c Python-2.7.15/Modules/dbmmodule.
  static char *which_dbm = "GNU gdbm";
  #elif defined(HAVE_GDBM_DASH_NDBM_H)
  #include <gdbm-ndbm.h>
-diff -ru Python-2.7.15.orig/configure Python-2.7.15/configure
---- Python-2.7.15.orig/configure	2018-04-29 18:47:33.000000000 -0400
-+++ Python-2.7.15/configure	2018-05-03 21:02:13.000000000 -0400
+diff -ruN Python-2.7.17.orig/configure Python-2.7.17/configure
+--- Python-2.7.17.orig/configure	2019-10-19 13:38:44.000000000 -0500
++++ Python-2.7.17/configure	2020-04-21 04:12:43.000000000 -0500
 @@ -5516,7 +5516,7 @@
  	  ;;
      Darwin*)
@@ -144,7 +144,16 @@ diff -ru Python-2.7.15.orig/configure Python-2.7.15/configure
  	RUNSHARED=DYLD_LIBRARY_PATH=`pwd`${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}
  	;;
      AIX*)
-@@ -8474,8 +8474,8 @@
+@@ -8421,7 +8421,7 @@
+     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -compatibility_version $(VERSION) -current_version $(VERSION)';;
+   Darwin/*)
+     gcc_version=`gcc -dumpversion`
+-    if test ${gcc_version} '<' 4.0
++    if test `echo ${gcc_version} | cut -f1 -d.` -lt 4
+         then
+             LIBTOOL_CRUFT="-lcc_dynamic"
+         else
+@@ -8481,8 +8481,8 @@
  
      fi
  
@@ -155,7 +164,7 @@ diff -ru Python-2.7.15.orig/configure Python-2.7.15/configure
      LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -compatibility_version $(VERSION) -current_version $(VERSION)';;
  esac
  
-@@ -8648,9 +8648,9 @@
+@@ -8655,9 +8655,9 @@
  			fi
  		else
  			# building for OS X 10.3 and later
@@ -168,7 +177,7 @@ diff -ru Python-2.7.15.orig/configure Python-2.7.15/configure
  		fi
  		;;
  	Linux*|GNU*|QNX*)
-@@ -9041,7 +9041,7 @@
+@@ -9048,7 +9048,7 @@
  if test "x$ac_cv_lib_intl_textdomain" = xyes; then :
  
  $as_echo "#define WITH_LIBINTL 1" >>confdefs.h
@@ -176,8 +185,8 @@ diff -ru Python-2.7.15.orig/configure Python-2.7.15/configure
 +LIBS="-lintl $LIBS"
  fi
  
- 
-@@ -14593,7 +14593,7 @@
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing bind_textdomain_codeset" >&5
+@@ -14609,7 +14609,7 @@
  
  # first curses configure check
  ac_save_cppflags="$CPPFLAGS"
@@ -186,7 +195,7 @@ diff -ru Python-2.7.15.orig/configure Python-2.7.15/configure
  
  for ac_header in curses.h ncurses.h
  do :
-@@ -15198,7 +15198,7 @@
+@@ -15214,7 +15214,7 @@
  
  if test $ac_sys_system = Darwin
  then
@@ -195,10 +204,10 @@ diff -ru Python-2.7.15.orig/configure Python-2.7.15/configure
  fi
  
  
-diff -ru Python-2.7.15.orig/setup.py Python-2.7.15/setup.py
---- Python-2.7.15.orig/setup.py	2018-04-29 18:47:33.000000000 -0400
-+++ Python-2.7.15/setup.py	2018-05-03 20:59:49.000000000 -0400
-@@ -282,13 +282,17 @@
+diff -ruN Python-2.7.17.orig/setup.py Python-2.7.17/setup.py
+--- Python-2.7.17.orig/setup.py	2019-10-19 13:38:44.000000000 -0500
++++ Python-2.7.17/setup.py	2020-04-21 04:12:43.000000000 -0500
+@@ -328,13 +328,17 @@
                                                longest, g)
  
          if missing:
@@ -216,7 +225,7 @@ diff -ru Python-2.7.15.orig/setup.py Python-2.7.15/setup.py
  
          if self.failed:
              failed = self.failed[:]
-@@ -296,6 +300,7 @@
+@@ -342,6 +346,7 @@
              print "Failed to build these modules:"
              print_three_column(failed)
              print
@@ -224,7 +233,7 @@ diff -ru Python-2.7.15.orig/setup.py Python-2.7.15/setup.py
  
      def build_extension(self, ext):
  
-@@ -945,53 +950,8 @@
+@@ -991,53 +996,8 @@
          # construct a list of paths to look for the header file in on
          # top of the normal inc_dirs.
          db_inc_paths = [
@@ -279,7 +288,7 @@ diff -ru Python-2.7.15.orig/setup.py Python-2.7.15/setup.py
          db_inc_paths = [p for p in db_inc_paths if os.path.exists(p)]
  
          db_ver_inc_map = {}
-@@ -1117,12 +1077,7 @@
+@@ -1163,12 +1123,7 @@
          # We hunt for #define SQLITE_VERSION "n.n.n"
          # We need to find >= sqlite version 3.0.8
          sqlite_incdir = sqlite_libdir = None
@@ -293,7 +302,7 @@ diff -ru Python-2.7.15.orig/setup.py Python-2.7.15/setup.py
                             ]
          if cross_compiling:
              sqlite_inc_paths = []
-@@ -1136,7 +1091,7 @@
+@@ -1182,7 +1137,7 @@
          if host_platform == 'darwin':
              sysroot = macosx_sdk_root()
  
@@ -302,7 +311,7 @@ diff -ru Python-2.7.15.orig/setup.py Python-2.7.15/setup.py
              d = d_
              if host_platform == 'darwin' and is_macosx_sdk_path(d):
                  d = os.path.join(sysroot, d[1:])
-@@ -1168,11 +1123,9 @@
+@@ -1214,11 +1169,9 @@
              sqlite_dirs_to_check = [
                  os.path.join(sqlite_incdir, '..', 'lib64'),
                  os.path.join(sqlite_incdir, '..', 'lib'),
@@ -315,7 +324,7 @@ diff -ru Python-2.7.15.orig/setup.py Python-2.7.15/setup.py
              if sqlite_libfile:
                  sqlite_libdir = [os.path.abspath(os.path.dirname(sqlite_libfile))]
  
-@@ -1292,7 +1245,7 @@
+@@ -1338,7 +1291,7 @@
                          if self.compiler.find_library_file(lib_dirs,
                                                                 'gdbm_compat'):
                              gdbm_libs.append('gdbm_compat')
@@ -324,7 +333,7 @@ diff -ru Python-2.7.15.orig/setup.py Python-2.7.15/setup.py
                              print "building dbm using gdbm"
                              dbmext = Extension(
                                  'dbm', ['dbmmodule.c'],
-@@ -1362,7 +1315,7 @@
+@@ -1408,7 +1361,7 @@
                  # _curses_panel.so must link with panelw.
                  panel_library = 'panelw'
              curses_libs = [curses_library]
@@ -333,7 +342,7 @@ diff -ru Python-2.7.15.orig/setup.py Python-2.7.15/setup.py
                                      [os.path.join(d, 'ncursesw') for d in inc_dirs])
              exts.append( Extension('_curses', ['_cursesmodule.c'],
                                     include_dirs = curses_incs,
-@@ -2111,7 +2064,8 @@
+@@ -2157,7 +2110,8 @@
                          sources=sources,
                          depends=depends)
          ext_test = Extension('_ctypes_test',

--- a/10.9-libcxx/stable/main/finkinfo/languages/python34.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python34.info
@@ -54,7 +54,7 @@ Source-Checksum: SHA256(d46a8f6fe91679e199c671b1b0a30aaf172d2acb5bcab25beb35f16c
 #Source2: https://www.python.org/ftp/python/doc/3.4.3/python-3.4.3-docs-html.tar.bz2
 #Source2-MD5: cb6bd508aff25471fb4f32cc848a8c5b
 PatchFile: %n.patch
-PatchFile-MD5: 9cbbce4d4bf4331c936765377d5bfcf8
+PatchFile-MD5: 12ef0f8067e3682542c1cd773e62ca28
 PatchScript: <<
 	#!/bin/sh -ex
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/languages/python34.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python34.patch
@@ -126,6 +126,15 @@ diff -ru Python-3.4.10.orig/configure Python-3.4.10/configure
  	RUNSHARED=DYLD_LIBRARY_PATH=`pwd`${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}
  	;;
      AIX*)
+@@ -8380,7 +8380,7 @@
+     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -compatibility_version $(VERSION) -current_version $(VERSION)';;
+   Darwin/*)
+     gcc_version=`gcc -dumpversion`
+-    if test ${gcc_version} '<' 4.0
++    if test `echo ${gcc_version} | cut -f1 -d.` -lt 4
+         then
+             LIBTOOL_CRUFT="-lcc_dynamic"
+         else
 @@ -8440,8 +8440,8 @@
  
      fi

--- a/10.9-libcxx/stable/main/finkinfo/languages/python35.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python35.info
@@ -51,7 +51,7 @@ Source-Checksum: SHA256(c24a37c63a67f53bdd09c5f287b5cff8e8b98f857bf348c577d454d3
 #Source2: https://www.python.org/ftp/python/doc/%v/python-%v-docs-html.tar.bz2
 #Source2-MD5: c576463076f94da8daaf39f8eaeacd14
 PatchFile: %n.patch
-PatchFile-MD5: d2d93026dbe6ca333f18834fc058560c
+PatchFile-MD5: f07ce62c88ca3be5afd05362a935f0a6
 PatchScript: <<
 	#!/bin/sh -ex
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/languages/python35.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python35.patch
@@ -126,6 +126,15 @@ diff -ru Python-3.5.7.orig/configure Python-3.5.7/configure
  	RUNSHARED=DYLD_LIBRARY_PATH=`pwd`${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}
  	;;
      AIX*)
+@@ -9087,7 +9087,7 @@
+     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -compatibility_version $(VERSION) -current_version $(VERSION)';;
+   Darwin/*)
+     gcc_version=`gcc -dumpversion`
+-    if test ${gcc_version} '<' 4.0
++    if test `echo ${gcc_version} | cut -f1 -d.` -lt 4
+         then
+             LIBTOOL_CRUFT="-lcc_dynamic"
+         else
 @@ -9147,8 +9147,8 @@
  
      fi

--- a/10.9-libcxx/stable/main/finkinfo/languages/python36.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python36.info
@@ -49,7 +49,7 @@ Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
 Source-Checksum: SHA256(5e2f5f554e3f8f7f0296f7e73d8600c4e9acbaee6b2555b83206edf5153870da)
 
 PatchFile: %n.patch
-PatchFile-MD5: 1b771a074e8bc573619e6388afba77d1
+PatchFile-MD5: d1f5d23c7ee06375a290374404552ecb
 PatchScript: <<
 	#!/bin/sh -ex
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/languages/python36.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python36.patch
@@ -137,6 +137,15 @@ diff -ru Python-3.6.8.orig/configure Python-3.6.8/configure
  	RUNSHARED=DYLD_LIBRARY_PATH=`pwd`${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}
  	;;
      AIX*)
+@@ -9087,7 +9087,7 @@
+     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -compatibility_version $(VERSION) -current_version $(VERSION)';;
+   Darwin/*)
+     gcc_version=`gcc -dumpversion`
+-    if test ${gcc_version} '<' 4.0
++    if test `echo ${gcc_version} | cut -f1 -d.` -lt 4
+         then
+             LIBTOOL_CRUFT="-lcc_dynamic"
+         else
 @@ -9237,8 +9237,8 @@
  
      fi

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -52,7 +52,7 @@ Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
 Source-Checksum: SHA256(e85a76ea9f3d6c485ec1780fca4e500725a4a7bbc63c78ebc44170de9b619d94)
 
 PatchFile: %n.patch
-PatchFile-MD5: 4d0a8d5fc56341a2958d51199b10d978
+PatchFile-MD5: 2d47c28843a13238bbe9495c42c8b910
 PatchScript: <<
 	#!/bin/sh -ex
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.patch
@@ -135,6 +135,15 @@ diff -ru Python-3.7.4.orig/configure Python-3.7.4/configure
  	RUNSHARED=DYLD_LIBRARY_PATH=`pwd`${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}
  	;;
      AIX*)
+@@ -9087,7 +9087,7 @@
+     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -compatibility_version $(VERSION) -current_version $(VERSION)';;
+   Darwin/*)
+     gcc_version=`gcc -dumpversion`
+-    if test ${gcc_version} '<' 4.0
++    if test `echo ${gcc_version} | cut -f1 -d.` -lt 4
+         then
+             LIBTOOL_CRUFT="-lcc_dynamic"
+         else
 @@ -9284,8 +9284,8 @@
  
      fi


### PR DESCRIPTION
don't compare numbers as strings
Closes #598 
Only python27 was updated to the latest upstream, which is the last python27 ever. python36-38 were left at their current older versions since it was more critical to get the patch in (latest branch versions still have this problem).

For some reason, python38 doesn't FTBFS with Xcode11.4 even though the relevant detection code is the same AFAICT.