### PR TITLE
Update pysvn to 1.9.11 for svn19 1.13 compatibility and add py38 variant

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pysvn-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pysvn-py.info
@@ -1,9 +1,9 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: pysvn-py%type_pkg[python]
-Version: 1.9.10
+Version: 1.9.11
 Revision: 1
-Type: python (2.7 3.4 3.5 3.6 3.7)
+Type: python (2.7 3.4 3.5 3.6 3.7 3.8)
 
 Description: Python SVN Extension
 DescDetail: <<
@@ -20,7 +20,7 @@ License: BSD
 Homepage: https://pysvn.sourceforge.io
 
 Source: mirror:sourceforge:pysvn/pysvn-%v.tar.gz
-Source-Checksum: SHA256(bc66c05bd0c2d9ea0bac85bed248945df2818ea796ece8f9ad6d97b01a39ab8e)
+Source-Checksum: SHA256(4a3ebe03973ccf17b59d97b8666b528e90a5b0228f5e34370c7cff3221cc4f1b)
 
 Depends: <<
 	libapr.0-shlibs (>= 1.7.0-1),
@@ -50,7 +50,11 @@ CompileScript: <<
 		--apu-inc-dir="`%p/bin/apu-1-config --includedir`" \
 		--pycxx-dir=$PYCXXDIR
 	
-	pythonlibs=`%p/bin/python%type_raw[python]-config --ldflags`
+	if [ %type_pkg[python] -lt 38 ]; then
+		pythonlibs=`%p/bin/python%type_raw[python]-config --ldflags`
+	else
+		pythonlibs=`%p/bin/python%type_raw[python]-config --ldflags --embed`
+	fi
 	perl -pi -e "s|%p/Python|${pythonlibs}|" Makefile
 	make
 <<


### PR DESCRIPTION
pysvn 1.9.10 fails to build against `svn19` 1.13. I've bumped the version to latest upstream, tested to build both against `svn19-dev` 1.12.1 and 1.13.0, and also added a `py38` variant.
https://pysvn.sourceforge.io/downloads.html only states support for Python 3.5 upwards, but the `py34` variant built without any obvious problems (again with both `svn19` versions).