### PR TITLE
Add Java fix to R; CRAN rJava

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rjava-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rjava-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 0.9-8
-Revision: 2
+Version: 0.9-12
+Revision: 1
 Description: Low-level R to Java interface
 Homepage: https://cran.r-project.org/package=rJava
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:rJava_%v.tar.gz
-Source-MD5: 51ae0d690ceed056ebe7c4be71fc6c7a
+Source-MD5: 8d17e50cda6297a85254f7b9cd57db60
 SourceDirectory: rJava
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -48,19 +48,28 @@ CustomMirror: <<
 <<
 Depends: <<
 	fink (>= 0.27.2),
-	r-base%type_pkg[rversion],
+	( %type_raw[rversion] = 3.6 ) r-base%type_pkg[rversion] (>= 3.6.3-2),
+	( %type_raw[rversion] = 3.5 ) r-base%type_pkg[rversion] (>= 3.5.3-3),
+	( %type_raw[rversion] = 3.4 ) r-base%type_pkg[rversion] (>= 3.4.4-2),
+	( %type_raw[rversion] = 3.3 ) r-base%type_pkg[rversion] (>= 3.3.3-4),
+	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion] (>= 3.2.5-5),
+	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion] (>= 3.1.3-9),
 	libgettext8-shlibs,
 	system-java
 <<
 BuildDepends: <<
 	fink (>= 0.38.3),
-	r-base%type_pkg[rversion]-dev,
+	( %type_raw[rversion] = 3.6 ) r-base%type_pkg[rversion]-dev (>= 3.6.3-2),
+	( %type_raw[rversion] = 3.5 ) r-base%type_pkg[rversion]-dev (>= 3.5.3-3),
+	( %type_raw[rversion] = 3.4 ) r-base%type_pkg[rversion]-dev (>= 3.4.4-2),
+	( %type_raw[rversion] = 3.3 ) r-base%type_pkg[rversion]-dev (>= 3.3.3-4),
+	( %type_raw[rversion] = 3.2 ) r-base%type_pkg[rversion]-dev (>= 3.2.5-5),
+	( %type_raw[rversion] = 3.1 ) r-base%type_pkg[rversion]-dev (>= 3.1.3-9),
 	libgettext8-dev,
 	system-java-dev
 <<
 CompileScript: <<
   #!/bin/bash -ev
-  export TMPDIR=%b/tmp
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
@@ -95,9 +104,6 @@ DescPackaging: <<
   Package validation fixed by prefixing @rpath to the the shared library identification
   name of a dynamic shared library for libjri.jnilib and setting BuildDepends on fink
   to 0.38.3 for support of that feature.
-<<
-DescUsage: <<
-JGR is started by entering "library(JGR)" followed by "JGR()" at the R prompt.
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base31.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base31.info
@@ -182,9 +182,14 @@ InstallScript: <<
   
   # Fix JAVA
   export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
-  sed -i -e "s|JAR = |JAR = ${JAVA_HOME}/bin/jar #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
-  sed -i -e "s|JAVA = |JAVA = ${JAVA_HOME}/bin/java #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
-  sed -i -e "s|JAVAC = |JAVAC = ${JAVA_HOME}/bin/javac #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
+  	sed -i -e "s|JAVA_HOME=|JAVA_HOME=${JAVA_HOME}} #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
+  fi
+  
+  sed -i -e 's|JAR = |JAR = $(/usr/libexec/java_home)/bin/jar #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVA = |JAVA = $(/usr/libexec/java_home)/bin/java #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVAC = |JAVAC = $(/usr/libexec/java_home)/bin/javac #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVAH = |JAVAH = $(/usr/libexec/java_home)/bin/javah #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
 <<
 RunTimeVars: <<
   R_HOME: %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base31.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base31.info
@@ -181,11 +181,6 @@ InstallScript: <<
   chmod -R g-w %i
   
   # Fix JAVA
-  export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
-  if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
-  	sed -i -e "s|JAVA_HOME=|JAVA_HOME=${JAVA_HOME}} #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
-  fi
-  
   sed -i -e 's|JAR = |JAR = $(/usr/libexec/java_home)/bin/jar #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVA = |JAVA = $(/usr/libexec/java_home)/bin/java #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVAC = |JAVAC = $(/usr/libexec/java_home)/bin/javac #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
