### PR TITLE
Setuptools-py update to 47.3.1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py.info
@@ -1,10 +1,10 @@
 Info2: << 
 Package: setuptools-tng-py%type_pkg[python]
 Type: python (3.5 3.6 3.7 3.8)
-Version: 49.2.1
+Version: 50.3.2
 Revision: 1
 Source: https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-%v.zip
-Source-Checksum: SHA256(88094d17c8d273390659a72e9d93374cd7bfd188c12bf2747b306e2bed48df18)
+Source-Checksum: SHA256(ed0519d27a243843b05d82a5e9d01b0b083d9934eaa3d02779a23da18077bd3c)
 
 BuildDepends: fink (>=0.32)
 Depends: python%type_pkg[python]
@@ -25,10 +25,13 @@ HomePage: https://pypi.python.org/pypi/setuptools
 #InfoTest: <<
 #Circular dependencies if testing is enabled
 #	TestDepends: <<
+#		jaraco.envs-py%type_pkg[python],
+#		jaraco.functools-py%type_pkg[python],
 #		mock-py%type_pkg[python],
 #		paver-py%type_pkg[python],
 #		pytest-py%type_pkg[python],
-#		pytest-fixture-config-py%type_pkg[python]
+#		pytest-fixture-config-py%type_pkg[python],
+#		pytest-virtualenv-py%type_pkg[python]
 #	<<
 #	TestScript: <<
 #		%p/bin/python%type_raw[python] -m pytest  || exit 2

--- a/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py.info
@@ -1,11 +1,10 @@
 Info2: << 
 Package: setuptools-tng-py%type_pkg[python]
-Type: python (2.7 3.4 3.5 3.6 3.7 3.8)
-Version: 40.2.0
+Type: python (3.5 3.6 3.7 3.8)
+Version: 47.3.1
 Revision: 1
-#Source: https://pypi.python.org/packages/b0/04/d7aac18d0d8b1b9bd9b88af02af8090e72653753bced3226f9903cabb991/setuptools-%v.zip
 Source: https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-%v.zip
-Source-MD5: 592efabea3a65d8e97a025ed52f69b12
+Source-Checksum: SHA256(843037738d1e34e8b326b5e061f474aca6ef9d7ece41329afbc8aac6195a3920)
 
 BuildDepends: fink (>=0.32)
 Depends: python%type_pkg[python]
@@ -23,13 +22,17 @@ InstallScript: <<
 LICENSE: OSI-Approved
 HomePage: https://pypi.python.org/pypi/setuptools
 
-# Does not pass on macosx with /tmp really being /private/tmp
-# http://bugs.python.org/setuptools/issue125
-# Tests also need pytest which introduces a circular dep.
 #InfoTest: <<
-#    TestScript: <<
-#      %p/bin/python%type_raw[python] setup.py test  || exit 2
-#    <<
+#Circular dependencies if testing is enabled
+#	TestDepends: <<
+#		mock-py%type_pkg[python],
+#		paver-py%type_pkg[python],
+#		pytest-py%type_pkg[python],
+#		pytest-fixture-config-py%type_pkg[python]
+#	<<
+#	TestScript: <<
+#		%p/bin/python%type_raw[python] -m pytest  || exit 2
+#	<<
 #<<
 
 DescDetail: <<

--- a/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py.info
@@ -1,10 +1,10 @@
 Info2: << 
 Package: setuptools-tng-py%type_pkg[python]
 Type: python (3.5 3.6 3.7 3.8)
-Version: 47.3.1
+Version: 49.2.1
 Revision: 1
 Source: https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-%v.zip
-Source-Checksum: SHA256(843037738d1e34e8b326b5e061f474aca6ef9d7ece41329afbc8aac6195a3920)
+Source-Checksum: SHA256(88094d17c8d273390659a72e9d93374cd7bfd188c12bf2747b306e2bed48df18)
 
 BuildDepends: fink (>=0.32)
 Depends: python%type_pkg[python]

--- a/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py.info
@@ -11,7 +11,7 @@ Depends: python%type_pkg[python]
 Replaces: distribute-py%type_pkg[python] (<< 0.7.2-3), setuptools-py%type_pkg[python] (<< 0.7.2-3)
 
 Description: EasyInstall and python eggs
-Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
+Maintainer: None <fink-devel@lists.sourceforge.net>
 DocFiles: docs
 CompileScript: echo Skipping compile stage
 InstallScript: <<
