### PR TITLE
PostgreSQL upstream updates August 2020

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 10.12
+Version: 10.14
 Revision: 1
 Type: postgresql 10
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 50a69fdba082a9edd5598c3afb52bc3c
-Source-Checksum: SHA256(388f7f888c4fbcbdf424ec2bce52535195b426010b720af7bea767e23e594ae7)
+Source-MD5: b3943822ebbf46f791c72f48ff0d5128
+Source-Checksum: SHA256(381cd8f491d8f77db2f4326974542a50095b5fa7709f24d7c5b760be2518b23b)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql11.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql11.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 11.7
+Version: 11.9
 Revision: 1
 Type: postgresql 11
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 1cf8e7533b103e2aa9de6e76d477f67d
-Source-Checksum: SHA256(324ae93a8846fbb6a25d562d271bc441ffa8794654c5b2839384834de220a313)
+Source-MD5: 2d20502cbce1c7531bb69e56f5c5c65a
+Source-Checksum: SHA256(35618aa72e0372091f923c42389c6febd07513157b4fbb9408371706afbb6635)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql12.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql12.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 12.2
+Version: 12.4
 Revision: 1
 Type: postgresql 12
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: a88ceea8ecf2741307f663e4539b58b7
-Source-Checksum: SHA256(ad1dcc4c4fc500786b745635a9e1eba950195ce20b8913f50345bb7d5369b5de)
+Source-MD5: 80ebbf0e55193b123760e5f8e48c6cff
+Source-Checksum: SHA256(bee93fbe2c32f59419cb162bcc0145c58da9a8644ee154a30b9a5ce47de606cc)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.6.17
+Version: 9.6.19
 Revision: 1
 Epoch: 1
 Type: postgresql 9.6
@@ -32,8 +32,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 4a12dd9e2afe140a8d2d4366471b075f
-Source-Checksum: SHA256(f6e1e32d32545f97c066f3c19f4d58dfab1205c01252cf85c5c92294ace1a0c2)
+Source-MD5: 96d5f5f8e78eea6cada9d2e02718cc28
+Source-Checksum: SHA256(61f93a94ccddbe0b2d1afaf03f04ba605d8af5b774ff9b830e5adeb50ab55cb0)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1


### PR DESCRIPTION
PR contains:

PostgreSQL upstream updates 12.4 11.9 10.14  9.6.19 to fix security issues
CVE-2020-14349 and  CVE-2020-14350 .
