### PR TITLE
Fix extutils-makemaker-pm to deal with hardened system-perl on 10.15

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.11.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.11.info
@@ -1,6 +1,6 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: extutils-makemaker-pm.info -*-
 Package: extutils-makemaker-pm
-Version: 7.36
+Version: 7.44
 Revision: 1
 Distribution: 10.11
 Depends: system-perl5182, %n5182 (>= %v)

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.12.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.12.info
@@ -1,6 +1,6 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: extutils-makemaker-pm.info -*-
 Package: extutils-makemaker-pm
-Version: 7.36
+Version: 7.44
 Revision: 1
 Distribution: 10.12
 Depends: system-perl5182, %n5182 (>= %v)

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.13.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.13.info
@@ -1,6 +1,6 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: extutils-makemaker-pm.info -*-
 Package: extutils-makemaker-pm
-Version: 7.36
+Version: 7.44
 Revision: 1
 Distribution: 10.13
 Depends: system-perl5182, %n5182 (>= %v)

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.14.5.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.14.5.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: extutils-makemaker-pm.info -*-
 Package: extutils-makemaker-pm
-Version: 7.36
-Revision: 2
+Version: 7.44
+Revision: 1
 Distribution: 10.14.5
 Depends: system-perl5184, %n5184 (>= %v)
 Type: bundle

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.14.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.14.info
@@ -1,6 +1,6 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: extutils-makemaker-pm.info -*-
 Package: extutils-makemaker-pm
-Version: 7.36
+Version: 7.44
 Revision: 1
 Distribution: 10.14
 Depends: system-perl5182, %n5182 (>= %v)

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.15.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.15.info
@@ -2,8 +2,8 @@
 Package: extutils-makemaker-pm
 Version: 7.44
 Revision: 1
-Distribution: 10.10
-Depends: system-perl5182, %n5182 (>= %v)
+Distribution: 10.15
+Depends: system-perl5184, %n5184 (>= %v)
 Type: bundle
 Description: ExtUtils::MakeMaker for /usr/bin/perl
 DescDetail: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.9.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm-10.9.info
@@ -1,6 +1,6 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: extutils-makemaker-pm.info -*-
 Package: extutils-makemaker-pm
-Version: 7.36
+Version: 7.44
 Revision: 1
 Distribution: 10.9
 Depends: system-perl5162, %n5162 (>= %v)

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm.info
@@ -1,8 +1,8 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: extutils-makemaker-pm.patch -*-
 Info2: <<
 Package: extutils-makemaker-pm%type_pkg[perl]
-Version: 7.36
 Revision: 1
+Version: 7.44
 
 Type: perl (5.16.2 5.18.2 5.18.4)
 Distribution: <<
@@ -28,6 +28,10 @@ DescPort: <<
 	
 	It appears that Cwd::cwd can't get the cwd from within fink's build
 	environment but Cwd::getcwd can. Patch MakeMaker.pm to use getcwd.
+	
+	On 10.15, Apple hardened system-perl to disallow loading from relative
+	paths. So patch INST_ARCHLIB to be an absolute path. The relative path
+	test "CHILD INST_ARCHLIB" is patched to use full paths.
 <<
 
 # Dependencies:
@@ -50,10 +54,10 @@ Provides: %N-bin
 # Unpack Phase:
 #Source: mirror:cpan:modules/by-module/ExtUtils/ExtUtils-MakeMaker-%v.tar.gz
 Source: mirror:cpan:authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-%v.tar.gz
-Source-Checksum: SHA256(06cef6429315cdc6afa9b2dc6fbdfa33538b6f68c827f441294621858e28c558)
+Source-Checksum: SHA256(52a18f8271250faf5f3527499dd2b78d3b4fd3b064408d0cfdda9a3538887188)
 
 PatchFile: %{ni}.patch
-PatchFile-MD5: 4e690e03f0f654f0922c2261038f1c4e
+PatchFile-MD5: 4f00b40fb3b44fa11c0fb36bb509720c
 PatchFile2: %{ni}-sdk.patch
 PatchFile2-MD5: b528e11f18f145224a423088f730b7a4 
 PatchScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm.info
@@ -65,7 +65,7 @@ PatchScript: <<
 	/usr/bin/sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 	darwin_vers=`uname -r | cut -d. -f1`
 	# only apply SDK fix for 10.14+ (that hides system-headers) and systemperl
-	if [[ "$darwin_vers" -ge 18 && $type_num[perl] -eq 5184 ]]; then
+	if [[ "$darwin_vers" -ge 18 && %type_num[perl] -eq 5184 ]]; then
 	  patch -p1 < %{PatchFile2}
 	fi
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm.info
@@ -1,8 +1,8 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: extutils-makemaker-pm.patch -*-
 Info2: <<
 Package: extutils-makemaker-pm%type_pkg[perl]
