### PR TITLE
matplotlib 2.2.5

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py.info
@@ -1,68 +1,69 @@
 Info2: <<
 
 Package: matplotlib-py%type_pkg[python]
-Version: 1.5.3
+Version: 2.2.5
 Revision: 1
 Source: https://pypi.python.org/packages/source/m/matplotlib/matplotlib-%v.tar.gz
-Source-MD5: ba993b06113040fee6628d74b80af0fd
+Source-Checksum: SHA256(a3037a840cd9dfdc2df9fee8af8f76ca82bfab173c0f9468193ca7a89a2b60ea)
 
 Type: python (2.7 3.4 3.5 3.6 3.7)
 
 Maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 Depends: <<
- atk1-shlibs (>= 1.32.0-1),
- cairo-shlibs (>= 1.12.14-1),
- cycler-py%type_pkg[python],
- dateutil-py%type_pkg[python],
- fontconfig2-shlibs (>= 2.10.0-1),
- freetype219-shlibs (>= 2.6-1),
- glib2-shlibs (>= 2.22.0-1),
- gtk+2-shlibs (>= 2.18.0-1),
- libpng16-shlibs,
- pango1-xft2-ft219-shlibs (>= 1.24.5-4),
- poppler-bin,
- python%type_pkg[python],
- pyparsing-py%type_pkg[python],
- pyqt4-mac-py%type_pkg[python],
- pyqt5-mac-py%type_pkg[python],
- pytz-py%type_pkg[python],
- qhull6.3.1-shlibs,
- numpy-py%type_pkg[python],
- six-py%type_pkg[python] (>= 1.4.0-1),
- tcltk-shlibs,
- tetex-base,
- tornado-py%type_pkg[python],
- x11-shlibs,
- ( %type_pkg[python] <= 27 ) pygtk2-gtk-py%type_pkg[python],
- ( %type_pkg[python] <= 27 ) wxgtk2.8-py%type_pkg[python]
+	atk1-shlibs (>= 1.32.0-1),
+	cairo-shlibs (>= 1.12.14-1),
+	cycler-py%type_pkg[python] (>= 0.10.0),
+	dateutil-py%type_pkg[python] (>= 2.1),
+	fontconfig2-shlibs (>= 2.10.0-1),
+	freetype219-shlibs (>= 2.6-1),
+	glib2-shlibs (>= 2.22.0-1),
+	gtk+2-shlibs (>= 2.18.0-1),
+	kiwisolver-py%type_pkg[python],
+	libpng16-shlibs,
+	numpy-py%type_pkg[python],
+	pango1-xft2-ft219-shlibs (>= 1.24.5-4),
+	poppler-bin,
+	pyparsing-py%type_pkg[python],
+	pyqt4-mac-py%type_pkg[python],
+	pyqt5-mac-py%type_pkg[python],
+	python%type_pkg[python],
+	pytz-py%type_pkg[python],
+	six-py%type_pkg[python] (>= 1.4.0-1),
+	tcltk-shlibs,
+	tetex-base,
+	tornado-py%type_pkg[python],
+	x11-shlibs,
+	( %type_pkg[python] <= 27 ) backports.functools-lru-cache-py%type_pkg[python],
+	( %type_pkg[python] <= 27 ) pygtk2-gtk-py%type_pkg[python],
+	( %type_pkg[python] <= 27 ) subprocess32-py%type_pkg[python],
+	( %type_pkg[python] <= 27 ) wxgtk2.8-py%type_pkg[python]
 <<
 
 BuildDepends: <<
