### PR TITLE
Fix slang2 testing on 11.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/slang2.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/slang2.info
@@ -30,7 +30,7 @@ UseMaxBuildJobs: False
 SetCFLAGS: -isystem %p/include
 NoSetCFLAGS: true
 NoSetLDFLAGS: true
-SetLDFLAGS: -Wl,-search_paths_first -L%b/src/elfobjs -L%p/lib
+SetLDFLAGS: -Wl,-search_paths_first -Wl,-headerpad_max_install_names -L%b/src/elfobjs -L%p/lib
 
 ConfigureParams: <<
   --mandir=%p/share/man \
@@ -48,10 +48,10 @@ InstallScript: <<
 InfoTest: <<
 TestScript: <<
 #!/bin/sh -ev
-install_name_tool -id %b/src/elfobjs/libslang.2.dylib %b/src/elfobjs/libslang.2.dylib
+install_name_tool -id %b/src/elfobjs/libslang.2.dylib %b/src/elfobjs/libslang.%v.dylib
 install_name_tool -change %p/lib/libslang.2.dylib %b/src/elfobjs/libslang.2.dylib %b/slsh/objs/slsh_exe
 make check || exit 2
-install_name_tool -id %p/lib/libslang.2.dylib %b/src/elfobjs/libslang.2.dylib
+install_name_tool -id %p/lib/libslang.2.dylib %b/src/elfobjs/libslang.%v.dylib
 install_name_tool -change %b/src/elfobjs/libslang.2.dylib %p/lib/libslang.2.dylib %b/slsh/objs/slsh_exe
 <<
 <<


### PR DESCRIPTION
Using i_n_t on the SONAME symlink causes the actual library to be rebuilt with the original install_name during `make check`, which then fails.
Use i_n_t on the physical file to avoid the rebuild.