### PR TITLE
OpenBLAS update to 0.3.10 and new fix for missing CLOCK_REALTIME

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: openblas
-Version: 0.3.9
+Version: 0.3.10
 Revision: 1
 Type: gcc (10)
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
@@ -11,10 +11,10 @@ BuildDepends: fink (>= 0.30.0), gcc%type_raw[gcc]-compiler
 Depends: %N-shlibs (= %v-%r)
 
 Source: https://github.com/xianyi/OpenBLAS/archive/v%v.tar.gz
-Source-MD5: 28cc19a6acbf636f5aab5f10b9a0dfe1
+Source-MD5: 4727a1333a380b67c8d7c7787a3d9c9a
 SourceRename: OpenBLAS-%v.tar.gz
 PatchFile: %n.patch
-PatchFile-MD5: c8465ba2b714cd59678c4ea627990234
+PatchFile-MD5: 7b1f22a79e3509435dd3c57e9394f20e
 
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 
@@ -35,7 +35,10 @@ CompileScript: <<
 	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 libs netlib shared
 	cd benchmark
 	mkdir -m 755 bin
-	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp veclib goto smallscaling
+	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp LIBSUFFIX=dylib veclib goto smallscaling
+	for x in smallscaling *.goto; do
+		install_name_tool -change %b/exports/../libopenblas.0.dylib %p/lib/libopenblas.0.dylib $x
+	done
 	mv *.veclib *.goto smallscaling bin
 <<
 
@@ -72,9 +75,9 @@ InfoTest: <<
 		echo OpenBLAS
 		for x in *.goto; do
 			echo OPENBLAS_NUM_THREADS=$ncore OMP_NUM_THREADS=1 $x
-			OPENBLAS_NUM_THREADS=$ncore OMP_NUM_THREADS=1 ./$x 2>&1 | awk '(NR < 4)||((NR-2)%%20 == 0)'
+			DYLD_LIBRARY_PATH=%b OPENBLAS_NUM_THREADS=$ncore OMP_NUM_THREADS=1 ./$x 2>&1 | awk '(NR < 4)||((NR-2)%%20 == 0)'
 		done
-		OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=$ncore ./smallscaling
+		DYLD_LIBRARY_PATH=%b OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=$ncore ./smallscaling
 	<<
 <<
 
@@ -142,6 +145,8 @@ identical assembler and object code.)
   Including, but not using patches for build with clang without -fopenmp option;
   for that FOPENMP needs to be set instead to
   "-I$(ls -d %p/lib/gcc%type_raw[gcc]/lib/gcc/x86_64-*/%type_raw[gcc]*/include) -L%p/lib/gcc%type_raw[gcc]/lib -lgomp"
+0.3.10: extended 10.11 patch to missing CLOCK_REALTIME;
+  build dynamically linked benchmarks (static versions grew to > 1.5 GB).
 <<
 # Info2
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
@@ -35,9 +35,11 @@ CompileScript: <<
 	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 libs netlib shared
 	cd benchmark
 	mkdir -m 755 bin
-	cp -a Makefile Makefile.orig
 	# 6 tests require clock_gettime, disable if missing (on 10.11)
-	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 saxpy.goto || egrep -v 'saxpy.*daxpy.*.caxpy\.|scopy.*dcopy.*ccopy\.|st[pr][ms]v.*dt[pr][ms]v.*ct[pr][ms]v\.' Makefile.orig >| Makefile
+	if [ "$darwin_vers" -lt 16 ]; then
+		mv Makefile Makefile.orig
+		egrep -v 'saxpy.*daxpy.*.caxpy\.|scopy.*dcopy.*ccopy\.|st[pr][ms]v.*dt[pr][ms]v.*ct[pr][ms]v\.' Makefile.orig > Makefile
+	fi
 	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp LIBSUFFIX=dylib veclib goto smallscaling
 	for x in smallscaling *.goto; do
 		install_name_tool -change %b/exports/../libopenblas.0.dylib %p/lib/libopenblas.0.dylib $x

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
@@ -14,7 +14,7 @@ Source: https://github.com/xianyi/OpenBLAS/archive/v%v.tar.gz
 Source-MD5: 4727a1333a380b67c8d7c7787a3d9c9a
 SourceRename: OpenBLAS-%v.tar.gz
 PatchFile: %n.patch
-PatchFile-MD5: 7b1f22a79e3509435dd3c57e9394f20e
+PatchFile-MD5: 38268179357f21681e208c3467e6869c
 
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 
@@ -35,6 +35,9 @@ CompileScript: <<
 	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 libs netlib shared
 	cd benchmark
 	mkdir -m 755 bin