-Revision: 1
 Version: 7.44
+Revision: 2
 
 Type: perl (5.16.2 5.18.2 5.18.4)
 Distribution: <<
@@ -64,7 +64,8 @@ PatchScript: <<
 	#!/bin/bash -ev
 	/usr/bin/sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 	darwin_vers=`uname -r | cut -d. -f1`
-	if [ "$darwin_vers" -ge 18 ]; then
+	# only apply SDK fix for 10.14+ (that hides system-headers) and systemperl
+	if [[ "$darwin_vers" -ge 18 && $type_num[perl] -eq 5184 ]]; then
 	  patch -p1 < %{PatchFile2}
 	fi
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm.info
@@ -64,8 +64,8 @@ PatchScript: <<
 	#!/bin/bash -ev
 	/usr/bin/sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 	darwin_vers=`uname -r | cut -d. -f1`
-	# only apply SDK fix for 10.14+ (that hides system-headers) and systemperl
-	if [[ "$darwin_vers" -ge 18 && %type_num[perl] -eq 5184 ]]; then
+	# only apply SDK fix for 10.14/10.15 (which hide system-headers) and their systemperl
+	if [[ ("$darwin_vers" -eq 18 || "$darwin_vers" -eq 19) && %type_num[perl] -eq 5184 ]]; then
 	  patch -p1 < %{PatchFile2}
 	fi
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/extutils-makemaker-pm.patch
@@ -24,3 +24,36 @@ diff -ru ExtUtils-MakeMaker-6.68.orig/lib/ExtUtils/MakeMaker.pm ExtUtils-MakeMak
          $Recognized_Att_Keys{uc $item} = $Config{$item};
          print "Attribute '\U$item\E' => '$Config{$item}'\n"
              if ($Verbose >= 2);
+diff -ruN ExtUtils-MakeMaker-7.44-orig/lib/ExtUtils/MM_Any.pm ExtUtils-MakeMaker-7.44/lib/ExtUtils/MM_Any.pm
+--- ExtUtils-MakeMaker-7.44-orig/lib/ExtUtils/MM_Any.pm	2020-01-14 10:35:54.000000000 -0600
++++ ExtUtils-MakeMaker-7.44/lib/ExtUtils/MM_Any.pm	2020-05-01 04:44:32.000000000 -0500
+@@ -1912,7 +1912,7 @@
+ sub init_INST {
+     my($self) = shift;
+ 
+-    $self->{INST_ARCHLIB} ||= $self->catdir($Curdir,"blib","arch");
++    $self->{INST_ARCHLIB} ||= $self->catdir(File::Spec->rel2abs($Curdir),"blib","arch");
+     $self->{INST_BIN}     ||= $self->catdir($Curdir,'blib','bin');
+ 
+     # INST_LIB typically pre-set if building an extension after
+diff -ruN ExtUtils-MakeMaker-7.44-orig/t/INST.t ExtUtils-MakeMaker-7.44/t/INST.t
+--- ExtUtils-MakeMaker-7.44-orig/t/INST.t	2019-04-27 11:29:41.000000000 -0500
++++ ExtUtils-MakeMaker-7.44/t/INST.t	2020-05-01 05:05:40.000000000 -0500
+@@ -94,7 +94,7 @@
+ # INST_*
+ is( $mm->{INST_ARCHLIB},
+     $mm->{PERL_CORE} ? $mm->{PERL_ARCHLIB}
+-                     : File::Spec->catdir($Curdir, 'blib', 'arch'),
++                     : File::Spec->catdir(File::Spec->rel2abs($Curdir), 'blib', 'arch'),
+                                      'INST_ARCHLIB');
+ is( $mm->{INST_BIN},     File::Spec->catdir($Curdir, 'blib', 'bin'),
+                                      'INST_BIN' );
+@@ -108,7 +108,7 @@
+ my $normalize = $^O =~ /android/ ? \&Cwd::realpath : sub {shift};
+ is( $normalize->($c_mm->{INST_ARCHLIB}),
+     $normalize->($c_mm->{PERL_CORE} ? $c_mm->{PERL_ARCHLIB}
+-                       : File::Spec->catdir($Updir, 'blib', 'arch')),
++                       : File::Spec->catdir(File::Spec->rel2abs($Curdir), 'blib', 'arch')),
+                                      'CHILD INST_ARCHLIB');
+ is( $c_mm->{INST_BIN},     File::Spec->catdir($Updir, 'blib', 'bin'),
+                                      'CHILD INST_BIN' );


### PR DESCRIPTION
Fix #461 by patching EU::MM to use absolute paths for INST_ARCHLIB so that system-perl on 10.15 is happy loading bundles.