### PR TITLE
f-p-p: search for Xcode's otool-classic before falling back to /usr/bin/otool

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/fink-package-precedence.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/fink-package-precedence.info
@@ -1,10 +1,10 @@
 Package: fink-package-precedence
-Version: 0.34
+Version: 0.35
 Revision: 1
 
 Source: none
 PatchFile: %n.patch
-PatchFile-MD5: 8a2202897d9061afa60f007872b2e85a
+PatchFile-MD5: 92cf767b456c75665b54b9453ab7b8af
 PatchScript: sed 's,@PREFIX@,%p,g; s,@VERSION@,%v,g' < %{PatchFile} | patch -p1
 
 Depends: dpkg, xcode

--- a/10.9-libcxx/stable/main/finkinfo/devel/fink-package-precedence.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/fink-package-precedence.info
@@ -4,7 +4,7 @@ Revision: 1
 
 Source: none
 PatchFile: %n.patch
-PatchFile-MD5: 92cf767b456c75665b54b9453ab7b8af
+PatchFile-MD5: 453d178329f12020bf63b7faba8bcefe
 PatchScript: sed 's,@PREFIX@,%p,g; s,@VERSION@,%v,g' < %{PatchFile} | patch -p1
 
 Depends: dpkg, xcode

--- a/10.9-libcxx/stable/main/finkinfo/devel/fink-package-precedence.patch
+++ b/10.9-libcxx/stable/main/finkinfo/devel/fink-package-precedence.patch
@@ -316,10 +316,10 @@ diff -Nurd -x'*~' fink-package-precedence-0.35.orig/fink-package-precedence fink
 +}
 +
 +if ($opts{'libs'}) {
-+	chomp(my $xcode_home = `xcode-select -print-path`);
++	chomp(my $xcodepath=`xcode-select -print-path 2>/dev/null`);
 +	my $otool = '/Library/Developer/CommandLineTools/usr/bin/otool-classic';
 +	if (!-x $otool) {
-+		$otool = $xcode_home . '/Toolchains/XcodeDefault.xctoolchain/usr/bin/otool-classic';
++		$otool = $xcodepath . '/Toolchains/XcodeDefault.xctoolchain/usr/bin/otool-classic';
 +	}
 +	if (!-x $otool) {
 +		$otool = '/usr/bin/otool';

--- a/10.9-libcxx/stable/main/finkinfo/devel/fink-package-precedence.patch
+++ b/10.9-libcxx/stable/main/finkinfo/devel/fink-package-precedence.patch
@@ -1,7 +1,7 @@
-diff -Nurd -x'*~' fink-package-precedence-0.34.orig/fink-package-precedence fink-package-precedence-0.34/fink-package-precedence
---- fink-package-precedence-0.34.orig/fink-package-precedence	1969-12-31 19:00:00.000000000 -0500
-+++ fink-package-precedence-0.34/fink-package-precedence	2016-11-20 07:28:02.000000000 -0500
-@@ -0,0 +1,424 @@
+diff -Nurd -x'*~' fink-package-precedence-0.35.orig/fink-package-precedence fink-package-precedence-0.35/fink-package-precedence
+--- fink-package-precedence-0.35.orig/fink-package-precedence	1969-12-31 19:00:00.000000000 -0500
++++ fink-package-precedence-0.35/fink-package-precedence	2020-07-23 14:18:05.000000000 -0500
+@@ -0,0 +1,428 @@
 +#!/usr/bin/perl
 +# -*- mode: Perl; tab-width: 4; -*-
 +
@@ -316,7 +316,11 @@ diff -Nurd -x'*~' fink-package-precedence-0.34.orig/fink-package-precedence fink
 +}
 +
 +if ($opts{'libs'}) {
++	chomp(my $xcode_home = `xcode-select -print-path`);
 +	my $otool = '/Library/Developer/CommandLineTools/usr/bin/otool-classic';
++	if (!-x $otool) {
++		$otool = $xcode_home . '/Toolchains/XcodeDefault.xctoolchain/usr/bin/otool-classic';
++	}
 +	if (!-x $otool) {
 +		$otool = '/usr/bin/otool';
 +	}


### PR DESCRIPTION
currently, f-p-p tests for the command line tools' `otool-classic` before falling back to `/usr/bin/otool`. f-p-p should also check for Xcode's `otool-classic` before giving up.
Tested with libidn2.0-shlibs as per #613 

Fixes #616 