### PR TITLE
fix build-paths in binary

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/net/alpine.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/alpine.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: alpine
 Version: 2.22
-Revision: 3
+Revision: 4
 Source: http://alpine.x10host.com/alpine/release/src/alpine-%v.tar.xz
 Source-checksum: SHA256(849567c1b6f71fde3aaa1c97cf0577b12a525d9e22c0ea47797c4bf1cd2bbfdb)
 PatchFile: alpine.patch
@@ -16,6 +16,9 @@ BuildDepends: cyrus-sasl2-dev, libgettext8-dev, libiconv-dev, libncurses5, openl
 GCC: 4.0
 Conflicts: pine, pine-ssl, alpine, re-alpine
 Replaces: pine, pine-ssl, alpine, re-alpine
+# local-support-info and pinerc paths are set explicitly because the
+# autoconf defaults are based on --prefix, which is set to %d (rather
+# than %p) for other reasons
 ConfigureParams: <<
 	--prefix=%d \
 	--bindir=%i/bin \
@@ -27,7 +30,10 @@ ConfigureParams: <<
 	--with-ssl-certs-dir=%p/etc/ssl/certs \
 	--with-ssl-dir=%p \
 	--without-pubcookie \
-	--without-tcl
+	--without-tcl \
+	--with-local-support-info=%p/lib/pine.info \
+	--with-system-pinerc=%p/lib/pine.conf \
+	--with-system-fixed-pinerc=%p/lib/pine.conf.fixed
 <<
 SetLDFLAGS: -lintl
 UseMaxBuildJobs: false


### PR DESCRIPTION
Resolves bug noted in #607 

Not sure why we're patching both configure and its configure.ac template, but whatever.