### PR TITLE
Move H5api_adpt.h header into main -dev package to match hdf5.100.v* …

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/hdf5.10-oldapi.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/hdf5.10-oldapi.info
@@ -3,7 +3,7 @@ Package: hdf5.10-oldapi
 # v1.8.17 bumps libhdf5_cpp to libN=12.
 # v1.8.21 (last 1.8) bumps libhdf5_cpp to libN=16.
 Version: 1.8.16
-Revision: 4
+Revision: 5
 Description: Scientific data format (v1.6 API)--headers
 License: OSI-Approved
 Maintainer: None <fink-devel@lists.sourceforge.net>
@@ -24,7 +24,8 @@ Replaces: <<
 	hdf5.8-oldapi,
 	hdf5.9,
 	hdf5.9-oldapi,
-	hdf5.10,  
+	hdf5.10,
+	hdf5-oldapi-cpp11 (<< 1.8.16-5),
 	hdf5.100.v1.8, 
 	hdf5.100.v1.10
 <<
@@ -185,7 +186,6 @@ SplitOff4: <<
 	opt/hdf5v1.6/lib/libhdf5_cpp.la
 	opt/hdf5v1.6/lib/libhdf5_hl_cpp.la
     opt/hdf5v1.6/include/H5AbstractDs.h
-    opt/hdf5v1.6/include/H5api_adpt.h
     opt/hdf5v1.6/include/H5ArrayType.h
     opt/hdf5v1.6/include/H5AtomType.h
     opt/hdf5v1.6/include/H5Attribute.h
@@ -243,6 +243,10 @@ for your package.
 
 DescPackaging: <<
     Former Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
+
+	Revision 5: move H5api_adpt.h into main package so that netcdf* HDF5 detection works
+	without installing the cpp package.  (Kind of weird since this file seems like it's
+	for DLLs, but whatever.)  No real reason this was in the cpp package, anyway.
 
 	Install libs and headers %p/opt/hdf5v1.6.  Libs go in %p/opt/hdf5v1.6/lib to avoid file overlap 
 	with hdf5.8, and headers go in %p/opt/hdf5v.16/include because packages that use hdf5 seem to

--- a/10.9-libcxx/stable/main/finkinfo/sci/hdf5.10.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/hdf5.10.info
@@ -3,7 +3,7 @@ Package: hdf5.10
 # v1.8.17 bumps libhdf5_cpp to libN=12.
 # v1.8.21 (last 1.8) bumps libhdf5_cpp to libN=16.
 Version: 1.8.16
-Revision: 6
+Revision: 7
 Description: Scientific data format (v1.8 API)--headers
 License: OSI-Approved
 Maintainer: None <fink-devel@lists.sourceforge.net>
@@ -24,7 +24,8 @@ Replaces: <<
 	hdf5.8-oldapi,
 	hdf5.9,
 	hdf5.9-oldapi,
-	%N-oldapi,  
+	%N-oldapi,
+	hdf5-cpp11 (<< 1.8.16-7),
 	hdf5.100.v1.8, 
 	hdf5.100.v1.10
 <<
@@ -187,7 +188,6 @@ SplitOff4: <<
 	lib/libhdf5_cpp.la
 	lib/libhdf5_hl_cpp.la
     include/H5AbstractDs.h
-    include/H5api_adpt.h
     include/H5ArrayType.h
     include/H5AtomType.h
     include/H5Attribute.h
@@ -237,6 +237,10 @@ Fink's "%N*" packages are intended to replace the corresponding ones from
 
 DescPackaging: <<
     Former Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
+
+	Revision 7: move H5api_adpt.h into main package so that netcdf* HDF5 detection works
+	without installing the cpp package.  (Kind of weird since this file seems like it's
+	for DLLs, but whatever.)  No real reason this was in the cpp package, anyway.
 
 	Make sure to update the netcdf* (>> 3.6.3) packages when this is updated.
 


### PR DESCRIPTION
…packages.

This eliminates needing the -cpp packages for base hdf5 detection.
Fixes #651