### PR TITLE
ninja update to 1.10.0 with tests

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/ninja.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/ninja.info
@@ -15,14 +15,15 @@
 # maintainership of) the affected package.
 
 Package: ninja
-Version: 1.8.2
+Version: 1.10.0
 Revision: 1
 Maintainer: Max Horn <max@quendi.de>
 
 Source: https://github.com/ninja-build/%n/archive/v%v.tar.gz
-Source-MD5: 5fdb04461cc7f5d02536b3bfc0300166
+Source-MD5: cf1d964113a171da42a8940e7607e71a
 SourceRename: %n-%v.tar.gz
 #SourceDirectory: martine-ninja-50af448
+BuildDepends: re2c
 
 CompileScript: ./configure.py --bootstrap
 InstallScript: <<
@@ -34,10 +35,17 @@ InstallScript: <<
   install -m 755 misc/bash-completion %i/etc/bash_completion.d/
 <<
 
-# Building ninja tests requires gtest, which is not yet available in Fink
-#InfoTest: TestScript: make check || exit
+# ninja tests requires build with cmake (builds a larger executable in build-cmake)
+InfoTest: <<
+  TestDepends: cmake
+  TestScript: <<
+    cmake -Bbuild-cmake -H.
+    cmake --build build-cmake
+    ./build-cmake/ninja_test || exit 2
+  <<
+<<
 
-DocFiles: COPYING  HACKING.md  README
+DocFiles: COPYING README.md doc/manual.asciidoc
 
 Description: Small build system with a focus on speed
 DescDetail: <<


### PR DESCRIPTION
Suggested update after 3½ years and seeing comments in a dependent package (#582) about performance improvements for versions >= 1.9.
The test setup seems to have changed, no longer needing a `gtest` but rather the build option using `cmake`. For some reason this also creates a 3x larger executable than the `./configure.py` build, but I could not identify differences in functionality between the two. Therefore still installing the latter and just using the former for the test suite. Comments welcome if we should rather switch to a pure cmake build.