### PR TITLE
Fix GnuTLS 3.6.13 build when xcode isn't installed

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-shlibs.info
@@ -32,7 +32,13 @@ PatchFile-MD5: e486231c88c44082fe75a7d0984fc06d
 PatchScript: <<
 	#!/bin/bash -ev
 	XCODE_VERSION=`xcodebuild -version 2>/dev/null | head -n 1 | cut -f 2 -d ' '`
+	XCODE_CLT_VERSION=`pkgutil --pkg-info com.apple.pkg.CLTools_Executables | grep version | cut -d: -f2 | cut -d'.' -f1-2`
 	if `dpkg --compare-versions $XCODE_VERSION ge 11.4`; then
+		# -no_weak_imports causes failure with Xcode11.4
+		# https://gitlab.com/gnutls/gnutls/-/issues/966
+		%{default_script}
+		autoreconf -vfi
+	elif `dpkg --compare-versions $XCODE_CLT_VERSION ge 11.4`; then
 		# -no_weak_imports causes failure with Xcode11.4
 		# https://gitlab.com/gnutls/gnutls/-/issues/966
 		%{default_script}

--- a/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-shlibs.info
@@ -33,12 +33,7 @@ PatchScript: <<
 	#!/bin/bash -ev
 	XCODE_VERSION=`xcodebuild -version 2>/dev/null | head -n 1 | cut -f 2 -d ' '`
 	XCODE_CLT_VERSION=`pkgutil --pkg-info com.apple.pkg.CLTools_Executables | grep version | cut -d: -f2 | cut -d'.' -f1-2`
-	if `dpkg --compare-versions $XCODE_VERSION ge 11.4`; then
-		# -no_weak_imports causes failure with Xcode11.4
-		# https://gitlab.com/gnutls/gnutls/-/issues/966
-		%{default_script}
-		autoreconf -vfi
-	elif `dpkg --compare-versions $XCODE_CLT_VERSION ge 11.4`; then
+	if `dpkg --compare-versions $XCODE_VERSION ge 11.4` || `dpkg --compare-versions $XCODE_CLT_VERSION ge 11.4`; then
 		# -no_weak_imports causes failure with Xcode11.4
 		# https://gitlab.com/gnutls/gnutls/-/issues/966
 		%{default_script}

--- a/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-shlibs.info
@@ -1,6 +1,6 @@
 Package: gnutls30-shlibs
 Version: 3.6.13
-Revision: 1
+Revision: 2
 Source: https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-%v.tar.xz
 Source-MD5: bb1fe696a11543433785b4fc70ca225f
 GCC: 4.0
@@ -90,9 +90,9 @@ InfoTest: <<
   <<
 <<
 Shlibs: <<
-	%p/lib/gnutls30/libgnutls.30.dylib         58.0.0 %n (>= 3.6.10-1)
-	%p/lib/gnutls30/libgnutls-openssl.27.dylib 28.0.0 %n (>= 3.6.10-1)
-	%p/lib/gnutls30/libgnutlsxx.28.dylib       30.0.0 %n (>= 3.6.10-1)
+	%p/lib/gnutls30/libgnutls.30.dylib         58.0.0 %n (>= 3.6.13-2)
+	%p/lib/gnutls30/libgnutls-openssl.27.dylib 28.0.0 %n (>= 3.6.13-2)
+	%p/lib/gnutls30/libgnutlsxx.28.dylib       30.0.0 %n (>= 3.6.13-2)
 <<
 
 SplitOff: <<


### PR DESCRIPTION
This builds on #599. If xcode isn't installed, but the command-line tools are, the patch still won't be applied correctly. This small change should fix that. Since nothing is changed with the compilation, the revision has not been bumped.