### PR TITLE
Tcl/TK 8.6.10

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/tcltk-8.6.10.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/tcltk-8.6.10.info
@@ -1,0 +1,253 @@
+Package: tcltk
+Epoch: 1
+
+# update itcl path-flags in "itk" and versions in "iwidgets" when updating
+Version: 8.6.10
+
+Revision: 1
+BuildDepends: <<
+	fink (>= 0.28),
+	fink-package-precedence,
+	fontconfig2-dev (>= 2.10.0-1),
+	freetype219 (>= 2.6-1),
+	pkgconfig,
+	x11-dev,
+	xft2-dev (>= 2.2.0-1)
+<<
+Depends: <<
+	%N-shlibs (= %e:%v-%r),
+	fontconfig2-shlibs (>= 2.10.0-1),
+	freetype219-shlibs (>= 2.6-1),
+	x11-shlibs,
+	xft2-shlibs (>= 2.2.0-1)
+<<
+Source: mirror:sourceforge:tcl/tcl%v-src.tar.gz
+Source-MD5: 97c55573f8520bcab74e21bfd8d0aadc
+SourceDirectory: tcl%v
+Source2: mirror:sourceforge:tcl/tk%v-src.tar.gz
+Source2-MD5: 602a47ad9ecac7bf655ada729d140a94
+PatchFile: %n-%v.patch
+PatchFile-MD5: 9070cd293f1e515b6eadf5b6f3980bf2
+PatchScript: <<
+	%{default_script}
+	# patch *ancient* darwin-ignorant autoconf
+	perl -pi -e 's/(a so sl)/dylib \1/' tk%v/unix/configure
+	# autoconf2.6ish patch for modern XQuartz paths
+	perl -pi -e "s|/usr/lpp/Xamples|/opt/X11|" tk%v/unix/configure
+<<
+NoSourceDirectory: true
+SetCPPFLAGS: -MD -g
+ConfigureParams: --enable-shared --enable-threads --disable-corefoundation --exec-prefix=%p --mandir=%p/share/man tcl_cv_type_64bit="long long"
+InfoTest: <<
+	TestScript: <<
+		cd tcl%v/unix;make -k test || exit 2
+		fink-package-precedence --depfile-ext='\.d' --prohibit-bdep=%n-dev .
+	<<
+<<
+CompileScript: <<
+#!/bin/sh -ev
+
+	pushd tcl%v/unix
+		export COMMAND_MODE=legacy
+		./configure %c
+		make -w
+	popd
+
+	pushd tk%v/unix
+		export DYLD_FALLBACK_LIBRARY_PATH=%b/tcl%v/unix
+		export ac_cv_path_tclsh=%b/tcl%v/unix/tclsh
+		./configure %c
+#		make genstubs
+		make -w
+	popd
+	fink-package-precedence --depfile-ext='\.d' --prohibit-bdep=%n-dev .
+<<
+InstallScript: <<
+#!/bin/sh -ev
+	MAJORVER=8.6
+
+	mkdir -p %i/share/doc/%n
+	make -C tcl%v/unix INSTALL_ROOT=%d install
+	make -C tk%v/unix  INSTALL_ROOT=%d install
+
+	ln -s wish${MAJORVER}  %i/bin/wish
+	ln -s tclsh${MAJORVER} %i/bin/tclsh
+
+	ln -s tk${MAJORVER} %i/lib/tk
+	ln -s libtk${MAJORVER}.dylib %i/lib/libtk.dylib
+	ln -s libtkstub${MAJORVER}.a %i/lib/libtkstub.a
+	/usr/bin/ranlib %i/lib/libtclstub${MAJORVER}.a
+
+	ln -s tcl${MAJORVER} %i/lib/tcl
+	ln -s libtcl${MAJORVER}.dylib %i/lib/libtcl.dylib
+	ln -s libtclstub${MAJORVER}.a %i/lib/libtclstub.a
+	/usr/bin/ranlib %i/lib/libtkstub${MAJORVER}.a
+
+	for pkg in tcl tk; do
+		mkdir -p %i/include/tcltk-private/${pkg}${MAJORVER}/{generic,unix}
+		cp ${pkg}%v/generic/*.h %i/include/tcltk-private/${pkg}${MAJORVER}/generic
+		cp ${pkg}%v/unix/*.h    %i/include/tcltk-private/${pkg}${MAJORVER}/unix
+
+		pushd %i/include
+			for hdr in *.h ; do
+				if [ -f tcltk-private/${pkg}${MAJORVER}/generic/${hdr} ]; then
+					ln -sf ../../../${hdr} tcltk-private/${pkg}${MAJORVER}/generic
+				fi
+			done
+		popd
+
+		perl -pi -e "s,%b/${pkg}%v/unix,%p/lib,; s,%b,%p/include/tcltk-private,; s,/${pkg}%v,/${pkg}${MAJORVER},g" %i/lib/*Config.sh %i/lib/*/*Config.sh
+	done
+
+	# manually fix install names (fink wants full path even though
+	# private and dlopen'ed). Why are these .dylib not .so ?
+	chmod u+w %i/lib/thread2.8.5/libthread2.8.5.dylib
+	chmod u+w %i/lib/tdbcpostgres1.1.1/libtdbcpostgres1.1.1.dylib
+	for modulepath in \
+		itcl4.2.0/libitcl4.2.0.dylib \
+		sqlite3.30.1.2/libsqlite3.30.1.2.dylib \
+		tdbc1.1.1/libtdbc1.1.1.dylib \
+		tdbcmysql1.1.1/libtdbcmysql1.1.1.dylib \
+		tdbcodbc1.1.1/libtdbcodbc1.1.1.dylib \
+		tdbcpostgres1.1.1/libtdbcpostgres1.1.1.dylib \
+		thread2.8.5/libthread2.8.5.dylib \
+	; do
+		install_name_tool -id %p/lib/$modulepath %i/lib/$modulepath
+	done
+<<
+DocFiles: <<
+	tcl%v/license.terms:LICENSE.tcl
+	tcl%v/README.md:README.tcl
+	tcl%v/ChangeLog:ChangeLog.tcl
+	tcl%v/changes:changes.tcl
+	tk%v/license.terms:LICENSE.tk
+	tk%v/README.md:README.tk
+	tk%v/ChangeLog:ChangeLog.tk 
+<<
+SplitOff: <<
+	Package: %N-shlibs
+	Depends: <<
+		fontconfig2-shlibs (>= 2.10.0-1),
+		freetype219-shlibs (>= 2.6-1),
+		x11-shlibs,
+		xft2-shlibs (>= 2.2.0-1)
+	<<
+	Files: <<
+		lib/libtcl8.6.dylib
+		lib/libtk8.6.dylib
+		lib/itcl4.2.0/libitcl4.2.0.dylib
+		lib/sqlite3.30.1.2/libsqlite3.30.1.2.dylib
+		lib/tdbc1.1.1/libtdbc1.1.1.dylib
+		lib/tdbcmysql1.1.1/libtdbcmysql1.1.1.dylib
+		lib/tdbcodbc1.1.1/libtdbcodbc1.1.1.dylib
+		lib/tdbcpostgres1.1.1/libtdbcpostgres1.1.1.dylib
+		lib/thread2.8.5/libthread2.8.5.dylib
+	<<
+	Shlibs: <<
+		%p/lib/libtcl8.6.dylib 8.6.0 %n (>= 8.6.0-1)
+		%p/lib/libtk8.6.dylib 8.6.0 %n (>= 8.6.0-1)
+		!%p/lib/itcl4.2.0/libitcl4.2.0.dylib
+		!%p/lib/sqlite3.30.1.2/libsqlite3.30.1.2.dylib
+		!%p/lib/tdbc1.1.1/libtdbc1.1.1.dylib
+		!%p/lib/tdbcmysql1.1.1/libtdbcmysql1.1.1.dylib
+		!%p/lib/tdbcodbc1.1.1/libtdbcodbc1.1.1.dylib
+		!%p/lib/tdbcpostgres1.1.1/libtdbcpostgres1.1.1.dylib
+		!%p/lib/thread2.8.5/libthread2.8.5.dylib
+	<<
+	DocFiles: <<
+		tcl%v/license.terms:LICENSE.tcl
+		tcl%v/README.md:README.tcl
+		tcl%v/ChangeLog:ChangeLog.tcl
+		tcl%v/changes:changes.tcl
+		tk%v/license.terms:LICENSE.tk
+		tk%v/README.md:README.tk
+		tk%v/ChangeLog:ChangeLog.tk 
+	<<
+<<
+SplitOff2: <<
+	Package: %N-dev
+	BuildDependsOnly: True
+	Depends: %N (= %e:%v-%r), %N-shlibs (= %e:%v-%r)
+	Conflicts: system-tcltk-dev
+	Replaces: %N (<< 1:8.6.5-1), system-tcltk-dev
+	Files: <<
+		lib/*Config.sh
+		include
+		lib/libtcl*
+		lib/libtk*
+		lib/pkgconfig
+		share/man/man3
+		share/man/mann
+	<<
+	DocFiles: <<
+		tcl%v/license.terms:LICENSE.tcl
+		tcl%v/README.md:README.tcl
+		tcl%v/ChangeLog:ChangeLog.tcl
+		tcl%v/changes:changes.tcl
+		tk%v/license.terms:LICENSE.tk
+		tk%v/README.md:README.tk
+		tk%v/ChangeLog:ChangeLog.tk
+	<<
+	DescUsage: <<
+Packages that want to use the supplied internal-interface headers
+should BuildDepends on %n of at least epoch 1 or higher.
+	<<
+<<
+Description: Tool Command Language and the Tk toolkit
+DescPort: <<
+	We add /System/Library/Tcl and /usr/lib to TCL_PACKAGE_PATH so
+	that Tcl packages (such as darwinports) installed in the
+	standard system locations will be found.
+
+	What is COMMAND_MODE?
+
+	Pass CPPFLAGS so it works as everyone expects (*after* local
+	flags), despite how build system incorrectly reimplements it
+	differently.
+<<
+DescPackaging: <<
+	tcl and tk are build in separate/parallel dirs. Clearer to do
+	NoSourceDirectory and have them both subdirs of %b than to
+	have one be %b and keep having to 'cd ..'
+
+	Make sure tk build finds tclsh from current build rather than
+	different-version one from installed fink package or different
+	arch and build-options one from OS X. Thanks pogma for helping
+	make sure tclsh finds its libtcl
+
+	Don't try xft's older detection method. And fink's (newer) xft
+	detection publishes x11 flags, so don't also pass them
+	explicitly (unix/Makefile mis-orders them before fink's)
+
+	Installed *Config.sh scripts encode build-dir paths as well as
+	runtime paths, which other packages may read and then try to
+	access. We cannot allow that (no guarantee that they exist, or
+	where they exist, or that they are the correct arch or build-
+	options, etc), so adjust to point to the installed locations.
+
+	Building extensions sometimes needs access to internal
+	headers, so install them in a private location. Point
+	*Config.sh vars accordingly. Thanks fedora!
+
+	As of 1:8.6.5-1, some build-time config files moved %N->%N-dev
+<<
+DescDetail: <<
+Tcl provides a portable scripting environment for Unix, Windows,
+and Macintosh that supports string processing and pattern matching,
+native file system access, shell-like control over other programs,
+TCP/IP networking, timers, and event-driven I/O.
+
+Tcl has traditional programming constructs like variables, loops,
+procedures, namespaces, error handling, script packages, 
+and dynamic loading of DLLs.
+
+Tk provides portable GUIs on UNIX, Windows, and Macintosh.
+A powerful widget set and the concise scripting interface to Tk make
+it a breeze to develop sophisticated user interfaces.
+<<
+PostInstScript: <<
+	update-alternatives --remove Object.3 %p/share/man/man3/Object.3.tcltk
+<<
+License: BSD
+Homepage: http://www.tcl.tk
+Maintainer: Daniel Macks <dmacks@netspace.org>

--- a/10.9-libcxx/stable/main/finkinfo/languages/tcltk-8.6.10.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/tcltk-8.6.10.patch
@@ -1,0 +1,201 @@
+diff -uNr tcltk-8.6.10.orig/tcl8.6.10/generic/tclInt.h tcltk-8.6.10/tcl8.6.10/generic/tclInt.h
+--- tcltk-8.6.10.orig/tcl8.6.10/generic/tclInt.h	2019-11-13 11:57:08.000000000 -0600
++++ tcltk-8.6.10/tcl8.6.10/generic/tclInt.h	2020-11-08 06:21:12.000000000 -0600
+@@ -3277,7 +3277,7 @@
+ MODULE_SCOPE int	TclClockOldscanObjCmd(
+ 			    ClientData clientData, Tcl_Interp *interp,
+ 			    int objc, Tcl_Obj *const objv[]);
+-MODULE_SCOPE int	Tcl_CloseObjCmd(ClientData clientData,
++extern int	Tcl_CloseObjCmd(ClientData clientData,
+ 			    Tcl_Interp *interp, int objc,
+ 			    Tcl_Obj *const objv[]);
+ MODULE_SCOPE int	Tcl_ConcatObjCmd(ClientData clientData,
+@@ -3458,7 +3458,7 @@
+ MODULE_SCOPE int	Tcl_RepresentationCmd(ClientData clientData,
+ 			    Tcl_Interp *interp, int objc,
+ 			    Tcl_Obj *const objv[]);
+-MODULE_SCOPE int	Tcl_ReturnObjCmd(ClientData clientData,
++extern int	Tcl_ReturnObjCmd(ClientData clientData,
+ 			    Tcl_Interp *interp, int objc,
+ 			    Tcl_Obj *const objv[]);
+ MODULE_SCOPE int	Tcl_ScanObjCmd(ClientData clientData,
+diff -uNr tcltk-8.6.10.orig/tcl8.6.10/generic/tclPort.h tcltk-8.6.10/tcl8.6.10/generic/tclPort.h
+--- tcltk-8.6.10.orig/tcl8.6.10/generic/tclPort.h	2019-06-17 13:39:57.000000000 -0500
++++ tcltk-8.6.10/tcl8.6.10/generic/tclPort.h	2020-11-08 06:21:12.000000000 -0600
+@@ -20,7 +20,7 @@
+ #if defined(_WIN32)
+ #   include "tclWinPort.h"
+ #else
+-#   include "tclUnixPort.h"
++#   include "../unix/tclUnixPort.h"
+ #endif
+ #include "tcl.h"
+ 
+diff -uNr tcltk-8.6.10.orig/tcl8.6.10/unix/configure tcltk-8.6.10/tcl8.6.10/unix/configure
+--- tcltk-8.6.10.orig/tcl8.6.10/unix/configure	2019-11-21 13:10:50.000000000 -0600
++++ tcltk-8.6.10/tcl8.6.10/unix/configure	2020-11-08 06:21:12.000000000 -0600
+@@ -18820,7 +18820,7 @@
+     else
+         TCL_LIB_FLAG="-ltcl`echo ${TCL_VERSION} | tr -d .`"
+     fi
+-    TCL_BUILD_LIB_SPEC="-L`pwd | sed -e 's/ /\\\\ /g'` ${TCL_LIB_FLAG}"
++    TCL_BUILD_LIB_SPEC="`pwd`/${TCL_LIB_FILE}"
+     TCL_LIB_SPEC="-L${libdir} ${TCL_LIB_FLAG}"
+ fi
+ VERSION='${VERSION}'
+@@ -18864,7 +18864,7 @@
+     TCL_STUB_LIB_FLAG="-ltclstub`echo ${TCL_VERSION} | tr -d .`"
+ fi
+ 
+-TCL_BUILD_STUB_LIB_SPEC="-L`pwd | sed -e 's/ /\\\\ /g'` ${TCL_STUB_LIB_FLAG}"
++TCL_BUILD_STUB_LIB_SPEC="`pwd`/${TCL_STUB_LIB_FILE}"
+ TCL_STUB_LIB_SPEC="-L${TCL_STUB_LIB_DIR} ${TCL_STUB_LIB_FLAG}"
+ TCL_BUILD_STUB_LIB_PATH="`pwd`/${TCL_STUB_LIB_FILE}"
+ TCL_STUB_LIB_PATH="${TCL_STUB_LIB_DIR}/${TCL_STUB_LIB_FILE}"
+@@ -19048,7 +19048,7 @@
+ 
+ 
+ 
+-CFLAGS="${CFLAGS} ${CPPFLAGS}"; CPPFLAGS=""
++EXTRA_CC_SWITCHES="${EXTRA_CC_SWITCHES} ${CPPFLAGS}"; CPPFLAGS=""
+ 
+ : ${CONFIG_STATUS=./config.status}
+ ac_clean_files_save=$ac_clean_files
+diff -uNr tcltk-8.6.10.orig/tk8.6.10/unix/Makefile.in tcltk-8.6.10/tk8.6.10/unix/Makefile.in
+--- tcltk-8.6.10.orig/tk8.6.10/unix/Makefile.in	2019-11-20 13:56:52.000000000 -0600
++++ tcltk-8.6.10/tk8.6.10/unix/Makefile.in	2020-11-08 06:21:12.000000000 -0600
+@@ -149,7 +149,7 @@
+ # X11 include files accessible (the configure script will try to
+ # set this value, and will cause it to be an empty string if the
+ # include files are accessible via /usr/include).
+-X11_INCLUDES		= @XINCLUDES@
++X11_INCLUDES		= $(XFT_CFLAGS) @XINCLUDES@
+ 
+ AQUA_INCLUDES		= -I$(MAC_OSX_DIR) -I$(XLIB_DIR)
+ 
+@@ -266,6 +266,9 @@
+ LIBS = @LIBS@ $(X11_LIB_SWITCHES) @TCL_LIBS@
+ WISH_LIBS = $(TCL_LIB_SPEC) @LIBS@ $(X11_LIB_SWITCHES) @TCL_LIBS@ @EXTRA_WISH_LIBS@
+ 
++# support for embedded libraries on Darwin / Mac OS X
++DYLIB_INSTALL_DIR       = ${libdir}
++
+ # The symbols below provide support for dynamic loading and shared
+ # libraries.  See configure.in for a description of what the
+ # symbols mean.  The values of the symbols are normally set by the
+@@ -283,9 +286,6 @@
+ CC_SEARCH_FLAGS	= @CC_SEARCH_FLAGS@
+ LD_SEARCH_FLAGS	= @LD_SEARCH_FLAGS@
+ 
+-# support for embedded libraries on Darwin / Mac OS X
+-DYLIB_INSTALL_DIR	= ${LIB_RUNTIME_DIR}
+-
+ # support for building the Aqua resource file
+ TK_RSRC_FILE		= @TK_RSRC_FILE@
+ WISH_RSRC_FILE		= @WISH_RSRC_FILE@
+@@ -330,18 +330,18 @@
+ 
+ CC_SWITCHES_NO_STUBS = ${CFLAGS} ${CFLAGS_WARNING} ${SHLIB_CFLAGS} \
+ -I${UNIX_DIR} -I${GENERIC_DIR} -I${BMAP_DIR} -I${TCL_GENERIC_DIR} \
+--I${TCL_PLATFORM_DIR} ${@TK_WINDOWINGSYSTEM@_INCLUDES} ${AC_FLAGS} \
+-${PROTO_FLAGS} ${SECURITY_FLAGS} ${MEM_DEBUG_FLAGS} ${KEYSYM_FLAGS} \
+-${NO_DEPRECATED_FLAGS} @EXTRA_CC_SWITCHES@
++-I${TCL_PLATFORM_DIR} ${AC_FLAGS} ${PROTO_FLAGS} ${SECURITY_FLAGS} \
++${MEM_DEBUG_FLAGS} ${KEYSYM_FLAGS} ${NO_DEPRECATED_FLAGS} \
++@EXTRA_CC_SWITCHES@ ${@TK_WINDOWINGSYSTEM@_INCLUDES}
+ 
+ CC_SWITCHES = $(CC_SWITCHES_NO_STUBS) @TCL_STUB_FLAGS@
+ 
+ APP_CC_SWITCHES = $(CC_SWITCHES_NO_STUBS) @EXTRA_APP_CC_SWITCHES@
+ 
+ DEPEND_SWITCHES = ${CFLAGS} -I${UNIX_DIR} -I${GENERIC_DIR} -I${BMAP_DIR} \
+--I${TCL_GENERIC_DIR} -I${TCL_PLATFORM_DIR} ${@TK_WINDOWINGSYSTEM@_INCLUDES} \
+-${AC_FLAGS} ${PROTO_FLAGS} ${SECURITY_FLAGS} ${MEM_DEBUG_FLAGS} \
+-${KEYSYM_FLAGS} @EXTRA_CC_SWITCHES@
++-I${TCL_GENERIC_DIR} -I${TCL_PLATFORM_DIR} ${AC_FLAGS} ${PROTO_FLAGS} \
++${SECURITY_FLAGS} ${MEM_DEBUG_FLAGS} ${KEYSYM_FLAGS} @EXTRA_CC_SWITCHES@ \
++${@TK_WINDOWINGSYSTEM@_INCLUDES}
+ 
+ WISH_OBJS = tkAppInit.o
+ 
+@@ -1202,7 +1202,7 @@
+ 
+ # NB: tkUnixRFont.o uses nondefault CFLAGS
+ tkUnixRFont.o: $(UNIX_DIR)/tkUnixRFont.c
+-	$(CC) -c $(CC_SWITCHES) $(XFT_CFLAGS) $(UNIX_DIR)/tkUnixRFont.c
++	$(CC) -c $(CC_SWITCHES) $(UNIX_DIR)/tkUnixRFont.c
+ 
+ tkUnixInit.o: $(UNIX_DIR)/tkUnixInit.c tkConfig.sh
+ 	$(CC) -c $(CC_SWITCHES) -DTK_LIBRARY=\"${TK_LIBRARY}\" \
+diff -uNr tcltk-8.6.10.orig/tk8.6.10/unix/configure tcltk-8.6.10/tk8.6.10/unix/configure
+--- tcltk-8.6.10.orig/tk8.6.10/unix/configure	2019-11-20 13:56:52.000000000 -0600
++++ tcltk-8.6.10/tk8.6.10/unix/configure	2020-11-08 06:21:12.000000000 -0600
+@@ -10004,19 +10004,14 @@
+ 	echo "$as_me:$LINENO: result: $enable_xft" >&5
+ echo "${ECHO_T}$enable_xft" >&6
+     else
+-	found_xft="yes"
+-			XFT_CFLAGS=`xft-config --cflags 2>/dev/null` || found_xft="no"
+-	XFT_LIBS=`xft-config --libs 2>/dev/null` || found_xft="no"
+-	if test "$found_xft" = "no" ; then
+ 	    found_xft=yes
+ 	    XFT_CFLAGS=`pkg-config --cflags xft fontconfig 2>/dev/null` || found_xft="no"
+ 	    XFT_LIBS=`pkg-config --libs xft fontconfig 2>/dev/null` || found_xft="no"
+-	fi
+ 	echo "$as_me:$LINENO: result: $found_xft" >&5
+ echo "${ECHO_T}$found_xft" >&6
+ 		if test "$found_xft" = "yes" ; then
+ 	    tk_oldCFlags=$CFLAGS
+-	    CFLAGS="$CFLAGS $XINCLUDES $XFT_CFLAGS"
++	    CFLAGS="$CFLAGS $XFT_CFLAGS $XINCLUDES"
+ 	    tk_oldLibs=$LIBS
+ 	    LIBS="$tk_oldLIBS $XFT_LIBS $XLIBSW"
+ 	    echo "$as_me:$LINENO: checking for X11/Xft/Xft.h" >&5
+@@ -10081,7 +10076,7 @@
+ 	fi
+ 		if test "$found_xft" = "yes" ; then
+ 	    tk_oldCFlags=$CFLAGS
+-	    CFLAGS="$CFLAGS $XINCLUDES $XFT_CFLAGS"
++	    CFLAGS="$CFLAGS $XFT_CFLAGS $XINCLUDES"
+ 	    tk_oldLibs=$LIBS
+ 	    LIBS="$tk_oldLIBS $XFT_LIBS $XLIBSW"
+ 
+@@ -11059,7 +11054,7 @@
+ 	else
+ 	    TK_LIB_FLAG="-ltk`echo ${TK_VERSION} | tr -d .`"
+ 	fi
+-	TK_BUILD_LIB_SPEC="-L`pwd | sed -e 's/ /\\\\ /g'` ${TK_LIB_FLAG}"
++	TK_BUILD_LIB_SPEC="`pwd`/${TK_LIB_FILE}"
+     fi
+     TK_LIB_SPEC="-L${libdir} ${TK_LIB_FLAG}"
+ fi
+@@ -11079,7 +11074,7 @@
+     TK_STUB_LIB_FLAG="-ltkstub`echo ${TK_VERSION} | tr -d .`"
+ fi
+ 
+-TK_BUILD_STUB_LIB_SPEC="-L`pwd | sed -e 's/ /\\\\ /g'` ${TK_STUB_LIB_FLAG}"
++TK_BUILD_STUB_LIB_SPEC="`pwd`/${TK_STUB_LIB_FILE}"
+ TK_STUB_LIB_SPEC="-L${TK_STUB_LIB_DIR} ${TK_STUB_LIB_FLAG}"
+ TK_BUILD_STUB_LIB_PATH="`pwd`/${TK_STUB_LIB_FILE}"
+ TK_STUB_LIB_PATH="${TK_STUB_LIB_DIR}/${TK_STUB_LIB_FILE}"
+@@ -11268,7 +11263,7 @@
+ LTLIBOBJS=$ac_ltlibobjs
+ 
+ 
+-CFLAGS="${CFLAGS} ${CPPFLAGS}"; CPPFLAGS=""
++EXTRA_CC_SWITCHES="${EXTRA_CC_SWITCHES} ${CPPFLAGS}"; CPPFLAGS=""
+ 
+ : ${CONFIG_STATUS=./config.status}
+ ac_clean_files_save=$ac_clean_files
+diff -uNr tcltk-8.6.10.orig/tk8.6.10/unix/tkConfig.sh.in tcltk-8.6.10/tk8.6.10/unix/tkConfig.sh.in
+--- tcltk-8.6.10.orig/tk8.6.10/unix/tkConfig.sh.in	2019-11-20 13:56:52.000000000 -0600
++++ tcltk-8.6.10/tk8.6.10/unix/tkConfig.sh.in	2020-11-08 06:21:12.000000000 -0600
+@@ -32,7 +32,7 @@
+ TK_LIB_FILE='@TK_LIB_FILE@'
+ 
+ # Additional libraries to use when linking Tk.
+-TK_LIBS='@XLIBSW@ @XFT_LIBS@ @LIBS@ @TCL_LIBS@'
++TK_LIBS='@XFT_LIBS@ @XLIBSW@ @LIBS@ @TCL_LIBS@'
+ 
+ # Top-level directory in which Tk's platform-independent files are
+ # installed.


### PR DESCRIPTION
Update our Tcl/TK to 8.6.10.
On 11.0, current 8.6.7 fails:

> gcc -dynamiclib -Os -pipe   -L/opt/sw3/lib/x86_64-darwin -L/opt/sw3/lib -prebind -headerpad_max_install_names -Wl,-search_paths_first  -Wl,-single_module -o libtcl8.6.dylib regcomp.o regexec.o regfree.o regerror.o tclAlloc.o tclAssembly.o tclAsync.o tclBasic.o tclBinary.o tclCkalloc.o tclClock.o tclCmdAH.o tclCmdIL.o tclCmdMZ.o tclCompCmds.o tclCompCmdsGR.o tclCompCmdsSZ.o tclCompExpr.o tclCompile.o tclConfig.o tclDate.o tclDictObj.o tclDisassemble.o tclEncoding.o tclEnsemble.o tclEnv.o tclEvent.o tclExecute.o tclFCmd.o tclFileName.o tclGet.o tclHash.o tclHistory.o tclIndexObj.o tclInterp.o tclIO.o tclIOCmd.o tclIORChan.o tclIORTrans.o tclIOGT.o tclIOSock.o tclIOUtil.o tclLink.o tclListObj.o tclLiteral.o tclLoad.o tclMain.o tclNamesp.o tclNotify.o tclObj.o tclOptimize.o tclPanic.o tclParse.o tclPathObj.o tclPipe.o tclPkg.o tclPkgConfig.o tclPosixStr.o tclPreserve.o tclProc.o tclRegexp.o tclResolve.o tclResult.o tclScan.o tclStringObj.o tclStrToD.o tclThread.o tclThreadAlloc.o tclThreadJoin.o tclThreadStorage.o tclStubInit.o tclTimer.o tclTrace.o tclUtf.o tclUtil.o tclVar.o tclZlib.o tclTomMathInterface.o tclUnixChan.o tclUnixEvent.o tclUnixFCmd.o tclUnixFile.o tclUnixPipe.o tclUnixSock.o tclUnixTime.o tclUnixInit.o tclUnixThrd.o tclUnixCompat.o tclUnixNotfy.o strstr.o strtoul.o strtod.o fixstrtod.o tclOO.o tclOOBasic.o tclOOCall.o tclOODefineCmds.o tclOOInfo.o tclOOMethod.o tclOOStubInit.o tclLoadDyld.o tclMacOSXBundle.o tclMacOSXFCmd.o tclMacOSXNotify.o bncore.o bn_reverse.o bn_fast_s_mp_mul_digs.o bn_fast_s_mp_sqr.o bn_mp_add.o bn_mp_and.o bn_mp_add_d.o bn_mp_clamp.o bn_mp_clear.o bn_mp_clear_multi.o bn_mp_cmp.o bn_mp_cmp_d.o bn_mp_cmp_mag.o bn_mp_cnt_lsb.o bn_mp_copy.o bn_mp_count_bits.o bn_mp_div.o bn_mp_div_d.o bn_mp_div_2.o bn_mp_div_2d.o bn_mp_div_3.o bn_mp_exch.o bn_mp_expt_d.o bn_mp_grow.o bn_mp_init.o bn_mp_init_copy.o bn_mp_init_multi.o bn_mp_init_set.o bn_mp_init_set_int.o bn_mp_init_size.o bn_mp_karatsuba_mul.o bn_mp_karatsuba_sqr.o bn_mp_lshd.o bn_mp_mod.o bn_mp_mod_2d.o bn_mp_mul.o bn_mp_mul_2.o bn_mp_mul_2d.o bn_mp_mul_d.o bn_mp_neg.o bn_mp_or.o bn_mp_radix_size.o bn_mp_radix_smap.o bn_mp_read_radix.o bn_mp_rshd.o bn_mp_set.o bn_mp_set_int.o bn_mp_shrink.o bn_mp_sqr.o bn_mp_sqrt.o bn_mp_sub.o bn_mp_sub_d.o bn_mp_to_unsigned_bin.o bn_mp_to_unsigned_bin_n.o bn_mp_toom_mul.o bn_mp_toom_sqr.o bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_s_mp_add.o bn_s_mp_mul_digs.o bn_s_mp_sqr.o bn_s_mp_sub.o   -lz  -lpthread  -compatibility_version 8.6 -current_version 8.6.7 -install_name "/opt/sw3/lib"/libtcl8.6.dylib -seg1addr 0xa000000 -sectcreate __TEXT __info_plist Tcl-Info.plist  
ld: warning: option -prebind is obsolete and being ignored
duplicate symbol '_fixstrtod' in:
    strtod.o
    fixstrtod.o
ld: 1 duplicate symbol for architecture x86_64

Notice the `-prebind` flag, so there must be some broken OS detection. Instead of fixing the detection, I upgraded the package. I used #592 partly to figure out changes, but did not change the X11 nature of our package.