+	cp -a Makefile Makefile.orig
+	# 6 tests require clock_gettime, disable if missing (on 10.11)
+	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 saxpy.goto || egrep -v 'saxpy.*daxpy.*.caxpy\.|scopy.*dcopy.*ccopy\.|st[pr][ms]v.*dt[pr][ms]v.*ct[pr][ms]v\.' Makefile.orig >| Makefile
 	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp LIBSUFFIX=dylib veclib goto smallscaling
 	for x in smallscaling *.goto; do
 		install_name_tool -change %b/exports/../libopenblas.0.dylib %p/lib/libopenblas.0.dylib $x
@@ -145,8 +148,10 @@ identical assembler and object code.)
   Including, but not using patches for build with clang without -fopenmp option;
   for that FOPENMP needs to be set instead to
   "-I$(ls -d %p/lib/gcc%type_raw[gcc]/lib/gcc/x86_64-*/%type_raw[gcc]*/include) -L%p/lib/gcc%type_raw[gcc]/lib -lgomp"
-0.3.10: extended 10.11 patch to missing CLOCK_REALTIME;
-  build dynamically linked benchmarks (static versions grew to > 1.5 GB).
+0.3.10: 6 benchmarks axpy, copy, tpmv, tpsv, trmv, trsv also using clock_gettime now
+  and failing on 10.11; disabled since substitute function from smallscaling.c does
+  not seem to produce accurate enough timings
+  Build dynamically linked benchmarks (static versions grew to > 1.5 GB).
 <<
 # Info2
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
@@ -1,7 +1,7 @@
 diff -uNr a/Makefile.system b/Makefile.system
 --- a/Makefile.system	2020-02-09 23:16:28.000000000 +0100
 +++ b/Makefile.system	2020-02-20 18:06:14.000000000 +0100
-@@ -487,8 +487,10 @@
+@@ -490,8 +490,10 @@
  endif
  
  ifeq ($(C_COMPILER), CLANG)
@@ -12,7 +12,7 @@ diff -uNr a/Makefile.system b/Makefile.system
  
  ifeq ($(C_COMPILER), INTEL)
  CCOMMON_OPT    += -fopenmp
-@@ -1204,8 +1206,8 @@
+@@ -1258,8 +1260,8 @@
  endif
 
 
@@ -22,7 +22,7 @@ diff -uNr a/Makefile.system b/Makefile.system
 
  ifeq ($(DEBUG), 1)
  COMMON_OPT += -g
-@@ -1273,19 +1275,19 @@
+@@ -1328,19 +1330,19 @@
  
  ifneq ($(DYNAMIC_ARCH), 1)
  ifndef SMP
@@ -50,9 +50,9 @@ diff -uNr a/Makefile.system b/Makefile.system
  endif
 
 diff -uNr a/benchmark/Makefile b/benchmark/Makefile
---- a/benchmark/Makefile   2020-02-09 23:16:28.000000000 +0100
-+++ b/benchmark/Makefile   2020-02-20 19:15:33.000000000 +0100
-@@ -19,8 +19,12 @@
+--- a/benchmark/Makefile   2020-06-14 22:03:04.000000000 +0200
++++ b/benchmark/Makefile   2020-07-01 16:47:19.000000000 +0200
+@@ -19,8 +19,13 @@
  #LIBATLAS = -fopenmp $(ATLAS)/liblapack_atlas.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
  
  # Atlas RHEL and Fedora
@@ -64,15 +64,16 @@ diff -uNr a/benchmark/Makefile b/benchmark/Makefile
 +# Atlas MacOS X Fink (Xcode clang does not support -fopenmp)
 +ATLAS=@PREFIX@/lib
 +LIBATLAS = $(FOPENMP) $(ATLAS)/liblapack.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
++
  
  # Intel standard
  # MKL=/opt/intel/mkl/lib/intel64
-@@ -2381,7 +2385,7 @@
+@@ -3431,7 +3436,7 @@
  
  
  smallscaling: smallscaling.c ../$(LIBNAME)
 -	$(CC) $(CFLAGS) -o $(@F) $^ $(EXTRALIB) -fopenmp -lm -lpthread
-+	$(CC) $(CFLAGS) -o $(@F) $^ $(EXTRALIB) $(FOPENMP) -lm -lpthread
++	$(CC) $(CFLAGS) -o $(@F) $^ $(EXTRALIB) $(FOPENMP) -fopenmp -lm -lpthread
  
  clean ::
  	@rm -f *.goto *.mkl *.acml *.atlas *.veclib *.essl smallscaling
