### PR TITLE
Fix build failure linking id3lib library on 10.15 by modernizing autotools components

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/id3lib4.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/id3lib4.info
@@ -13,14 +13,13 @@ BuildDepends: <<
 Depends: %N-shlibs (>= %v-%r), libiconv
 GCC: 4.0
 PatchFile: %n.patch
-PatchFile-MD5: a08b01883d87402759dadbd25a6cb7a8
+PatchFile-MD5: 1e3996f2fda6fc5de8be4c2d33013e70
 PatchScript: <<
 	%{default_script}
 	perl -pi -e 's/(AC_DEFUN\()(\S+)(,)/\1\[\2]\3/' m4/*.m4
 	mv configure.in configure.ac
 	autoreconf -vfi
 <<
-SetLIBS: -lz
 ConfigureParams: <<
 	--with-pic \
 	--enable-shared \
@@ -74,6 +73,7 @@ Patch mp3_parse.cpp to avoid a buffer overflow triggered by VBR files.
 Fixed upstream: http://id3lib.cvs.sourceforge.net/viewvc/id3lib/id3lib-stable/src/mp3_parse.cpp?r1=1.6&r2=1.7
 
 Modernize autotools files to deal with failure on 10.15 when linking the library.
+Make sure library is linked with libz.
 
 We patch the library name because the default is libid3-3.8.3.dylib.
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/id3lib4.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/id3lib4.info
@@ -16,6 +16,7 @@ PatchFile: %n.patch
 PatchFile-MD5: a08b01883d87402759dadbd25a6cb7a8
 PatchScript: <<
 	%{default_script}
+	perl -pi -e 's/(AC_DEFUN\()(\S+)(,)/\1\[\2]\3/' m4/*.m4
 	mv configure.in configure.ac
 	autoreconf -vfi
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/id3lib4.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/id3lib4.info
@@ -7,7 +7,8 @@ SourceDirectory: id3lib-%v
 BuildDepends: <<
 	autoconf2.6,
 	automake1.15,
-	libiconv-dev
+	libiconv-dev,
+	libtool2
 <<
 Depends: %N-shlibs (>= %v-%r), libiconv
 GCC: 4.0

--- a/10.9-libcxx/stable/main/finkinfo/libs/id3lib4.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/id3lib4.info
@@ -1,28 +1,36 @@
 Package: id3lib4
 Version: 3.8.3
-Revision: 2003
+Revision: 2004
 Source: mirror:sourceforge:id3lib/id3lib-%v.tar.gz
 Source-MD5: 19f27ddd2dda4b2d26a559a4f0f402a7
 SourceDirectory: id3lib-%v
 BuildDepends: <<
-	fink (>= 0.24.12),
+	autoconf2.6,
+	automake1.15,
 	libiconv-dev
 <<
 Depends: %N-shlibs (>= %v-%r), libiconv
 GCC: 4.0
 PatchFile: %n.patch
-PatchFile-MD5: e5b36311f8e807eb80cf19e20f8819d7
-NoSetLDFLAGS: true
-SetLIBS: -L%p/lib -lz
-ConfigureParams: --with-pic --enable-shared --disable-static --mandir=%i/share/man --infodir=%p/share/info --libexecdir=%p/lib
-UseMaxBuildJobs: true
+PatchFile-MD5: a08b01883d87402759dadbd25a6cb7a8
+PatchScript: <<
+	%{default_script}
+	mv configure.in configure.ac
+	autoreconf -vfi
+<<
+SetLIBS: -lz
+ConfigureParams: <<
+	--with-pic \
+	--enable-shared \
+	--disable-static
+<<
 DocFiles: COPYING AUTHORS  README* ChangeLog HISTORY THANKS TODO 
 Description: Library for manipulating ID3v1 and ID3v2 tag
 InfoTest: <<
 	TestScript: make -w check || exit 2
 <<
 InstallScript: <<
-  make install prefix=%i
+  make install DESTDIR=%d
 <<
 
 SplitOff: <<
@@ -36,7 +44,7 @@ SplitOff: <<
 
 SplitOff2: <<
   Package: %N-dev
-  Depends: %N-shlibs (>= %v-%r)
+  Depends: %N-shlibs (= %v-%r)
   BuildDependsOnly: true
   Conflicts: id3lib37-dev, id3lib3.7-dev
   Replaces: id3lib37-dev, id3lib3.7-dev
@@ -62,6 +70,10 @@ a highly stable and efficient implementation.
 DescPort: <<
 Patch mp3_parse.cpp to avoid a buffer overflow triggered by VBR files.
 Fixed upstream: http://id3lib.cvs.sourceforge.net/viewvc/id3lib/id3lib-stable/src/mp3_parse.cpp?r1=1.6&r2=1.7
+
+Modernize autotools files to deal with failure on 10.15 when linking the library.
+
+We patch the library name because the default is libid3-3.8.3.dylib.
 <<
 License: GPL
 Maintainer: Chris Zubrzycki <beren12@users.sourceforge.net>

--- a/10.9-libcxx/stable/main/finkinfo/libs/id3lib4.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/id3lib4.patch
@@ -1,74 +1,152 @@
-diff -ruN id3lib-3.8.3-orig/configure id3lib-3.8.3/configure
---- id3lib-3.8.3-orig/configure	2003-03-01 19:23:00.000000000 -0500
-+++ id3lib-3.8.3/configure	2011-07-27 17:24:03.000000000 -0400
-@@ -5581,7 +5581,7 @@
-     # FIXME: Relying on posixy $() will cause problems for
-     #        cross-compilation, but unfortunately the echo tests do not
-     #        yet detect zsh echo's removal of \ escapes.
--    archive_cmds='$nonopt $(test "x$module" = xyes && echo -bundle || echo -dynamiclib) $allow_undefined_flag -o $lib $libobjs $deplibs$linker_flags -install_name $rpath/$soname $verstring'
-+    archive_cmds='$nonopt $(test "x$module" = xyes && echo -bundle $allow_undefined_flag || echo -dynamiclib) -o $lib $libobjs $deplibs$linker_flags $(test "x$module" != xyes && echo -install_name $rpath/$soname $verstring)'
-     # We need to add '_' to the symbols in $export_symbols first
-     #archive_expsym_cmds="$archive_cmds"' && strip -s $export_symbols'
-     hardcode_direct=yes
-@@ -10296,7 +10296,6 @@
+diff -ruN id3lib-3.8.3-orig/ChangeLog id3lib-3.8.3/ChangeLog
+--- id3lib-3.8.3-orig/ChangeLog	2003-03-01 18:23:00.000000000 -0600
++++ id3lib-3.8.3/ChangeLog	2020-05-31 08:17:25.000000000 -0500
+@@ -1,3 +1,8 @@
++2006-02-17  Jerome Couderc
++
++    * Patch from Spoon to fix UTF-16 writing bug
++      http://sourceforge.net/tracker/index.php?func=detail&aid=1016290&group_id=979&atid=300979
++
+ 2003-03-02 Sunday 17:38   Thijmen Klok <thijmen@id3lib.org>
  
- for ac_header in \
+ 	* THANKS (1.20): added more people 
+diff -ruN id3lib-3.8.3-orig/Makefile.am id3lib-3.8.3/Makefile.am
+--- id3lib-3.8.3-orig/Makefile.am	2003-03-01 18:23:00.000000000 -0600
++++ id3lib-3.8.3/Makefile.am	2020-05-31 08:17:25.000000000 -0500
+@@ -11,6 +11,7 @@
+ 
+ # require automake 1.5
+ AUTOMAKE_OPTIONS = 1.5
++ACLOCAL_AMFLAGS = -I m4
+ 
+ EXTRA_DIST =                    \
+         HISTORY                 \
+diff -ruN id3lib-3.8.3-orig/configure.in id3lib-3.8.3/configure.in
+--- id3lib-3.8.3-orig/configure.in	2003-03-01 18:23:00.000000000 -0600
++++ id3lib-3.8.3/configure.in	2020-05-31 08:17:25.000000000 -0500
+@@ -11,11 +11,12 @@
+ # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
+ # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ 
+-# require autoconf 2.13
+-AC_PREREQ(2.13)
++# require autoconf 2.63
++AC_PREREQ(2.63)
+ 
+ # init autoconf (and check for presence fo reconf)
+ AC_INIT(reconf)
++AC_CONFIG_MACRO_DIR([m4])
+ 
+ ID3LIB_NAME=id3lib
+ 
+@@ -83,7 +84,7 @@
+ 
+ AC_SUBST(ID3LIB_FULLNAME)
+ 
+-AM_CONFIG_HEADER(config.h)
++AC_CONFIG_HEADERS([config.h])
+ 
+ AM_INIT_AUTOMAKE($PACKAGE,$VERSION)
+ 
+@@ -168,7 +169,7 @@
+ 		iconv_oldstyle=1, iconv_oldstyle=0)
+   if test $iconv_oldstyle = 1; then
+     AC_MSG_RESULT(const char **)
+-    AC_DEFINE(ID3LIB_ICONV_OLDSTYLE)
++    AC_DEFINE(ID3LIB_ICONV_OLDSTYLE, 1, [Desc])
+     #we'll check out the need of
+     #typecast in the call of iconv_open
+     AC_MSG_CHECKING(whether to typecast in iconv)
+@@ -184,7 +185,7 @@
+                    iconv_cast=0, iconv_cast=1)
+     if test $iconv_cast = 1; then
+       AC_MSG_RESULT(yes)
+-      AC_DEFINE(ID3LIB_ICONV_CAST_OK)
++      AC_DEFINE(ID3LIB_ICONV_CAST_OK, 1, [Desc])
+     else
+       AC_MSG_RESULT(no)
+     fi
+@@ -206,7 +207,7 @@
+                    iconv_cast=0, iconv_cast=1)
+     if test $iconv_cast = 1; then
+       AC_MSG_RESULT(yes)
+-      AC_DEFINE(ID3LIB_ICONV_CAST_OK)
++      AC_DEFINE(ID3LIB_ICONV_CAST_OK, 1, [Desc])
+     else
+       AC_MSG_RESULT(no)
+     fi
+@@ -227,7 +228,6 @@
+ )
+ AC_CHECK_HEADERS(               \
    string                        \
 -  iomanip.h                     \
-
- do
- as_ac_Header=`echo "ac_cv_header_$ac_header" | $as_tr_sh`
+   ,,AC_MSG_ERROR([Missing a vital header file for id3lib])
+ )
+ 
+@@ -296,12 +296,6 @@
+ AC_DEFINE_UNQUOTED(_ID3LIB_BINARY_AGE,            $ID3LIB_BINARY_AGE)
+ AC_DEFINE_UNQUOTED(_ID3_COMPILED_WITH_DEBUGGING, "${enable_debug}")
+ 
+-CONDITIONAL_SUBDIRS=
+-if test "x$ac_cv_lib_z_uncompress" = "xno"; then
+-  CONDITIONAL_SUBDIRS="$CONDITIONAL_SUBDIRS zlib"
+-fi
+-AC_CONFIG_SUBDIRS(zlib)
+-
+ CFLAGS="$CFLAGS -Wall"
+ 
+ AC_OUTPUT(                      \
 diff -ruN id3lib-3.8.3-orig/examples/demo_convert.cpp id3lib-3.8.3/examples/demo_convert.cpp
---- id3lib-3.8.3-orig/examples/demo_convert.cpp	2003-03-01 19:23:00.000000000 -0500
-+++ id3lib-3.8.3/examples/demo_convert.cpp	2011-07-27 17:24:17.000000000 -0400
+--- id3lib-3.8.3-orig/examples/demo_convert.cpp	2003-03-01 18:23:00.000000000 -0600
++++ id3lib-3.8.3/examples/demo_convert.cpp	2020-05-31 08:17:25.000000000 -0500
 @@ -84,7 +84,7 @@
    }
  }
  
 -int main( unsigned int argc, char * const argv[])
-+int main( int argc, char * const argv[])
++int main(int argc, char * const argv[])
  {
    flags_t ulFlag = ID3TT_ALL;
    gengetopt_args_info args;
 diff -ruN id3lib-3.8.3-orig/examples/demo_copy.cpp id3lib-3.8.3/examples/demo_copy.cpp
---- id3lib-3.8.3-orig/examples/demo_copy.cpp	2003-03-01 19:23:00.000000000 -0500
-+++ id3lib-3.8.3/examples/demo_copy.cpp	2011-07-27 17:24:17.000000000 -0400
+--- id3lib-3.8.3-orig/examples/demo_copy.cpp	2003-03-01 18:23:00.000000000 -0600
++++ id3lib-3.8.3/examples/demo_copy.cpp	2020-05-31 08:17:25.000000000 -0500
 @@ -81,7 +81,7 @@
    }
  }
  
 -int main( unsigned int argc, char * const argv[])
-+int main( int argc, char * const argv[])
++int main(int argc, char * const argv[])
  {
    int ulFlag = ID3TT_ID3;
    ID3D_INIT_DOUT();
 diff -ruN id3lib-3.8.3-orig/examples/demo_info.cpp id3lib-3.8.3/examples/demo_info.cpp
---- id3lib-3.8.3-orig/examples/demo_info.cpp	2003-03-01 19:23:00.000000000 -0500
-+++ id3lib-3.8.3/examples/demo_info.cpp	2011-07-27 17:24:17.000000000 -0400
+--- id3lib-3.8.3-orig/examples/demo_info.cpp	2003-03-01 18:23:00.000000000 -0600
++++ id3lib-3.8.3/examples/demo_info.cpp	2020-05-31 08:17:25.000000000 -0500
 @@ -309,7 +309,7 @@
  
  #define DEBUG
  
 -int main( unsigned int argc, char * const argv[])
-+int main( int argc, char * const argv[])
++int main(int argc, char * const argv[])
  {
    ID3D_INIT_DOUT();
  
 diff -ruN id3lib-3.8.3-orig/examples/demo_tag.cpp id3lib-3.8.3/examples/demo_tag.cpp
---- id3lib-3.8.3-orig/examples/demo_tag.cpp	2003-03-01 19:23:00.000000000 -0500
-+++ id3lib-3.8.3/examples/demo_tag.cpp	2011-07-27 17:24:17.000000000 -0400
+--- id3lib-3.8.3-orig/examples/demo_tag.cpp	2003-03-01 18:23:00.000000000 -0600
++++ id3lib-3.8.3/examples/demo_tag.cpp	2020-05-31 08:17:25.000000000 -0500
 @@ -46,7 +46,7 @@
      os << "v2";
  }
  
 -int main( unsigned int argc, char * const argv[])
-+int main( int argc, char * const argv[])
++int main(int argc, char * const argv[])
  {
    int ulFlag = ID3TT_ID3;
    ID3D_INIT_DOUT();
 diff -ruN id3lib-3.8.3-orig/examples/findeng.cpp id3lib-3.8.3/examples/findeng.cpp
---- id3lib-3.8.3-orig/examples/findeng.cpp	2003-03-01 19:23:00.000000000 -0500
-+++ id3lib-3.8.3/examples/findeng.cpp	2011-07-27 17:24:17.000000000 -0400
+--- id3lib-3.8.3-orig/examples/findeng.cpp	2003-03-01 18:23:00.000000000 -0600
++++ id3lib-3.8.3/examples/findeng.cpp	2020-05-31 08:17:25.000000000 -0500
 @@ -9,7 +9,7 @@
  using std::cout;
  using std::endl;
@@ -79,8 +157,8 @@ diff -ruN id3lib-3.8.3-orig/examples/findeng.cpp id3lib-3.8.3/examples/findeng.c
    ID3D_INIT_DOUT();
    ID3D_INIT_WARNING();
 diff -ruN id3lib-3.8.3-orig/examples/findstr.cpp id3lib-3.8.3/examples/findstr.cpp
---- id3lib-3.8.3-orig/examples/findstr.cpp	2003-03-01 19:23:00.000000000 -0500
-+++ id3lib-3.8.3/examples/findstr.cpp	2011-07-27 17:24:17.000000000 -0400
+--- id3lib-3.8.3-orig/examples/findstr.cpp	2003-03-01 18:23:00.000000000 -0600
++++ id3lib-3.8.3/examples/findstr.cpp	2020-05-31 08:17:25.000000000 -0500
 @@ -9,7 +9,7 @@
  using std::cout;
  using std::endl;
@@ -91,8 +169,8 @@ diff -ruN id3lib-3.8.3-orig/examples/findstr.cpp id3lib-3.8.3/examples/findstr.c
    ID3D_INIT_DOUT();
    ID3D_INIT_WARNING();
 diff -ruN id3lib-3.8.3-orig/examples/test_io.cpp id3lib-3.8.3/examples/test_io.cpp
---- id3lib-3.8.3-orig/examples/test_io.cpp	2003-03-01 19:23:00.000000000 -0500
-+++ id3lib-3.8.3/examples/test_io.cpp	2016-10-29 22:01:36.000000000 -0500
+--- id3lib-3.8.3-orig/examples/test_io.cpp	2003-03-01 18:23:00.000000000 -0600
++++ id3lib-3.8.3/examples/test_io.cpp	2020-05-31 08:17:25.000000000 -0500
 @@ -4,6 +4,8 @@
  #  include <config.h>
  #endif
@@ -102,7 +180,7 @@ diff -ruN id3lib-3.8.3-orig/examples/test_io.cpp id3lib-3.8.3/examples/test_io.c
  #include <id3/readers.h>
  #include <id3/writers.h>
  #include <id3/io_decorators.h>
-@@ -18,7 +18,7 @@
+@@ -18,7 +20,7 @@
  using namespace dami;
  
  int
@@ -111,32 +189,58 @@ diff -ruN id3lib-3.8.3-orig/examples/test_io.cpp id3lib-3.8.3/examples/test_io.c
  {
    ID3D_INIT_DOUT();
    ID3D_INIT_WARNING();
-diff -ruN id3lib-3.8.3-orig/ltmain.sh id3lib-3.8.3/ltmain.sh
---- id3lib-3.8.3-orig/ltmain.sh	2003-03-01 19:23:00.000000000 -0500
-+++ id3lib-3.8.3/ltmain.sh	2011-07-27 17:23:53.000000000 -0400
-@@ -1739,7 +1739,7 @@
+diff -ruN id3lib-3.8.3-orig/m4/id3_cxx.m4 id3lib-3.8.3/m4/id3_cxx.m4
+--- id3lib-3.8.3-orig/m4/id3_cxx.m4	2003-03-01 18:23:00.000000000 -0600
++++ id3lib-3.8.3/m4/id3_cxx.m4	2020-05-31 08:17:25.000000000 -0500
+@@ -81,7 +81,7 @@
  
- 	  if test "$installed" = no; then
- 	    notinst_deplibs="$notinst_deplibs $lib"
--	    need_relink=yes
-+	    need_relink=no
- 	  fi
- 
- 	  if test -n "$old_archive_from_expsyms_cmds"; then
-diff -ruN id3lib-3.8.3-orig/src/Makefile.in id3lib-3.8.3/src/Makefile.in
---- id3lib-3.8.3-orig/src/Makefile.in	2003-03-01 19:23:00.000000000 -0500
-+++ id3lib-3.8.3/src/Makefile.in	2011-07-27 17:24:13.000000000 -0400
-@@ -183,7 +183,7 @@
+   dnl Check whether we have bool
+   AC_MSG_CHECKING(whether C++ has bool)
+-  AC_TRY_RUN([main() { bool b1=true; bool b2=false; }],
++  AC_TRY_RUN([int main() { bool b1=true; bool b2=false; return 0; }],
+              [ AC_MSG_RESULT(yes) ],
+              [ AC_MSG_RESULT(no)
+                AC_DEFINE(CXX_HAS_NO_BOOL) ],
+diff -ruN id3lib-3.8.3-orig/src/Makefile.am id3lib-3.8.3/src/Makefile.am
+--- id3lib-3.8.3-orig/src/Makefile.am	2003-03-01 18:23:00.000000000 -0600
++++ id3lib-3.8.3/src/Makefile.am	2020-05-31 08:17:25.000000000 -0500
+@@ -78,5 +78,5 @@
  
  libid3_la_LDFLAGS = \
    -version-info $(LT_VERSION) \
 -  -release $(LT_RELEASE) \
-+    \
++  -no-undefined \
    -export-dynamic
- 
- subdir = src
---- a/src/mp3_parse.cpp	2003-03-02 01:23:00.000000000 +0100
-+++ b/src/mp3_parse.cpp	2009-09-27 19:44:18.000000000 +0200
+diff -ruN id3lib-3.8.3-orig/src/io_helpers.cpp id3lib-3.8.3/src/io_helpers.cpp
+--- id3lib-3.8.3-orig/src/io_helpers.cpp	2003-03-01 18:23:00.000000000 -0600
++++ id3lib-3.8.3/src/io_helpers.cpp	2020-05-31 08:17:25.000000000 -0500
+@@ -363,11 +363,22 @@
+     // Write the BOM: 0xFEFF
+     unicode_t BOM = 0xFEFF;
+     writer.writeChars((const unsigned char*) &BOM, 2);
++    // Patch from Spoon : 2004-08-25 14:17
++    //   http://sourceforge.net/tracker/index.php?func=detail&aid=1016290&group_id=979&atid=300979
++    // Wrong code
++    //for (size_t i = 0; i < size; i += 2)
++    //{
++    //  unicode_t ch = (data[i] << 8) | data[i+1];
++    //  writer.writeChars((const unsigned char*) &ch, 2);
++    //}
++    // Right code
++    unsigned char *pdata = (unsigned char *) data.c_str();
+     for (size_t i = 0; i < size; i += 2)
+     {
+-      unicode_t ch = (data[i] << 8) | data[i+1];
++      unicode_t ch = (pdata[i] << 8) | pdata[i+1];
+       writer.writeChars((const unsigned char*) &ch, 2);
+     }
++    // End patch
+   }
+   return writer.getCur() - beg;
+ }
+diff -ruN id3lib-3.8.3-orig/src/mp3_parse.cpp id3lib-3.8.3/src/mp3_parse.cpp
+--- id3lib-3.8.3-orig/src/mp3_parse.cpp	2003-03-01 18:23:00.000000000 -0600
++++ id3lib-3.8.3/src/mp3_parse.cpp	2020-05-31 08:17:25.000000000 -0500
 @@ -465,7 +465,7 @@
    // from http://www.xingtech.com/developer/mp3/
  

--- a/10.9-libcxx/stable/main/finkinfo/libs/id3lib4.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/id3lib4.patch
@@ -204,7 +204,13 @@ diff -ruN id3lib-3.8.3-orig/m4/id3_cxx.m4 id3lib-3.8.3/m4/id3_cxx.m4
 diff -ruN id3lib-3.8.3-orig/src/Makefile.am id3lib-3.8.3/src/Makefile.am
 --- id3lib-3.8.3-orig/src/Makefile.am	2003-03-01 18:23:00.000000000 -0600
 +++ id3lib-3.8.3/src/Makefile.am	2020-05-31 08:17:25.000000000 -0500
-@@ -78,5 +78,5 @@
+@@ -74,9 +74,11 @@
+ 
+ if ID3_NEEDZLIB
+ LDADD        = $(top_builddir)/zlib/src/libz.la
++else
++libid3_la_LIBADD  = -lz
+ endif
  
  libid3_la_LDFLAGS = \
    -version-info $(LT_VERSION) \


### PR DESCRIPTION
On 10.15, id3lib4 fails with this error:
```
/bin/sh ../libtool --mode=link g++  -g -O2 -Wall -Wno-unused -Wno-inline -Woverloaded-virtual -Wmissing-declarations    -o libid3.la -rpath /opt/sw/lib -version-info 3:0:0 -export-dynamic c_wrapper.lo field.lo field_binary.lo field_integer.lo field_string_ascii.lo field_string_unicode.lo frame.lo frame_impl.lo frame_parse.lo frame_render.lo globals.lo header.lo header_frame.lo header_tag.lo helpers.lo io.lo io_decorators.lo io_helpers.lo misc_support.lo mp3_parse.lo readers.lo spec.lo tag.lo tag_file.lo tag_find.lo tag_impl.lo tag_parse.lo tag_parse_lyrics3.lo tag_parse_musicmatch.lo tag_parse_v1.lo tag_render.lo utils.lo writers.lo  -L/opt/sw/lib -lz -liconv
mkdir .libs
rm -fr .libs/libid3.la .libs/libid3.* .libs/libid3.*

*** Warning: This library needs some functionality provided by -lz.
*** I have the capability to make that library automatically link in when
*** you link to this library.  But I can only do this if you have a
*** shared version of the library, which you do not appear to have.

*** Warning: This library needs some functionality provided by -liconv.
*** I have the capability to make that library automatically link in when
*** you link to this library.  But I can only do this if you have a
*** shared version of the library, which you do not appear to have.
*** The inter-library dependencies that have been dropped here will be
*** automatically added whenever a program is linked with this library
*** or is declared to -dlopen it.
g++ -dynamiclib -o .libs/libid3.3.0.0.dylib  c_wrapper.lo field.lo field_binary.lo field_integer.lo field_string_ascii.lo field_string_unicode.lo frame.lo frame_impl.lo frame_parse.lo frame_render.lo globals.lo header.lo header_frame.lo header_tag.lo helpers.lo io.lo io_decorators.lo io_helpers.lo misc_support.lo mp3_parse.lo readers.lo spec.lo tag.lo tag_file.lo tag_find.lo tag_impl.lo tag_parse.lo tag_parse_lyrics3.lo tag_parse_musicmatch.lo tag_parse_v1.lo tag_render.lo utils.lo writers.lo  -L/opt/sw/lib -lc -install_name /opt/sw/lib/libid3.3.dylib -compatibility_version 4 -current_version 4.0
Undefined symbols for architecture x86_64:
  "_compress", referenced from:
      dami::io::CompressedWriter::flush() in io_decorators.lo
  "_libiconv", referenced from:
      dami::convert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, ID3_TextEnc, ID3_TextEnc) in utils.lo
  "_libiconv_close", referenced from:
      dami::convert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, ID3_TextEnc, ID3_TextEnc) in utils.lo
  "_libiconv_open", referenced from:
      dami::convert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, ID3_TextEnc, ID3_TextEnc) in utils.lo
  "_uncompress", referenced from:
      dami::io::CompressedReader::CompressedReader(ID3_Reader&, unsigned int) in io_decorators.lo
```
For some reason `../libtool` eats up the `-lz -liconv` flags, but only on 10.15 (works OK on 10.13). The attached update modernizes the included autotools stuff, which lets linking work on 10.15.