### PR TITLE
build cleanup for PyQt5

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
@@ -18,7 +18,6 @@ PatchScript: <<
 Depends: <<
   libiconv,
   libpng16-shlibs,
-  openssl100-shlibs (>= 1.0.2p-1),
 #  ( %type_pkg[python] <= 27 ) pydbus-py%type_pkg[python],
   python%type_pkg[python],
   qt5-mac-enginio-shlibs (>= 5.6.0-1),
@@ -62,7 +61,6 @@ BuildDepends:<<
   fink-package-precedence,
   libiconv-dev,
   libpng16,
-  openssl100-dev (>= 1.0.2p-1),
 #  ( %type_pkg[python] <= 27 ) pydbus-py%type_pkg[python]-dev,
   qt5-mac-enginio (>= 5.6.0-1),
   qt5-mac-qtbase (>= 5.6.0-1),

--- a/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
@@ -4,7 +4,7 @@ Info3: <<
 Package: pyqt5-mac-py%type_pkg[python]
 Type: python (2.7 3.4 3.5 3.6 3.7)
 Version: 5.11.3
-Revision: 2
+Revision: 3
 Source: mirror:sourceforge:pyqt/PyQt5/PyQt-%v/PyQt5_gpl-%v.tar.gz
 Source-Checksum: SHA256(c9b57d15601d436faf35dacf8e0acefa220194829a653e771e80b189b3261073)
 
@@ -24,15 +24,17 @@ Depends: <<
   qt5-mac-enginio-shlibs (>= 5.6.0-1),
   qt5-mac-qtbluetooth-shlibs (>= 5.6.0-1),
   qt5-mac-qtcore-shlibs (>= 5.6.0-1),
-#  ( %type_pkg[python] <= 27 ) qt5-mac-qtdbus-shlibs (>= 5.6.0-1),
+  qt5-mac-qtdbus-shlibs (>= 5.6.0-1),
   qt5-mac-qtdeclarative-shlibs (>= 5.5.1-1),
   qt5-mac-qtdesigner-shlibs (>= 5.6.0-1),
   qt5-mac-qtgui-shlibs (>= 5.6.0-1),
   qt5-mac-qthelp-shlibs (>= 5.6.0-1),
+  qt5-mac-qtlocation-shlibs (>= 5.6.0-1),
   qt5-mac-qtmacextras-shlibs (>= 5.6.0-1),
   qt5-mac-qtmultimedia-shlibs (>= 5.6.0-1),
   qt5-mac-qtmultimediawidgets-shlibs (>= 5.6.0-1),
   qt5-mac-qtnetwork-shlibs (>= 5.6.0-1),
+  qt5-mac-qtnfc-shlibs (>= 5.6.0-1),
   qt5-mac-qtopengl-shlibs (>= 5.6.0-1),
   qt5-mac-qtpositioning-shlibs (>= 5.6.0-1),
   qt5-mac-qtprintsupport-shlibs (>= 5.6.0-1),
@@ -44,6 +46,9 @@ Depends: <<
   qt5-mac-qtsql-shlibs (>= 5.6.0-1),
   qt5-mac-qtsvg-shlibs (>= 5.6.0-1),
   qt5-mac-qttest-shlibs (>= 5.6.0-1),
+  qt5-mac-qtwebchannel-shlibs (>= 5.6.0-1),
+  qt5-mac-qtwebengine-shlibs (>= 5.6.0-1),
+  qt5-mac-qtwebenginecore-shlibs (>= 5.6.0-1),
   qt5-mac-qtwebkit-shlibs (>= 5.6.0-1),
   qt5-mac-qtwebsockets-shlibs (>= 5.6.0-1),
   qt5-mac-qtwidgets-shlibs (>= 5.6.0-1),
@@ -54,7 +59,6 @@ Depends: <<
 <<
 BuildDepends:<<
 #  ( %type_pkg[python] <= 27 ) dbus1.3-dev,
-  fink (>= 0.24.12),
   fink-package-precedence,
   libiconv-dev,
   libpng16,
@@ -63,7 +67,9 @@ BuildDepends:<<
   qt5-mac-enginio (>= 5.6.0-1),
   qt5-mac-qtbase (>= 5.6.0-1),
   qt5-mac-qtbase-dev-tools (>= 5.6.0-1),
+  qt5-mac-qtconnectivity (>= 5.6.0-1),
   qt5-mac-qtdeclarative (>= 5.6.0-1),
+  qt5-mac-qtlocation (>= 5.6.0-1),
   qt5-mac-qtmacextras (>= 5.6.0-1),
   qt5-mac-qtmultimedia (>= 5.6.0-1),
   qt5-mac-qtsensors (>= 5.6.0-1),
@@ -71,6 +77,8 @@ BuildDepends:<<
   qt5-mac-qtsvg (>= 5.6.0-1),
   qt5-mac-qttools (>= 5.6.0-1),
   qt5-mac-qttools-dev-tools (>= 5.6.0-1),
+  qt5-mac-qtwebchannel (>= 5.6.0-1),
+  qt5-mac-qtwebengine (>= 5.6.0-1),
   qt5-mac-qtwebkit (>= 5.6.0-1),
   qt5-mac-qtwebsockets (>= 5.6.0-1),
   qt5-mac-qtxmlpatterns (>= 5.6.0-1),

--- a/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
@@ -55,6 +55,7 @@ Depends: <<
 BuildDepends:<<
 #  ( %type_pkg[python] <= 27 ) dbus1.3-dev,
   fink (>= 0.24.12),
+  fink-package-precedence,
   libiconv-dev,
   libpng16,
   openssl100-dev (>= 1.0.2p-1),
@@ -99,8 +100,10 @@ export QTDIR=%p/lib/qt5-mac
     --no-dist-info \
     INCDIR_OPENGL+=/usr/X11R6/include \
     LFLAGS_PLUGIN="-bundle `%p/bin/python%type_raw[python]-config --ldflags`" \
-    LIBS="`%p/bin/python%type_raw[python]-config --ldflags`"
+    LIBS="`%p/bin/python%type_raw[python]-config --ldflags`" \
+    QMAKE_CXXFLAGS="-MD"
 make
+fink-package-precedence --depfile-ext='\.d' .
 <<
 InstallScript: <<
 #!/bin/sh -ev


### PR DESCRIPTION
Fixes the issues with #567
* Remove old inherited OpenSSL dep
* Add f-p-p to help track deps
* clean up deps to fit what's actually being used by the package