### PR TITLE
XEphem fixes for Guide Star Catalogue and other downloads

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/xephem.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xephem.info
@@ -1,14 +1,22 @@
+# -*- coding: ascii; tab-width: 4; x-counterpart: xephem.patch -*-
+Info2: <<
 Package: xephem
 Version: 3.7.7
-Revision: 1
+Revision: 2
 BuildDepends: <<
 	fink-buildenv-modules,
 	fink-package-precedence,
 	libxt-flat,
 	openmotif4,
+	openssl110-dev,
 	x11-dev
 <<
-Depends: libxt-flat-shlibs, openmotif4-shlibs, x11-shlibs
+Depends: <<
+	libxt-flat-shlibs,
+	openmotif4-shlibs,
+	openssl110-shlibs,
+	x11-shlibs
+<<
 Source: http://www.clearskyinstitute.com/xephem/%n-%v.tgz
 Source-MD5: 27c67061a89085bf2b0d4e9deb758a79
 
@@ -16,7 +24,7 @@ Source2: http://www.clearskyinstitute.com/xephem/wmm.cof
 Source2-MD5: 13a643a1cc4726081b5c727689963f3b
 
 PatchFile: %n.patch
-PatchFile-MD5: 730c045ab48919c720e01697c8644dac
+PatchFile-MD5: f102ed8a144033f41f25481c8027b096
 PatchScript: <<
 #!/bin/sh -ev
 . %p/sbin/fink-buildenv-helper.sh
@@ -33,40 +41,52 @@ fink-package-precedence --depfile-ext='\.d' .
 <<
 
 InstallScript: <<
-#! /bin/sh -ev
+#!/bin/sh -ev
+# need -f to pass --build-as-nobody
+mv -f ../wmm.cof GUI/xephem/auxil
+
+cd GUI/xephem
 mkdir %i/bin
 install -c -m 755 xephem %i/bin/xephem
-cd GUI/xephem
-mkdir -p %i/lib/xephem
-install -c -m 755 xephem %i/lib/xephem/xephem
-pwd
 
