### PR TITLE
Rtmpdump update to v2.4

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/net/librtmp1-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/librtmp1-shlibs.info
@@ -1,0 +1,100 @@
+# -*- coding: ascii; tab-width: 4; x-counterpart: rtmpdump.patch -*-
+Info4: <<
+Package: librtmp1-shlibs
+Version: 2.4-20190330
+Revision: 1
+Description: Shared ibraries for RTMP streaming
+DescDetail: <<
+	rtmpdump is a tool for dumping media content streamed over RTMP.
+	
+	rtmpdump makes a connection to the specified RTMP server and plays
+	the media specified by the given url. The url should be of the form
+
+	  rtmp[t][e]://hostname[:port][/app[/playpath]]
+	  
+	Plain rtmp, as well as tunneled and encrypted sessions are supported.
+<<
+DescPackaging: <<
+* FTBFS with openssl110
+* no more tarballs after 2.3 release.
+* The 2.4-20190330 tarball was created on 2020-07-12 with these
+commands, that correspond to commit hash
+c5f04a58fc2aeea6296ca7c44ee4734c18401aa3:
+git clone --depth=1 git://git.ffmpeg.org/rtmpdump rtmpdump-2.4-20190330
+tar -cj --exclude='\.git' -f rtmpdump-2.4-20190330.tar.bz2 rtmpdump-2.4-20190330
+<<
+Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
+License: LGPL2
+Homepage: https://rtmpdump.mplayerhq.hu/
+
+Source: mirror:sourceforge:fink/rtmpdump-%v.tar.bz2
+Source-MD5: 1a149d66063529e2066a9456d2e73d75
+
+PatchFile: %{ni}.patch
+PatchFile-MD5: 6cc508f132edbbcd2bc21d578dc62701
+
+BuildDepends: <<
+	fink-package-precedence,
+	gmp5,
+	gnutls30,
+	nettle7
+<<
+Depends: <<
+	gmp5-shlibs,
+	gnutls30-shlibs,
+	libhogweed5-shlibs,
+	nettle7-shlibs
+<<
+
+CompileScript: <<
+	make SYS=darwin prefix=%p INC="-MD -I%p/include" XLDFLAGS="-L%b/librtmp -L%p/lib/gnutls30 -L%p/lib"
+	fink-package-precedence --depfile-ext='\.d' .
+<<
+
+InstallScript: make -j1 install SYS=darwin prefix=%p DESTDIR=%d
+Shlibs: %p/lib/librtmp.1.dylib 0.0.0 %n (>= 2.4-1)
+
+DocFiles: ChangeLog COPYING README *.html
+
+SplitOff: <<
+	Package: librtmp1
+	Description: Devel files for RTMP streaming
+	License: LGPL2
+	
+	BuildDependsOnly: true
+	Depends: %N (= %v-%r)
+	Conflicts: librtmp, librtmp1
+	Replaces: librtmp, librtmp1
+	
+	Files: <<
+		include
+		lib/pkgconfig
+		lib/librtmp.a
+		lib/librtmp.dylib
+		share/man/man3
+	<<
+	
+	DocFiles: ChangeLog README librtmp/COPYING librtmp/*.html
+<<
+SplitOff2: <<
+	Package: rtmpdump
+	Description: RTMP streaming media client
+	License: GPL2
+
+	Depends: <<
+		%N (>= %v-%r),
+		gmp5-shlibs,
+		gnutls30-shlibs,
+		libhogweed5-shlibs,
+		nettle7-shlibs
+	<<
+	Files: <<
+		bin
+		sbin
+		share/man/man1
+		share/man/man8
+	<<
+
+	DocFiles: ChangeLog README librtmp/COPYING
+<<
+<<

--- a/10.9-libcxx/stable/main/finkinfo/net/librtmp1-shlibs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/net/librtmp1-shlibs.patch
@@ -1,0 +1,71 @@
+diff -ruN rtmpdump-2.4-20190330-orig/Makefile rtmpdump-2.4-20190330/Makefile
+--- rtmpdump-2.4-20190330-orig/Makefile	2020-07-12 06:06:19.000000000 -0500
++++ rtmpdump-2.4-20190330/Makefile	2020-07-12 06:21:50.000000000 -0500
+@@ -8,9 +8,9 @@
+ SYS=posix
+ #SYS=mingw
+ 
+-CRYPTO=OPENSSL
++#CRYPTO=OPENSSL
+ #CRYPTO=POLARSSL
+-#CRYPTO=GNUTLS
++CRYPTO=GNUTLS
+ LIBZ=-lz
+ LIB_GNUTLS=-lgnutls -lhogweed -lnettle -lgmp $(LIBZ)
+ LIB_OPENSSL=-lssl -lcrypto $(LIBZ)
+@@ -26,7 +26,7 @@
+ 
+ bindir=$(prefix)/bin
+ sbindir=$(prefix)/sbin
+-mandir=$(prefix)/man
++mandir=$(prefix)/share/man
+ 
+ BINDIR=$(DESTDIR)$(bindir)
+ SBINDIR=$(DESTDIR)$(sbindir)
+diff -ruN rtmpdump-2.4-20190330-orig/librtmp/Makefile rtmpdump-2.4-20190330/librtmp/Makefile
+--- rtmpdump-2.4-20190330-orig/librtmp/Makefile	2020-07-12 06:06:19.000000000 -0500
++++ rtmpdump-2.4-20190330/librtmp/Makefile	2020-07-12 06:21:44.000000000 -0500
+@@ -5,7 +5,7 @@
+ incdir=$(prefix)/include/librtmp
+ bindir=$(prefix)/bin
+ libdir=$(prefix)/lib
+-mandir=$(prefix)/man
++mandir=$(prefix)/share/man
+ BINDIR=$(DESTDIR)$(bindir)
+ INCDIR=$(DESTDIR)$(incdir)
+ LIBDIR=$(DESTDIR)$(libdir)
+@@ -16,8 +16,8 @@
+ AR=$(CROSS_COMPILE)ar
+ 
+ SYS=posix
+-CRYPTO=OPENSSL
+-#CRYPTO=GNUTLS
++#CRYPTO=OPENSSL
++CRYPTO=GNUTLS
+ DEF_POLARSSL=-DUSE_POLARSSL
+ DEF_OPENSSL=-DUSE_OPENSSL
+ DEF_GNUTLS=-DUSE_GNUTLS
+diff -ruN rtmpdump-2.4-20190330-orig/librtmp/hashswf.c rtmpdump-2.4-20190330/librtmp/hashswf.c
+--- rtmpdump-2.4-20190330-orig/librtmp/hashswf.c	2020-07-12 06:06:19.000000000 -0500
++++ rtmpdump-2.4-20190330/librtmp/hashswf.c	2020-07-12 06:38:24.000000000 -0500
+@@ -25,6 +25,7 @@
+ #include <string.h>
+ #include <ctype.h>
+ #include <time.h>
++#include <limits.h>
+ 
+ #include "rtmp_sys.h"
+ #include "log.h"
+diff -ruN rtmpdump-2.4-20190330-orig/librtmp/librtmp.pc.in rtmpdump-2.4-20190330/librtmp/librtmp.pc.in
+--- rtmpdump-2.4-20190330-orig/librtmp/librtmp.pc.in	2020-07-12 06:06:19.000000000 -0500
++++ rtmpdump-2.4-20190330/librtmp/librtmp.pc.in	2020-07-12 06:50:15.000000000 -0500
+@@ -6,8 +6,7 @@
+ Name: librtmp
+ Description: RTMP implementation
+ Version: @VERSION@
+-Requires: @CRYPTO_REQ@
+ URL: http://rtmpdump.mplayerhq.hu
+-Libs: -L${libdir} -lrtmp -lz @PUBLIC_LIBS@
++Libs: -L${libdir} -lrtmp @PUBLIC_LIBS@
+ Libs.private: @PRIVATE_LIBS@
+ Cflags: -I${incdir}

--- a/10.9-libcxx/stable/main/finkinfo/net/rtmpdump.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/rtmpdump.info
@@ -20,9 +20,9 @@ DescDetail: <<
 DescPackaging: Actual license is GPL2 but use Restrictive due to openssl.
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 License: Restrictive
-Homepage: http://rtmpdump.mplayerhq.hu/
+Homepage: https://rtmpdump.mplayerhq.hu/
 
-Source: http://rtmpdump.mplayerhq.hu/download/%{ni}-%v.tgz
+Source: https://rtmpdump.mplayerhq.hu/download/%{ni}-%v.tgz
 Source-MD5: eb961f31cd55f0acf5aad1a7b900ef59
 
 PatchFile: %{ni}.patch

--- a/10.9-libcxx/stable/main/finkinfo/net/rtmpdump.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/rtmpdump.info
@@ -5,7 +5,7 @@ Package: rtmpdump
 # v2.3 is the last release available as tarball. All newer releases are GIT only.
 # v2.4 bumps libN=1
 Version: 2.3
-Revision: 8
+Revision: 9
 Description: RTMP streaming media client
 DescDetail: <<
 	rtmpdump is a tool for dumping media content streamed over RTMP.
@@ -43,6 +43,8 @@ SplitOff: <<
 	
 	BuildDependsOnly: true
 	Depends: %n-shlibs (= %v-%r)
+	Conflicts: librtmp, librtmp1
+	Replaces: librtmp, librtmp1
 	
 	Files: <<
 		include


### PR DESCRIPTION
Updates rtmpdump to v2.4, which is a new libN=1.
v2.4 still doesn't build with openssl110, but has the option to use gnutls instead.
Also, they no longer provide tarballs after v2.3, so I made a snapshot tarball at the last commit in March 30, 2019.

I've successfully built ffmpeg and gst-plugins-bad against the new librtmp1. Libcurl4 is the only other package that uses the old librtmp-v2.3 package.