### PR TITLE
Fix libgsm.1.dylib install name

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sound/libgsm1-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/sound/libgsm1-shlibs.info
@@ -11,6 +11,12 @@ BuildDepends: fink (>= 0.24.12-1)
 PatchFile: %n.patch
 PatchFile-MD5: d3d582abe536e91f87718a91a9006982
 CompileScript: echo "Skipping compile stage"
+InfoTest: <<
+	TestScript: <<
+		make -w add-test/add INSTALL_ROOT=%p
+		./add-test/add < ./add-test/add_test.dta || exit 2
+	<<
+<<
 InstallScript: make -w install INSTALL_ROOT=%p GSM_INSTALL_ROOT=%i TOAST_INSTALL_ROOT=%i
 Shlibs: %p/lib/libgsm.1.dylib 2.0.0 %n (>= 1.0.13-101)
 DocFiles: README COPYRIGHT

--- a/10.9-libcxx/stable/main/finkinfo/sound/libgsm1-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/sound/libgsm1-shlibs.info
@@ -11,7 +11,11 @@ BuildDepends: fink (>= 0.24.12-1)
 PatchFile: %n.patch
 PatchFile-MD5: d3d582abe536e91f87718a91a9006982
 CompileScript: make INSTALL_ROOT=%p
-InstallScript: make -w install INSTALL_ROOT=%i
+InstallScript: <<
+	make -w install INSTALL_ROOT=%i
+	chmod 644 %i/lib/libgsm.1.dylib
+	install_name_tool -id %p/lib/libgsm.1.dylib %i/lib/libgsm.1.dylib
+<<
 Shlibs: %p/lib/libgsm.1.dylib 2.0.0 %n (>= 1.0.13-101)
 DocFiles: README COPYRIGHT
 Splitoff: <<

--- a/10.9-libcxx/stable/main/finkinfo/sound/libgsm1-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/sound/libgsm1-shlibs.info
@@ -10,12 +10,8 @@ SourceDirectory: gsm-1.0-pl19
 BuildDepends: fink (>= 0.24.12-1)
 PatchFile: %n.patch
 PatchFile-MD5: d3d582abe536e91f87718a91a9006982
-CompileScript: make INSTALL_ROOT=%p
-InstallScript: <<
-	make -w install INSTALL_ROOT=%i
-	chmod 644 %i/lib/libgsm.1.dylib
-	install_name_tool -id %p/lib/libgsm.1.dylib %i/lib/libgsm.1.dylib
-<<
+CompileScript: echo "Skipping compile stage"
+InstallScript: make -w install INSTALL_ROOT=%p GSM_INSTALL_ROOT=%i TOAST_INSTALL_ROOT=%i
 Shlibs: %p/lib/libgsm.1.dylib 2.0.0 %n (>= 1.0.13-101)
 DocFiles: README COPYRIGHT
 Splitoff: <<


### PR DESCRIPTION
`libgsm1-shlibs` fails validation on an `install_name` pointing to `%b`.
For some reason the Makefile is installing everything in mode 444; leaving `libgsm.1.dylib` owner-writable as is custom for about all other dylibs.