-# need -f to pass --build-as-nobody
-mv -f ../../../wmm.cof auxil/
+mkdir -p %i/lib/xephem/tools
+cp -R auxil catalogs fifos fits gallery help lo %i/lib/xephem
+install -c -m 755 tools/*.{awk,pl} %i/lib/xephem/tools
 
-cp -R auxil %i/lib/xephem
-cp -R catalogs %i/lib/xephem
-cp -R fifos %i/lib/xephem
-cp -R fits %i/lib/xephem
-cp -R gallery %i/lib/xephem
-cp -R help %i/lib/xephem
-cp -R lo %i/lib/xephem
-# cp -R tools %i/lib/xephem
 mkdir -p %i/share/man/man1
-install -c -m 755 xephem.1 %i/share/man/man1
+install -c -m 644 xephem.1 %i/share/man/man1
 <<
 
-DocFiles: Copyright
+DocFiles: Copyright INSTALL
 Description: Astronomical Software Ephemeris
 DescDetail: <<
 The brainchild of programmer Elwood Downey, XEphem is a star-charting,
 sky-simulating, ephemeris-generating celestial virtuoso that can do just about
 everything ...
+The package comes with basic datasets of the bright stars, constellations,
+major solar system objects and extragalactic sources, but provides download
+capabilities for the any stars from the Hubble Guide Star Catalogue (GSC) 4.2;
+additional catalogue files for millions of astronomical objects including
+excerpts of the GSC are available for download as CD images from
+http://www.clearskyinstitute.com/xephem/download.html
+These data are by default installed outside of the Fink space, so to be able
+to use them XEphem should be started as
+xephem -env TELHOME=/data_install_path
 <<
 DescPackaging: <<
 Builds and uses its own versions of many support libraries.
 
 Needs flat-namespace libXt for compatibility with openmotif4
+
+Hardcoded data directory %p/lib/xephem; additional catalogue and other data
+files installable in ~/Library/XEphem at the user level; in a location given
+by TELHOME at the system level (should also be possible to set with
+XEphem.ShareDir: /path/to/xephem in the settings, but this does not appear to
+be recognised).
+Includes patches for new GSC format, minorplanets.net download locations,
+plus a set of patches for OpenSSL support provided by Lutz Maendle at
+http://www.clearskyinstitute.com/xephem/contrib/xephem-3.7.7_openssl.patch
+http://www.clearskyinstitute.com/xephem/contrib/xephem-3.7.7_openssl_earthmenu.patch
 
 Previous maintainer: Kevin Horton <khorton02@gmail.com>
 <<
@@ -74,11 +94,14 @@ Previous maintainer: Kevin Horton <khorton02@gmail.com>
 PostInstScript: <<
 cat %p/share/doc/xephem/Copyright
 echo ""
-echo "Included In fink with permission"
+echo "Included in fink with permission."
 echo "A Full version of xephem is available for Mac OS X"
+echo "with up to 2 GB of additonal data files."
 echo "Go to http://www.clearskyinstitute.com for more information"
 <<
 
 License: Restrictive/Distributable
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Homepage: http://www.clearskyinstitute.com/xephem/
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/sci/xephem.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xephem.info
@@ -24,7 +24,7 @@ Source2: http://www.clearskyinstitute.com/xephem/wmm.cof
 Source2-MD5: 13a643a1cc4726081b5c727689963f3b
 
 PatchFile: %n.patch
-PatchFile-MD5: f102ed8a144033f41f25481c8027b096
+PatchFile-MD5: 0527ad010d8841d2f1fcfe472b33ece4
 PatchScript: <<
 #!/bin/sh -ev
 . %p/sbin/fink-buildenv-helper.sh
@@ -84,9 +84,10 @@ by TELHOME at the system level (should also be possible to set with
 XEphem.ShareDir: /path/to/xephem in the settings, but this does not appear to
 be recognised).
 Includes patches for new GSC format, minorplanets.net download locations,
-plus a set of patches for OpenSSL support provided by Lutz Maendle at
-http://www.clearskyinstitute.com/xephem/contrib/xephem-3.7.7_openssl.patch
-http://www.clearskyinstitute.com/xephem/contrib/xephem-3.7.7_openssl_earthmenu.patch
+plus a set of patches for OpenSSL and better WCS support provided by
+Lutz Maendle (xephem-3.7.7_openssl.patch, xephem-3.7.7_openssl_earthmenu.patch)
+and Roman Tolesnikov (libip.wcs.c) at
+http://www.clearskyinstitute.com/xephem/contrib
 
 Previous maintainer: Kevin Horton <khorton02@gmail.com>
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/xephem.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xephem.patch
@@ -175,6 +175,8 @@ diff -Nurd xephem-3.7.7.orig/GUI/xephem/auxil/mpcorb2edb.pl xephem-3.7.7/GUI/xep
  my $MPCFTPDIR = "/iau/MPCORB";
  my $MPCFILE = "MPCORB.DAT";
  my $MPCZIPFILE = "MPCORB.DAT.gz";
+
+# SSL patches provided by Lutz Mändle < lmaendle at gmx dot net >
 diff -Naur xephem-3.7.7.orig/GUI/xephem/net.h xephem-3.7.7/GUI/xephem/net.h
 --- xephem-3.7.7.orig/GUI/xephem/net.h	2005-03-20 12:04:50.000000000 +0100
 +++ xephem-3.7.7/GUI/xephem/net.h	2018-01-08 19:45:27.561208366 +0100
@@ -886,4 +888,53 @@ diff -Naur xephem-3.7.7.orig/GUI/xephem/earthmenu.c xephem-3.7.7/GUI/xephem/eart
  	    if (nr > 0) {
  		xe_msg (1, "File too large");
  		return (-1);
+
+# Patch for WCS to support CDi_j type rotation matrix; courtesy of Roman Tolesnikov, rtolesnikov at yahoo.com
+diff -Nurd xephem-3.7.7.orig/libip/wcs.c xephem-3.7.7/libip/wcs.c
+--- xephem-3.7.7.orig/libip/wcs.c	2005-04-09 23:13:28.000000000 +0200
++++ xephem-3.7.7/libip/wcs.c	2020-05-06 17:08:23.000000000 +0200
+@@ -235,7 +235,7 @@
+ {
+ 	FITSRow typestr;
+ 	double tmp;
+-
++	double cd[2][2];
+ 	if (fip->wcsset)
+ 	    return (0);
+ 
+@@ -251,10 +251,31 @@
+ 	if (getRealFITS (fip, "CRVAL2", &fip->yref) < 0) return (-1);
+ 	if (getRealFITS (fip, "CRPIX1", &fip->xrefpix) < 0) return (-1);
+ 	if (getRealFITS (fip, "CRPIX2", &fip->yrefpix) < 0) return (-1);
+-	if (getRealFITS (fip, "CDELT1", &fip->xinc) < 0) return (-1);
+-	if (getRealFITS (fip, "CDELT2", &fip->yinc) < 0) return (-1);
+-	if (getRealFITS (fip, "CROTA2", &fip->rot) < 0) return (-1);
+-	if (getStringFITS (fip, "CTYPE1", typestr) < 0) return (-1);
++	if (getStringFITS (fip, "CTYPE1", typestr) < 0) return (-1);
++	if (getRealFITS (fip, "CD1_1", &cd[0][0]) < 0) {
++	    /* If CD matrix is not present, revert to CDELT and CROT keywords */
++	    if (getRealFITS (fip, "CDELT1", &fip->xinc) < 0) return (-1);
++	    if (getRealFITS (fip, "CDELT2", &fip->yinc) < 0) return (-1);
++	    if (getRealFITS (fip, "CROTA2", &fip->rot) < 0) return (-1);
++	} else {
++	    if (getRealFITS (fip, "CD1_2", &cd[0][1]) < 0) return (-1);
++	    if (getRealFITS (fip, "CD2_1", &cd[1][0]) < 0) return (-1);
++	    if (getRealFITS (fip, "CD2_2", &cd[1][1]) < 0) return (-1);
++	    /* CD matrix now available, calculate {x,y}inc and rot values
++	    * CD1_1 =  CDELT1 * cos (CROTA2)
++	    * CD1_2 = -CDELT2 * sin (CROTA2)
++	    * CD2_1 =  CDELT1 * sin (CROTA2)
++	    * CD2_2 =  CDELT2 * cos (CROTA2) 
++	    * therefore:
++	    * CROT2 = ATAN2(-CD1_2, CD2_2)
++	    * CDELT1 = CD1_1/acos(CROT2)
++	    * CDELT2 = CD2_2/acos(CROT2)
++	    */
++	    tmp = atan2(-cd[0][1], cd[1][1]);
++	    fip->rot =  raddeg(tmp);
++	    fip->xinc = cd[0][0] / cos(tmp);
++	    fip->yinc = cd[1][1] / cos(tmp);
++	}
+ 	if (strncmp (typestr, "RA--", 4)) return (-1);
+ 	strncpy (fip->type, typestr+4, sizeof(fip->type)-1);
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/xephem.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xephem.patch
@@ -1,16 +1,19 @@
-diff -Nurd -x'*~' xephem-3.7.2.orig/GUI/xephem/Makefile xephem-3.7.2/GUI/xephem/Makefile
---- xephem-3.7.2.orig/GUI/xephem/Makefile	2006-05-13 19:06:06.000000000 -0400
-+++ xephem-3.7.2/GUI/xephem/Makefile	2007-06-15 00:34:30.000000000 -0400
-@@ -35,7 +35,7 @@
+diff -Nurd -x'*~' xephem-3.7.7.orig/GUI/xephem/Makefile xephem-3.7.7/GUI/xephem/Makefile
+--- xephem-3.7.7.orig/GUI/xephem/Makefile	2015-08-09 23:36:50.000000000 +0200
++++ xephem-3.7.7/GUI/xephem/Makefile	2018-01-08 21:20:45.200717791 +0100
+@@ -33,9 +33,9 @@
  CC = gcc
  CLDFLAGS = -g
  CFLAGS = $(LIBINC) $(CLDFLAGS) -O2 -Wall -I$(MOTIFI) -I/opt/X11/include
 -LDFLAGS = $(LIBLNK) $(CLDFLAGS) -L$(MOTIFL) -L/opt/X11/lib
 +AM_LDFLAGS = $(LIBLNK) $(CLDFLAGS) -L$(MOTIFL) -L/opt/X11/lib
  XLIBS = -lXm -lXp -lXt -lXext -lXmu -lX11
- LIBS = $(XLIBS) $(LIBLIB) -lm
+-LIBS = $(XLIBS) $(LIBLIB) -lm
++LIBS = $(XLIBS) $(LIBLIB) -lm -lssl
  
-@@ -181,7 +181,7 @@
+ # static linking on Apple using X11 libs from ports
+ # CC = gcc
+@@ -189,7 +189,7 @@
  all: libs xephem xephem.1
  
  xephem: $(INCS) $(OBJS)
@@ -19,15 +22,20 @@ diff -Nurd -x'*~' xephem-3.7.2.orig/GUI/xephem/Makefile xephem-3.7.2/GUI/xephem/
  
  xephem.1: xephem.man
  	nroff -man $? > $@
-@@ -187,8 +187,7 @@
- libs:
+@@ -200,7 +200,6 @@
  	cd ../../libjpegd; make
  	cd ../../liblilxml; make
  	cd ../../libpng; make
 -	cd ../../libz; make
  
  clean:
