### PR TITLE
Add legacy scons2 package to deal with libserf1 FTBFS

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/scons2.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/scons2.info
@@ -1,6 +1,6 @@
-Package: scons
-Version: 3.0.5
-Revision: 2
+Package: scons2
+Version: 2.5.1
+Revision: 1
 
 BuildDependsOnly: true
 Conflicts: scons, scons2
@@ -8,8 +8,8 @@ Replaces: scons, scons2
 
 Maintainer: None <fink-devel@lists.sourceforge.net>
 
-Source: mirror:sourceforge:scons/scons-src/%v/%n-src-%v.tar.gz
-Source-MD5: 2b8af50a1eb1e914b11c802c512c9951
+Source: mirror:sourceforge:scons/scons-src/%v/scons-src-%v.tar.gz
+Source-MD5: 2c1e650c6621aa1cfedc942791c0fb18
 
 PatchScript: <<
 	/usr/bin/find . -type f -name "*.py" -exec perl -pi -e 's|/usr/bin/env python|/usr/bin/python|g' {} \;
@@ -36,10 +36,11 @@ SCons is an Open Source software construction tool -- that is, a
 build tool; an improved substitute for the classic Make utility;
 a better way to build software.
 
-Packages needing to compile legacy scons scripts may use scons2 instead.
+This is the legacy scons package (v2.5.1) to be used when the main scons
+(v3 and up) package can't build something due to old code.
 <<
 DescPackaging: <<
 Former maintainer: Vincent Beffara
 <<
-Homepage: https://www.scons.org/
+Homepage: http://www.scons.org/
 License: BSD

--- a/10.9-libcxx/stable/main/finkinfo/libs/libserf1.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libserf1.info
@@ -8,7 +8,7 @@ Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 
 # Dependencies:
 Depends: %N-shlibs (= %v-%r)
-BuildDepends: fink (>= 0.24.12-1), libapr.0-dev (>= 1.6.3-1), libaprutil.0-dev (>= 1.6.1-1), openssl110-dev (>= 1.1.0h-1), scons (>= 2.4.1-1)
+BuildDepends: libapr.0-dev (>= 1.6.3-1), libaprutil.0-dev (>= 1.6.1-1), openssl110-dev (>= 1.1.0h-1), scons2 (>= 2.5.1-1)
 BuildDependsOnly: true
 
 # Unpack Phase:
@@ -71,6 +71,8 @@ operation.
 <<
 DescPackaging: <<
 Note that libserf0 and libserf1 can coexist since they have no files in common.
+Uses scons2 legacy package because scons-v3 can no longer build this.
+"ValueError: too many values to unpack" in env.SharedLibrary.
 
 Previously maintained by Christian Schaffner <chris01@users.sourceforge.net>
 


### PR DESCRIPTION
in #637 libserf1 can't build with scons-3.0.5 due to old code in env.SharedLibrary. This adds back a legacy scons2-v2.1.5 package that conflicts/replaces with current scons and allows libserf1 to build. This closes #637 