### PR TITLE
Matplotlib 2 and 3 updates

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/pyqt5-mac-py.info
@@ -80,8 +80,8 @@ BuildDepends:<<
   qt5-mac-qtwebkit (>= 5.6.0-1),
   qt5-mac-qtwebsockets (>= 5.6.0-1),
   qt5-mac-qtxmlpatterns (>= 5.6.0-1),
-  sip-py%type_pkg[python] (>= 4.19.13-2),
-  sip-py%type_pkg[python]-bin (>= 4.19.13-2)
+  sip-py%type_pkg[python] (>= 4.19.13-2), sip-py%type_pkg[python]  (<= 4.19.17-1),
+  sip-py%type_pkg[python]-bin (>= 4.19.13-2), sip-py%type_pkg[python]-bin (<= 4.19.17-1)
 <<
 
 UseMaxBuildJobs: true

--- a/10.9-libcxx/stable/main/finkinfo/languages/sip-pyqt4-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/sip-pyqt4-py.info
@@ -2,24 +2,31 @@
 Info2: <<
 
 Package: sip-pyqt4-py%type_pkg[python]
-Version: 4.19.13
-Revision: 2
+Version: 4.19.24
+Revision: 1
 Type: python (2.7 3.4 3.5 3.6 3.7)
 
-Source: mirror:sourceforge:pyqt/sip/sip-%v/sip-%v.tar.gz
-Source-Checksum: SHA256(e353a7056599bf5fbd5d3ff9842a6ab2ea3cf4e0304a0f925ec5862907c0d15e)
+# SF source has not been updated since 4.19.13
+# Source: mirror:sourceforge:pyqt/sip/sip-%v/sip-%v.tar.gz
+Source: https://www.riverbankcomputing.com/static/Downloads/sip/%v/sip-%v.tar.gz
+Source-Checksum: SHA256(edcd3790bb01938191eef0f6117de0bf56d1136626c0ddb678f3a558d62e41e5)
 
 GCC: 4.0
 Depends: python%type_pkg[python]
 BuildDepends: fink-buildenv-modules (>= 0.1.3-1), fink (>= 0.24.12-1)
 
 PatchFile: sip-py.patch
-PatchFile-MD5: d53f5e4456cca0104bdd5a5c7d0dfa99
+PatchFile-MD5: d08dcb0733f7f0bc886672b22777dbf9
 
 UseMaxBuildJobs: true
 CompileScript: <<
 	#!/bin/sh -ev
 	. %p/sbin/fink-buildenv-helper.sh
+ 	if [ %type_pkg[python] -lt 38 ]; then
+		LFLAGS_PY="`%p/bin/python%type_raw[python]-config --ldflags`"
+	else
+		LFLAGS_PY="-L%p/lib `%p/bin/python%type_raw[python]-config --embed --ldflags`"
+	fi
  	%p/bin/python%type_raw[python] configure.py \
 		--sip-module=PyQt4.sip \
 		--no-dist-info \
@@ -27,8 +34,9 @@ CompileScript: <<
 		-p macx-g++ \
 		-v %p/share/sip-py%type_pkg[python] \
 		INCDIR_OPENGL=$X11_INCLUDE_DIR \
+		LFLAGS_PLUGIN="-bundle $LFLAGS_PY"
 		LFLAGS_PLUGIN="-bundle `%p/bin/python%type_raw[python]-config --ldflags`"
-    perl -pi -e 's,exe = \"python.*,exe = \"%p/bin/python\",g' sipconfig.py
+ 	perl -pi -e 's,exe = \"python.*,exe = \"%p/bin/python\",g' sipconfig.py
 	make
 <<
 
@@ -36,7 +44,7 @@ InstallScript: <<
 	#!/bin/bash -ev
 	make install DESTDIR=%d
 <<
-DocFiles: LICENSE* NEWS README
+DocFiles: LICENSE* NEWS README ChangeLog
 
 DescPackaging: <<
 	Disable requirement of framework-built python on darwin.

--- a/10.9-libcxx/stable/main/finkinfo/languages/sip-pyqt5-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/sip-pyqt5-py.info
@@ -2,12 +2,14 @@
 Info2: <<
 
 Package: sip-pyqt5-py%type_pkg[python]
-Version: 4.19.13
-Revision: 2
+Version: 4.19.24
+Revision: 1
 Type: python (2.7 3.4 3.5 3.6 3.7)
 
-Source: mirror:sourceforge:pyqt/sip/sip-%v/sip-%v.tar.gz
-Source-Checksum: SHA256(e353a7056599bf5fbd5d3ff9842a6ab2ea3cf4e0304a0f925ec5862907c0d15e)
+# SF source has not been updated since 4.19.13
+# Source: mirror:sourceforge:pyqt/sip/sip-%v/sip-%v.tar.gz
+Source: https://www.riverbankcomputing.com/static/Downloads/sip/%v/sip-%v.tar.gz
+Source-Checksum: SHA256(edcd3790bb01938191eef0f6117de0bf56d1136626c0ddb678f3a558d62e41e5)
 
 GCC: 4.0
 Depends: python%type_pkg[python]
@@ -15,12 +17,17 @@ BuildDepends: fink-buildenv-modules (>= 0.1.3-1), fink (>= 0.24.12-1)
 Replaces: sip-py%type_pkg[python] (<= 4.19.13-1)
 
 PatchFile: sip-py.patch
-PatchFile-MD5: d53f5e4456cca0104bdd5a5c7d0dfa99
+PatchFile-MD5: d08dcb0733f7f0bc886672b22777dbf9
 
 UseMaxBuildJobs: true
 CompileScript: <<
 	#!/bin/sh -ev
 	. %p/sbin/fink-buildenv-helper.sh
+ 	if [ %type_pkg[python] -lt 38 ]; then
+		LFLAGS_PY="`%p/bin/python%type_raw[python]-config --ldflags`"
+	else
+		LFLAGS_PY="-L%p/lib `%p/bin/python%type_raw[python]-config --embed --ldflags`"
+	fi
  	%p/bin/python%type_raw[python] configure.py \
 		--sip-module=PyQt5.sip \
 		--no-dist-info \
@@ -28,8 +35,8 @@ CompileScript: <<
 		-p macx-g++ \
 		-v %p/share/sip-py%type_pkg[python] \
 		INCDIR_OPENGL=$X11_INCLUDE_DIR \
-		LFLAGS_PLUGIN="-bundle `%p/bin/python%type_raw[python]-config --ldflags`"
-    perl -pi -e 's,exe = \"python.*,exe = \"%p/bin/python\",g' sipconfig.py
+		LFLAGS_PLUGIN="-bundle $LFLAGS_PY"
+ 	perl -pi -e 's,exe = \"python.*,exe = \"%p/bin/python\",g' sipconfig.py
 	make
 <<
 
@@ -37,7 +44,8 @@ InstallScript: <<
 	#!/bin/bash -ev
 	make install DESTDIR=%d
 <<
-DocFiles: LICENSE* NEWS README
+
+DocFiles: LICENSE* NEWS README ChangeLog
 
 DescPackaging: <<
 	Disable requirement of framework-built python on darwin.

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/asn1crypto-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/asn1crypto-py.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: asn1crypto-py%type_pkg[python]
-Version: 0.24.0
+Version: 1.4.0
 Revision: 1
 Type: python (2.7 3.4 3.5 3.6 3.7 3.8)
 
@@ -11,7 +11,7 @@ License: BSD
 Homepage: https://pypi.org/project/asn1crypto
 
 Source: https://files.pythonhosted.org/packages/source/a/asn1crypto/asn1crypto-%v.tar.gz
-Source-Checksum: SHA256(9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49)
+Source-Checksum: SHA256(f4f6e119474e58e04a2b1af817eb585b4fd72bdd89b998624712b5c99be7641c)
 
 Depends: <<
 	python%type_pkg[python]
@@ -22,5 +22,33 @@ CompileScript: %p/bin/python%type_raw[python] setup.py build
 
 InstallScript: %p/bin/python%type_raw[python] setup.py install --root=%d
 
