### PR TITLE
Fixed asn1crypto DocFiles for case-sensitive FS, update to 1.4

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/asn1crypto-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/asn1crypto-py.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: asn1crypto-py%type_pkg[python]
-Version: 0.24.0
+Version: 1.4.0
 Revision: 1
 Type: python (2.7 3.4 3.5 3.6 3.7 3.8)
 
@@ -11,7 +11,7 @@ License: BSD
 Homepage: https://pypi.org/project/asn1crypto
 
 Source: https://files.pythonhosted.org/packages/source/a/asn1crypto/asn1crypto-%v.tar.gz
-Source-Checksum: SHA256(9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49)
+Source-Checksum: SHA256(f4f6e119474e58e04a2b1af817eb585b4fd72bdd89b998624712b5c99be7641c)
 
 Depends: <<
 	python%type_pkg[python]
@@ -22,5 +22,33 @@ CompileScript: %p/bin/python%type_raw[python] setup.py build
 
 InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
 
-DocFiles: LICENSE README.md
+DocFiles: readme.md changelog.md LICENSE docs
+
+DescDetail: <<
+A fast, pure Python library for parsing and serializing ASN.1 structures.
+In addition to an ASN.1 BER/DER decoder and DER serializer, the project
+includes a bunch of ASN.1 structures for use with various common
+cryptography standards:
+
+Standard        Module  Source
+X.509   asn1crypto.x509 RFC 5280
+CRL     asn1crypto.crl  RFC 5280
+CSR     asn1crypto.csr  RFC 2986, RFC 2985
+OCSP    asn1crypto.ocsp RFC 6960
+PKCS#12 asn1crypto.pkcs12       RFC 7292
+PKCS#8  asn1crypto.keys RFC 5208
+PKCS#1 v2.1 (RSA keys)  asn1crypto.keys RFC 3447
+DSA keys        asn1crypto.keys RFC 3279
+Elliptic curve keys     asn1crypto.keys SECG SEC1 V2
+PKCS#3 v1.4     asn1crypto.algos        PKCS#3 v1.4
+PKCS#5 v2.1     asn1crypto.algos        PKCS#5 v2.1
+CMS (and PKCS#7)        asn1crypto.cms  RFC 5652, RFC 2315
+TSP     asn1crypto.tsp  RFC 3161
+PDF signatures  asn1crypto.pdf  PDF 1.7
+
+It has been developed to overcome performance and API issues identified with
+the existing pyasn1 modules.
+asn1crypto is part of the modularcrypto family of Python packages.
+<<
+# Info2
 <<


### PR DESCRIPTION
Install failed because of a lower-case `readme.md`; also forwarded to latest upstream version.