- atk1 (>= 1.32.0-1),
- cairo (>= 1.12.14-1),
- fink-package-precedence,
- fontconfig2-dev (>= 2.10.0-1),
- freetype219 (>= 2.6-1),
- glib2-dev (>= 2.22.0-1),
- gtk+2-dev (>= 2.18.0-1),
- libpng16,
- pango1-xft2-ft219-dev (>= 1.24.5-4),
- pkgconfig (>= 0.21-1),
- qhull6.3.1-dev,
- setuptools-tng-py%type_pkg[python],
- tcltk-dev,
- tornado-py%type_pkg[python],
- x11-dev,
- ( %type_pkg[python] <= 27 ) pygtk2-gtk-py%type_pkg[python]-dev,
- ( %type_pkg[python] <= 27 ) wxgtk2.8-py%type_pkg[python]-dev,
- ( %type_pkg[python] <= 27 ) pygobject2-py%type_pkg[python]-dev
+	atk1 (>= 1.32.0-1),
+	cairo (>= 1.12.14-1),
+	fink-package-precedence,
+	fontconfig2-dev (>= 2.10.0-1),
+	freetype219 (>= 2.6-1),
+	glib2-dev (>= 2.22.0-1),
+	gtk+2-dev (>= 2.18.0-1),
+	libpng16,
+	pango1-xft2-ft219-dev (>= 1.24.5-4),
+	pkgconfig (>= 0.21-1),
+	setuptools-tng-py%type_pkg[python],
+	tcltk-dev,
+	tornado-py%type_pkg[python],
+	x11-dev,
+	( %type_pkg[python] <= 27 ) pygtk2-gtk-py%type_pkg[python]-dev,
+	( %type_pkg[python] <= 27 ) wxgtk2.8-py%type_pkg[python]-dev,
+	( %type_pkg[python] <= 27 ) pygobject2-py%type_pkg[python]-dev
 <<
 
 Recommends: <<
- ffmpeg,
- imagemagick,
- ipython-py%type_pkg[python],
- pil-py%type_pkg[python]
+	ffmpeg,
+	imagemagick,
+	ipython-py%type_pkg[python],
+	pil-py%type_pkg[python]
 <<
 
 GCC: 4.0
@@ -73,7 +74,7 @@ SetCXXFLAGS: -MD
 UseMaxBuildJobs: True
 
 PatchFile: %{ni}.patch
-PatchFile-MD5: f7d9e3995c451fbf370301e55bde0974
+PatchFile-MD5: 0adc807319e151732821476f3d1e431f
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 
 CompileScript:  <<
@@ -103,20 +104,25 @@ InstallScript: <<
  cp -R examples %i/share/doc/%n
 <<
 
-InfoTest: <<
- TestDepends: ffmpeg, inkscape, nose-py%type_pkg[python], ( %type_pkg[python] <= 27 ) mock-py%type_pkg[python]
- #TestSource: mirror:sourceforge:project/matplotlib/matplotlib/matplotlib-%v/matplotlib-%v.tar.gz
- #TestSource-MD5: 8cbeaae8ba9da703d926e74c3e7c8a57
- TestScript: <<
-  #!/bin/bash -ev
-  export PYTHONPATH=$(ls -d %b/build/lib.macosx-*-%type_raw[python])
-  %p/bin/python%type_raw[python] -B -c 'import matplotlib as m, sys; r=m.test(verbosity=1); sys.exit(1*(not r))' 
- <<
- TestSuiteSize: large
-<<
+# tests only work when matplotlib is built in develop mode
+#InfoTest: <<
+# TestDepends: <<
+# 	ffmpeg,
+# 	inkscape,
+# 	nose-py%type_pkg[python],
+# 	pytest-py%type_pkg[python],
+# 	( %type_pkg[python] <= 27 ) mock-py27
+# <<
+# TestScript: <<
+#  #!/bin/bash -ev
+#  export PYTHONPATH=%b/build/lib/python%type_raw[python]/site-packages
+#  %p/bin/py.test-%type_raw[python] || exit 2
+# <<
+# TestSuiteSize: large
+#<<
 
 License: OSI-Approved