@@ -256,6 +251,14 @@ SplitOff: <<
   !%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/R_de.dylib
   !%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/R_X11.dylib
   !%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/vfonts.dylib
+  <<
+  PostInstScript: <<
+    # Fix JAVA
+    export JAVA_HOME=$( grep "JAVA_HOME=" %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
+    if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
+  	  export JAVA_HOME=$(/usr/libexec/java_home)
+  	  sed -i -e "s|JAVA_HOME=[^\n]*|JAVA_HOME=${JAVA_HOME}}|g" %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
+    fi
   <<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base31.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base31.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: r-base31
 Version: 3.1.3
-Revision: 8
+Revision: 9
 Distribution: 10.9, 10.10, 10.11, 10.12
 Description: R Framework
 Type: rversion (3.1)
@@ -179,6 +179,12 @@ InstallScript: <<
   
   # Fix the permissions
   chmod -R g-w %i
+  
+  # Fix JAVA
+  export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
+  sed -i -e "s|JAR = |JAR = ${JAVA_HOME}/bin/jar #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e "s|JAVA = |JAVA = ${JAVA_HOME}/bin/java #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e "s|JAVAC = |JAVAC = ${JAVA_HOME}/bin/javac #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
 <<
 RunTimeVars: <<
   R_HOME: %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base32.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base32.info
@@ -179,9 +179,14 @@ InstallScript: <<
   
   # Fix JAVA
   export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
-  sed -i -e "s|JAR = |JAR = ${JAVA_HOME}/bin/jar #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
-  sed -i -e "s|JAVA = |JAVA = ${JAVA_HOME}/bin/java #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
-  sed -i -e "s|JAVAC = |JAVAC = ${JAVA_HOME}/bin/javac #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
+  	sed -i -e "s|JAVA_HOME=|JAVA_HOME=${JAVA_HOME}} #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
+  fi
+  
+  sed -i -e 's|JAR = |JAR = $(/usr/libexec/java_home)/bin/jar #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVA = |JAVA = $(/usr/libexec/java_home)/bin/java #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVAC = |JAVAC = $(/usr/libexec/java_home)/bin/javac #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVAH = |JAVAH = $(/usr/libexec/java_home)/bin/javah #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
 <<
 RunTimeVars: <<
   R_HOME: %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base32.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base32.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: r-base32
 Version: 3.2.5
-Revision: 4
+Revision: 5
 Distribution: 10.9, 10.10, 10.11, 10.12
 Description: R Framework
 Type: rversion (3.2)
@@ -176,6 +176,12 @@ InstallScript: <<
   
   # Fix the permissions
   chmod -R g-w %i
+  
+  # Fix JAVA
+  export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
+  sed -i -e "s|JAR = |JAR = ${JAVA_HOME}/bin/jar #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e "s|JAVA = |JAVA = ${JAVA_HOME}/bin/java #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e "s|JAVAC = |JAVAC = ${JAVA_HOME}/bin/javac #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
 <<
 RunTimeVars: <<
   R_HOME: %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base32.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base32.info
@@ -178,11 +178,6 @@ InstallScript: <<
   chmod -R g-w %i
   
   # Fix JAVA
-  export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
-  if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
-  	sed -i -e "s|JAVA_HOME=|JAVA_HOME=${JAVA_HOME}} #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
-  fi
-  
   sed -i -e 's|JAR = |JAR = $(/usr/libexec/java_home)/bin/jar #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVA = |JAVA = $(/usr/libexec/java_home)/bin/java #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVAC = |JAVAC = $(/usr/libexec/java_home)/bin/javac #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
@@ -253,6 +248,14 @@ SplitOff: <<
   !%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/lapack.dylib
   !%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/R_de.dylib
   !%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/R_X11.dylib
+  <<
+  PostInstScript: <<
+    # Fix JAVA
+    export JAVA_HOME=$( grep "JAVA_HOME=" %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
+    if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
+  	  export JAVA_HOME=$(/usr/libexec/java_home)
+  	  sed -i -e "s|JAVA_HOME=[^\n]*|JAVA_HOME=${JAVA_HOME}}|g" %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
+    fi
   <<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base33.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base33.info
@@ -178,9 +178,14 @@ InstallScript: <<
   
   # Fix JAVA
   export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
-  sed -i -e "s|JAR = |JAR = ${JAVA_HOME}/bin/jar #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
-  sed -i -e "s|JAVA = |JAVA = ${JAVA_HOME}/bin/java #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
-  sed -i -e "s|JAVAC = |JAVAC = ${JAVA_HOME}/bin/javac #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
+  	sed -i -e "s|JAVA_HOME=|JAVA_HOME=${JAVA_HOME}} #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
+  fi
+  
+  sed -i -e 's|JAR = |JAR = $(/usr/libexec/java_home)/bin/jar #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVA = |JAVA = $(/usr/libexec/java_home)/bin/java #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVAC = |JAVAC = $(/usr/libexec/java_home)/bin/javac #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVAH = |JAVAH = $(/usr/libexec/java_home)/bin/javah #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
 <<
 RunTimeVars: <<
   R_HOME: %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base33.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base33.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: r-base33
 Version: 3.3.3
-Revision: 3
+Revision: 4
 Description: R Framework
 Type: rversion (3.3)
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
@@ -175,6 +175,12 @@ InstallScript: <<
   
   # Fix the permissions
   chmod -R g-w %i
+  
+  # Fix JAVA
+  export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
+  sed -i -e "s|JAR = |JAR = ${JAVA_HOME}/bin/jar #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e "s|JAVA = |JAVA = ${JAVA_HOME}/bin/java #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e "s|JAVAC = |JAVAC = ${JAVA_HOME}/bin/javac #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
 <<
 RunTimeVars: <<
   R_HOME: %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base33.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base33.info
@@ -177,11 +177,6 @@ InstallScript: <<
   chmod -R g-w %i
   
   # Fix JAVA
-  export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
-  if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
-  	sed -i -e "s|JAVA_HOME=|JAVA_HOME=${JAVA_HOME}} #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
-  fi
-  
   sed -i -e 's|JAR = |JAR = $(/usr/libexec/java_home)/bin/jar #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVA = |JAVA = $(/usr/libexec/java_home)/bin/java #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVAC = |JAVAC = $(/usr/libexec/java_home)/bin/javac #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
@@ -252,6 +247,14 @@ SplitOff: <<
   !%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/lapack.dylib
   !%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/R_de.dylib
   !%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/R_X11.dylib
+  <<
+  PostInstScript: <<
+    # Fix JAVA
+    export JAVA_HOME=$( grep "JAVA_HOME=" %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
+    if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
+  	  export JAVA_HOME=$(/usr/libexec/java_home)
+  	  sed -i -e "s|JAVA_HOME=[^\n]*|JAVA_HOME=${JAVA_HOME}}|g" %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
+    fi
   <<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base34.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base34.info
@@ -178,9 +178,14 @@ InstallScript: <<
   
   # Fix JAVA
   export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
-  sed -i -e "s|JAR = |JAR = ${JAVA_HOME}/bin/jar #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
-  sed -i -e "s|JAVA = |JAVA = ${JAVA_HOME}/bin/java #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
-  sed -i -e "s|JAVAC = |JAVAC = ${JAVA_HOME}/bin/javac #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
+  	sed -i -e "s|JAVA_HOME=|JAVA_HOME=${JAVA_HOME}} #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
+  fi
+  
+  sed -i -e 's|JAR = |JAR = $(/usr/libexec/java_home)/bin/jar #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVA = |JAVA = $(/usr/libexec/java_home)/bin/java #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVAC = |JAVAC = $(/usr/libexec/java_home)/bin/javac #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVAH = |JAVAH = $(/usr/libexec/java_home)/bin/javah #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
 <<
 RunTimeVars: <<
   R_HOME: %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base34.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base34.info
@@ -177,11 +177,6 @@ InstallScript: <<
   chmod -R g-w %i
   
   # Fix JAVA
-  export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
-  if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
-  	sed -i -e "s|JAVA_HOME=|JAVA_HOME=${JAVA_HOME}} #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
-  fi
-  
   sed -i -e 's|JAR = |JAR = $(/usr/libexec/java_home)/bin/jar #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVA = |JAVA = $(/usr/libexec/java_home)/bin/java #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVAC = |JAVAC = $(/usr/libexec/java_home)/bin/javac #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
@@ -252,6 +247,14 @@ SplitOff: <<
   %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/lapack.so 0.0.0 %n (>= 3.4.0-1)
   %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/R_de.so 0.0.0 %n (>= 3.4.0-1)
   %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/R_X11.so 0.0.0 %n (>= 3.4.0-1)
+  <<
+  PostInstScript: <<
+    # Fix JAVA
+    export JAVA_HOME=$( grep "JAVA_HOME=" %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
+    if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
+  	  export JAVA_HOME=$(/usr/libexec/java_home)
+  	  sed -i -e "s|JAVA_HOME=[^\n]*|JAVA_HOME=${JAVA_HOME}}|g" %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
+    fi
   <<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base34.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base34.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: r-base34
 Version: 3.4.4
-Revision: 1
+Revision: 2
 Description: R Framework
 Type: rversion (3.4)
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
@@ -175,6 +175,12 @@ InstallScript: <<
   
   # Fix the permissions
   chmod -R g-w %i
+  
+  # Fix JAVA
+  export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
+  sed -i -e "s|JAR = |JAR = ${JAVA_HOME}/bin/jar #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e "s|JAVA = |JAVA = ${JAVA_HOME}/bin/java #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e "s|JAVAC = |JAVAC = ${JAVA_HOME}/bin/javac #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
 <<
 RunTimeVars: <<
   R_HOME: %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base35.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base35.info
@@ -178,9 +178,14 @@ InstallScript: <<
   
   # Fix JAVA
   export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
-  sed -i -e "s|JAR = |JAR = ${JAVA_HOME}/bin/jar #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
-  sed -i -e "s|JAVA = |JAVA = ${JAVA_HOME}/bin/java #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
-  sed -i -e "s|JAVAC = |JAVAC = ${JAVA_HOME}/bin/javac #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
+  	sed -i -e "s|JAVA_HOME=|JAVA_HOME=${JAVA_HOME}} #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
+  fi
+  
+  sed -i -e 's|JAR = |JAR = $(/usr/libexec/java_home)/bin/jar #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVA = |JAVA = $(/usr/libexec/java_home)/bin/java #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVAC = |JAVAC = $(/usr/libexec/java_home)/bin/javac #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVAH = |JAVAH = $(/usr/libexec/java_home)/bin/javah #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
 <<
 RunTimeVars: <<
   R_HOME: %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base35.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base35.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: r-base35
 Version: 3.5.3
-Revision: 2
+Revision: 3
 Description: R Framework
 Type: rversion (3.5)
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
@@ -175,6 +175,12 @@ InstallScript: <<
   
   # Fix the permissions
   chmod -R g-w %i
+  
+  # Fix JAVA
+  export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
+  sed -i -e "s|JAR = |JAR = ${JAVA_HOME}/bin/jar #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e "s|JAVA = |JAVA = ${JAVA_HOME}/bin/java #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e "s|JAVAC = |JAVAC = ${JAVA_HOME}/bin/javac #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
 <<
 RunTimeVars: <<
   R_HOME: %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base35.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base35.info
@@ -177,11 +177,6 @@ InstallScript: <<
   chmod -R g-w %i
   
   # Fix JAVA
-  export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
-  if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
-  	sed -i -e "s|JAVA_HOME=|JAVA_HOME=${JAVA_HOME}} #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
-  fi
-  
   sed -i -e 's|JAR = |JAR = $(/usr/libexec/java_home)/bin/jar #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVA = |JAVA = $(/usr/libexec/java_home)/bin/java #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVAC = |JAVAC = $(/usr/libexec/java_home)/bin/javac #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
@@ -252,6 +247,14 @@ SplitOff: <<
   %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/lapack.so 0.0.0 %n (>= 3.5.0-1)
   %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/R_de.so 0.0.0 %n (>= 3.5.0-1)
   %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/R_X11.so 0.0.0 %n (>= 3.5.0-1)
+  <<
+  PostInstScript: <<
+    # Fix JAVA
+    export JAVA_HOME=$( grep "JAVA_HOME=" %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
+    if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
+  	  export JAVA_HOME=$(/usr/libexec/java_home)
+  	  sed -i -e "s|JAVA_HOME=[^\n]*|JAVA_HOME=${JAVA_HOME}}|g" %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
+    fi
   <<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base36.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base36.info
@@ -173,9 +173,14 @@ InstallScript: <<
   
   # Fix JAVA
   export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
+  if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
+  	sed -i -e "s|JAVA_HOME=|JAVA_HOME=${JAVA_HOME}} #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
+  fi
+  
   sed -i -e 's|JAR = |JAR = $(/usr/libexec/java_home)/bin/jar #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVA = |JAVA = $(/usr/libexec/java_home)/bin/java #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVAC = |JAVAC = $(/usr/libexec/java_home)/bin/javac #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVAH = |JAVAH = $(/usr/libexec/java_home)/bin/javah #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
 <<
 RunTimeVars: <<
   R_HOME: %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base36.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base36.info
@@ -172,11 +172,6 @@ InstallScript: <<
   chmod -R g-w %i
   
   # Fix JAVA
-  export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
-  if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
-  	sed -i -e "s|JAVA_HOME=|JAVA_HOME=${JAVA_HOME}} #|g" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
-  fi
-  
   sed -i -e 's|JAR = |JAR = $(/usr/libexec/java_home)/bin/jar #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVA = |JAVA = $(/usr/libexec/java_home)/bin/java #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVAC = |JAVAC = $(/usr/libexec/java_home)/bin/javac #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
@@ -247,6 +242,14 @@ SplitOff: <<
   %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/lapack.so 0.0.0 %n (>= 3.6.0-1)
   %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/R_de.so 0.0.0 %n (>= 3.6.0-1)
   %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/modules/R_X11.so 0.0.0 %n (>= 3.6.0-1)
+  <<
+  PostInstScript: <<
+    # Fix JAVA
+    export JAVA_HOME=$( grep "JAVA_HOME=" %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
+    if [ ${JAVA_HOME} != $(/usr/libexec/java_home) ]; then
+  	  export JAVA_HOME=$(/usr/libexec/java_home)
+  	  sed -i -e "s|JAVA_HOME=[^\n]*|JAVA_HOME=${JAVA_HOME}}|g" %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths
+    fi
   <<
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base36.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base36.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: r-base36
 Version: 3.6.3
-Revision: 1
+Revision: 2
 Description: R Framework
 Type: rversion (3.6)
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
@@ -170,6 +170,13 @@ InstallScript: <<
   
   # Fix the permissions
   chmod -R g-w %i
+  
+  # Fix JAVA
+  #export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
+  export JAVA_HOME=$(/usr/libexec/java_home)
+  sed -i -e 's|JAR = |JAR = $(/usr/libexec/java_home)/bin/jar #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVA = |JAVA = $(/usr/libexec/java_home)/bin/java #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
+  sed -i -e 's|JAVAC = |JAVAC = $(/usr/libexec/java_home)/bin/javac #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
 <<
 RunTimeVars: <<
   R_HOME: %p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base36.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base36.info
@@ -172,8 +172,7 @@ InstallScript: <<
   chmod -R g-w %i
   
   # Fix JAVA
-  #export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
-  export JAVA_HOME=$(/usr/libexec/java_home)
+  export JAVA_HOME=$( grep "JAVA_HOME=" %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/ldpaths | sed -e "s|: \${JAVA_HOME=\([^\}]*\)}|\1|" )
   sed -i -e 's|JAR = |JAR = $(/usr/libexec/java_home)/bin/jar #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVA = |JAVA = $(/usr/libexec/java_home)/bin/java #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf
   sed -i -e 's|JAVAC = |JAVAC = $(/usr/libexec/java_home)/bin/javac #|g' %i/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/etc/Makeconf


### PR DESCRIPTION
R has Java settings stored in Makeconf and ldpaths, but they do not match.  The fix is to modify Makeconf to read ldpaths.

With Java fix to r-base, rJava builds without any extra fix.