@@ -51,6 +51,8 @@ DescPackaging: <<
 	Because of dependency deadlocks against setuptools-py when a 
 	'real' distribute-py package is installed, we have introduced 
 	setuputils-tng, which has no Conflicts against it.
+
+Former maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 <<
 
 SplitOff: <<

--- a/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py27.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py27.info
@@ -1,0 +1,80 @@
+Info2: << 
+Package: setuptools-tng-py%type_pkg[python]
+# 44.1.1 last version to support py27
+Type: python (2.7)
+Version: 44.1.1
+Revision: 1
+Source: https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-%v.zip
+Source-Checksum: SHA256(c67aa55db532a0dadc4d2e20ba9961cbd3ccc84d544e9029699822542b5a476b)
+
+BuildDepends: fink (>=0.32)
+Depends: python%type_pkg[python]
+Replaces: distribute-py%type_pkg[python] (<< 0.7.2-3), setuptools-py%type_pkg[python] (<< 0.7.2-3)
+
+Description: EasyInstall and python eggs
+Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
+DocFiles: docs
+CompileScript: echo Skipping compile stage
+InstallScript: <<
+  %p/bin/python%type_raw[python] setup.py install --root=%d --single-version-externally-managed
+  rm %i/bin/easy_install
+<<
+
+LICENSE: OSI-Approved
+HomePage: https://pypi.python.org/pypi/setuptools
+
+#InfoTest: <<
+#Circular dependencies if testing is enabled
+#	TestDepends: <<
+#		mock-py%type_pkg[python],
+#		paver-py%type_pkg[python],
+#		pytest-py%type_pkg[python],
+#		pytest-fixture-config-py%type_pkg[python]
+#	<<
+#	TestScript: <<
+#		%p/bin/python%type_raw[python] -m pytest  || exit 2
+#	<<
+#<<
+
+DescDetail: <<
+Easily download, build, install, upgrade, and uninstall Python
+packages.
+
+This package replaces the distribute and setuptools packages.
+
+See also: pip and virtualenv
+<<
+
+DescPackaging: <<
+	Because of dependency deadlocks against setuptools-py when a 
+	'real' distribute-py package is installed, we have introduced 
+	setuputils-tng, which has no Conflicts against it.
+<<
+
+SplitOff: <<
+	Package: distribute-py%type_pkg[python]
+	Description: OBSOLETE: use setuptools-tng-py%type_pkg[python] instead
+	RuntimeDepends: fink-obsolete-packages,  setuptools-tng-py%type_pkg[python]
+	Provides: setuptools-py%type_pkg[python]
+	DocFiles: docs
+	DescDetail: <<
+		Distribute has been merged back into setuptools 0.7.  setuptools-tng
+		should now be used rather than distribute or the prior Fink setuptools.
+		(It's still called setuptools upstream.)
+	<<
+<<
+
+SplitOff2: <<
+	Package: setuptools-py%type_pkg[python]
+	Description: OBSOLETE: use setuptools-tng-py%type_pkg[python] instead
+	RuntimeDepends: fink-obsolete-packages,  setuptools-tng-py%type_pkg[python]
+	DocFiles: docs
+	DescDetail: <<
+		Distribute has been merged back into setuptools 0.7.  setuptools-tng
+		should now be used rather than distribute or the prior Fink setuptools.
+		(It's still called setuptools upstream.)
+	<<
+<<
+
+## Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py27.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py27.info
@@ -12,7 +12,7 @@ Depends: python%type_pkg[python]
 Replaces: distribute-py%type_pkg[python] (<< 0.7.2-3), setuptools-py%type_pkg[python] (<< 0.7.2-3)
 
 Description: EasyInstall and python eggs
-Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
+Maintainer: None <fink-devel@lists.sourceforge.net>
 DocFiles: docs
 CompileScript: echo Skipping compile stage
 InstallScript: <<
@@ -49,6 +49,8 @@ DescPackaging: <<
 	Because of dependency deadlocks against setuptools-py when a 
 	'real' distribute-py package is installed, we have introduced 
 	setuputils-tng, which has no Conflicts against it.
+
+Former maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 <<
 
 SplitOff: <<

--- a/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py27.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py27.info
@@ -1,5 +1,5 @@
 Info2: << 
-Package: setuptools-tng-py%type_pkg[python]
+Package: setuptools-tng-py27
 # 44.1.1 last version to support py27
 Type: python (2.7)
 Version: 44.1.1

--- a/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py34.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py34.info
@@ -1,5 +1,5 @@
 Info2: << 
-Package: setuptools-tng-py%type_pkg[python]
+Package: setuptools-tng-py34
 # 43.0.0 is last version to support py34
 Type: python (3.4)
 Version: 43.0.0

--- a/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py34.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py34.info
@@ -1,0 +1,80 @@
+Info2: << 
+Package: setuptools-tng-py%type_pkg[python]
+# 43.0.0 is last version to support py34
+Type: python (3.4)
+Version: 43.0.0
+Revision: 1
+Source: https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-%v.zip
+Source-Checksum: SHA256(db45ebb4a4b3b95ff0aca3ce5fe1e820ce17be393caf8902c78aa36240e8c378)
+
+BuildDepends: fink (>=0.32)
+Depends: python%type_pkg[python]
+Replaces: distribute-py%type_pkg[python] (<< 0.7.2-3), setuptools-py%type_pkg[python] (<< 0.7.2-3)
+
+Description: EasyInstall and python eggs
+Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
+DocFiles: docs
+CompileScript: echo Skipping compile stage
+InstallScript: <<
+  %p/bin/python%type_raw[python] setup.py install --root=%d --single-version-externally-managed
+  rm %i/bin/easy_install
+<<
+
+LICENSE: OSI-Approved
+HomePage: https://pypi.python.org/pypi/setuptools
+
+#InfoTest: <<
+#Circular dependencies if testing is enabled
+#	TestDepends: <<
+#		mock-py%type_pkg[python],
+#		paver-py%type_pkg[python],
+#		pytest-py%type_pkg[python],
+#		pytest-fixture-config-py%type_pkg[python]
+#	<<
+#	TestScript: <<
+#		%p/bin/python%type_raw[python] -m pytest  || exit 2
+#	<<
+#<<
+
+DescDetail: <<
+Easily download, build, install, upgrade, and uninstall Python
+packages.
+
+This package replaces the distribute and setuptools packages.
+
+See also: pip and virtualenv
+<<
+
+DescPackaging: <<
+	Because of dependency deadlocks against setuptools-py when a 
+	'real' distribute-py package is installed, we have introduced 
+	setuputils-tng, which has no Conflicts against it.
+<<
+
+SplitOff: <<
+	Package: distribute-py%type_pkg[python]
+	Description: OBSOLETE: use setuptools-tng-py%type_pkg[python] instead
+	RuntimeDepends: fink-obsolete-packages,  setuptools-tng-py%type_pkg[python]
+	Provides: setuptools-py%type_pkg[python]
+	DocFiles: docs
+	DescDetail: <<
+		Distribute has been merged back into setuptools 0.7.  setuptools-tng
+		should now be used rather than distribute or the prior Fink setuptools.
+		(It's still called setuptools upstream.)
+	<<
+<<
+
+SplitOff2: <<
+	Package: setuptools-py%type_pkg[python]
+	Description: OBSOLETE: use setuptools-tng-py%type_pkg[python] instead
+	RuntimeDepends: fink-obsolete-packages,  setuptools-tng-py%type_pkg[python]
+	DocFiles: docs
+	DescDetail: <<
+		Distribute has been merged back into setuptools 0.7.  setuptools-tng
+		should now be used rather than distribute or the prior Fink setuptools.
+		(It's still called setuptools upstream.)
+	<<
+<<
+
+## Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py34.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py34.info
@@ -12,7 +12,7 @@ Depends: python%type_pkg[python]
 Replaces: distribute-py%type_pkg[python] (<< 0.7.2-3), setuptools-py%type_pkg[python] (<< 0.7.2-3)
 
 Description: EasyInstall and python eggs
-Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
+Maintainer: None <fink-devel@lists.sourceforge.net>
 DocFiles: docs
 CompileScript: echo Skipping compile stage
 InstallScript: <<
@@ -49,6 +49,8 @@ DescPackaging: <<
 	Because of dependency deadlocks against setuptools-py when a 
 	'real' distribute-py package is installed, we have introduced 
 	setuputils-tng, which has no Conflicts against it.
+
+Former maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 <<
 
 SplitOff: <<


### PR DESCRIPTION
Update setuptools to the latest upstream (including separate last versions for py27 and py34).
Still can't enable tests because of circular dependencies on pytest (and a couple missing modules we don't have).
Tested using the new setuptools-tng-py37 on several pymods