- 	touch x.o
+ 	rm -fr *.o ../../lib*/*.[ao]
+diff -Nurd -x'*~' xephem-3.7.2.orig/xephem xephem-3.7.2/xephem
+--- xephem-3.7.2.orig/xephem	1969-12-31 19:00:00.000000000 -0500
++++ xephem-3.7.2/xephem	2007-06-15 00:14:19.000000000 -0400
+@@ -0,0 +1,2 @@
++#!/bin/sh
++@FINKPREFIX@/lib/xephem/xephem -env TELHOME=${TELHOME:-@FINKPREFIX@/lib}
 diff -Nurd -x'*~' xephem-3.7.2.orig/GUI/xephem/patchlevel.c xephem-3.7.2/GUI/xephem/patchlevel.c
 --- xephem-3.7.2.orig/GUI/xephem/patchlevel.c	2006-11-12 21:22:26.000000000 -0500
 +++ xephem-3.7.2/GUI/xephem/patchlevel.c	2007-06-15 00:14:19.000000000 -0400
@@ -47,9 +55,835 @@ diff -Nurd -x'*~' xephem-3.7.2.orig/GUI/xephem/time.c xephem-3.7.2/GUI/xephem/ti
  #include <stdio.h>
  #include <time.h>
  #include <math.h>
-diff -Nurd -x'*~' xephem-3.7.2.orig/xephem xephem-3.7.2/xephem
---- xephem-3.7.2.orig/xephem	1969-12-31 19:00:00.000000000 -0500
-+++ xephem-3.7.2/xephem	2007-06-15 00:14:19.000000000 -0400
-@@ -0,0 +1,2 @@
-+#!/bin/sh
-+@FINKPREFIX@/lib/xephem/xephem -env TELHOME=@FINKPREFIX@/lib
+diff -Nurd -x'*~' xephem-3.7.7.orig/GUI/xephem/fallbacks.c xephem-3.7.7/GUI/xephem/fallbacks.c
+--- xephem-3.7.7.orig/GUI/xephem/fallbacks.c	2015-04-09 02:20:19.000000000 +0200
++++ xephem-3.7.7/GUI/xephem/fallbacks.c	2020-05-05 23:49:14.000000000 +0200
+@@ -747,10 +747,10 @@
+     "XEphem*WebDB*URL1.value: http://celestrak.com/NORAD/elements/science.txt",
+     "XEphem*WebDB*URL2.value: http://celestrak.com/NORAD/elements/tle-new.txt",
+     "XEphem*WebDB*URL3.value: http://celestrak.com/NORAD/elements/amateur.txt",
+-    "XEphem*WebDB*URL4.value: http://www.minorplanetcenter.org/iau/Ephemerides/Comets/Soft03Cmt.txt",
+-    "XEphem*WebDB*URL5.value: http://www.minorplanetcenter.org/iau/Ephemerides/CritList/Soft03CritList.txt",
+-    "XEphem*WebDB*URL6.value: http://www.minorplanetcenter.org/iau/Ephemerides/Distant/Soft03Distant.txt",
+-    "XEphem*WebDB*URL7.value: http://www.minorplanetcenter.org/iau/Ephemerides/Unusual/Soft03Unusual.txt",
++    "XEphem*WebDB*URL4.value: http://minorplanetcenter.net/iau/Ephemerides/Comets/Soft03Cmt.txt",
++    "XEphem*WebDB*URL5.value: http://minorplanetcenter.net/iau/Ephemerides/CritList/Soft03CritList.txt",
++    "XEphem*WebDB*URL6.value: http://minorplanetcenter.net/iau/Ephemerides/Distant/Soft03Distant.txt",
++    "XEphem*WebDB*URL7.value: http://minorplanetcenter.net/iau/Ephemerides/Unusual/Soft03Unusual.txt",
+     "XEphem*WebDB.x: 200",
+     "XEphem*WebDB.y: 200",
+     "XEphem*WeekStart.Monday.set: False",
+@@ -866,7 +866,7 @@
+     "XEphem.SOHOhost: sohowww.nascom.nasa.gov",
+     "XEphem.SatViewUp: 0",
+     "XEphem.SaturnBackground: #151515",
+-    "XEphem.ShareDir: .",
++    "XEphem.ShareDir: @FINKPREFIX@/lib/xephem",
+     "XEphem.Sitename: Chicago, Illinois",
+     "XEphem.SkyAnnotColor: #bfc1c6",
+     "XEphem.SkyCnsBndColor: #435964",
+diff -Nurd -x'*~' xephem-3.7.7.orig/GUI/xephem/gscnet.c xephem-3.7.7/GUI/xephem/gscnet.c
+--- xephem-3.7.7.orig/GUI/xephem/gscnet.c	2010-10-06 23:12:40.000000000 +0200
++++ xephem-3.7.7/GUI/xephem/gscnet.c	2020-05-05 18:39:53.000000000 +0200
+@@ -11,7 +11,7 @@
+ 
+ static int moreObjF (ObjF **opp, int nop, int nnew);
+ 
+-/* fetch GSC 2.3 stars around the given field of view from STScI.
++/* fetch GSC 2.4 stars around the given field of view from STScI.
+  * if find some add them to the list at *opp and return new total, else
+  * limit FOV to 30 arc mins -- these fields can be very dense.
+  * return -1 with a diagnostic message in msg[].
+@@ -29,7 +29,7 @@
+ {
+ #define	GSC23MAXFOV	degrad(30./60.0)		/* max fov */
+ 	/* http://gsss.stsci.edu/webservices/vo/ConeSearch.aspx?RA=10.0&DEC=5.0&SR=0.2&FORMAT=CSV */
+-	static char ifmt[] = "%[^,],%lf,%lf,%*[^,],%*[^,],%*[^,],%*[^,],%lf,%lf,%*[^,],%*[^,],%lf,%lf,%lf,%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%d";
++	static char ifmt[] = "%[^,],%*[^,],%lf,%lf,%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%lf,%*[^,],%*[^,],%lf,%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%lf,%*[^,],%*[^,],%lf,%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%lf,%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%*[^,],%d";
+ 	static char gfmt[] = " GET http://%s%s?RA=%g&DEC=%g&SR=%g&FORMAT=CSV HTTP/1.0\r\nUser-Agent: xephem/%s\r\n\r\n";
+ 	char host[1024];
+ 	char buf[2048];
+@@ -41,7 +41,7 @@
+ 	if (fov > GSC23MAXFOV) {
+ 	    static int fovwarned;
+ 	    if (!fovwarned) {
+-		xe_msg (1, "All GSC 2.3 downloads will be limited to %.2f degree FOV",
++		xe_msg (1, "All GSC 2.4 downloads will be limited to %.2f degree FOV",
+ 							raddeg(GSC23MAXFOV));
+ 		fovwarned = 1;
+ 	    }
+@@ -80,19 +80,21 @@
+ 	while ((n = recvlineb (sockfd, buf, sizeof(buf))) > 0) {
+ 	    char name[1024];
+ 	    double radeg, decdeg;
+-	    double fmag, jmag, bmag, vmag, rmag;
++	    double fmag, jmag, bmag, vmag, j2mag;
+ 	    int class;
+ 	    Obj *op;
+ 
+ 	    /* look for total */
+-	    if (sscanf (buf, " Objects found : %d", &nstars) == 1)
++	    if (sscanf (buf, " Objects found : %d", &nstars) == 1 ||
++		sscanf (buf, "#Objects found : %d", &nstars) == 1) {
+ 		continue;
++	    }
+ 
+ 	    /* crack */
+ 	    if (sscanf (buf, ifmt, name, &radeg, &decdeg, &fmag, &jmag, &bmag,
+-						&vmag, &rmag, &class) != 9)
++						&vmag, &j2mag, &class) != 9)
+ 		continue;
+-	    if (fmag>lmag && jmag>lmag && bmag>lmag && vmag>lmag && rmag>lmag)
++	    if (fmag>lmag && jmag>lmag && bmag>lmag && vmag>lmag && j2mag>lmag)
+ 		continue;
+ 
+ 	    /* good -- grow list */
+@@ -106,7 +108,7 @@
+ 	    zero_mem ((void *)op, sizeof(ObjF));
+ 
+ 	    /* add */
+-	    (void) sprintf (op->o_name, "GSC2.3 %.*s", MAXNM-8, name);
++	    (void) sprintf (op->o_name, "GSC2.4 %.*s", MAXNM-8, name);
+ 	    op->o_type = FIXED;
+ 	    switch (class) {
+ 	    case 0: op->f_class = 'S'; break;
+@@ -120,12 +122,12 @@
+ 		set_fmag (op, vmag);
+ 	    else if (bmag<=lmag)
+ 		set_fmag (op, bmag);
+-	    else if (rmag<=lmag)
+-		set_fmag (op, rmag);
+ 	    else if (fmag<=lmag)
+ 		set_fmag (op, fmag);
+-	    else
++	    else if (jmag<=lmag)
+ 		set_fmag (op, jmag);
++	    else
++		set_fmag (op, j2mag);
+ 
+ 	    if (nstars > 0)
+ 		pm_set (100*nnew++/nstars);
+diff -Nurd xephem-3.7.7.orig/GUI/xephem/auxil/mpcorb2edb.pl xephem-3.7.7/GUI/xephem/auxil/mpcorb2edb.pl
+--- xephem-3.7.7.orig/GUI/xephem/auxil/mpcorb2edb.pl	2014-07-11 04:46:35.000000000 +0200
++++ xephem-3.7.7/GUI/xephem/auxil/mpcorb2edb.pl	2018-01-08 02:54:53.603935652 +0100
+@@ -78,7 +78,7 @@
+ # setup cutoff mag
+ my $dimmag = 13;			# dimmest mag to be saved in "bright" file
+ # set site and file in case of -f
+-my $MPCSITE = "http://www.minorplanetcenter.net";
++my $MPCSITE = "https://minorplanetcenter.net";
+ my $MPCFTPDIR = "/iau/MPCORB";
+ my $MPCFILE = "MPCORB.DAT";
+ my $MPCZIPFILE = "MPCORB.DAT.gz";
+diff -Naur xephem-3.7.7.orig/GUI/xephem/net.h xephem-3.7.7/GUI/xephem/net.h
+--- xephem-3.7.7.orig/GUI/xephem/net.h	2005-03-20 12:04:50.000000000 +0100
++++ xephem-3.7.7/GUI/xephem/net.h	2018-01-08 19:45:27.561208366 +0100
+@@ -20,6 +20,13 @@
+ #include <sys/select.h>
+ #endif
+ 
++#include <openssl/ssl.h>
++
++typedef struct {
++	int fd;		//file desciptor for the underlying connection socket
++	SSL *ssl;	//ssl connection for use with SSL_read( )and SSL_write()
++} XE_SSL_FD;
++
+ /* support functions */
+ 
+ extern int httpGET (char *host, char *GETcmd, char msg[]);
+@@ -29,8 +36,11 @@
+ extern int recvline (int fd, char buf[], int max);
+ extern int recvlineb (int sock, char *buf, int size);
+ extern int sendbytes (int fd, unsigned char buf[], int n);
+-
+-
++extern int httpsGET (char *host, char *GETcmd, char msg[], XE_SSL_FD *ssl_fd);
++extern int ssl_recvbytes (XE_SSL_FD *ssl_fd, unsigned char buf[], int n);
++extern int ssl_readbytes (XE_SSL_FD *ssl_fd, unsigned char buf[], int n);
++extern int ssl_recvline (XE_SSL_FD *ssl_fd, char buf[], int max);
++extern int ssl_recvlineb (XE_SSL_FD *ssl_fd, char *buf, int size);
+ 
+ /* For RCS Only -- Do Not Edit
+  * @(#) $RCSfile: net.h,v $ $Date: 2003/03/17 07:26:21 $ $Revision: 1.3 $ $Name:  $
+diff -Naur xephem-3.7.7.orig/GUI/xephem/netmenu.c xephem-3.7.7/GUI/xephem/netmenu.c
+--- xephem-3.7.7.orig/GUI/xephem/netmenu.c	2010-10-06 23:12:40.000000000 +0200
++++ xephem-3.7.7/GUI/xephem/netmenu.c	2018-01-08 22:02:16.090940142 +0100
+@@ -9,6 +9,8 @@
+ #include <string.h>
+ #include <unistd.h>
+ 
++#include <openssl/ssl.h>
++
+ #include <Xm/Form.h>
+ #include <Xm/Label.h>
+ #include <Xm/PushB.h>
+@@ -70,12 +72,24 @@
+ 
+ static char netcategory[] = "Network";	/* Save category */
+ 
++static SSL_METHOD *ssl_method;	/* global ssl dispatch structure for creating a ssl context */
++static SSL_CTX *ssl_ctx;	/* global ssl context structure for creating ssl connections */
++
+ /* call to set up without actually bringing up the menus.
+  */
+ void
+ net_create()
+ {
+ 	if (!netshell_w) {
++	    if (SSL_library_init() < 0) {
++		fprintf (stderr, "Could not initialize the OpenSSL library !\n");
++	    } else {
++		ssl_method = SSLv23_client_method();	/* deprecated since openssl 1.1.x */
++//		ssl_method = TLS_client_method();	/* since openssl 1.1.x */
++		ssl_ctx = SSL_CTX_new (ssl_method);
++		SSL_CTX_set_options (ssl_ctx, SSL_OP_NO_SSLv2);
++	    };
++
+ 	    net_create_form();
+ 	    (void) net_save();	/* confirming here is just annoying */
+ 	}
+@@ -251,8 +265,8 @@
+             struct {
+ 		unsigned char  VN;	/* version number */
+ 		unsigned char  CD;	/* command code */
+-		unsigned short DSTPORT;	/* destination port */
+-		unsigned long  DSTIP;	/* destination IP addres */
++		uint16_t       DSTPORT;	/* destination port */
++		uint32_t       DSTIP;	/* destination IP address */
+ 	    } SocksPacket;
+ 
+ 	    struct hostent *hs = gethostbyname (socks_host);
+@@ -390,7 +404,7 @@
+ 
+ /* read up to and including the next '\n' from socket fd into buf[max].
+  * we silently ignore all '\r'. we add a trailing '\0'.
+- * return line lenth (not counting \0) if all ok, else -1.
++ * return line length (not counting \0) if all ok, else -1.
+  * N.B. this never reads ahead -- if that's ok, recvlineb() is better
+  */
+ int
+@@ -445,6 +459,216 @@
+ 		if (nr <= 0) {
+ 		    ok = nr;
+ 		    rb_next = 0;
++		    rb_unk = 0;
++		    break;
++		}
++		rb_next = 0;
++		rb_unk = nr;
++	    }
++
++	    if ((c = rb_linebuf[rb_next++]) != '\r')
++		*buf++ = c;
++
++	} while (buf-origbuf < size && c != '\n');
++
++	/* always give back a real line regardless, else status */
++	if (ok > 0) {
++	    *buf = '\0';
++	    ok = buf - origbuf;
++	}
++
++	return (ok);
++}
++
++/* open the host, do the given GET cmd, and return a socket fd for the result.
++ * on success it fills the XE_SSL_FD structure for later use by SSL_read() and necessary cleanup.
++ * return -1 and with excuse in msg[], else 0 if ok.
++ * N.B. can be called before we are created if net set in app defaults.
++ */
++int
++httpsGET (char *host, char *GETcmd, char msg[], XE_SSL_FD *ssl_fd)
++{
++	char buf[2048];
++	int fd;
++	int connected;
++	SSL *ssl;
++	int n;
++	int ret;
++	int httpsport = 443;
++
++	/* open connection */
++	if (proxy_on) {
++	    fd = mkconnection (proxy_host, proxy_port, msg);
++	    if (fd < 0)
++		return (-1);
++
++	    /* fill buf with CONNECT */
++	    (void) sprintf (buf, "CONNECT %1$s:%2$d HTTP/1.0\r\nUser-Agent: xephem/%3$s\r\nHost: %1$s:%2$d\r\n\r\n", host, httpsport, PATCHLEVEL);
++
++	    /* add proxy auth if enabled */
++	    if (!auth_w)
++		net_create_form();
++	    if (XmToggleButtonGetState (auth_w))
++		addAuth(buf);
++
++	    /* log it */
++	    xe_msg (0, "https proxy connect: %s", buf);
++
++	    /* send it */
++	    n = strlen (buf);
++	    if (sendbytes(fd, (unsigned char *)buf, n) < 0) {
++		(void) sprintf (msg, "%s: send error: %s", proxy_host, syserrstr());
++		(void) close (fd);
++		return (-1);
++	    }
++
++	    connected = 0;
++	    while (recvline (fd, buf, sizeof(buf)) > 1) {
++		xe_msg (0, "Rcv: %s", buf);
++		if (strstr (buf, "200 "))
++		    connected = 1;
++	    }
++	    if (!connected) {
++		(void) sprintf (msg, "%s: connect error: %s", proxy_host, syserrstr());
++		(void) close (fd);
++		return (-1);
++	    }
++	} else {
++	    /* SOCKS or direct are both handled by mkconnection() */
++	    fd = mkconnection (host, httpsport, msg);
++	    if (fd < 0)
++		return (-1);
++	}
++
++	/* fill buf with GETcmd */
++	(void) sprintf (buf, "%s", GETcmd);
++
++	/* start ssl connection */
++	ssl = SSL_new (ssl_ctx);
++	SSL_set_fd (ssl, fd);
++	SSL_connect (ssl);
++
++	/* log it */
++	xe_msg (0, "https: %s", buf);
++
++	/* send it */
++	n = strlen (buf);
++	ret = SSL_write (ssl, (unsigned char *)buf, n);
++	if (ret <= 0) {
++	    (void) sprintf (msg, "%s: ssl send error code: %d", host, SSL_get_error (ssl, ret));
++	    (void) SSL_free (ssl);
++	    (void) close (fd);
++	    return (-1);
++	}
++
++	/* caller can read response */
++	ssl_fd->fd = fd;
++	ssl_fd->ssl = ssl;
++	return (fd);
++}
++
++/* receive exactly n bytes from ssl connection ssl_fd into buf.
++ * return -1, 0 or n.
++ * N.B. with fallback to ordinary read from socket if ssl_fd->ssl is NULL
++ */
++int
++ssl_recvbytes (XE_SSL_FD *ssl_fd, unsigned char buf[], int n)
++{
++	int ns, tot;
++
++	for (tot = 0; tot < n; tot += ns) {
++	    if (tout (TOUT, ssl_fd->fd, 0) < 0)
++		return (-1);
++	    if (ssl_fd->ssl)
++		ns = SSL_read (ssl_fd->ssl, (void *)(buf+tot), n-tot);
++	    else
++		ns = read (ssl_fd->fd, (void *)(buf+tot), n-tot);
++	    if (ns <= 0)
++		return (ns);
++	}
++	return (n);
++}
++
++/* like read(2) except we time out and allow user to cancel.
++ * receive up to n bytes from ssl connection ssl_fd into buf.
++ * return count, or 0 on eof or -1 on error.
++ * N.B. with fallback to ordinary read from socket if ssl_fd->ssl is NULL
++ */
++int
++ssl_readbytes (XE_SSL_FD *ssl_fd, unsigned char buf[], int n)
++{
++	int ns;
++
++	if (tout (TOUT, ssl_fd->fd, 0) < 0)
++	    return (-1);
++	if (ssl_fd->ssl)
++	    ns = SSL_read (ssl_fd->ssl, (void *)buf, n);
++	else
++	    ns = read (ssl_fd->fd, (void *)buf, n);
++	return (ns);
++}
++
++/* read up to and including the next '\n' from ssl into buf[max].
++ * we silently ignore all '\r'. we add a trailing '\0'.
++ * return line length (not counting \0) if all ok, else -1.
++ * N.B. with fallback to ordinary read from socket if ssl_fd->ssl is NULL
++ */
++int
++ssl_recvline (XE_SSL_FD *ssl_fd, char buf[], int max)
++{
++	unsigned char c;
++	int n;
++
++	max--;	/* leave room for trailing \0 */
++
++	for (n = 0; n < max && ssl_recvbytes (ssl_fd, &c, 1) == 1; ) {
++	    if (c != '\r') {
++		buf[n++] = c;
++		if (c == '\n') {
++		    buf[n] = '\0';
++		    return (n);
++		}
++	    }
++	}
++
++	return (-1);
++}
++
++/* rather like ssl_recvline but reads ahead in big chunk for efficiency.
++ * return length if read a line ok, 0 if hit eof, -1 if error.
++ * N.B. we silently swallow all '\r'.
++ * N.B. we read ahead and can hide bytes after each call.
++ * N.B. with fallback to ordinary read from socket if ssl_fd->ssl is NULL
++ */
++int
++ssl_recvlineb (XE_SSL_FD *ssl_fd, char *buf, int size)
++{
++	char *origbuf = buf;		/* save to prevent overfilling buf */
++	char c = '\0';
++	int ok = 1;
++
++	/* always leave room for trailing \n */
++	size -= 1;
++
++	/* read and copy linebuf[next] to buf until buf fills or copied a \n */
++	do {
++
++	    if (rb_next >= rb_unk) {
++		/* linebuf is empty -- refill */
++
++		int nr;
++
++		if (tout (TOUT, ssl_fd->fd, 0) < 0) {
++		    nr = -1;
++		    break;
++		}
++		if (ssl_fd->ssl)
++		    nr = SSL_read (ssl_fd->ssl, rb_linebuf, sizeof(rb_linebuf));
++		else
++		    nr = read (ssl_fd->fd, rb_linebuf, sizeof(rb_linebuf));
++		if (nr <= 0) {
++		    ok = nr;
++		    rb_next = 0;
+ 		    rb_unk = 0;
+ 		    break;
+ 		}
+diff -Naur xephem-3.7.7.orig/GUI/xephem/sunmenu.c xephem-3.7.7/GUI/xephem/sunmenu.c
+--- xephem-3.7.7.orig/GUI/xephem/sunmenu.c	2012-04-02 00:38:50.000000000 +0200
++++ xephem-3.7.7/GUI/xephem/sunmenu.c	2018-01-08 22:09:43.585825210 +0100
+@@ -884,9 +884,11 @@
+ 	int isjpeg, jpegl;
+ 	int njpeg;
+ 	unsigned char *jpeg;
++	XE_SSL_FD ssl_fd;
+ 	int fd, nr;
+ 	struct tm tm;
+ 
++	memset(&ssl_fd, 0, sizeof(ssl_fd));
+ 	memset(&tm, 0, sizeof(struct tm));
+ 
+ 	/* get desired type and size */
+@@ -899,18 +901,18 @@
+ 
+ 	/* build GET command */
+ 	sprintf (get, "GET http://%s%s HTTP/1.0\r\nUser-Agent: xephem/%s\r\n\r\n", sohohost, fn, PATCHLEVEL);
+-
++	
+ 	/* query server */
+-	fd = httpGET (sohohost, get, buf);
++	fd = httpsGET (sohohost, get, buf, &ssl_fd);
+ 	if (fd < 0) {
+-	    xe_msg (1, "http get: %s", buf);
++	    xe_msg (1, "https get: %s", buf);
+ 	    return (-1);
+ 	}
+ 
+ 	/* read header (everything to first blank line), looking for jpeg */
+ 	isjpeg = 0;
+ 	jpegl = 0;
+-	while (recvline (fd, buf, sizeof(buf)) > 1) {
++	while (ssl_recvline (&ssl_fd, buf, sizeof(buf)) > 1) {
+ 	    xe_msg (0, "Rcv: %s", buf);
+ 	    if (strstr (buf, "Content-Type:") && strstr (buf, "image/jpeg"))
+ 		isjpeg = 1;
+@@ -923,15 +925,17 @@
+ 	    }
+ 	}
+ 	if (!isjpeg) {
+-	    while (recvline (fd, buf, sizeof(buf)) > 0)
++	    while (ssl_recvline (&ssl_fd, buf, sizeof(buf)) > 0)
+ 		xe_msg (0, "Rcv: %s", buf);
+ 	    xe_msg (1, "Error talking to SOHO .. see File->System log\n");
+-	    close (fd);
++	    SSL_free (ssl_fd.ssl);
++	    close (ssl_fd.fd);
+ 	    return (-1);
+ 	}
+ 	if (jpegl == 0) {
+ 	    xe_msg (1, "No Content-Length in header");
+-	    close (fd);
++	    SSL_free (ssl_fd.ssl);
++	    close (ssl_fd.fd);
+ 	    return (-1);
+ 	}
+ 
+@@ -941,20 +945,22 @@
+ 	for (njpeg = 0; njpeg < jpegl; njpeg += nr) {
+ 	    pm_set (100*njpeg/jpegl);
+ 	    jpeg = (unsigned char *) XtRealloc ((char*)jpeg, njpeg+NSREAD);
+-	    nr = readbytes (fd, jpeg+njpeg, NSREAD);
+-	    if (nr < 0) {
+-		xe_msg (1, "%s:\n%s", sohohost, syserrstr());
++	    nr = SSL_read (ssl_fd.ssl, jpeg+njpeg, NSREAD);
++	    if (nr <= 0) {
++		xe_msg (1, "%s: ssl read error code: %d", sohohost, SSL_get_error(ssl_fd.ssl, nr));
+ 		pm_down();
+-		close (fd);
++		SSL_free (ssl_fd.ssl);
++		close (ssl_fd.fd);
+ 		return (-1);
+ 	    }
+ 	    if (nr == 0)
+ 		break;
+ 	}
+ 	pm_down();
+-	close (fd);
++	SSL_free (ssl_fd.ssl);
++	close (ssl_fd.fd);
+ 
+-        sprintf (fn, "/%s_%s.jpg", filetime, filetype);
++	sprintf (fn, "/%s_%s.jpg", filetime, filetype);
+ 	/* display jpeg */
+ 	if (displayPic (fn, jpeg, njpeg) < 0)
+ 	    return (-1);
+diff -Naur xephem-3.7.7.orig/GUI/xephem/ucac.c xephem-3.7.7/GUI/xephem/ucac.c
+--- xephem-3.7.7.orig/GUI/xephem/ucac.c	2013-03-02 03:41:37.000000000 +0100
++++ xephem-3.7.7/GUI/xephem/ucac.c	2018-01-08 21:53:08.398538689 +0100
+@@ -18,15 +18,15 @@
+ 
+ #define	MAXFOV	15.0			/* max fov, degs */
+ 
+-typedef unsigned char UC;		/* byte */
+-typedef unsigned int UI;		/* unsigned integer */
++typedef unsigned char XE_UC;		/* byte */
++typedef unsigned int XE_UI;		/* unsigned integer */
+ 
+ /* access an I*2 or I*4 at offset i in UC array a in little-endian byte order.
+  * a bit slow but ultra portable.
+  */
+-#define	I2(a,i)		((int)(short)((((UI)(a)[i]) | (((UI)(a)[i+1])<<8))))
+-#define	I4(a,i)		((int)((((UI)(a)[i]) | (((UI)(a)[i+1])<<8) | \
+-				(((UI)(a)[i+2])<<16) | (((UI)(a)[i+3])<<24))))
++#define	I2(a,i)		((int)(short)((((XE_UI)(a)[i]) | (((XE_UI)(a)[i+1])<<8))))
++#define	I4(a,i)		((int)((((XE_UI)(a)[i]) | (((XE_UI)(a)[i+1])<<8) | \
++				(((XE_UI)(a)[i+2])<<16) | (((XE_UI)(a)[i+3])<<24))))
+ 
+ /* keep track of an array of ObjF */
+ typedef struct {
+@@ -48,9 +48,9 @@
+ 
+ #define	DPMAS	(1.0/3600000.0)		/* degrees per milliarcsecond */
+ 
+-typedef UC U2Star[44];			/* UCAC2 record */
+-typedef UC U3Star[84];			/* UCAC3 record */
+-typedef UC U4Star[78];			/* UCAC4 record */
++typedef XE_UC U2Star[44];		/* UCAC2 record */
++typedef XE_UC U3Star[84];		/* UCAC3 record */
++typedef XE_UC U4Star[78];		/* UCAC4 record */
+ static char *basedir;			/* full dir with zone files and index */
+ static FILE *indexfp;			/* index file handle */
+ 
+@@ -293,7 +293,7 @@
+ read4Index (int rz, int dz, int *nskip, int *nnew)
+ {
+ 	off_t offset;
+-	UC i4[4];
++	XE_UC i4[4];
+ 
+ 	offset = (rz*NZH4 + dz)*sizeof(i4);
+ 	if (fseek (indexfp, offset, SEEK_SET) < 0) {
+@@ -508,7 +508,7 @@
+ read3Index (int rz, int dz, int *nskip, int *nnew)
+ {
+ 	off_t offset;
+-	UC i4[4];
++	XE_UC i4[4];
+ 
+ 	offset = (rz*NZH + dz)*sizeof(i4);
+ 	if (fseek (indexfp, offset, SEEK_SET) < 0) {
+@@ -663,7 +663,7 @@
+ get2N (int rz, int dz, int *idp)
+ {
+ 	off_t offset;
+-	UC nat[4];
++	XE_UC nat[4];
+ 
+ 	offset = (dz*NZW + rz)*sizeof(nat);
+ 	if (fseek (indexfp, offset, SEEK_SET) < 0)
+diff -Naur xephem-3.7.7.orig/GUI/xephem/usno.c xephem-3.7.7/GUI/xephem/usno.c
+--- xephem-3.7.7.orig/GUI/xephem/usno.c	2005-03-20 12:04:51.000000000 +0100
++++ xephem-3.7.7/GUI/xephem/usno.c	2016-10-26 18:59:16.469149437 +0200
+@@ -14,8 +14,8 @@
+ #define	CATBPR	12	/* bytes per star record in .cat file */
+ #define	ACCBPR	30	/* bytes per record in .acc file */
+ 
+-typedef unsigned int UI;
+-typedef unsigned char UC;
++typedef unsigned int XE_UI;
++typedef unsigned char XE_UC;
+ 
+ /* One Field star */
+ typedef struct {
+@@ -36,7 +36,7 @@
+     double lr[2], int *nd, double fd[2], double ld[2], int zone[2], char msg[]);
+ static int fetchSwath (int zone, double maxmag, double fr, double lr,
+     double fd, double ld, StarArray *sap, char msg[]);
+-static int crackCatBuf (UC buf[CATBPR], FieldStar *fsp);
++static int crackCatBuf (XE_UC buf[CATBPR], FieldStar *fsp);
+ static int addGS (StarArray *sap, FieldStar *fsp);
+ 
+ static char *cdpath;		/* where CD rom is mounted */
+@@ -236,7 +236,7 @@
+ {
+ 	char fn[1024];
+ 	char buf[ACCBPR];
+-	UC catbuf[CATBPR];
++	XE_UC catbuf[CATBPR];
+ 	FieldStar fs;
+ 	long frec;
+ 	long os;
+@@ -314,13 +314,13 @@
+  * return 0 if ok, else -1.
+  */
+ static int
+-crackCatBuf (UC buf[CATBPR], FieldStar *fsp)
++crackCatBuf (XE_UC buf[CATBPR], FieldStar *fsp)
+ {
+-#define	BEUPACK(b) (((UI)((b)[0])<<24) | ((UI)((b)[1])<<16) | ((UI)((b)[2])<<8)\
+-							    | ((UI)((b)[3])))
++#define	BEUPACK(b) (((XE_UI)((b)[0])<<24) | ((XE_UI)((b)[1])<<16) | ((XE_UI)((b)[2])<<8)\
++							    | ((XE_UI)((b)[3])))
+ 	double ra, dec;
+ 	int red, blu;
+-	UI mag;
++	XE_UI mag;
+ 
+ 	/* first 4 bytes are packed RA, big-endian */
+ 	ra = BEUPACK(buf)/(100.0*3600.0*15.0);
+diff -Naur xephem-3.7.7.orig/GUI/xephem/webdbmenu.c xephem-3.7.7/GUI/xephem/webdbmenu.c
+--- xephem-3.7.7.orig/GUI/xephem/webdbmenu.c	2012-11-23 06:22:09.000000000 +0100
++++ xephem-3.7.7/GUI/xephem/webdbmenu.c	2018-01-08 21:58:01.975042039 +0100
+@@ -404,6 +404,10 @@
+ char *url;
+ {
+ 	static char http[] = "http://";
++	static char https[] = "https://";
++	char *transport = http;
++	int ltransport = strlen (transport);
++	int ishttp = 0;
+ 	char buf[512], msg[1024];
+ 	char l0[512], l1[512], l2[512];
+ 	char *l0p = l0, *l1p = l1, *l2p = l2;
+@@ -411,21 +415,31 @@
+ 	char *slash, *dot;
+ 	char filename[256];
+ 	FILE *fp;
++	XE_SSL_FD ssl_fd;
+ 	int sockfd;
+ 	int nfound;
+ 
++	memset(&ssl_fd, 0, sizeof(ssl_fd));
++
+ 	/* start */
+ 	watch_cursor(1);
+ 	l0[0] = l1[0] = l2[0] = '\0';
+ 
+ 	/* find transport and host */
+-	if (strncmp (url, http, 7)) {
+-	    xe_msg (1, "URL must begin with %s", http);
++	if (!strncmp (url, transport, ltransport)) {
++	    ishttp = 1;
++	} else {
++	    transport = https;
++	    ltransport = strlen (transport);
++	}
++
++	if ((!ishttp) && (strncmp (url, transport, ltransport))) {
++	    xe_msg (1, "URL must begin with %s or %s", http, https);
+ 	    watch_cursor (0);
+ 	    return;
+ 	}
+ 
+-	slash = strchr (url+7, '/');
++	slash = strchr (url+ltransport, '/');
+ 	dot = strrchr (url, '.');
+ 	if (!slash || !dot) {
+ 	    xe_msg (1, "Badly formed URL");
+@@ -434,11 +448,16 @@
+ 	}
+ 
+ 	/* connect to check url */
+-	sprintf (host, "%.*s", (int)(slash-url-7), url+7);
++	sprintf (host, "%.*s", (int)(slash-url-ltransport), url+ltransport);
+ 	sprintf (buf, "GET %s HTTP/1.1\r\nHost: %s\r\nConnection: close\r\nUser-Agent: xephem/%s\r\n\r\n",
+ 						url, host, PATCHLEVEL);
+ 	stopd_up();
+-	sockfd = httpGET (host, buf, msg);
++	if (ishttp) {
++	    sockfd = httpGET (host, buf, msg);
++	    ssl_fd.fd = sockfd;
++	} else {
++	    sockfd = httpsGET (host, buf, msg, &ssl_fd);
++	}
+ 	if (sockfd < 0) {
+ 	    xe_msg (1, "http GET to %s failed: %s%s\n", host, buf, msg);
+ 	    stopd_down();
+@@ -447,20 +466,22 @@
+ 	}
+ 
+ 	/* create local file */
+-	slash = strrchr (url+7, '/');
++	slash = strrchr (url+ltransport, '/');
+ 	sprintf (filename, "%s/%.*sedb", getPrivateDir(), (int)(dot-slash), slash+1);
+ 	fp = fopen (filename, "w");
+ 	if (!fp) {
+ 	    xe_msg (1, "%s:\n%s", filename, syserrstr());
+ 	    watch_cursor (0);
+-	    close (sockfd);
++	    if (!ishttp)
++		SSL_free (ssl_fd.ssl);
++	    close (ssl_fd.fd);
+ 	    return;
+ 	}
+ 
+ 	/* copy to file, insuring only .edb lines.
+ 	 */
+ 	nfound = 0;
+-	while (recvlineb (sockfd, l2p, sizeof(l2)) > 0) {
++	while (ssl_recvlineb (&ssl_fd, l2p, sizeof(l2)) > 0) {
+ 	    char *lrot;
+ 	    Obj o;
+ 
+@@ -484,7 +505,9 @@
+ 
+ 	/* tidy up and done */
+ 	fclose (fp);
+-	close (sockfd);
++	if (!ishttp)
++	    SSL_free (ssl_fd.ssl);
++	close (ssl_fd.fd);
+ 	if (!nfound) {
+ 	    xe_msg (1, "No objects in file");
+ 	    remove (filename);
+diff -Naur xephem-3.7.7.orig/GUI/xephem/xephem.h xephem-3.7.7/GUI/xephem/xephem.h
+--- xephem-3.7.7.orig/GUI/xephem/xephem.h	2012-12-30 18:01:12.000000000 +0100
++++ xephem-3.7.7/GUI/xephem/xephem.h	2016-10-26 20:09:47.000000000 +0200
+@@ -12,12 +12,12 @@
+ 
+ #include <stdarg.h>		/* be kind to those who don't use xe_msg() */
+ 
++#include "net.h"		/* has to be included before astro.h because of openssl */
+ #include "astro.h"
+ #include "ip.h"
+ 
+ /* local glue files */
+ #include "map.h"
+-#include "net.h"
+ #include "patchlevel.h"
+ #include "preferences.h"
+ #include "db.h"
+diff -Naur xephem-3.7.7.orig/GUI/xephem/earthmenu.c xephem-3.7.7/GUI/xephem/earthmenu.c
+--- xephem-3.7.7.orig/GUI/xephem/earthmenu.c	2012-11-23 05:15:39.000000000 +0100
++++ xephem-3.7.7/GUI/xephem/earthmenu.c	2018-09-24 01:17:34.248048815 +0200
+@@ -4886,8 +4886,11 @@
+ 	int nrawgif;
+ 	char buf[1024];
+ 	int w, h;
++	XE_SSL_FD ssl_fd;
+ 	int fd;
+ 
++	memset(&ssl_fd, 0, sizeof(ssl_fd));
++
+ 	/* open test case, else real network */
+ 	fd = openh ("/tmp/latest_cmoll.gif", O_RDONLY);
+ 	if (fd >= 0) {
+@@ -4902,12 +4905,12 @@
+ 	    stopd_up();
+ 
+ 	    /* make connection to server for the file */
+-	    xe_msg (0, "Getting\nhttp://%s%s", wxhost, wxfile);
+-	    (void) sprintf (buf, "GET http://%s%s HTTP/1.0\r\nUser-Agent: xephem/%s\r\n\r\n",
+-						wxhost, wxfile, PATCHLEVEL);
+-	    fd = httpGET (wxhost, buf, buf);
++	    xe_msg (0, "Getting\nhttps://%s%s", wxhost, wxfile);
++	    (void) sprintf (buf, "GET %s HTTP/1.1\r\nHost: %s\r\nConnection: close\r\nUser-Agent: xephem/%s\r\n\r\n",
++						wxfile, wxhost, PATCHLEVEL);
++	    fd = httpsGET (wxhost, buf, buf, &ssl_fd);
+ 	    if (fd < 0) {
+-		xe_msg (1, "http get:\n%s", buf);
++		xe_msg (1, "https get:\n%s", buf);
+ 		stopd_down();
+ 		return (-1);
+ 	    }
+@@ -4915,7 +4918,7 @@
+ 	    /* read header, looking for some header info */
+ 	    isgif = 0;
+ 	    length = 0;
+-	    while (recvline (fd, buf, sizeof(buf)) > 1) {
++	    while (ssl_recvline (&ssl_fd, buf, sizeof(buf)) > 1) {
+ 		xe_msg (0, "Rcv: %s", buf);
+ 		if (strstr (buf, "image/gif"))
+ 		    isgif = 1;
+@@ -4923,9 +4926,10 @@
+ 		    length = atoi (buf+15);
+ 	    }
+ 	    if (!isgif) {
+-		while (recvline (fd, buf, sizeof(buf)) > 1)
++		while (ssl_recvline (&ssl_fd, buf, sizeof(buf)) > 1)
+ 		    xe_msg (0, "Rcv: %s", buf);
+-		close (fd);
++		SSL_free (ssl_fd.ssl);
++		close (ssl_fd.fd);
+ 		stopd_down();
+ 		return (-1);
+ 	    }
+@@ -4936,12 +4940,13 @@
+ 	    pm_up();
+ 	    for (nrawgif = 0; nrawgif < sizeof(rawgif); nrawgif += nr) {
+ 		pm_set (100*nrawgif/length);
+-		nr = readbytes (fd, rawgif+nrawgif, 4096);
++		nr = SSL_read (ssl_fd.ssl, rawgif+nrawgif, 4096);
+ 		if (nr < 0) {
+-		    xe_msg (1, "%s:\n%s", wxhost, syserrstr());
++		    xe_msg (1, "%s: ssl read error code: %d", wxhost, SSL_get_error(ssl_fd.ssl, nr));
+ 		    stopd_down();
+ 		    pm_down();
+-		    close (fd);
++		    SSL_free (ssl_fd.ssl);
++		    close (ssl_fd.fd);
+ 		    return (-1);
+ 		}
+ 		if (nr == 0)
+@@ -4949,7 +4954,8 @@
+ 	    }
+ 	    stopd_down();
+ 	    pm_down();
+-	    close (fd);
++	    SSL_free (ssl_fd.ssl);
++	    close (ssl_fd.fd);
+ 	    if (nr > 0) {
+ 		xe_msg (1, "File too large");
+ 		return (-1);
+


### PR DESCRIPTION
Upstream package has not seen any real updates in 5 years but is still working fine, however some of the online sources for background star catalogues, minor planets and comets ephemerides have moved and/or changed formats.

The initial motivation for the fix was the failure to load background stars from the HST Guide Star Catalogue 2.4 (enabled in the `Field stars` menu, which is still successfully accessed, but could not be parsed due to a change in no. and order of columns. The download test was also trying to access R band magnitudes, which are missing for almost all stars in GSC, making the setup fail. I have replaced them with the IR J magnitude; this is only used as a last fallback option for a stellar magnitude.

Also updated default URLs for some other sites, but reading them in via the `Download` menu still fails on parsing them for reasons I could not track down – especially as the files are already provided in XEphem format and can simply be manually placed into the `catalogs` or `~/Library/XEphem` directory.
Added additional patches from http://www.clearskyinstitute.com/xephem/contrib/contrib.html that should enable handling of `https` downloads.

Since the package only comes with a very minimal set of data files, I have also tried to make it easier to use separately downloaded catalogue files (from the complete tarballs on the XEphem site or directly from online sources like minorplanetcenter.net). The executable is now patched to use the Fink install location `%p/lib/xephem` as hardcoded default, and will therefore find the included data without the wrapper script setting `TELHOME`. If additional data are installed outside of %p – e.g. the CD versions of the GSC 2.2 come with a `pkg` installer putting them in `/usr/local/xephem` – launching xephem with the `-env TELHOME=/usr/local` option will let it find them (it would also find them automatically in the user's `~/Library/XEphem`, but this would provide an option to make them available system-wide).