-DocFiles: LICENSE README.md
+DocFiles: readme.md changelog.md LICENSE docs
+
+DescDetail: <<
+A fast, pure Python library for parsing and serializing ASN.1 structures.
+In addition to an ASN.1 BER/DER decoder and DER serializer, the project
+includes a bunch of ASN.1 structures for use with various common
+cryptography standards:
+
+Standard        Module  Source
+X.509   asn1crypto.x509 RFC 5280
+CRL     asn1crypto.crl  RFC 5280
+CSR     asn1crypto.csr  RFC 2986, RFC 2985
+OCSP    asn1crypto.ocsp RFC 6960
+PKCS#12 asn1crypto.pkcs12       RFC 7292
+PKCS#8  asn1crypto.keys RFC 5208
+PKCS#1 v2.1 (RSA keys)  asn1crypto.keys RFC 3447
+DSA keys        asn1crypto.keys RFC 3279
+Elliptic curve keys     asn1crypto.keys SECG SEC1 V2
+PKCS#3 v1.4     asn1crypto.algos        PKCS#3 v1.4
+PKCS#5 v2.1     asn1crypto.algos        PKCS#5 v2.1
+CMS (and PKCS#7)        asn1crypto.cms  RFC 5652, RFC 2315
+TSP     asn1crypto.tsp  RFC 3161
+PDF signatures  asn1crypto.pdf  PDF 1.7
+
+It has been developed to overcome performance and API issues identified with
+the existing pyasn1 modules.
+asn1crypto is part of the modularcrypto family of Python packages.
+<<
+# Info2
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py.info
@@ -16,14 +16,14 @@ Depends: <<
  atk1-shlibs (>= 1.32.0-1),
  cairo-shlibs (>= 1.12.14-1),
  cycler-py%type_pkg[python] (>= 0.10.0-1),
- dateutil-py%type_pkg[python],
+ dateutil-py%type_pkg[python] (>= 2.7.3-1),
  fontconfig2-shlibs (>= 2.10.0-1),
  glib2-shlibs (>= 2.22.0-1),
  gtk+2-shlibs (>= 2.18.0-1),
- kiwisolver-py%type_pkg[python],
+ kiwisolver-py%type_pkg[python] (>= 1.2.0-1),
  libpng16-shlibs,
  pango1-xft2-ft219-shlibs (>= 1.24.5-4),
- pil-py%type_pkg[python],
+ pil-py%type_pkg[python] (>= 6.2.0-1),
  poppler-bin,
  python%type_pkg[python],
  pyparsing-py%type_pkg[python],
@@ -62,8 +62,7 @@ BuildDepends: <<
 Recommends: <<
  ffmpeg,
  imagemagick,
- ipython-py%type_pkg[python],
- pil-py%type_pkg[python]
+ ipython-py%type_pkg[python]
 <<
 
 BuildConflicts: libharfbuzz0-dev, qhull5-dev, qhull6-dev, qhull6.3.1-dev
@@ -77,45 +76,46 @@ SetLDFLAGS: -L%p/lib -lz -lbz2 -lpng16
 UseMaxBuildJobs: True
 
 PatchFile: %{ni}.patch
-PatchFile-MD5: 4da6d6a9685122fda5b2f2bf3481820d
+PatchFile-MD5: 98e8db5dd66b9f68f9ad19e7fb5a01ee
 PatchScript: sed 's|@PREFIX@|%p|g;s|@PY_PKG@|%type_pkg[python]|g;s|@PY_RAW@|%type_raw[python]|g' < %{PatchFile} | patch -p1
 
 CompileScript:  <<
  #!/bin/sh -ev
  cp -a setup.cfg{.template,}
- # build against a local copy of freetype-2.6.1 to ensure exact version match
- # (set via SetMFLAGS in TestInfo; should we set this unconditionally?):
+ # Build against a local copy of freetype-2.6.1 to ensure exact version match
  mkdir build
  mv ../freetype-2.6.1 build
  export MPLLOCALFREETYPE="$MFLAGS"
  export PKG_CONFIG_PATH="%p/lib/glib-2.0/pkgconfig-strict:$PKG_CONFIG_PATH"
  OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES %p/bin/python%type_raw[python] setup.py build
  fink-package-precedence --depfile-ext='\.d' build
- rsync -aC lib/matplotlib/tests/{tinypages,*.ipynb,*.pfb,*.ttf} build/lib.macosx-*-%type_raw[python]/matplotlib/tests
 <<
 
 InfoTest: <<
  TestDepends: <<
+  certifi-py%type_pkg[python] (>= 2019.11.28-1),
   ffmpeg,
   inkscape,
-  pytest-py%type_pkg[python]
+  numpy-py%type_pkg[python] (>= 1.18.1-1),
+  pyparsing-py%type_pkg[python] (>= 2.4.5-1),
+  pytest-py%type_pkg[python] (>= 3.6.0)
  <<
  # test_backends_nbagg checks for nbconvert but fails with older versions.
  TestConflicts: nbconvert-py%type_pkg[python] (<= 6.0.0-1)
- #SetMFLAGS: True
- #TestConfigureParams: --local_freetype=True
  TestScript: <<
-  # conftest.py throws import errors when trying to run tests anywhere but in the
-  # directory matplotlib is imported from - remove them again before installation,
-  # as they would also triple install size.
-  rsync -aC lib/matplotlib/tests/baseline_images build/lib.macosx-*-%type_raw[python]/matplotlib/tests
-  rsync -aC lib/mpl_toolkits/tests/baseline_images build/lib.macosx-*-%type_raw[python]/mpl_toolkits/tests
-  # warnings if flaky extension is not installed, but with it some tests fail on
-  # passing a 'reruns' kwarg that is unknown to any version of flaky 3.x.
-  perl -pi -e 's|(mark.flaky.)(reruns=)(.)|${1}max_runs=${3}, min_passes=2|;' build/lib.macosx-*-%type_raw[python]/matplotlib/tests/test*.py
-  # pytest can end up importing mpl_toolkits from %p/lib/python* (without tests)
-  # regardless of sys.path unless running from the eventual install dir in %i,
-  # so defer actual running of the tests to Install phase.
+  #!/bin/sh -ev
+  export LANG=en_US.UTF-8
+  export PYTHONPATH=%b/build/lib/python%type_raw[python]/site-packages
+  mkdir -p $PYTHONPATH
+  OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES %p/bin/python%type_raw[python] setup.py develop --no-deps --prefix %b/build
+  # Comparison images are expected in `Path(__file__).parent / "baseline_images"`
+  # - mpl_toolkits still may not find them if matplotlib is already installed in system path.
+  ln -s ../../../../lib/matplotlib/tests/baseline_images build/lib.macosx*-%type_raw[python]/matplotlib/tests
+  ln -s ../../../../lib/mpl_toolkits/tests/baseline_images build/lib.macosx*-%type_raw[python]/mpl_toolkits/tests
+  PYTHONPATH="${PYTHONPATH}:$(ls -d %b/build/lib.macosx*-%type_raw[python])"
+  %p/bin/python%type_raw[python] -Bm pytest lib/mpl_toolkits || echo 'mpl_toolkits tests not working with installed matplotlib'
+  %p/bin/python%type_raw[python] -Bm pytest -k 'not (_pdflatex or _rcupdate or _marker_clipping or _interactive_backend or (_mixedmode and pdf))' lib/matplotlib || exit 2
+  rm build/lib.macosx*-%type_raw[python]/m*/tests/baseline_images
  <<
  TestSuiteSize: large
 <<
@@ -125,13 +125,6 @@ InstallScript: <<
  export PKG_CONFIG_PATH="%p/lib/glib-2.0/pkgconfig-strict:$PKG_CONFIG_PATH"
  OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES %p/bin/python%type_raw[python] setup.py install --root %d
  export LANG=en_US.UTF-8 PYTHONPATH=%i/lib/python%type_raw[python]/site-packages
- # Check if tests have been installed and setup (for `--tests`)
- if [ -d ${PYTHONPATH}/matplotlib/tests/baseline_images ]; then
-  cd $PYTHONPATH
-  # test_backend_tk might fail on accessing display
-  %p/bin/python%type_raw[python] -Bm pytest -k 'not (_pdflatex or _rcupdate or _marker_clipping or _interactive_backend or (_mixedmode and pdf))' || exit 2
-  rm -r m*/tests/baseline_images result_images .pytest_cache
- fi
 <<
 
 License: OSI-Approved
@@ -161,7 +154,7 @@ DescPackaging: <<
  falling back to the local copy until mpl is converted to libqhull_r or we
  find a way to install the non-reentrant dylib with libqhull-shlibs as well.
  (cf. http://www.qhull.org/html/qh-code.htm#reentrant .)
- The 'save to file' interface seems broken with qt4 and ipython.
+ Qt4 backend to be phased out and already unsupported with ipython --pylab.
  Enabled build against wxpython400, requires patch to ipython-py 7.5.0 for
  pylab environment; RuntimeError in backends/backend_wx.py on exit.
  [ Added patch from https://github.com/matplotlib/matplotlib/pull/14292 - merged in 3.1.1]
@@ -174,9 +167,10 @@ DescPackaging: <<
  - workaround taken from the same site.
  Test suite requires exact version match of freetype built against (2.6.1),
  set by local_freetype=True in setup.cfg, to ensure correct image comparison.
- Enforced here by MPLLOCALFREETYPE set with a hack from SetMFLAGS in InfoTest
- and always used in build against local source copy.
+ Always used in build against local source copy - this will create and link
+ against a packaged ft2font.cpython-*-darwin.so.
  Patched tests to make them use matching versions of [i]python and jupyter.
+ Changed 'reruns' kwarg to 'max_runs' to keep flaky 3.x happy.
 <<
 Homepage: http://matplotlib.sf.net
 DescUsage: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py.patch
@@ -1,7 +1,7 @@
-diff -ruNd matplotlib-1.5.1.orig/lib/matplotlib/font_manager.py matplotlib-1.5.1/lib/matplotlib/font_manager.py
---- matplotlib-1.5.1.orig/lib/matplotlib/font_manager.py	2016-01-10 19:06:08.000000000 -0800
-+++ matplotlib-1.5.1/lib/matplotlib/font_manager.py	2016-02-07 12:11:39.000000000 -0800
-@@ -138,6 +138,11 @@
+diff -ruNd matplotlib-3.1.0.orig/lib/matplotlib/font_manager.py matplotlib-3.1.0/lib/matplotlib/font_manager.py
+--- matplotlib-3.1.0.orig/lib/matplotlib/font_manager.py	2019-05-18 20:01:10.000000000 +0200
++++ matplotlib-3.1.0/lib/matplotlib/font_manager.py	2019-05-28 14:51:29.000000000 +0200
+@@ -154,6 +154,11 @@
      "/Library/Fonts/",
      "/Network/Library/Fonts/",
      "/System/Library/Fonts/",
@@ -11,91 +11,83 @@ diff -ruNd matplotlib-1.5.1.orig/lib/matplotlib/font_manager.py matplotlib-1.5.1
 +    # fonts installed via Fink
 +    "@PREFIX@/lib/X11/fonts",
      # fonts installed via MacPorts
-     "/opt/local/share/fonts"
-     ""
-diff -ruNd matplotlib-1.5.1.orig/setup.cfg.template matplotlib-1.5.1/setup.cfg.template
---- matplotlib-1.5.1.orig/setup.cfg.template	2016-01-10 18:43:13.000000000 -0800
-+++ matplotlib-1.5.1/setup.cfg.template	2016-02-07 12:04:29.000000000 -0800
-@@ -57,18 +57,18 @@
- #           otherwise skip silently. This is the default
- #           behavior
+     "/opt/local/share/fonts",
+     # user fonts
+diff -ruNd matplotlib-3.3.0.orig/setup.cfg.template matplotlib-3.3.0/setup.cfg.template
+--- matplotlib-3.3.0.orig/setup.cfg.template	2020-07-16 06:57:08.000000000 +0200
++++ matplotlib-3.3.0/setup.cfg.template	2020-08-11 20:22:15.000000000 +0200
+@@ -29,6 +29,11 @@
+ # It is never built on Linux or Windows, regardless of the config value.
  #
--#agg = auto
--#cairo = auto
--#gtk = auto
+ #macosx = True
 +agg = True
-+cairo = True
-+gtk = True
- #gtk3agg = auto
- #gtk3cairo = auto
--#gtkagg = auto
-+gtkagg = True
- #macosx = auto
- #pyside = auto
--#qt4agg = auto
--#tkagg = auto
-+qt5agg = True
 +tkagg = True
- #windowing = auto
--#wxagg = auto
++qt4agg = True
++qt5agg = True
 +wxagg = True
  
  [rc_options]
  # User-configurable options
-diff -ruNd matplotlib-1.5.1.orig/setup.py matplotlib-1.5.1/setup.py
---- matplotlib-1.5.1.orig/setup.py	2016-01-10 19:06:08.000000000 -0800
-+++ matplotlib-1.5.1/setup.py	2016-02-07 12:05:31.000000000 -0800
-@@ -220,6 +220,10 @@
-     with open('lib/matplotlib/mpl-data/matplotlibrc', 'w') as fd:
-         fd.write(template % {'backend': default_backend})
+@@ -41,3 +46,4 @@
+ # default is determined by fallback.
+ #
+ #backend = Agg
++backend = Qt5Agg
+diff -ruNd matplotlib-3.3.2.orig/setupext.py matplotlib-3.3.2/setupext.py
+--- matplotlib-3.3.2.orig/setupext.py	2020-09-15 09:04:28.000000000 +0200
++++ matplotlib-3.3.2/setupext.py	2020-10-09 20:36:24.000000000 +0200
+@@ -596,10 +596,10 @@
+         if sys.platform != 'win32':  # compilation on non-windows
+             env = {**env, "CFLAGS": "{} -fPIC".format(env.get("CFLAGS", ""))}
+             subprocess.check_call(
+-                ["./configure", "--with-zlib=no", "--with-bzip2=no",
+-                 "--with-png=no", "--with-harfbuzz=no", "--enable-static",
+-                 "--disable-shared"],
+-                env=env, cwd=src_path)
++                ["./configure --prefix=@PREFIX@ --libdir=@PREFIX@/lib/freetype219/lib" +
++                 "--with-zlib=no --with-bzip2=no --with-png=no --with-harfbuzz=no" +
++                 "--enable-static --disable-shared"],
++                shell=True, env=env, cwd=src_path)
+             if 'GNUMAKE' in env:
+                 make = env['GNUMAKE']
+             elif 'MAKE' in env:
+--- matplotlib-3.2.0.orig/lib/matplotlib/tests/test_backend_nbagg.py	2020-02-01 21:41:08.000000000 +0100
++++ matplotlib-3.2.0/lib/matplotlib/tests/test_backend_nbagg.py	2020-03-11 22:28:56.000000000 +0100
+@@ -5,6 +5,7 @@
  
-+    for mod in ext_modules:
-+        mod.include_dirs.append('@PREFIX@/include')
-+        mod.library_dirs.append('@PREFIX@/lib')
-+
-     # Build in verbose mode if requested
-     if setupext.options['verbose']:
-         for mod in ext_modules:
-diff -ruNd matplotlib-1.5.1.orig/setupext.py matplotlib-1.5.1/setupext.py
---- matplotlib-1.5.1.orig/setupext.py	2016-01-10 19:06:08.000000000 -0800
-+++ matplotlib-1.5.1/setupext.py	2016-02-07 12:10:49.000000000 -0800
-@@ -150,8 +150,8 @@
+ import pytest
  
-     basedir_map = {
-         'win32': ['win32_static', ],
--        'darwin': ['/usr/local/', '/usr', '/usr/X11',
--                   '/opt/X11', '/opt/local'],
-+        'darwin': ['@PREFIX@/lib/freetype219', '@PREFIX@',
-+                   '/usr', '/usr/X11', '/opt/X11'],
-         'sunos5': [os.getenv('MPLIB_BASE') or '/usr/local', ],
-         'gnu0': ['/usr'],
-         'aix5': ['/usr/local'],
-@@ -1003,14 +1003,14 @@
-         self.__class__.found_external = True
-         try:
-             return self._check_for_pkg_config(
--                'qhull', 'qhull/qhull_a.h', min_version='2003.1')
-+                'qhull', 'libqhull/qhull_a.h', min_version='2003.1')
-         except CheckFailed as e:
-             self.__class__.found_pkgconfig = False
-             # Qhull may not be in the pkg-config system but may still be
-             # present on this system, so check if the header files can be
-             # found.
-             include_dirs = [
--                os.path.join(x, 'qhull') for x in get_include_dirs()]
-+                os.path.join(x, 'libqhull') for x in get_include_dirs()]
-             if has_include_file(include_dirs, 'qhull_a.h'):
-                 return 'Using system Qhull (version unknown, no pkg-config info)'
-             else:
-diff -ruNd matplotlib-1.5.1.orig/src/qhull_wrap.c matplotlib-1.5.1/src/qhull_wrap.c
---- matplotlib-1.5.1.orig/src/qhull_wrap.c	2016-01-03 19:45:23.000000000 -0800
-+++ matplotlib-1.5.1/src/qhull_wrap.c	2016-02-07 12:14:11.000000000 -0800
-@@ -7,7 +7,7 @@
-  */
- #include "Python.h"
- #include "numpy/noprefix.h"
--#include "qhull/qhull_a.h"
-+#include "libqhull/qhull_a.h"
- #include <stdio.h>
++pytest.importorskip('nbconvert')
+ nbformat = pytest.importorskip('nbformat')
  
- 
+ # From https://blog.thedataincubator.com/2016/06/testing-jupyter-notebooks/
+@@ -16,7 +16,7 @@
+     with TemporaryDirectory() as tmpdir:
+         out_path = Path(tmpdir, "out.ipynb")
+         subprocess.check_call(
+-            ["jupyter", "nbconvert", "--to", "notebook",
++            ["jupyter-py@PY_PKG@", "nbconvert", "--to", "notebook",
+              "--execute", "--ExecutePreprocessor.timeout=500",
+              "--output", str(out_path), str(nb_path)],
+             env={**os.environ, "IPYTHONDIR": tmpdir})
+diff -ruNd matplotlib-3.1.0.orig/lib/matplotlib/tests/test_nbagg_01.ipynb matplotlib-3.1.0/lib/matplotlib/tests/test_nbagg_01.ipynb
+--- matplotlib-3.1.0.orig/lib/matplotlib/tests/test_nbagg_01.ipynb	2019-04-01 02:50:07.000000000 +0200
++++ matplotlib-3.1.0/lib/matplotlib/tests/test_nbagg_01.ipynb	2019-05-29 01:15:44.000000000 +0200
+@@ -843,7 +843,7 @@
+   "kernelspec": {
+    "display_name": "Python 3",
+    "language": "python",
+-   "name": "python3"
++   "name": "python@PY_RAW@"
+   },
+   "language_info": {
+    "codemirror_mode": {
+@@ -854,7 +854,7 @@
+    "mimetype": "text/x-python",
+    "name": "python",
+    "nbconvert_exporter": "python",
+-   "pygments_lexer": "ipython3",
++   "pygments_lexer": "ipython3-py@PY_PKG@",
+    "version": "3.6.3"
+   },
+   "toc": {

--- a/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py.patch
@@ -51,6 +51,54 @@ diff -ruNd matplotlib-3.3.2.orig/setupext.py matplotlib-3.3.2/setupext.py
              if 'GNUMAKE' in env:
                  make = env['GNUMAKE']
              elif 'MAKE' in env:
+diff -ruNd matplotlib-3.0.3.orig/lib/matplotlib/tests/test_backend_pdf.py matplotlib-3.0.3/lib/matplotlib/tests/test_backend_pdf.py
+--- matplotlib-3.0.3.orig/lib/matplotlib/tests/test_backend_pdf.py	2020-09-15 09:04:27.000000000 +0200
++++ matplotlib-3.0.3/lib/matplotlib/tests/test_backend_pdf.py	2020-10-19 19:33:33.000000000 +0200
+@@ -227,7 +227,7 @@
+ 
+ 
+ # This tests tends to hit a TeX cache lock on AppVeyor.
+-@pytest.mark.flaky(reruns=3)
++@pytest.mark.flaky(max_runs=3, min_passes=2)
+ @needs_usetex
+ def test_missing_psfont(monkeypatch):
+     """An error is raised if a TeX font lacks a Type-1 equivalent"""
+diff -ruNd matplotlib-3.3.2.orig/lib/matplotlib/tests/test_backend_ps.py matplotlib-3.3.2/lib/matplotlib/tests/test_backend_ps.py
+--- matplotlib-3.3.2.orig/lib/matplotlib/tests/test_backend_ps.py	2020-09-15 09:04:27.000000000 +0200
++++ matplotlib-3.3.2/lib/matplotlib/tests/test_backend_ps.py	2020-10-19 22:33:33.000000000 +0200
+@@ -20,7 +20,7 @@
+ 
+ 
+ # This tests tends to hit a TeX cache lock on AppVeyor.
+-@pytest.mark.flaky(reruns=3)
++@pytest.mark.flaky(max_runs=3, min_passes=2)
+ @pytest.mark.parametrize('orientation', ['portrait', 'landscape'])
+ @pytest.mark.parametrize('format, use_log, rcParams', [
+     ('ps', False, {}),
+diff -ruNd matplotlib-3.3.2.orig/lib/matplotlib/tests/test_backends_interactive.py matplotlib-3.3.2/lib/matplotlib/tests/test_backends_interactive.py
+--- matplotlib-3.3.2.orig/lib/matplotlib/tests/test_backends_interactive.py	2020-09-15 09:04:27.000000000 +0200
++++ matplotlib-3.3.2/lib/matplotlib/tests/test_backends_interactive.py	2020-10-19 22:49:43.000000000 +0200
+@@ -144,7 +144,7 @@
+ 
+ @pytest.mark.parametrize("backend", _get_testable_interactive_backends())
+ @pytest.mark.parametrize("toolbar", ["toolbar2", "toolmanager"])
+-@pytest.mark.flaky(reruns=3)
++@pytest.mark.flaky(max_runs=3, min_passes=2)
+ def test_interactive_backend(backend, toolbar):
+     if backend == "macosx":
+         if toolbar == "toolmanager":
+diff -ruNd matplotlib-3.0.3.orig/lib/matplotlib/tests/test_lines.py matplotlib-3.0.3/lib/matplotlib/tests/test_lines.py
+--- matplotlib-3.0.3.orig/lib/matplotlib/tests/test_lines.py	2019-03-01 04:33:38.000000000 +0100
++++ matplotlib-3.0.3/lib/matplotlib/tests/test_lines.py	2020-10-19 19:33:33.000000000 +0200
+@@ -28,7 +28,7 @@
+ 
+ # Runtimes on a loaded system are inherently flaky. Not so much that a rerun
+ # won't help, hopefully.
+-@pytest.mark.flaky(reruns=3)
++@pytest.mark.flaky(max_runs=3, min_passes=1)
+ def test_invisible_Line_rendering():
+     """
+     GitHub issue #1256 identified a bug in Line.draw method
 --- matplotlib-3.2.0.orig/lib/matplotlib/tests/test_backend_nbagg.py	2020-02-01 21:41:08.000000000 +0100
 +++ matplotlib-3.2.0/lib/matplotlib/tests/test_backend_nbagg.py	2020-03-11 22:28:56.000000000 +0100
 @@ -5,6 +5,7 @@

--- a/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py27.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py27.info
@@ -78,14 +78,14 @@ SetLDFLAGS: -L%p/lib -lz -lbz2 -lpng16
 UseMaxBuildJobs: True
 
 PatchFile: %{ni}.patch
-PatchFile-MD5: f15a8c2f4fef95677cbfb20cb8481f72
+PatchFile-MD5: c3cbdb2c7c28dcc5d72d0a3247a13085
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 
 CompileScript:  <<
  #!/bin/sh -ev
  cp -a setup.cfg{.template,}
- # build against a local copy of freetype-2.6.1 to ensure exact version match
- # (set via SetMFLAGS in TestInfo; should we set this unconditionally?):
+ # Build against a local copy of freetype-2.6.1 to ensure exact version match
+ # - this will create and link against a packaged ft2font.cpython-*-darwin.so.
  mkdir build
  mv ../freetype-2.6.1 build
  export MPLLOCALFREETYPE="$MFLAGS"
@@ -108,19 +108,12 @@ InfoTest: <<
  SetMFLAGS: True
  TestConfigureParams: --local_freetype=True
  TestScript: <<
-  # conftest.py throws import errors when trying to run tests anywhere but in the
-  # directory matplotlib is imported from - remove them again before installation,
-  # as they would also triple install size.
-  rsync -aC lib/matplotlib/tests build/lib.macosx-*-%type_raw[python]/matplotlib
-  rsync -aC lib/matplotlib/sphinxext/tests build/lib.macosx-*-%type_raw[python]/matplotlib/sphinxext
-  rsync -aC lib/mpl_toolkits/tests build/lib.macosx-*-%type_raw[python]/mpl_toolkits
-  # warnings if flaky extension is not installed, but with it some tests fail on
-  # passing a 'reruns' kwarg that is unknown to any version of flaky 3.x.
-  perl -pi -e 's|(mark.flaky.)(reruns=)(.)|${1}max_runs=${3}, min_passes=2|;' build/lib.macosx-*-%type_raw[python]/matplotlib/tests/test_back*.py
-  perl -pi -e 's|(mark.flaky.)(reruns=)(.)|${1}max_runs=${3}, min_passes=1|;' build/lib.macosx-*-%type_raw[python]/matplotlib/tests/test_lines.py
-  # pytest can end up importing mpl_toolkits from %p/lib/python* (without tests)
-  # regardless of sys.path unless running from the eventual install dir in %i,
-  # so defer actual running of the tests to Install phase.
+  #!/bin/sh -ev
+  export LANG=en_US.UTF-8
+  export PYTHONPATH=%b/build/lib/python%type_raw[python]/site-packages
+  mkdir -p $PYTHONPATH || exit 2
+  OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES %p/bin/python%type_raw[python] setup.py develop --prefix %b/build || exit 2
+   %p/bin/python%type_raw[python] -Bm pytest -k 'not (_pdflatex or _rcupdate)' || exit 2
  <<
  TestSuiteSize: large
 <<
@@ -129,18 +122,6 @@ InstallScript: <<
  #!/bin/sh -ev
  export PKG_CONFIG_PATH="%p/lib/glib-2.0/pkgconfig-strict:$PKG_CONFIG_PATH"
  OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES %p/bin/python%type_raw[python] setup.py install --root %d
- export LANG=en_US.UTF-8 PYTHONPATH=%i/lib/python%type_raw[python]/site-packages
- # Check if tests have been installed and setup (for `--tests`)
- if [ -d ${PYTHONPATH}/matplotlib/tests ]; then
-  cd $PYTHONPATH
-  # Seems unable to import mpl_toolkits even directly from $PYTHONPATH if matplotlib is not already installed.
-  if (%p/bin/python%type_raw[python] -Bc 'import mpl_toolkits'); then
-   %p/bin/python%type_raw[python] -Bm pytest -k 'not (_pdflatex or _rcupdate)' || exit 2
-  else
-   %p/bin/python%type_raw[python] -Bm pytest -k 'not (_pdflatex or _rcupdate or _polycollection_close or _parasite)' matplotlib || exit 2
-  fi
-  rm -r matplotlib/tests matplotlib/sphinxext/tests mpl_toolkits/tests result_images .pytest_cache
- fi
 <<
 
 License: OSI-Approved
@@ -186,7 +167,10 @@ DescPackaging: <<
  Test suite requires exact version match of freetype built against (2.6.1),
  set by local_freetype=True in setup.cfg, to ensure correct image comparison.
  Enforced here by MPLLOCALFREETYPE set with a hack from SetMFLAGS in InfoTest.
- 1-2 Failures and Errors in 2.1.1.
+ 1-2 Failures and Errors in 2.1.1 - this will create and link against a packaged
+ ft2font.cpython-*-darwin.so.
+ Patched tests to make them use matching versions of [i]python and jupyter.
+ Changed 'reruns' kwarg to 'max_runs' to keep flaky 3.x happy.
 <<
 Homepage: http://matplotlib.sf.net
 DescUsage: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py27.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py27.info
@@ -1,0 +1,200 @@
+Info2: <<
+
+Package: matplotlib-py27
+Version: 2.2.5
+Revision: 1
+Source: https://files.pythonhosted.org/packages/source/m/matplotlib/matplotlib-%v.tar.gz
+Source-Checksum: SHA256(a3037a840cd9dfdc2df9fee8af8f76ca82bfab173c0f9468193ca7a89a2b60ea)
+Source2: http://download.savannah.gnu.org/releases/freetype/freetype-2.6.1.tar.gz
+Source2-MD5: 348e667d728c597360e4a87c16556597
+
+Type: python (2.7)
+
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+Depends: <<
+ atk1-shlibs (>= 1.32.0-1),
+ cairo-shlibs (>= 1.12.14-1),
+ cycler-py%type_pkg[python] (>= 0.10.0-1),
+ dateutil-py%type_pkg[python],
+ fontconfig2-shlibs (>= 2.10.0-1),
+ freetype219-shlibs (>= 2.6-1),
+ glib2-shlibs (>= 2.22.0-1),
+ gtk+2-shlibs (>= 2.18.0-1),
+ kiwisolver-py%type_pkg[python],
+ libpng16-shlibs,
+ pango1-xft2-ft219-shlibs (>= 1.24.5-4),
+ poppler-bin,
+ python%type_pkg[python],
+ pyparsing-py%type_pkg[python],
+ pyqt4-mac-py%type_pkg[python],
+ pyqt5-mac-py%type_pkg[python],
+ pytz-py%type_pkg[python],
+ numpy-py%type_pkg[python],
+ sip-pyqt4-py%type_pkg[python] (>= 4.19.22-1),
+ sip-pyqt5-py%type_pkg[python] (>= 4.19.22-1),
+ six-py%type_pkg[python] (>= 1.4.0-1),
+ tcltk-shlibs,
+ tetex-base,
+ tornado-py%type_pkg[python],
+ wxpython400-py%type_pkg[python],
+ x11-shlibs,
+ pygtk2-gtk-py%type_pkg[python]
+<<
+
+BuildDepends: <<
+ atk1 (>= 1.32.0-1),
+ cairo (>= 1.12.14-1),
+ fink-package-precedence,
+ fontconfig2-dev (>= 2.10.0-1),
+ freetype219 (>= 2.6-1),
+ glib2-dev (>= 2.22.0-1),
+ gtk+2-dev (>= 2.18.0-1),
+ libpng16,
+ pango1-xft2-ft219-dev (>= 1.24.5-4),
+ pkgconfig (>= 0.21-1),
+ setuptools-tng-py%type_pkg[python],
+ tcltk-dev,
+ tornado-py%type_pkg[python],
+ wxpython400-py%type_pkg[python],
+ x11-dev,
+ pygtk2-gtk-py%type_pkg[python]-dev
+<<
+
+Recommends: <<
+ ffmpeg,
+ imagemagick,
+ ipython-py%type_pkg[python],
+ pil-py%type_pkg[python]
+<<
+
+BuildConflicts: qhull5-dev, qhull6-dev, qhull6.3.1-dev, qhull7.2-dev
+
+GCC: 4.0
+
+NoSetCPPFLAGS: True
+SetCPPFLAGS: -I%p/include/pygtk-2.0 -DNSIG=32 -MD
+SetCXXFLAGS: -MD
+SetLDFLAGS: -L%p/lib -lz -lbz2 -lpng16
+UseMaxBuildJobs: True
+
+PatchFile: %{ni}.patch
+PatchFile-MD5: f15a8c2f4fef95677cbfb20cb8481f72
+PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
+
+CompileScript:  <<
+ #!/bin/sh -ev
+ cp -a setup.cfg{.template,}
+ # build against a local copy of freetype-2.6.1 to ensure exact version match
+ # (set via SetMFLAGS in TestInfo; should we set this unconditionally?):
+ mkdir build
+ mv ../freetype-2.6.1 build
+ export MPLLOCALFREETYPE="$MFLAGS"
+ export PKG_CONFIG_PATH="%p/lib/glib-2.0/pkgconfig-strict:$PKG_CONFIG_PATH"
+ OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES %p/bin/python%type_raw[python] setup.py build
+ fink-package-precedence --depfile-ext='\.d' build
+<<
+
+InfoTest: <<
+ TestSource: http://download.savannah.gnu.org/releases/freetype/freetype-2.6.1.tar.gz
+ TestSource-MD5: 348e667d728c597360e4a87c16556597
+ TestDepends: <<
+  ffmpeg,
+  inkscape,
+  pytest-py%type_pkg[python],
+  backports.functools-lru-cache-py%type_pkg[python],
+  mock-py%type_pkg[python],
+  subprocess32-py%type_pkg[python]
+ <<
+ SetMFLAGS: True
+ TestConfigureParams: --local_freetype=True
+ TestScript: <<
+  # conftest.py throws import errors when trying to run tests anywhere but in the
+  # directory matplotlib is imported from - remove them again before installation,
+  # as they would also triple install size.
+  rsync -aC lib/matplotlib/tests build/lib.macosx-*-%type_raw[python]/matplotlib
+  rsync -aC lib/matplotlib/sphinxext/tests build/lib.macosx-*-%type_raw[python]/matplotlib/sphinxext
+  rsync -aC lib/mpl_toolkits/tests build/lib.macosx-*-%type_raw[python]/mpl_toolkits
+  # warnings if flaky extension is not installed, but with it some tests fail on
+  # passing a 'reruns' kwarg that is unknown to any version of flaky 3.x.
+  perl -pi -e 's|(mark.flaky.)(reruns=)(.)|${1}max_runs=${3}, min_passes=2|;' build/lib.macosx-*-%type_raw[python]/matplotlib/tests/test_back*.py
+  perl -pi -e 's|(mark.flaky.)(reruns=)(.)|${1}max_runs=${3}, min_passes=1|;' build/lib.macosx-*-%type_raw[python]/matplotlib/tests/test_lines.py
+  # pytest can end up importing mpl_toolkits from %p/lib/python* (without tests)
+  # regardless of sys.path unless running from the eventual install dir in %i,
+  # so defer actual running of the tests to Install phase.
+ <<
+ TestSuiteSize: large
+<<
+
+InstallScript: <<
+ #!/bin/sh -ev
+ export PKG_CONFIG_PATH="%p/lib/glib-2.0/pkgconfig-strict:$PKG_CONFIG_PATH"
+ OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES %p/bin/python%type_raw[python] setup.py install --root %d
+ export LANG=en_US.UTF-8 PYTHONPATH=%i/lib/python%type_raw[python]/site-packages
+ # Check if tests have been installed and setup (for `--tests`)
+ if [ -d ${PYTHONPATH}/matplotlib/tests ]; then
+  cd $PYTHONPATH
+  # Seems unable to import mpl_toolkits even directly from $PYTHONPATH if matplotlib is not already installed.
+  if (%p/bin/python%type_raw[python] -Bc 'import mpl_toolkits'); then
+   %p/bin/python%type_raw[python] -Bm pytest -k 'not (_pdflatex or _rcupdate)' || exit 2
+  else
+   %p/bin/python%type_raw[python] -Bm pytest -k 'not (_pdflatex or _rcupdate or _polycollection_close or _parasite)' matplotlib || exit 2
+  fi
+  rm -r matplotlib/tests matplotlib/sphinxext/tests mpl_toolkits/tests result_images .pytest_cache
+ fi
+<<
+
+License: OSI-Approved
+DocFiles: README.rst INSTALL.rst examples tutorials
+# API_CHANGES
+Description: Pure python 2D plotting with a Matlab syntax
+DescDetail: <<
+Produces publication quality figures using in a variety of hardcopy 
+formats (PNG, JPG, TIFF, PS) and interactive GUI environments
+across platforms. matplotlib can be used in python scripts,
+interactively from the python shell (ala matlab or mathematica), 
+in web application servers generating dynamic charts, or embedded 
+in applications.
+
+Includes GTK, TkAgg, GTKAgg, WxAgg, SVG, PS and Agg backends.
+<<
+DescPackaging: <<
+ Checks for qt, qt4, cairo (their python bindings) but doesn't use
+ those test results, so don't bother setting dependencies or forcing
+ non-detection of them.
+ Added dependencies on six-py, and poppler-bin for pdftops.
+ Recommended optional dependencies:
+  ImageMagick: for animation module to be able to save to animated gif
+  ffmpeg: for animation module to be able to save to movie formats
+  pil-py: read and write a larger selection of image file formats
+
+ qhull not recognised by pkg-config; as of 2.1 requires version 2015.2 / 7.2,
+ but mpl does not link against the reentrant version (libqhull_r.dylib) -
+ falling back to the local copy until mpl is converted to libqhull_r or we
+ find a way to install the non-reentrant dylib with libqhull-shlibs as well.
+ (cf. http://www.qhull.org/html/qh-code.htm#reentrant .)
+ The 'save to file' interface emits debugging messages with qt4 and ipython.
+ Tried to build against wxpython300, but python segfaults either on
+ exit (with ipython) or plotting (without); wxpython400 appears to be not
+ recognised on configuration, but the WXAgg backend is built and linked
+ against it.
+
+ Multiprocessing in setupext BackendQtBase.check_requirements tends to hang
+ in the build sandbox - trying a second pass after timeout, but on 10.13 fork()
+ inevitably fails, apparently related to this thread safety issue:
+ https://blog.phusion.nl/2017/10/13/why-ruby-app-servers-break-on-macos-high-sierra-and-what-can-be-done-about-it/
+ - workaround taken from the same site.
+ Test suite requires exact version match of freetype built against (2.6.1),
+ set by local_freetype=True in setup.cfg, to ensure correct image comparison.
+ Enforced here by MPLLOCALFREETYPE set with a hack from SetMFLAGS in InfoTest.
+ 1-2 Failures and Errors in 2.1.1.
+<<
+Homepage: http://matplotlib.sf.net
+DescUsage: <<
+ To use within IPython, invoke as `ipython --matplotlib[=backend]` or
+ `ipython --pylab[=backend]`, where backend is one of
+ ['auto', 'gtk', 'gtk3', 'inline', 'nbagg', 'qt', 'qt4', 'tk', 'wx']
+ (as far as installed - not all of these are available with Python3.x; the
+ Qt5Agg backend currently does not work with IPython's %matplotlib magic).
+<<
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py27.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py27.patch
@@ -1,0 +1,298 @@
+diff -ruNd matplotlib-1.5.1.orig/lib/matplotlib/font_manager.py matplotlib-1.5.1/lib/matplotlib/font_manager.py
+--- matplotlib-1.5.1.orig/lib/matplotlib/font_manager.py	2016-01-10 19:06:08.000000000 -0800
++++ matplotlib-1.5.1/lib/matplotlib/font_manager.py	2016-02-07 12:11:39.000000000 -0800
+@@ -146,6 +147,11 @@
+     "/Library/Fonts/",
+     "/Network/Library/Fonts/",
+     "/System/Library/Fonts/",
++    # new XQuartz font location
++    "/opt/X11/share/fonts",
++    "/opt/X11/share/fonts/TTF",
++    # fonts installed via Fink
++    "@PREFIX@/lib/X11/fonts",
+     # fonts installed via MacPorts
+     "/opt/local/share/fonts"
+     ""
+diff -ruNd matplotlib-2.1.1.orig/setup.cfg.template matplotlib-2.1.1/setup.cfg.template
+--- matplotlib-2.1.1.orig/setup.cfg.template	2017-12-06 04:37:54.000000000 +0100
++++ matplotlib-2.1.1/setup.cfg.template	2017-12-15 22:57:50.000000000 +0100
+@@ -64,18 +64,19 @@
+ #           otherwise skip silently. This is the default
+ #           behavior
+ #
+-#agg = auto
+-#cairo = auto
+-#gtk = auto
++agg = True
++cairo = True
++gtk = True
+ #gtk3agg = auto
+ #gtk3cairo = auto
+-#gtkagg = auto
++gtkagg = True
+ #macosx = auto
+ #pyside = auto
+-#qt4agg = auto
+-#tkagg = auto
++qt4agg = True
++qt5agg = True
++tkagg = True
+ #windowing = auto
+-#wxagg = auto
++wxagg = False
+ 
+ [rc_options]
+ # User-configurable options
+@@ -88,7 +89,7 @@
+ # if you have disabled the relevant extension modules.  Agg will be used
+ # by default.
+ #
+-#backend = Agg
++backend = Qt5Agg
+ #
+ 
+ [package_data]
+diff -ruNd matplotlib-2.2.0.orig/setup.py matplotlib-2.2.0/setup.py
+--- matplotlib-2.2.0.orig/setup.py	2018-03-06 05:47:09.000000000 +0100
++++ matplotlib-2.2.0/setup.py	2018-03-08 21:18:33.000000000 +0100
+@@ -282,6 +282,10 @@
+             fd.write(
+                 template.safe_substitute(TEMPLATE_BACKEND=default_backend))
+ 
++        for mod in ext_modules:
++            mod.include_dirs.append('@PREFIX@/include')
++            mod.library_dirs.append('@PREFIX@/lib')
++
+         # Build in verbose mode if requested
+         if setupext.options['verbose']:
+             for mod in ext_modules:
+diff -ruNd matplotlib-2.2.0.orig/setupext.py matplotlib-2.2.0/setupext.py
+--- matplotlib-2.2.0.orig/setupext.py	2019-02-26 01:18:32.000000000 +0100
++++ matplotlib-2.2.0/setupext.py	2019-03-28 14:10:11.000000000 +0100
+@@ -105,7 +105,7 @@
+     BytesIO
+         The file loaded into memory.
+     """
+-    cache_dir = _get_xdg_cache_dir()
++    cache_dir = '@PREFIX@/src'
+ 
+     def get_from_cache(local_fn):
+         if cache_dir is None:
+@@ -308,8 +308,8 @@
+ 
+     basedir_map = {
+         'win32': win_bases,
+-        'darwin': ['/usr/local/', '/usr', '/usr/X11',
+-                   '/opt/X11', '/opt/local'],
++        'darwin': ['@PREFIX@/lib/freetype219', '@PREFIX@',
++                   '/usr', '/usr/X11', '/opt/X11'],
+         'sunos5': [os.getenv('MPLIB_BASE') or '/usr/local', ],
+         'gnu0': ['/usr'],
+         'aix5': ['/usr/local'],
+@@ -1305,8 +1305,9 @@
+             cflags = 'CFLAGS="{0} -fPIC" '.format(os.environ.get('CFLAGS', ''))
+ 
+             subprocess.check_call(
+-                [cflags + './configure --with-zlib=no --with-bzip2=no '
+-                 '--with-png=no --with-harfbuzz=no'], shell=True, cwd=src_path)
++                [cflags + './configure --prefix=@PREFIX@ --libdir=@PREFIX@/lib/freetype219/lib '
++                 '--with-zlib=no --with-bzip2=no --with-png=no --with-harfbuzz=no'],
++                shell=True, cwd=src_path)
+             subprocess.check_call(
+                 [cflags + 'make'], shell=True, cwd=src_path)
+         else:
+@@ -1965,8 +1966,18 @@
+                 msg = res.get(timeout=10)[0]
+             except multiprocessing.TimeoutError:
+                 p.terminate()
+-                # No result returned. Probably hanging, terminate the process.
+-                raise CheckFailed("Check timed out")
++                # No result returned. Probably hanging, try once more.
++                try:
++                    p = multiprocessing.Pool()
++                    res = p.map_async(self.callback, [self])
++                    msg = res.get(timeout=60)[0]
++                except multiprocessing.TimeoutError:
++                    p.terminate()
++                    # Still hanging, terminate the process.
++                    raise CheckFailed("Check timed out")
++                except:
++                    p.close()
++                    raise
+             except:
+                 # Some other error.
+                 p.close()
+diff -ruNd matplotlib-2.0.0.orig/src/_macosx.m matplotlib-2.0.0/src/_macosx.m
+--- matplotlib-2.0.0.orig/src/_macosx.m	2016-09-19 23:46:20.000000000 +0100
++++ matplotlib-2.0.0/src/_macosx.m	2016-09-21 13:33:08.000000000 +0100
+@@ -3062,16 +3062,15 @@
+      && GetCurrentProcess(&psn)==noErr
+      && SetFrontProcess(&psn)==noErr) return true;
+ #endif
+-    PyErr_SetString(PyExc_RuntimeError,
++    PyErr_WarnEx(PyExc_RuntimeWarning,
+         "Python is not installed as a framework. The Mac OS X backend will "
+         "not be able to function correctly if Python is not installed as a "
+         "framework. See the Python documentation for more information on "
+         "installing Python as a framework on Mac OS X. Please either reinstall "
+-        "Python as a framework, or try one of the other backends. If you are "
+-        "using (Ana)Conda please install python.app and replace the use of 'python' "
+-        "with 'pythonw'. See 'Working with Matplotlib on OSX' "
++        "Python as a framework, try one of the other backends, or proceed at "
++        " your own risk! See 'Working with Matplotlib on OSX' "
+-        "in the Matplotlib FAQ for more information.");
++        "in the Matplotlib FAQ for more information.", 1);
+-    return false;
++    return true;
+ }
+ 
+ static struct PyMethodDef methods[] = {
+diff -ruNd matplotlib-2.2.0.orig/lib/matplotlib/tests/test_arrow_patches.py matplotlib-2.2.0/lib/matplotlib/tests/test_arrow_patches.py
+--- matplotlib-2.2.0.orig/lib/matplotlib/tests/test_arrow_patches.py     2018-03-06 05:47:09.000000000 +0100
++++ matplotlib-2.2.0/lib/matplotlib/tests/test_arrow_patches.py  2018-03-09 00:29:12.000000000 +0100
+@@ -3,6 +3,8 @@
+ import matplotlib.pyplot as plt
+ from matplotlib.testing.decorators import image_comparison
+ import matplotlib.patches as mpatches
++import os
++import pytest
+ 
+ 
+ def draw_arrow(ax, t, r):
+@@ -11,6 +11,8 @@
+                                 fc="b", ec='k'))
+ 
+ 
++@pytest.mark.skipif(os.getenv('SHELL') == '/usr/bin/false',
++                    reason='Hangs indefinitely in Fink build environment')
+ @image_comparison(baseline_images=['fancyarrow_test_image'])
+ def test_fancyarrow():
+     # Added 0 to test division by zero error described in issue 3930
+diff -ruNd matplotlib-2.2.0.orig/lib/matplotlib/tests/test_artist.py matplotlib-2.2.0/lib/matplotlib/tests/test_artist.py
+--- matplotlib-2.2.0.orig/lib/matplotlib/tests/test_artist.py    2018-03-09 01:38:06.000000000 +0100
++++ matplotlib-2.2.0/lib/matplotlib/tests/test_artist.py 2018-03-09 01:38:33.000000000 +0100
+@@ -6,6 +6,7 @@
+ 
+ import numpy as np
+ 
++import os
+ import pytest
+ 
+ import matplotlib.pyplot as plt
+@@ -96,6 +97,8 @@
+     assert isinstance(c._transOffset, mtransforms.IdentityTransform)
+ 
+ 
++@pytest.mark.skipif(os.getenv('SHELL') == '/usr/bin/false',
++                    reason='Hangs indefinitely in Fink build environment')
+ @image_comparison(baseline_images=["clip_path_clipping"], remove_text=True)
+ def test_clipping():
+     exterior = mpath.Path.unit_rectangle().deepcopy()
+@@ -144,6 +144,8 @@
+     assert len(svg.getvalue()) < 20000
+ 
+ 
++@pytest.mark.skipif(os.getenv('SHELL') == '/usr/bin/false',
++                    reason='Hangs indefinitely in Fink build environment')
+ @image_comparison(baseline_images=['hatching'], remove_text=True,
+                   style='default')
+ def test_hatching():
+diff -ruNd matplotlib-2.2.0.orig/lib/matplotlib/tests/test_axes.py matplotlib-2.2.0/lib/matplotlib/tests/test_axes.py
+--- matplotlib-2.2.0.orig/lib/matplotlib/tests/test_axes.py    2018-03-06 05:47:09.000000000 +0100
++++ matplotlib-2.2.0/lib/matplotlib/tests/test_axes.py   2018-03-09 02:16:29.000000000 +0100
+@@ -5,6 +5,7 @@
+ from itertools import chain, product
+ from distutils.version import LooseVersion
+ import io
++import os
+ 
+ import datetime
+ 
+@@ -75,6 +76,8 @@
+     ax.matshow(a)
+ 
+ 
++@pytest.mark.skipif(os.getenv('SHELL') == '/usr/bin/false',
++                    reason='Hangs indefinitely in Fink build environment')
+ @image_comparison(baseline_images=['formatter_ticker_001',
+                                    'formatter_ticker_002',
+                                    'formatter_ticker_003',
+@@ -136,6 +139,8 @@
+     ax.plot(x, y)
+ 
+ 
++@pytest.mark.skipif(os.getenv('SHELL') == '/usr/bin/false',
++                    reason='Hangs indefinitely in Fink build environment')
+ @image_comparison(baseline_images=["twin_axis_locaters_formatters"])
+ def test_twin_axis_locaters_formatters():
+     vals = np.linspace(0, 1, num=5, endpoint=True)
+diff -ruNd matplotlib-2.2.0.orig/lib/matplotlib/backends/backend_wx.py matplotlib-2.2.0/lib/matplotlib/backends/backend_wx.py
+--- matplotlib-2.2.0.orig/lib/matplotlib/backends/backend_wx.py	2018-03-06 05:47:09.000000000 +0100
++++ matplotlib-2.2.0/lib/matplotlib/backends/backend_wx.py	2019-06-10 02:03:44.000000000 +0200
+@@ -1253,7 +1253,7 @@
+             # Rationale for line above: see issue 2941338.
+         except AttributeError:
+             pass  # classic toolbar lacks the attribute
+-        if not self.IsBeingDeleted():
++        if self and not self.IsBeingDeleted():
+             wx.Frame.Destroy(self, *args, **kwargs)
+             if self.toolbar is not None:
+                 self.toolbar.Destroy()
+diff --git a/lib/matplotlib/cbook/__init__.py b/lib/matplotlib/cbook/__init__.py
+--- a/lib/matplotlib/cbook/__init__.py     2019-03-01 04:33:38.000000000 +0100
++++ b/lib/matplotlib/cbook/__init__.py     2019-06-07 20:02:00.000000000 +0200
+@@ -2114,7 +2114,9 @@
+     """
+     # Iterate over columns for ndarrays, over rows otherwise.
+     X = np.atleast_1d(X.T if isinstance(X, np.ndarray) else np.asarray(X))
+-    if X.ndim == 1 and X.dtype.type != np.object_:
++    if len(X) == 0:
++        return [[]]
++    elif X.ndim == 1 and np.ndim(X[0]) == 0:
+         # 1D array of scalars: directly return it.
+         return [X]
+     elif X.ndim in [1, 2]:
+diff --git a/lib/matplotlib/tests/test_cbook.py b/lib/matplotlib/tests/test_cbook.py
+--- a/lib/matplotlib/tests/test_cbook.py     2019-02-26 01:18:32.000000000 +0100
++++ b/lib/matplotlib/tests/test_cbook.py     2019-06-07 20:03:30.000000000 +0200
+@@ -505,6 +505,40 @@ class dummy():
+     assert 1 == next(it)
+ 
+ 
++def test_reshape2d():
++    class dummy():
++        pass
++    xnew = cbook._reshape_2D([], 'x')
++    assert np.shape(xnew) == (1, 0)
++
++    x = [dummy() for j in range(5)]
++
++    xnew = cbook._reshape_2D(x, 'x')
++    assert np.shape(xnew) == (1, 5)
++
++    x = np.arange(5)
++    xnew = cbook._reshape_2D(x, 'x')
++    assert np.shape(xnew) == (1, 5)
++
++    x = [[dummy() for j in range(5)] for i in range(3)]
++    xnew = cbook._reshape_2D(x, 'x')
++    assert np.shape(xnew) == (3, 5)
++
++    # this is strange behaviour, but...
++    x = np.random.rand(3, 5)
++    xnew = cbook._reshape_2D(x, 'x')
++    assert np.shape(xnew) == (5, 3)
++
++    # Now test with a list of lists with different lengths, which means the
++    # array will internally be converted to a 1D object array of lists
++    x = [[1, 2, 3], [3, 4], [2]]
++    xnew = cbook._reshape_2D(x, 'x')
++    assert isinstance(xnew, list)
++    assert isinstance(xnew[0], np.ndarray) and xnew[0].shape == (3,)
++    assert isinstance(xnew[1], np.ndarray) and xnew[1].shape == (2,)
++    assert isinstance(xnew[2], np.ndarray) and xnew[2].shape == (1,)
++
++
+ class TestFuncParser(object):
+     x_test = np.linspace(0.01, 0.5, 3)
+     validstrings = ['linear', 'quadratic', 'cubic', 'sqrt', 'cbrt',

--- a/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py27.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py27.patch
@@ -122,31 +122,6 @@ diff -ruNd matplotlib-2.2.0.orig/setupext.py matplotlib-2.2.0/setupext.py
              except:
                  # Some other error.
                  p.close()
-diff -ruNd matplotlib-2.0.0.orig/src/_macosx.m matplotlib-2.0.0/src/_macosx.m
---- matplotlib-2.0.0.orig/src/_macosx.m	2016-09-19 23:46:20.000000000 +0100
-+++ matplotlib-2.0.0/src/_macosx.m	2016-09-21 13:33:08.000000000 +0100
-@@ -3062,16 +3062,15 @@
-      && GetCurrentProcess(&psn)==noErr
-      && SetFrontProcess(&psn)==noErr) return true;
- #endif
--    PyErr_SetString(PyExc_RuntimeError,
-+    PyErr_WarnEx(PyExc_RuntimeWarning,
-         "Python is not installed as a framework. The Mac OS X backend will "
-         "not be able to function correctly if Python is not installed as a "
-         "framework. See the Python documentation for more information on "
-         "installing Python as a framework on Mac OS X. Please either reinstall "
--        "Python as a framework, or try one of the other backends. If you are "
--        "using (Ana)Conda please install python.app and replace the use of 'python' "
--        "with 'pythonw'. See 'Working with Matplotlib on OSX' "
-+        "Python as a framework, try one of the other backends, or proceed at "
-+        " your own risk! See 'Working with Matplotlib on OSX' "
--        "in the Matplotlib FAQ for more information.");
-+        "in the Matplotlib FAQ for more information.", 1);
--    return false;
-+    return true;
- }
- 
- static struct PyMethodDef methods[] = {
 diff -ruNd matplotlib-2.2.0.orig/lib/matplotlib/tests/test_arrow_patches.py matplotlib-2.2.0/lib/matplotlib/tests/test_arrow_patches.py
 --- matplotlib-2.2.0.orig/lib/matplotlib/tests/test_arrow_patches.py     2018-03-06 05:47:09.000000000 +0100
 +++ matplotlib-2.2.0/lib/matplotlib/tests/test_arrow_patches.py  2018-03-09 00:29:12.000000000 +0100
@@ -226,6 +201,55 @@ diff -ruNd matplotlib-2.2.0.orig/lib/matplotlib/tests/test_axes.py matplotlib-2.
  @image_comparison(baseline_images=["twin_axis_locaters_formatters"])
  def test_twin_axis_locaters_formatters():
      vals = np.linspace(0, 1, num=5, endpoint=True)
+diff -ruNd matplotlib-2.2.5.orig/lib/matplotlib/tests/test_backend_pdf.py matplotlib-2.2.5/lib/matplotlib/tests/test_backend_pdf.py
+--- matplotlib-2.2.5.orig/lib/matplotlib/tests/test_backend_pdf.py	2020-02-02 07:14:27.000000000 +0100
++++ matplotlib-2.2.5/lib/matplotlib/tests/test_backend_pdf.py	2020-10-19 19:33:33.000000000 +0200
+@@ -201,7 +201,7 @@
+ 
+ 
+ # This tests tends to hit a TeX cache lock on AppVeyor.
+-@pytest.mark.flaky(reruns=3)
++@pytest.mark.flaky(max_runs=3, min_passes=2)
+ @needs_usetex
+ def test_missing_psfont(monkeypatch):
+     """An error is raised if a TeX font lacks a Type-1 equivalent"""
+nk.build/matplotlib-py35-3.0.3-1/matplotlib-3.0.3/lib/matplotlib/tests/test_backend_ps.py{\,.bak,}                                                  <
+diff -ruNd matplotlib-2.2.5.orig/lib/matplotlib/tests/test_backend_ps.py matplotlib-2.2.5/lib/matplotlib/tests/test_backend_ps.py
+--- matplotlib-2.2.5.orig/lib/matplotlib/tests/test_backend_ps.py	2020-02-02 07:14:27.000000000 +0100
++++ matplotlib-2.2.5/lib/matplotlib/tests/test_backend_ps.py	2020-10-19 19:33:33.000000000 +0200
+@@ -29,7 +29,7 @@
+ 
+ 
+ # This tests tends to hit a TeX cache lock on AppVeyor.
+-@pytest.mark.flaky(reruns=3)
++@pytest.mark.flaky(max_runs=3, min_passes=2)
+ @pytest.mark.parametrize('format, use_log, rcParams', [
+     ('ps', False, {}),
+     pytest.param('ps', False, {'ps.usedistiller': 'ghostscript'},
+diff -ruNd matplotlib-2.2.5.orig/lib/matplotlib/tests/test_backends_interactive.py matplotlib-2.2.5/lib/matplotlib/tests/test_backends_interactive.py
+--- matplotlib-2.2.5.orig/lib/matplotlib/tests/test_backends_interactive.py	2020-02-02 07:14:27.000000000 +0100
++++ matplotlib-2.2.5/lib/matplotlib/tests/test_backends_interactive.py	2020-10-19 22:01:13.000000000 +0200
+@@ -51,7 +51,7 @@
+ 
+ 
+ @pytest.mark.parametrize("backend", _get_testable_interactive_backends())
+-@pytest.mark.flaky(reruns=3)
++@pytest.mark.flaky(max_runs=3, min_passes=2)
+ def test_backend(backend):
+     environ = os.environ.copy()
+     environ["MPLBACKEND"] = backend
+diff -ruNd matplotlib-2.2.5.orig/lib/matplotlib/tests/test_lines.py matplotlib-2.2.5/lib/matplotlib/tests/test_lines.py
+--- matplotlib-2.2.5.orig/lib/matplotlib/tests/test_lines.py	2020-02-02 07:14:27.000000000 +0100
++++ matplotlib-2.2.5/lib/matplotlib/tests/test_lines.py	2020-10-19 19:33:33.000000000 +0200
+@@ -19,7 +19,7 @@
+ 
+ # Runtimes on a loaded system are inherently flaky. Not so much that a rerun
+ # won't help, hopefully.
+-@pytest.mark.flaky(reruns=3)
++@pytest.mark.flaky(max_runs=3, min_passes=1)
+ def test_invisible_Line_rendering():
+     """
+     Github issue #1256 identified a bug in Line.draw method
 diff -ruNd matplotlib-2.2.0.orig/lib/matplotlib/backends/backend_wx.py matplotlib-2.2.0/lib/matplotlib/backends/backend_wx.py
 --- matplotlib-2.2.0.orig/lib/matplotlib/backends/backend_wx.py	2018-03-06 05:47:09.000000000 +0100
 +++ matplotlib-2.2.0/lib/matplotlib/backends/backend_wx.py	2019-06-10 02:03:44.000000000 +0200

--- a/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py35.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py35.info
@@ -77,45 +77,39 @@ SetLDFLAGS: -L%p/lib -lz -lbz2 -lpng16
 UseMaxBuildJobs: True
 
 PatchFile: %{ni}.patch
-PatchFile-MD5: 4da6d6a9685122fda5b2f2bf3481820d
+PatchFile-MD5: 92910980d40ac771da93a8fbcd52f6bd
 PatchScript: sed 's|@PREFIX@|%p|g;s|@PY_PKG@|%type_pkg[python]|g;s|@PY_RAW@|%type_raw[python]|g' < %{PatchFile} | patch -p1
 
 CompileScript:  <<
  #!/bin/sh -ev
  cp -a setup.cfg{.template,}
- # build against a local copy of freetype-2.6.1 to ensure exact version match
- # (set via SetMFLAGS in TestInfo; should we set this unconditionally?):
  mkdir build
  mv ../freetype-2.6.1 build
  export MPLLOCALFREETYPE="$MFLAGS"
  export PKG_CONFIG_PATH="%p/lib/glib-2.0/pkgconfig-strict:$PKG_CONFIG_PATH"
  OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES %p/bin/python%type_raw[python] setup.py build
  fink-package-precedence --depfile-ext='\.d' build
- rsync -aC lib/matplotlib/tests/{tinypages,*.ipynb,*.pfb,*.ttf} build/lib.macosx-*-%type_raw[python]/matplotlib/tests
 <<
 
 InfoTest: <<
  TestDepends: <<
   ffmpeg,
   inkscape,
-  pytest-py%type_pkg[python]
+  pytest-py%type_pkg[python] (>= 3.6.0)
  <<
  # test_backends_nbagg checks for nbconvert but fails with older versions.
  TestConflicts: nbconvert-py%type_pkg[python] (<= 6.0.0-1)
  #SetMFLAGS: True
  #TestConfigureParams: --local_freetype=True
  TestScript: <<
-  # conftest.py throws import errors when trying to run tests anywhere but in the
-  # directory matplotlib is imported from - remove them again before installation,
-  # as they would also triple install size.
-  rsync -aC lib/matplotlib/tests/baseline_images build/lib.macosx-*-%type_raw[python]/matplotlib/tests
-  rsync -aC lib/mpl_toolkits/tests/baseline_images build/lib.macosx-*-%type_raw[python]/mpl_toolkits/tests
-  # warnings if flaky extension is not installed, but with it some tests fail on
-  # passing a 'reruns' kwarg that is unknown to any version of flaky 3.x.
-  perl -pi -e 's|(mark.flaky.)(reruns=)(.)|${1}max_runs=${3}, min_passes=2|;' build/lib.macosx-*-%type_raw[python]/matplotlib/tests/test*.py
-  # pytest can end up importing mpl_toolkits from %p/lib/python* (without tests)
-  # regardless of sys.path unless running from the eventual install dir in %i,
-  # so defer actual running of the tests to Install phase.
+  #!/bin/sh -ev
+  export LANG=en_US.UTF-8
+  export PYTHONPATH=%b/build/lib/python%type_raw[python]/site-packages
+  mkdir -p $PYTHONPATH
+  OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES %p/bin/python%type_raw[python] setup.py develop --prefix %b/build
+  %p/bin/python%type_raw[python] -Bm pytest -k 'not (_pdflatex or _rcupdate or _mixedsubplots or backend_qt5)' || exit 2
+  # Qt4 and Qt5 backends cannot be loaded in the same session.
+  %p/bin/python%type_raw[python] -Bm pytest lib/matplotlib/tests/test_backend_qt5.py || exit 2
  <<
  TestSuiteSize: large
 <<
@@ -124,14 +118,6 @@ InstallScript: <<
  #!/bin/sh -ev
  export PKG_CONFIG_PATH="%p/lib/glib-2.0/pkgconfig-strict:$PKG_CONFIG_PATH"
  OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES %p/bin/python%type_raw[python] setup.py install --root %d
- export LANG=en_US.UTF-8 PYTHONPATH=%i/lib/python%type_raw[python]/site-packages
- # Check if tests have been installed and setup (for `--tests`)
- if [ -d ${PYTHONPATH}/matplotlib/tests/baseline_images ]; then
-  cd $PYTHONPATH
-  # test_backend_tk might fail on accessing display
-  %p/bin/python%type_raw[python] -Bm pytest -k 'not (_pdflatex or _rcupdate or _marker_clipping or _interactive_backend or (_mixedmode and pdf))' || exit 2
-  rm -r m*/tests/baseline_images result_images .pytest_cache
- fi
 <<
 
 License: OSI-Approved
@@ -175,10 +161,12 @@ DescPackaging: <<
  Test suite requires exact version match of freetype built against (2.6.1),
  set by local_freetype=True in setup.cfg, to ensure correct image comparison.
  Enforced here by MPLLOCALFREETYPE set with a hack from SetMFLAGS in InfoTest
- and always used in build against local source copy.
+ and always used in build against local source copy - this will create and link
+ against a packaged ft2font.cpython-*-darwin.so.
  Patched tests to make them use matching versions of [i]python and jupyter.
- Even with `-Wmodule` thousands of warnings
-  `RemovedInPytest4Warning: MarkInfo objects are deprecated`
+ Changed 'reruns' kwarg to 'max_runs' to keep flaky 3.x happy.
+ Merged https://github.com/matplotlib/matplotlib/commit/a3b9ef7 to replace
+ `request.keywords.get` deprecated/removed in newer pytest versions.
 <<
 Homepage: http://matplotlib.sf.net
 DescUsage: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py35.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py35.info
@@ -1,15 +1,15 @@
 # -*- coding: ascii; tab-width: 4 -*-; tab-width: 4; x-counterpart: matplotlib-py.patch -*-
 Info2: <<
 
-Package: matplotlib-py%type_pkg[python]
-Version: 3.3.2
+Package: matplotlib-py35
+Version: 3.0.3
 Revision: 1
 Source: https://files.pythonhosted.org/packages/source/m/matplotlib/matplotlib-%v.tar.gz
-Source-Checksum: SHA256(3d2edbf59367f03cd9daf42939ca06383a7d7803e3993eb5ff1bee8e8a3fbb6b)
+Source-Checksum: SHA256(e1d33589e32f482d0a7d1957bf473d43341115d40d33f578dad44432e47df7b7)
 Source2: http://download.savannah.gnu.org/releases/freetype/freetype-2.6.1.tar.gz
 Source2-MD5: 348e667d728c597360e4a87c16556597
 
-Type: python (3.6 3.7)
+Type: python (3.5)
 
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
 Depends: <<
@@ -164,7 +164,7 @@ DescPackaging: <<
  The 'save to file' interface seems broken with qt4 and ipython.
  Enabled build against wxpython400, requires patch to ipython-py 7.5.0 for
  pylab environment; RuntimeError in backends/backend_wx.py on exit.
- [ Added patch from https://github.com/matplotlib/matplotlib/pull/14292 - merged in 3.1.1]
+ Added patch from https://github.com/matplotlib/matplotlib/pull/14292 -
  Fix performance regression when plotting values from Numpy array sub-classes.
 
  Multiprocessing in setupext BackendQtBase.check_requirements tends to hang
@@ -177,6 +177,8 @@ DescPackaging: <<
  Enforced here by MPLLOCALFREETYPE set with a hack from SetMFLAGS in InfoTest
  and always used in build against local source copy.
  Patched tests to make them use matching versions of [i]python and jupyter.
+ Even with `-Wmodule` thousands of warnings
+  `RemovedInPytest4Warning: MarkInfo objects are deprecated`
 <<
 Homepage: http://matplotlib.sf.net
 DescUsage: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py35.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py35.patch
@@ -1,0 +1,235 @@
+diff -ruNd matplotlib-3.0.3.orig/lib/matplotlib/font_manager.py matplotlib-3.0.3/lib/matplotlib/font_manager.py
+--- matplotlib-3.0.3.orig/lib/matplotlib/font_manager.py	2019-03-01 04:33:08.000000000 +0100
++++ matplotlib-3.0.3/lib/matplotlib/font_manager.py	2019-03-13 21:56:39.000000000 +0100
+@@ -127,6 +127,11 @@
+     "/Library/Fonts/",
+     "/Network/Library/Fonts/",
+     "/System/Library/Fonts/",
++    # new XQuartz font location
++    "/opt/X11/share/fonts",
++    "/opt/X11/share/fonts/TTF",
++    # fonts installed via Fink
++    "@PREFIX@/lib/X11/fonts",
+     # fonts installed via MacPorts
+     "/opt/local/share/fonts",
+ ]
+diff -ruNd matplotlib-3.0.3.orig/setup.cfg.template matplotlib-3.0.3/setup.cfg.template
+--- matplotlib-3.0.3.orig/setup.cfg.template	2019-03-01 04:33:08.000000000 +0100
++++ matplotlib-3.0.3/setup.cfg.template	2019-03-13 22:55:39.000000000 +0100
+@@ -13,7 +13,7 @@
+ # set this to True.  It will download and build a specific version of
+ # FreeType, and then use that to build the ft2font extension.  This
+ # ensures that test images are exactly reproducible.
+-#local_freetype = False
++local_freetype = True
+ 
+ [status]
+ # To suppress display of the dependencies and their versions
+@@ -62,9 +62,15 @@
+ #           otherwise skip silently. This is the default
+ #           behavior
+ #
+-#agg = auto
++agg = True
++cairo = True
++gtk = True
+ #macosx = auto
+-#tkagg = auto
++tkagg = True
++gtkagg = True
++qt4agg = True
++qt5agg = True
++wxagg = True
+ #windowing = auto
+ 
+ [rc_options]
+@@ -78,6 +84,7 @@
+ # modules.  The default is determined by fallback.
+ #
+ #backend = Agg
++backend = Qt5Agg
+ 
+ [package_data]
+ # Package additional files found in the lib/matplotlib directories.
+diff -ruNd matplotlib-3.0.3.orig/setupext.py matplotlib-3.0.3/setupext.py
+--- matplotlib-3.0.3.orig/setupext.py	2019-03-01 04:33:08.000000000 +0100
++++ matplotlib-3.0.3/setupext.py	2019-03-13 21:56:39.000000000 +0100
+@@ -1197,9 +1197,9 @@
+             env = {**os.environ,
+                    "CFLAGS": "{} -fPIC".format(os.environ.get("CFLAGS", ""))}
+             subprocess.check_call(
+-                ["./configure", "--with-zlib=no", "--with-bzip2=no",
+-                 "--with-png=no", "--with-harfbuzz=no"],
+-                env=env, cwd=src_path)
++                ["./configure --prefix=@PREFIX@ --libdir=@PREFIX@/lib/freetype219/lib",
++                 "--with-zlib=no", "--with-bzip2=no", "--with-png=no", "--with-harfbuzz=no"],
++                shell=True, env=env, cwd=src_path)
+             subprocess.check_call(["make"], env=env, cwd=src_path)
+         else:
+             # compilation on windows
+diff -ruNd matplotlib-3.0.3.orig/lib/matplotlib/__init__.py matplotlib-3.0.3/lib/matplotlib/__init__.py
+--- matplotlib-3.0.3.orig/lib/matplotlib/__init__.py	2019-03-01 04:33:38.000000000 +0100
++++ matplotlib-3.0.3/lib/matplotlib/__init__.py	2019-05-29 00:17:44.000000000 +0200
+@@ -472,7 +472,7 @@
+ def checkdep_inkscape():
+     if checkdep_inkscape.version is None:
+         try:
+-            s = subprocess.Popen(['inkscape', '-V'],
++            s = subprocess.Popen(['inkscape', '-z', '-V'],
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE)
+             stdout, stderr = s.communicate()
+diff -ruNd matplotlib-3.0.3.orig/lib/matplotlib/tests/test_backend_nbagg.py matplotlib-3.0.3/lib/matplotlib/tests/test_backend_nbagg.py
+--- matplotlib-3.0.3.orig/lib/matplotlib/tests/test_backend_nbagg.py	2019-03-01 04:33:38.000000000 +0100
++++ matplotlib-3.0.3/lib/matplotlib/tests/test_backend_nbagg.py	2019-05-29 00:45:44.000000000 +0200
+@@ -15,7 +15,7 @@
+     """
+     with tempfile.NamedTemporaryFile(suffix=".ipynb",
+                                      mode='w+t') as fout:
+-        args = ["jupyter", "nbconvert", "--to", "notebook", "--execute",
++        args = ["jupyter-py@PY_PKG@", "nbconvert", "--to", "notebook", "--execute",
+           "--ExecutePreprocessor.timeout=500",
+           "--output", fout.name, nb_file]
+         subprocess.check_call(args)
+diff -ruNd matplotlib-3.0.3.orig/lib/matplotlib/tests/test_nbagg_01.ipynb matplotlib-3.0.3/lib/matplotlib/tests/test_nbagg_01.ipynb
+--- matplotlib-3.0.3.orig/lib/matplotlib/tests/test_nbagg_01.ipynb	2019-04-01 02:50:07.000000000 +0200
++++ matplotlib-3.0.3/lib/matplotlib/tests/test_nbagg_01.ipynb	2019-05-29 01:15:44.000000000 +0200
+@@ -843,7 +843,7 @@
+   "kernelspec": {
+    "display_name": "Python 3",
+    "language": "python",
+-   "name": "python3"
++   "name": "python@PY_RAW@"
+   },
+   "language_info": {
+    "codemirror_mode": {
+@@ -854,7 +854,7 @@
+    "mimetype": "text/x-python",
+    "name": "python",
+    "nbconvert_exporter": "python",
+-   "pygments_lexer": "ipython3",
++   "pygments_lexer": "ipython3-py@PY_PKG@",
+    "version": "3.6.3"
+   },
+   "toc": {
+diff -ruNd matplotlib-3.0.3.orig/lib/matplotlib/backends/backend_wx.py matplotlib-3.0.3/lib/matplotlib/backends/backend_wx.py
+--- matplotlib-3.0.3.orig/lib/matplotlib/backends/backend_wx.py	2019-02-26 01:18:32.000000000 +0100
++++ matplotlib-3.0.3/lib/matplotlib/backends/backend_wx.py	2019-06-10 02:03:44.000000000 +0200
+@@ -1243,7 +1243,7 @@
+             # Rationale for line above: see issue 2941338.
+         except AttributeError:
+             pass  # classic toolbar lacks the attribute
+-        if not self.IsBeingDeleted():
++        if self and not self.IsBeingDeleted():
+             wx.Frame.Destroy(self, *args, **kwargs)
+             if self.toolbar is not None:
+                 self.toolbar.Destroy()
+diff --git a/lib/matplotlib/cbook/__init__.py b/lib/matplotlib/cbook/__init__.py
+--- a/lib/matplotlib/cbook/__init__.py     2019-03-01 04:33:38.000000000 +0100
++++ b/lib/matplotlib/cbook/__init__.py     2019-06-07 20:02:00.000000000 +0200
+@@ -1393,7 +1393,9 @@
+     """
+     # Iterate over columns for ndarrays, over rows otherwise.
+     X = np.atleast_1d(X.T if isinstance(X, np.ndarray) else np.asarray(X))
+-    if X.ndim == 1 and X.dtype.type != np.object_:
++    if len(X) == 0:
++        return [[]]
++    elif X.ndim == 1 and np.ndim(X[0]) == 0:
+         # 1D array of scalars: directly return it.
+         return [X]
+     elif X.ndim in [1, 2]:
+diff --git a/lib/matplotlib/tests/test_cbook.py b/lib/matplotlib/tests/test_cbook.py
+--- a/lib/matplotlib/tests/test_cbook.py     2019-03-01 04:33:38.000000000 +0100
++++ b/lib/matplotlib/tests/test_cbook.py     2019-06-07 20:03:30.000000000 +0200
+@@ -494,6 +494,66 @@ class dummy():
+     assert 1 == next(it)
+ 
+ 
++def test_reshape2d():
++    class dummy():
++        pass
++    xnew = cbook._reshape_2D([], 'x')
++    assert np.shape(xnew) == (1, 0)
++
++    x = [dummy() for j in range(5)]
++
++    xnew = cbook._reshape_2D(x, 'x')
++    assert np.shape(xnew) == (1, 5)
++
++    x = np.arange(5)
++    xnew = cbook._reshape_2D(x, 'x')
++    assert np.shape(xnew) == (1, 5)
++
++    x = [[dummy() for j in range(5)] for i in range(3)]
++    xnew = cbook._reshape_2D(x, 'x')
++    assert np.shape(xnew) == (3, 5)
++
++    # this is strange behaviour, but...
++    x = np.random.rand(3, 5)
++    xnew = cbook._reshape_2D(x, 'x')
++    assert np.shape(xnew) == (5, 3)
++
++    # Now test with a list of lists with different lengths, which means the
++    # array will internally be converted to a 1D object array of lists
++    x = [[1, 2, 3], [3, 4], [2]]
++    xnew = cbook._reshape_2D(x, 'x')
++    assert isinstance(xnew, list)
++    assert isinstance(xnew[0], np.ndarray) and xnew[0].shape == (3,)
++    assert isinstance(xnew[1], np.ndarray) and xnew[1].shape == (2,)
++    assert isinstance(xnew[2], np.ndarray) and xnew[2].shape == (1,)
++
++    # We now need to make sure that this works correctly for Numpy subclasses
++    # where iterating over items can return subclasses too, which may be
++    # iterable even if they are scalars. To emulate this, we make a Numpy
++    # array subclass that returns Numpy 'scalars' when iterating or accessing
++    # values, and these are technically iterable if checking for example
++    # isinstance(x, collections.abc.Iterable).
++
++    class ArraySubclass(np.ndarray):
++
++        def __iter__(self):
++            for value in super().__iter__():
++                yield np.array(value)
++
++        def __getitem__(self, item):
++            return np.array(super().__getitem__(item))
++
++    v = np.arange(10, dtype=float)
++    x = ArraySubclass((10,), dtype=float, buffer=v.data)
++
++    xnew = cbook._reshape_2D(x, 'x')
++
++    # We check here that the array wasn't split up into many individual
++    # ArraySubclass, which is what used to happen due to a bug in _reshape_2D
++    assert len(xnew) == 1
++    assert isinstance(xnew[0], ArraySubclass)
++
++
+ def test_safe_first_element_pandas_series(pd):
+     # delibrately create a pandas series with index not starting from 0
+     s = pd.Series(range(5), index=range(10, 15))
+diff -ruNd matplotlib-3.0.1.orig/src/_macosx.m matplotlib-3.0.1/src/_macosx.m
+--- matplotlib-3.0.1.orig/src/_macosx.m	2018-10-25 17:31:16.000000000 +0200
++++ matplotlib-3.0.1/src/_macosx.m	2018-10-26 02:10:36.000000000 +0200
+@@ -2595,16 +2595,15 @@
+      && GetCurrentProcess(&psn)==noErr
+      && SetFrontProcess(&psn)==noErr) return true;
+ #endif
+-    PyErr_SetString(PyExc_ImportError,
++    PyErr_WarnEx(PyExc_ImportWarning,
+         "Python is not installed as a framework. The Mac OS X backend will "
+         "not be able to function correctly if Python is not installed as a "
+         "framework. See the Python documentation for more information on "
+         "installing Python as a framework on Mac OS X. Please either reinstall "
+-        "Python as a framework, or try one of the other backends. If you are "
+-        "using (Ana)Conda please install python.app and replace the use of "
+-        "'python' with 'pythonw'. See 'Working with Matplotlib on OSX' in the "
+-        "Matplotlib FAQ for more information.");
+-    return false;
++        "Python as a framework, try one of the other backends, or proceed at "
++        " your own risk! See 'Working with Matplotlib on OSX' "
++        "Matplotlib FAQ for more information.", 1);
++    return true;
+ }
+ 
+ static struct PyMethodDef methods[] = {

--- a/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py35.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/matplotlib-py35.patch
@@ -79,6 +79,90 @@ diff -ruNd matplotlib-3.0.3.orig/lib/matplotlib/__init__.py matplotlib-3.0.3/lib
                                   stdout=subprocess.PIPE,
                                   stderr=subprocess.PIPE)
              stdout, stderr = s.communicate()
+diff -ruNd matplotlib-3.0.3.orig/lib/matplotlib/testing/conftest.py matplotlib-3.0.3/lib/matplotlib/testing/conftest.py
+--- matplotlib-3.0.3.orig/lib/matplotlib/testing/conftest.py	2019-03-01 04:33:38.000000000 +0100
++++ matplotlib-3.0.3/lib/matplotlib/testing/conftest.py	2020-10-19 19:17:59.000000000 +0200
+@@ -24,19 +24,19 @@
+     with _cleanup_cm():
+ 
+         backend = None
+-        backend_marker = request.keywords.get('backend')
++        backend_marker = request.node.get_closest_marker('backend')
+         if backend_marker is not None:
+             assert len(backend_marker.args) == 1, \
+                 "Marker 'backend' must specify 1 backend."
+-            backend = backend_marker.args[0]
++            backend, = backend_marker.args
+             prev_backend = matplotlib.get_backend()
+
+         style = '_classic_test'  # Default of cleanup and image_comparison too.
+-        style_marker = request.keywords.get('style')
++        style_marker = request.node.get_closest_marker('style')
+         if style_marker is not None:
+             assert len(style_marker.args) == 1, \
+                 "Marker 'style' must specify 1 style."
+-            style = style_marker.args[0]
++            style, = style_marker.args
+
+         matplotlib.testing.setup()
+         if backend is not None:
+@@ -73,7 +73,7 @@
+     # pytest won't get confused.
+     # We annotate the decorated function with any parameters captured by this
+     # fixture so that they can be used by the wrapper in image_comparison.
+-    baseline_images = request.keywords['baseline_images'].args[0]
++    baseline_images, = request.node.get_closest_marker('baseline_images').args
+     if baseline_images is None:
+         # Allow baseline image list to be produced on the fly based on current
+         # parametrization.
+diff -ruNd matplotlib-3.0.3.orig/lib/matplotlib/tests/test_backend_pdf.py matplotlib-3.0.3/lib/matplotlib/tests/test_backend_pdf.py
+--- matplotlib-3.0.3.orig/lib/matplotlib/tests/test_backend_pdf.py	2019-03-01 04:33:38.000000000 +0100
++++ matplotlib-3.0.3/lib/matplotlib/tests/test_backend_pdf.py	2020-10-19 19:33:33.000000000 +0200
+@@ -192,7 +192,7 @@
+ 
+ 
+ # This tests tends to hit a TeX cache lock on AppVeyor.
+-@pytest.mark.flaky(reruns=3)
++@pytest.mark.flaky(max_runs=3, min_passes=2)
+ @needs_usetex
+ def test_missing_psfont(monkeypatch):
+     """An error is raised if a TeX font lacks a Type-1 equivalent"""
+diff -ruNd matplotlib-3.0.3.orig/lib/matplotlib/tests/test_backend_ps.py matplotlib-3.0.3/lib/matplotlib/tests/test_backend_ps.py
+--- matplotlib-3.0.3.orig/lib/matplotlib/tests/test_backend_ps.py	2019-03-01 04:33:38.000000000 +0100
++++ matplotlib-3.0.3/lib/matplotlib/tests/test_backend_ps.py	2020-10-19 19:33:33.000000000 +0200
+@@ -24,7 +24,7 @@
+ 
+ 
+ # This tests tends to hit a TeX cache lock on AppVeyor.
+-@pytest.mark.flaky(reruns=3)
++@pytest.mark.flaky(max_runs=3, min_passes=2)
+ @pytest.mark.parametrize('format, use_log, rcParams', [
+     ('ps', False, {}),
+     pytest.param('ps', False, {'ps.usedistiller': 'ghostscript'},
+diff -ruNd matplotlib-3.0.3.orig/lib/matplotlib/tests/test_backends_interactive.py matplotlib-3.0.3/lib/matplotlib/tests/test_backends_interactive.py
+--- matplotlib-3.0.3.orig/lib/matplotlib/tests/test_backends_interactive.py	2019-03-01 04:33:38.000000000 +0100
++++ matplotlib-3.0.3/lib/matplotlib/tests/test_backends_interactive.py	2020-10-19 19:33:33.000000000 +0200
+@@ -109,7 +109,7 @@
+ 
+ 
+ @pytest.mark.parametrize("backend", _get_testable_interactive_backends())
+-@pytest.mark.flaky(reruns=3)
++@pytest.mark.flaky(max_runs=3, min_passes=2)
+ def test_interactive_backend(backend):
+     if subprocess.run([sys.executable, "-c", _test_script],
+                       env={**os.environ, "MPLBACKEND": backend},
+diff -ruNd matplotlib-3.0.3.orig/lib/matplotlib/tests/test_lines.py matplotlib-3.0.3/lib/matplotlib/tests/test_lines.py
+--- matplotlib-3.0.3.orig/lib/matplotlib/tests/test_lines.py	2019-03-01 04:33:38.000000000 +0100
++++ matplotlib-3.0.3/lib/matplotlib/tests/test_lines.py	2020-10-19 19:33:33.000000000 +0200
+@@ -18,7 +18,7 @@
+ 
+ # Runtimes on a loaded system are inherently flaky. Not so much that a rerun
+ # won't help, hopefully.
+-@pytest.mark.flaky(reruns=3)
++@pytest.mark.flaky(max_runs=3, min_passes=1)
+ def test_invisible_Line_rendering():
+     """
+     Github issue #1256 identified a bug in Line.draw method
 diff -ruNd matplotlib-3.0.3.orig/lib/matplotlib/tests/test_backend_nbagg.py matplotlib-3.0.3/lib/matplotlib/tests/test_backend_nbagg.py
 --- matplotlib-3.0.3.orig/lib/matplotlib/tests/test_backend_nbagg.py	2019-03-01 04:33:38.000000000 +0100
 +++ matplotlib-3.0.3/lib/matplotlib/tests/test_backend_nbagg.py	2019-05-29 00:45:44.000000000 +0200
@@ -208,28 +292,3 @@ diff --git a/lib/matplotlib/tests/test_cbook.py b/lib/matplotlib/tests/test_cboo
  def test_safe_first_element_pandas_series(pd):
      # delibrately create a pandas series with index not starting from 0
      s = pd.Series(range(5), index=range(10, 15))
-diff -ruNd matplotlib-3.0.1.orig/src/_macosx.m matplotlib-3.0.1/src/_macosx.m
---- matplotlib-3.0.1.orig/src/_macosx.m	2018-10-25 17:31:16.000000000 +0200
-+++ matplotlib-3.0.1/src/_macosx.m	2018-10-26 02:10:36.000000000 +0200
-@@ -2595,16 +2595,15 @@
-      && GetCurrentProcess(&psn)==noErr
-      && SetFrontProcess(&psn)==noErr) return true;
- #endif
--    PyErr_SetString(PyExc_ImportError,
-+    PyErr_WarnEx(PyExc_ImportWarning,
-         "Python is not installed as a framework. The Mac OS X backend will "
-         "not be able to function correctly if Python is not installed as a "
-         "framework. See the Python documentation for more information on "
-         "installing Python as a framework on Mac OS X. Please either reinstall "
--        "Python as a framework, or try one of the other backends. If you are "
--        "using (Ana)Conda please install python.app and replace the use of "
--        "'python' with 'pythonw'. See 'Working with Matplotlib on OSX' in the "
--        "Matplotlib FAQ for more information.");
--    return false;
-+        "Python as a framework, try one of the other backends, or proceed at "
-+        " your own risk! See 'Working with Matplotlib on OSX' "
-+        "Matplotlib FAQ for more information.", 1);
-+    return true;
- }
- 
- static struct PyMethodDef methods[] = {


### PR DESCRIPTION
Moving this into its own PR to include updates and suggestions from #671 and #677 plus enabling tests and wxpython400/pyqt4-mac 4.12/pyqt5-mac 5.11 backends for matplotlib 2.2.5 (py27), 3.0.3 (py35) and 3.3.2 (py36+).

To upgrade the SIP libraries to the required version without having to update Qt5 to > 5.7, the `sip-pyqt[45]` versions have been bumped beyond those of `sip-py[-bin]`, which need to stay at <~ 4.19.17 to still build pyqt5-mac against qt5-5.7.

Taking up the discussion from https://github.com/fink/fink-distributions/issues/671#issuecomment-711152458:

> Regarding your 2.2.5-py27:
you're building a local freetype.dylib that has the same install_name as Fink's so that the *.so modules use the ft-2.6.1 library during tests (to get matching results), but once installed the *.so link paths find Fink's FT library in %p/lib/ft219/lib ? I think that's what's happening, but just want to confirm.
But FT-2.6.1 should only be a TestSource. We don't want to download it when someone is not running tests.

No, afaics the `ft2font.cpython-NN-darwin.so` that is built and installed does not point to any of Fink's FT installation (which is at 2.6.3), but provides the full required subset of functions itself.
```
/sw/lib/python3.9/site-packages/matplotlib/ft2font.cpython-39-darwin.so:
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/sw/lib/libbz2.1.dylib (compatibility version 1.0.1, current version 1.0.6)
	/sw/lib/libpng16.16.dylib (compatibility version 54.0.0, current version 54.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.4)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```
So I guess we cannot simply remove it and drop Fink's 2.6.3 in as replacement – probably would have to rebuild and link against the system freetype after the test phase, but that would seem to defeat the purpose of the tests to some extent, not testing the actual version that is getting installed in the end.
So the FT-2.6.1 source is used unconditionally (it is small compared to the full matplotlib source), not sure if linking against Fink's slightly newer version and getting rid of a ~1 MB .so would justify the changes in setup.

> Instead of the rsync magic, does %p/bin/python%type_raw[python] setup.py develop --root=... work? Might clean up the way the build process is ordered (testing in InstallScript, etc).

Yes; while it cannot install to a root inside %i during the test phase, choosing another path inside %b just creates some .pth files and directories pointing to the actual tree created in the compile phase, so it is testing pretty much what is eventually being installed. For 3.3.2 I still needed pointers to the `baseline_images` dirs, and `mpl_toolkits` apparently is inevitably first looked up in `%p/lib/python%type_raw[python]/site-packages` once installed, but the rest of the tests are passing with a few identified failures.

> Missing pytest-mpl-py package.

I reviewed the TestDepends and found it is not actually needed nor changes the number of enabled tests in any way.

> Are the BuildConflicts against qhull*-dev needed? I don't see a difference in the build process or the final _qhull.so module.

The qhull packages are irrelevant for the build since matplotlib only looks for the non-reentrant version and thus will now build its own local copy. It seems there were conflicts with Fink's reentrant libraries installed, but I checked that with the new qhull8.0-dev at least this is no longer the case. I have not tried again with the older versions, so I left the BuildConflicts in place for now. But if you did not find any differences with your 2.2.5 builds, it's probably safe to remove them.