-DocFiles: README.rst INSTALL CHANGELOG CONTRIBUTING.md
+DocFiles: README.rst INSTALL.rst LICENSE/*
 # API_CHANGES
 Description: Pure python 2D plotting with a Matlab syntax
 DescDetail: <<
@@ -130,27 +136,23 @@ in applications.
 Includes GTK, TkAgg, GTKAgg, SVG, PS and Agg backends.
 <<
 DescPackaging: <<
- Checks for qt, qt4, cairo (their python bindings) but doesn't use
- those test results, so don't bother setting dependencies or forcing
- non-detection of them.
- Added dependencies on six-py, and poppler-bin for pdftops.
- Recommended optional dependencies:
+* Checks for qt, qt4, cairo (their python bindings) but doesn't use
+  those test results, so don't bother setting dependencies or forcing
+  non-detection of them.
+* Qt5Agg is broken (need newer Qt5 than 5.7?).
+* Added dependencies on six-py, and poppler-bin for pdftops.
+* Recommended optional dependencies:
   ImageMagick: for animation module to be able to save to animated gif
   ffmpeg: for animation module to be able to save to movie formats
   pil-py: read and write a larger selection of image file formats
- qhull not recognised by pkg-config, but can still be used with patch
- to account for nonstandard include path of packaged version.
- The 'save to file' interface seems broken with qt4 and ipython.
- Tried to build against wxpython300, but python segfaults either on
- exit (with ipython) or plotting (without).
+* v2.2.5 requires qhull 2015.2, but does not work with our 2020.2/8.0.2.
+* The 'save to file' interface seems broken with qt4 and ipython.
+* Tried to build against wxpython300, but python segfaults either on
+  exit (with ipython) or plotting (without).
 
- Multiprocessing in setupext BackendQtBase.check_requirements hangs
- indefinitely in the build sandbox - therefore forcing it to fail;
- as long as there is no PyQt5 this will still recognise the Qt4 backend.
- 1 error with test_use_url URL lookup due to gist.github.com certificate
- being rejected by openssl 1.0.2.
-
- Use clang fix from https://github.com/mdboom/matplotlib/commit/3b0f5959bbea065b07538f9952ae520ab5a06c27.
+* Tests are disabled because they expect to be run with a very specific
+  version of freetype/fontconfig. Different versions produce very slightly
+  different test images, which then fail comparison.
 <<
 Homepage: http://matplotlib.sf.net
 DescUsage: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py.patch
@@ -1,7 +1,7 @@
-diff -ruNd matplotlib-1.5.1.orig/lib/matplotlib/font_manager.py matplotlib-1.5.1/lib/matplotlib/font_manager.py
---- matplotlib-1.5.1.orig/lib/matplotlib/font_manager.py	2016-01-10 19:06:08.000000000 -0800
-+++ matplotlib-1.5.1/lib/matplotlib/font_manager.py	2016-02-07 12:11:39.000000000 -0800
-@@ -138,6 +138,11 @@
+diff -ruN matplotlib-2.2.5-orig/lib/matplotlib/font_manager.py matplotlib-2.2.5/lib/matplotlib/font_manager.py
+--- matplotlib-2.2.5-orig/lib/matplotlib/font_manager.py	2020-02-02 00:14:26.000000000 -0600
++++ matplotlib-2.2.5/lib/matplotlib/font_manager.py	2020-10-04 19:11:30.000000000 -0500
+@@ -145,6 +145,11 @@
      "/Library/Fonts/",
      "/Network/Library/Fonts/",
      "/System/Library/Fonts/",
@@ -13,10 +13,10 @@ diff -ruNd matplotlib-1.5.1.orig/lib/matplotlib/font_manager.py matplotlib-1.5.1
      # fonts installed via MacPorts
      "/opt/local/share/fonts"
      ""
-diff -ruNd matplotlib-1.5.1.orig/setup.cfg.template matplotlib-1.5.1/setup.cfg.template
---- matplotlib-1.5.1.orig/setup.cfg.template	2016-01-10 18:43:13.000000000 -0800
-+++ matplotlib-1.5.1/setup.cfg.template	2016-02-07 12:04:29.000000000 -0800
-@@ -57,18 +57,18 @@
+diff -ruN matplotlib-2.2.5-orig/setup.cfg.template matplotlib-2.2.5/setup.cfg.template
+--- matplotlib-2.2.5-orig/setup.cfg.template	2020-02-02 00:14:27.000000000 -0600
++++ matplotlib-2.2.5/setup.cfg.template	2020-10-04 20:43:37.000000000 -0500
+@@ -64,18 +64,18 @@
  #           otherwise skip silently. This is the default
  #           behavior
  #
@@ -34,35 +34,35 @@ diff -ruNd matplotlib-1.5.1.orig/setup.cfg.template matplotlib-1.5.1/setup.cfg.t
  #pyside = auto
 -#qt4agg = auto
 -#tkagg = auto
-+qt5agg = True
++qt5agg = False
 +tkagg = True
  #windowing = auto
 -#wxagg = auto
-+wxagg = True
++wxagg = False
  
  [rc_options]
  # User-configurable options
-diff -ruNd matplotlib-1.5.1.orig/setup.py matplotlib-1.5.1/setup.py
---- matplotlib-1.5.1.orig/setup.py	2016-01-10 19:06:08.000000000 -0800
-+++ matplotlib-1.5.1/setup.py	2016-02-07 12:05:31.000000000 -0800
-@@ -220,6 +220,10 @@
-     with open('lib/matplotlib/mpl-data/matplotlibrc', 'w') as fd:
-         fd.write(template % {'backend': default_backend})
+diff -ruN matplotlib-2.2.5-orig/setup.py matplotlib-2.2.5/setup.py
+--- matplotlib-2.2.5-orig/setup.py	2020-02-02 00:14:27.000000000 -0600
++++ matplotlib-2.2.5/setup.py	2020-10-04 19:13:00.000000000 -0500
+@@ -282,6 +282,10 @@
+             fd.write(
+                 template.safe_substitute(TEMPLATE_BACKEND=default_backend))
  
 +    for mod in ext_modules:
 +        mod.include_dirs.append('@PREFIX@/include')
 +        mod.library_dirs.append('@PREFIX@/lib')
 +
-     # Build in verbose mode if requested
-     if setupext.options['verbose']:
-         for mod in ext_modules:
-diff -ruNd matplotlib-1.5.1.orig/setupext.py matplotlib-1.5.1/setupext.py
---- matplotlib-1.5.1.orig/setupext.py	2016-01-10 19:06:08.000000000 -0800
-+++ matplotlib-1.5.1/setupext.py	2016-02-07 12:10:49.000000000 -0800
-@@ -150,8 +150,8 @@
+         # Build in verbose mode if requested
+         if setupext.options['verbose']:
+             for mod in ext_modules:
+diff -ruN matplotlib-2.2.5-orig/setupext.py matplotlib-2.2.5/setupext.py
+--- matplotlib-2.2.5-orig/setupext.py	2020-02-02 00:14:27.000000000 -0600
++++ matplotlib-2.2.5/setupext.py	2020-10-04 19:14:32.000000000 -0500
+@@ -308,8 +308,8 @@
  
      basedir_map = {
-         'win32': ['win32_static', ],
+         'win32': win_bases,
 -        'darwin': ['/usr/local/', '/usr', '/usr/X11',
 -                   '/opt/X11', '/opt/local'],
 +        'darwin': ['@PREFIX@/lib/freetype219', '@PREFIX@',
@@ -70,32 +70,3 @@ diff -ruNd matplotlib-1.5.1.orig/setupext.py matplotlib-1.5.1/setupext.py
          'sunos5': [os.getenv('MPLIB_BASE') or '/usr/local', ],
          'gnu0': ['/usr'],
          'aix5': ['/usr/local'],
-@@ -1003,14 +1003,14 @@
-         self.__class__.found_external = True
-         try:
-             return self._check_for_pkg_config(
--                'qhull', 'qhull/qhull_a.h', min_version='2003.1')
-+                'qhull', 'libqhull/qhull_a.h', min_version='2003.1')
-         except CheckFailed as e:
-             self.__class__.found_pkgconfig = False
-             # Qhull may not be in the pkg-config system but may still be
-             # present on this system, so check if the header files can be
-             # found.
-             include_dirs = [
--                os.path.join(x, 'qhull') for x in get_include_dirs()]
-+                os.path.join(x, 'libqhull') for x in get_include_dirs()]
-             if has_include_file(include_dirs, 'qhull_a.h'):
-                 return 'Using system Qhull (version unknown, no pkg-config info)'
-             else:
-diff -ruNd matplotlib-1.5.1.orig/src/qhull_wrap.c matplotlib-1.5.1/src/qhull_wrap.c
---- matplotlib-1.5.1.orig/src/qhull_wrap.c	2016-01-03 19:45:23.000000000 -0800
-+++ matplotlib-1.5.1/src/qhull_wrap.c	2016-02-07 12:14:11.000000000 -0800
-@@ -7,7 +7,7 @@
-  */
- #include "Python.h"
- #include "numpy/noprefix.h"
--#include "qhull/qhull_a.h"
-+#include "libqhull/qhull_a.h"
- #include <stdio.h>
- 
- 


### PR DESCRIPTION
explicitly turn off backends that currently don’t work
explain why tests are currently disabled
Moves #671 forward