@@ -122,10 +123,27 @@ diff -uNr a/benchmark/smallscaling.c b/benchmark/smallscaling.c
      double inc_factor = exp(log((double)MAX_SIZE / MIN_SIZE) / NB_SIZE);
      BenchParam param;
      int test_id;
+diff -uNr a/common.h b/common.h
+--- a/common.h		2020-06-14 22:03:04.000000000 +0200
++++ b/common.h		2020-07-01 18:22:15.000000000 +0200
+@@ -497,6 +497,13 @@
+ #define RPCC64BIT
+ #endif // !RPCC_DEFINED
+ 
++/* substitute missing CLOCK_REALTIME on pre-10.12 OS X */
++#if defined(OS_DARWIN) && !defined(CLOCK_REALTIME)
++#include <mach/clock_types.h>
++#define CLOCK_REALTIME REALTIME_CLOCK
++#define CLOCK_PROCESS_CPUTIME_ID SYSTEM_CLOCK
++#endif // !CLOCK_REALTIME
++
+ #if !defined(BLAS_LOCK_DEFINED) && defined(__GNUC__)
+ static void __inline blas_lock(volatile BLASULONG *address){
+
 diff -uNr a/Makefile b/Makefile
 --- a/Makefile		2019-08-11 23:23:27.000000000 +0100
 +++ b/Makefile		2019-11-06 19:18:15.000000000 +0100
-@@ -109,8 +109,10 @@
+@@ -124,8 +124,10 @@
  ifeq ($(OSNAME), Darwin)
 	@$(MAKE) -C exports dyn
 	@ln -fs $(LIBDYNNAME) $(LIBPREFIX).dylib

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
@@ -73,7 +73,7 @@ diff -uNr a/benchmark/Makefile b/benchmark/Makefile
  
  smallscaling: smallscaling.c ../$(LIBNAME)
 -	$(CC) $(CFLAGS) -o $(@F) $^ $(EXTRALIB) -fopenmp -lm -lpthread
-+	$(CC) $(CFLAGS) -o $(@F) $^ $(EXTRALIB) $(FOPENMP) -fopenmp -lm -lpthread
++	$(CC) $(CFLAGS) -o $(@F) $^ $(EXTRALIB) $(FOPENMP) -lm -lpthread
  
  clean ::
  	@rm -f *.goto *.mkl *.acml *.atlas *.veclib *.essl smallscaling
@@ -123,23 +123,6 @@ diff -uNr a/benchmark/smallscaling.c b/benchmark/smallscaling.c
      double inc_factor = exp(log((double)MAX_SIZE / MIN_SIZE) / NB_SIZE);
      BenchParam param;
      int test_id;
-diff -uNr a/common.h b/common.h
---- a/common.h		2020-06-14 22:03:04.000000000 +0200
-+++ b/common.h		2020-07-01 18:22:15.000000000 +0200
-@@ -497,6 +497,13 @@
- #define RPCC64BIT
- #endif // !RPCC_DEFINED
- 
-+/* substitute missing CLOCK_REALTIME on pre-10.12 OS X */
-+#if defined(OS_DARWIN) && !defined(CLOCK_REALTIME)
-+#include <mach/clock_types.h>
-+#define CLOCK_REALTIME REALTIME_CLOCK
-+#define CLOCK_PROCESS_CPUTIME_ID SYSTEM_CLOCK
-+#endif // !CLOCK_REALTIME
-+
- #if !defined(BLAS_LOCK_DEFINED) && defined(__GNUC__)
- static void __inline blas_lock(volatile BLASULONG *address){
-
 diff -uNr a/Makefile b/Makefile
 --- a/Makefile		2019-08-11 23:23:27.000000000 +0100
 +++ b/Makefile		2019-11-06 19:18:15.000000000 +0100


### PR DESCRIPTION
New upstream version with two additional changes:

1. I got another report on a build failure of the entire benchmark suite on 10.11 due to missing CLOCK_REALTIME etc. support in `time.h`; judging from [this comment](https://github.com/Tarsnap/tarsnap/issues/286#issuecomment-331666331) this is systemic to Xcode 8 and earlier. Trying to work around here with `mach/clock_types.h` definitions, but yet to be tested on 10.11.
EDIT: The failure occurs for 6 of the benchmarks that have been newly added or changed to use `clock_gettime`; see comment for resolution.

2. Switched the benchmark build to dynamically linked binaries, since the `*.goto` executables were growing well beyond 1 GB in total. No obvious performance differences to the statically linked versions.