### PR TITLE
new gperf version 3.1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/gperf.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/gperf.info
@@ -1,17 +1,23 @@
 Package: gperf
-Version: 3.0.4
+Version: 3.1
 Revision: 1
 Maintainer: David Fang <fangism@users.sourceforge.net>
 #
 Source: gnu
-Source-MD5: c1f1db32fb6598d6a93e6e88796a8632
-ConfigureParams: --mandir=%p/share/man --infodir=%p/share/info
+Source-MD5: 9e251c0a618ad0824b51117d5d9db87e
+ConfigureParams: --docdir=%p/share/doc/%n
+# There are external deps but mis-orders -I flags, so don't bother
+# setting fink's to avoid needlessly-disconcerting compiler commands.
+# Upstream rejects handling of standard flag variables. See:
+# http://savannah.gnu.org/patch/index.php?9418
+NoSetCPPFLAGS: true
+NoSetLDFLAGS: true
 GCC: 4.0
 DocFiles: <<
 AUTHORS COPYING* ChangeLog* NEWS README
 <<
 InfoDocs: gperf.info
-InstallScript: make install DESTDIR=%d docdir=%p/share/doc/%n
+InstallScript: make install DESTDIR=%d
 #
 InfoTest: <<
 	TestScript: make -j1 -k check || exit 2


### PR DESCRIPTION
New version of the stand-alone to sync with 52b6737 update to libiconv's onboard version.