### PR TITLE
Update openblas to upstream 0.3.9 and gcc10

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
@@ -1,9 +1,9 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: openblas
-Version: 0.3.8
+Version: 0.3.9
 Revision: 1
-Type: gcc (9)
+Type: gcc (10)
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
 
 BuildDependsOnly: true
@@ -11,10 +11,10 @@ BuildDepends: fink (>= 0.30.0), gcc%type_raw[gcc]-compiler
 Depends: %N-shlibs (= %v-%r)
 
 Source: https://github.com/xianyi/OpenBLAS/archive/v%v.tar.gz
-Source-MD5: a3cb780c2d79e3fe13af58a261308fdf
+Source-MD5: 28cc19a6acbf636f5aab5f10b9a0dfe1
 SourceRename: OpenBLAS-%v.tar.gz
 PatchFile: %n.patch
-PatchFile-MD5: 3aefa8256082dd2c2edf04e4d25c6a7d
+PatchFile-MD5: c8465ba2b714cd59678c4ea627990234
 
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 
@@ -22,12 +22,15 @@ SetCC: gcc-fsf-%type_raw[gcc]
 
 CompileScript: <<
 	#!/bin/sh -ev
+	perl -pi -e 's|(^# )(DYNAMIC_ARCH = 1)|$2|;' Makefile.rule
 	# set arch to minimum model supported in OS version
 	darwin_vers=$(uname -r | cut -d. -f1)
 	if [ "$darwin_vers" -ge 18 ]; then
 		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=cascadelake -march=ivybridge|g;" Makefile.system
+		export DYNAMIC_LIST="SANDYBRIDGE HASWELL SKYLAKEX"
 	else
-		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=cascadelake -march=core2|g;" Makefile.system
+		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=skylake-avx512 -march=core2|g;" Makefile.system
+		export DYNAMIC_LIST="CORE2 PENRYN NEHALEM SANDYBRIDGE HASWELL"
 	fi
 	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 libs netlib shared
 	cd benchmark

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
@@ -1,7 +1,7 @@
 diff -uNr a/Makefile.system b/Makefile.system
 --- a/Makefile.system	2020-02-09 23:16:28.000000000 +0100
 +++ b/Makefile.system	2020-02-20 18:06:14.000000000 +0100
-@@ -486,8 +486,10 @@
+@@ -487,8 +487,10 @@
  endif
  
  ifeq ($(C_COMPILER), CLANG)
@@ -12,7 +12,7 @@ diff -uNr a/Makefile.system b/Makefile.system
  
  ifeq ($(C_COMPILER), INTEL)
  CCOMMON_OPT    += -fopenmp
-@@ -1201,8 +1203,8 @@
+@@ -1204,8 +1206,8 @@
  endif
 
 
@@ -22,7 +22,7 @@ diff -uNr a/Makefile.system b/Makefile.system
 
  ifeq ($(DEBUG), 1)
  COMMON_OPT += -g
-@@ -1274,19 +1274,19 @@
+@@ -1273,19 +1275,19 @@
  
  ifneq ($(DYNAMIC_ARCH), 1)
  ifndef SMP
@@ -67,7 +67,7 @@ diff -uNr a/benchmark/Makefile b/benchmark/Makefile
  
  # Intel standard
  # MKL=/opt/intel/mkl/lib/intel64
-@@ -2338,7 +2342,7 @@
+@@ -2381,7 +2385,7 @@
  
  
  smallscaling: smallscaling.c ../$(LIBNAME)
