### PR TITLE
flex-devel update to 2.6.4 and PDF doc build

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/flex-devel.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/flex-devel.info
@@ -1,19 +1,20 @@
 Package: flex-devel
-Version: 2.6.0
+Version: 2.6.4
 Revision: 1
 BuildDepends: <<
 	fink (>= 0.28.0-1),
 	fink-package-precedence,
 	libgettext8-dev,
-	help2man
+	help2man,
+	texinfo
 <<
 Depends: libgettext8-shlibs
 Description: Fast lexical analyser generator
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 
-Source: mirror:sourceforge:flex/flex-%v.tar.bz2
-Source-MD5: 266270f13c48ed043d95648075084d59
+Source: https://github.com/westes/flex/releases/download/v%v/flex-%v.tar.gz
+Source-MD5: 2882e3179748cc9f9c23ec593d6adc8d
 
 UseMaxBuildJobs: false
 
@@ -26,15 +27,19 @@ CompileScript: <<
 	export lt_cv_sys_max_cmd_len=65536
 	%{default_script}
 	fink-package-precedence .
+	cd doc
+	make pdf
 <<
 InstallScript: <<
 	make install DESTDIR=%d
-	rm -rf %i/lib/flex/man %i/lib/flex/share %i/lib/flex/info
 <<
 
-InfoTest: TestScript: make check || exit 2
+InfoTest: <<
+	TestDepends: bison
+	InfoTest: TestScript: make check || exit 2
+<<
 
-DocFiles: AUTHORS COPYING ChangeLog INSTALL NEWS ONEWS README* THANKS TODO
+DocFiles: ABOUT-NLS AUTHORS COPYING ChangeLog NEWS ONEWS README.md THANKS doc/flex.pdf examples
 Homepage: https://github.com/westes/flex
 
 DescDetail: <<
@@ -47,6 +52,9 @@ This is a version of Flex that generates better C++ code than the
 standard 2.5.4 Flex, but also has some compatibility problems with
 the older flex as well, so it installs into %p/lib/flex and must
 be explicitly linked by projects that want to use it.
+To access this version's documentation, set MANPATH=%p/lib/flex/man
+INFOPATH=%p/lib/flex/info or add the paths via the '-M' and '-d'
+flags, respectively.
 <<
 DescUsage: <<
 You will need to explicitly add the paths to this version of flex


### PR DESCRIPTION
New upstream version, added the PDF manual to the docs – this does increase the installed size by about 1 MB.

On a related issue, does anyone recall details about the compatibility problems of the newer version vs. the standard 2.5.4a package? I.e. is Fink stuck with defaulting to a quarter-century old (alpha?) version that no longer has an original source location? There is a "final" version 2.5.39 of the 2.5 branch, but as `flex-devel` originally seems to have branched off with 2.5.35, I presume any issues that version had would be present in 2.5.39 as well... There are also some older versions on https://github.com/westes/flex/releases (but not quite as old as 2.5.4), but it's unclear whether these are alpha, beta or gamma versions, and none of them even has a working `configure` (attempts to generate a new build with `autogen.sh` failing early on missing `Makefile.in`...).
OTOH the only packages I could spot that explicitly depend on `flex` (rather than `flex-devel` or listing it as a `BuildConflict` / pointing to the system `/usr/bin/flex`) are
`apple-gdb biopython-py27 cscope detex ginac2 pcb`
and I just successfully rebuilt all 6 against a default `flex` updated to 2.5.39`...