@@ -141,7 +141,7 @@ diff -uNr a/Makefile.install b/Makefile.install
 +++ b/Makefile.install	2019-11-06 2019-11-06 20:13:02.000000000 +0100
 @@ -84,8 +84,7 @@
 	@-cp $(LIBDYNNAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
-	@-install_name_tool -id "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)/$(LIBDYNNAME)" "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)/$(LIBDYNNAME)"
+	@-install_name_tool -id "$(OPENBLAS_LIBRARY_DIR)/$(LIBPREFIX).$(MAJOR_VERSION).dylib" "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)/$(LIBDYNNAME)"
 	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \
 -	ln -fs $(LIBDYNNAME) $(LIBPREFIX).dylib ; \
 -	ln -fs $(LIBDYNNAME) $(LIBPREFIX).$(MAJOR_VERSION).dylib
@@ -149,142 +149,3 @@ diff -uNr a/Makefile.install b/Makefile.install
  endif
  ifeq ($(OSNAME), WINNT)
 	@-cp $(LIBDLLNAME) "$(DESTDIR)$(OPENBLAS_BINARY_DIR)"
-diff --git a/.travis.yml b/.travis.yml
-index 9e18412e8..0f20aef5c 100644
---- a/.travis.yml
-+++ b/.travis.yml
-@@ -176,7 +176,7 @@ matrix:
-     - <<: *test-macos
-       osx_image: xcode10.1
-       env:
--        - CC="/Applications/Xcode-10.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -isysroot /Applications/Xcode-10.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.1.sdk"
-+        - CC="/Applications/Xcode-10.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
-         - CFLAGS="-O2 -Wno-macro-redefined -isysroot /Applications/Xcode-10.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.1.sdk -arch arm64 -miphoneos-version-min=10.0"
-         - BTYPE="TARGET=ARMV8 BINARY=64 HOSTCC=clang NOFORTRAN=1"
- 
-diff --git a/Makefile.prebuild b/Makefile.prebuild
-index a366004a1..b00f13368 100644
---- a/Makefile.prebuild
-+++ b/Makefile.prebuild
-@@ -42,7 +42,7 @@ all: getarch_2nd
- 	./getarch_2nd  1 >> $(TARGET_CONF)
- 
- config.h : c_check f_check getarch
--	perl ./c_check $(TARGET_MAKE) $(TARGET_CONF) $(CC) $(TARGET_FLAGS)
-+	perl ./c_check $(TARGET_MAKE) $(TARGET_CONF) $(CC) $(TARGET_FLAGS) $(CFLAGS)
- ifneq ($(ONLY_CBLAS), 1)
- 	perl ./f_check $(TARGET_MAKE) $(TARGET_CONF) $(FC) $(TARGET_FLAGS)
- else
-@@ -59,13 +59,13 @@ endif
- 
- 
- getarch : getarch.c cpuid.S dummy $(CPUIDEMU)
--	$(HOSTCC) $(CFLAGS) $(EXFLAGS) -o $(@F) getarch.c cpuid.S $(CPUIDEMU)
-+	$(HOSTCC) $(HOST_CFLAGS) $(EXFLAGS) -o $(@F) getarch.c cpuid.S $(CPUIDEMU)
- 
- getarch_2nd : getarch_2nd.c config.h dummy
- ifndef TARGET_CORE
--	$(HOSTCC) -I. $(CFLAGS) -o $(@F) getarch_2nd.c
-+	$(HOSTCC) -I. $(HOST_CFLAGS) -o $(@F) getarch_2nd.c
- else
--	$(HOSTCC) -I. $(CFLAGS) -DBUILD_KERNEL -o $(@F) getarch_2nd.c
-+	$(HOSTCC) -I. $(HOST_CFLAGS) -DBUILD_KERNEL -o $(@F) getarch_2nd.c
- endif
- 
- dummy:
-diff --git a/Makefile.system b/Makefile.system
-index c0e45515f..cf9e9bafa 100644
---- a/Makefile.system
-+++ b/Makefile.system
-@@ -214,7 +214,7 @@ ifndef GOTOBLAS_MAKEFILE
- export GOTOBLAS_MAKEFILE = 1
- 
- # Generating Makefile.conf and config.h
--DUMMY := $(shell $(MAKE) -C $(TOPDIR) -f Makefile.prebuild CC="$(CC)" FC="$(FC)" HOSTCC="$(HOSTCC)" CFLAGS="$(GETARCH_FLAGS)" BINARY=$(BINARY) USE_OPENMP=$(USE_OPENMP) TARGET_CORE=$(TARGET_CORE) ONLY_CBLAS=$(ONLY_CBLAS) TARGET=$(TARGET) all)
-+DUMMY := $(shell $(MAKE) -C $(TOPDIR) -f Makefile.prebuild CC="$(CC)" FC="$(FC)" HOSTCC="$(HOSTCC)" HOST_CFLAGS="$(GETARCH_FLAGS)" CFLAGS="$(CFLAGS)" BINARY=$(BINARY) USE_OPENMP=$(USE_OPENMP) TARGET_CORE=$(TARGET_CORE) ONLY_CBLAS=$(ONLY_CBLAS) TARGET=$(TARGET) all)
- 
- ifndef TARGET_CORE
- include $(TOPDIR)/Makefile.conf
-diff --git a/c_check b/c_check
-index 555b2eccf..c7899c84f 100644
---- a/c_check
-+++ b/c_check
-@@ -18,11 +18,12 @@ $binary = $ENV{"BINARY"};
- $makefile = shift(@ARGV);
- $config   = shift(@ARGV);
- 
--$compiler_name = join(" ", @ARGV);
-+$compiler_name = shift(@ARGV);
-+$flags = join(" ", @ARGV);
- 
- # First, we need to know the target OS and compiler name
- 
--$data = `$compiler_name -E ctest.c`;
-+$data = `$compiler_name $flags -E ctest.c`;
- 
- if ($?) {
-     printf STDERR "C Compiler ($compiler_name) is something wrong.\n";
-@@ -175,7 +176,7 @@ if ($defined == 0) {
- 
- # Do again
- 
--$data = `$compiler_name -E ctest.c`;
-+$data = `$compiler_name $flags -E ctest.c`;
- 
- if ($?) {
-     printf STDERR "C Compiler ($compiler_name) is something wrong.\n";
-@@ -195,7 +196,7 @@ if (($architecture eq "mips") || ($architecture eq "mips64")) {
- 	print $tmpf "void main(void){ __asm__ volatile($code); }\n";
- 
- 	$args = "$msa_flags -o $tmpf.o $tmpf";
--	my @cmd = ("$compiler_name $args");
-+	my @cmd = ("$compiler_name $flags $args >/dev/null 2>/dev/null");
- 	system(@cmd) == 0;
- 	if ($? != 0) {
- 	    $have_msa = 0;
-@@ -236,7 +237,7 @@ if (($architecture eq "x86") || ($architecture eq "x86_64")) {
- 	if ($compiler eq "PGI") {
- 	    $args = " -tp skylake -c -o $tmpf.o $tmpf";
- 	}
--	my @cmd = ("$compiler_name $args >/dev/null 2>/dev/null");
-+	my @cmd = ("$compiler_name $flags $args >/dev/null 2>/dev/null");
- 	system(@cmd) == 0;
- 	if ($? != 0) {
- 	    $no_avx512 = 1;
-@@ -247,7 +248,7 @@ if (($architecture eq "x86") || ($architecture eq "x86_64")) {
-     }
- }
- 
--$data = `$compiler_name -S ctest1.c && grep globl ctest1.s | head -n 1 && rm -f ctest1.s`;
-+$data = `$compiler_name $flags -S ctest1.c && grep globl ctest1.s | head -n 1 && rm -f ctest1.s`;
- 
- $data =~ /globl\s([_\.]*)(.*)/;
- 
-@@ -263,19 +264,6 @@ if ($architecture ne $hostarch) {
- 
- $cross = 1 if ($os ne $hostos);
- 
--# rework cross suffix and architecture if we are on OSX cross-compiling for ARMV8-based IOS
--# the initial autodetection will have been confused by the command-line arguments to clang
--# and the cross-compiler apparently still claims to build for x86_64 in its CC -E output
--if (($os eq "Darwin") && ($cross_suffix ne "")) {
--  my $tmpnam = `xcrun --sdk iphoneos --find clang`;
--  $cross_suffix = substr($tmpnam, 0, rindex($tmpnam, "/")+1 ); 
--# this should produce something like $cross_suffix="/Applications/Xcode-10.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/";
--  $cross =1;
--  $architecture = arm64;
--}
--
--
--
- $openmp = "" if $ENV{USE_OPENMP} != 1;
- 
- $linker_L = "";
-@@ -283,7 +271,7 @@ $linker_l = "";
- $linker_a = "";
- 
- {
--    $link = `$compiler_name -c ctest2.c -o ctest2.o 2>&1 && $compiler_name $openmp -v ctest2.o -o ctest2 2>&1 && rm -f ctest2.o ctest2 ctest2.exe`;
-+    $link = `$compiler_name $flags -c ctest2.c -o ctest2.o 2>&1 && $compiler_name $flags $openmp -v ctest2.o -o ctest2 2>&1 && rm -f ctest2.o ctest2 ctest2.exe`;
- 
-     $link =~ s/\-Y\sP\,/\-Y/g;


### PR DESCRIPTION
On the beginners mailing list this build failure for version 0.3.8 was reported https://sourceforge.net/p/fink/mailman/message/37022781/
due to the CPU version not being detected on the build system. The update includes fixes for auto-detecting a range of newer hardware like https://github.com/xianyi/OpenBLAS/commit/303bdb6 so hopefully may address this. Also switched to gcc10 for the build; tested with numpy-py38.