### PR TITLE
udunits2 2.2.28 - new upstream

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/udunits2.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/udunits2.info
@@ -1,21 +1,20 @@
-Info2: <<
 Package: udunits2
-Version: 2.2.26
+Version: 2.2.28
 Revision: 1
 Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
-Type: gcc (9)
 
-BuildDepends: expat1, fink-package-precedence, gcc%type_pkg[gcc]-compiler
-Depends: %N-shlibs (= %v-%r), expat1-shlibs, gcc%type_pkg[gcc]-shlibs
+BuildDepends: expat1, fink-package-precedence
+Depends: %N-shlibs (= %v-%r), expat1-shlibs
 
-Source: ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-%v.tar.gz
-Source-MD5: 5803837c6019236d24a9c9795cc8b462
-Source-Checksum: SHA1(714332946db3d71faca228436eb9f024b0f269f4)
+Source: https://artifacts.unidata.ucar.edu/repository/downloads-udunits/udunits-%v.tar.gz
+Source-MD5: 8078c95d92dec08fbfb1bce42473d475
+Source-Checksum: SHA1(4395de6cd3a4f9e088fa0f1cc86c4af6a06dc6d8)
+SourceDirectory: udunits-%v
 
 # Patch configure not to link like Puma on Yosemite and later 10.x .
 PatchScript:  perl -pi -e 's/(10\.\[012\])(\*)/\1\,.\2/' configure
 
-SetCC: gcc-fsf-%type_raw[gcc]
+SetCC: gcc
 SetCPPFLAGS: -Df2cFortran
 
 ConfigureParams:  --disable-static --docdir=%p/share/doc/%N
@@ -33,8 +32,8 @@ InfoTest: <<
 InstallScript: <<
 	make install DESTDIR=%d
 <<
-DocFiles: ANNOUNCEMENT CHANGE_LOG BACKLOG README %N.html %N.pdf 
-InfoDocs: %n.info
+DocFiles: CHANGE_LOG BACKLOG README COPYRIGHT %N.html prog/%Nprog.html lib/%Nlib.html
+InfoDocs: %n.info %nprog.info %nlib.info
 Description: Units of physical quantities
 DescPackaging: <<
 Decided not just to use the "udunits" name, since this version builds 
@@ -50,14 +49,14 @@ Its three main components are:
 	3) an extensive database of units.
 <<
 License: OSI-Approved
-Homepage: http://www.unidata.ucar.edu/software/udunits/
+Homepage: https://www.unidata.ucar.edu/software/udunits/
 Splitoff: <<
-	Depends: expat1-shlibs, gcc%type_pkg[gcc]-shlibs
 	Package: %N-shlibs
+	Depends: expat1-shlibs
 	Description: Units of physical quantities (shared libs)
 	Files: lib/lib%N.0*.dylib
 	Shlibs: %p/lib/lib%N.0.dylib 2.0.0 %n (>= 2.1.22-1)
-	DocFiles: ANNOUNCEMENT CHANGE_LOG BACKLOG README
+	DocFiles: CHANGE_LOG BACKLOG README COPYRIGHT %N.html prog/%Nprog.html lib/%Nlib.html
 <<
 Splitoff2: <<
 	Package: %N-dev
@@ -71,6 +70,5 @@ Splitoff2: <<
 	lib/lib%N.la
 	lib/lib%N.dylib
 	<<
-	DocFiles: ANNOUNCEMENT CHANGE_LOG BACKLOG README
-<<
+	DocFiles: CHANGE_LOG BACKLOG README COPYRIGHT %N.html prog/%Nprog.html lib/%Nlib.html
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/udunits2.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/udunits2.info
@@ -5,8 +5,8 @@ Revision: 1
 Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 Type: gcc (9)
 
-BuildDepends: expat1, fink-package-precedence
-Depends: %N-shlibs (= %v-%r), expat1-shlibs
+BuildDepends: expat1, fink-package-precedence, gcc%type_pkg[gcc]-compiler
+Depends: %N-shlibs (= %v-%r), expat1-shlibs, gcc%type_pkg[gcc]-shlibs
 
 Source: ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-%v.tar.gz
 Source-MD5: 5803837c6019236d24a9c9795cc8b462
@@ -52,7 +52,7 @@ Its three main components are:
 License: OSI-Approved
 Homepage: http://www.unidata.ucar.edu/software/udunits/
 Splitoff: <<
-	Depends: expat1-shlibs
+	Depends: expat1-shlibs, gcc%type_pkg[gcc]-shlibs
 	Package: %N-shlibs
 	Description: Units of physical quantities (shared libs)
 	Files: lib/lib%N.0*.dylib

--- a/10.9-libcxx/stable/main/finkinfo/sci/udunits2.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/udunits2.info
@@ -1,19 +1,21 @@
+Info2: <<
 Package: udunits2
-Version: 2.2.20
+Version: 2.2.26
 Revision: 1
 Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
+Type: gcc (9)
 
 BuildDepends: expat1, fink-package-precedence
 Depends: %N-shlibs (= %v-%r), expat1-shlibs
 
 Source: ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-%v.tar.gz
-Source-MD5: 1586b70a49dfe05da5fcc29ef239dce0
-Source-Checksum: SHA1(88187885d002f4477396f5e766ed7da9c27097e2)
+Source-MD5: 5803837c6019236d24a9c9795cc8b462
+Source-Checksum: SHA1(714332946db3d71faca228436eb9f024b0f269f4)
 
 # Patch configure not to link like Puma on Yosemite and later 10.x .
 PatchScript:  perl -pi -e 's/(10\.\[012\])(\*)/\1\,.\2/' configure
 
-SetCC: gcc
+SetCC: gcc-fsf-%type_raw[gcc]
 SetCPPFLAGS: -Df2cFortran
 
 ConfigureParams:  --disable-static --docdir=%p/share/doc/%N
@@ -70,4 +72,5 @@ Splitoff2: <<
 	lib/lib%N.dylib
 	<<
 	DocFiles: ANNOUNCEMENT CHANGE_LOG BACKLOG README
+<<
 <<


### PR DESCRIPTION
Updated the UDUNITS2 package to the latest upstream version. Only major change is to use GCC 9 as the compiler, so it plays nice with Fortran (I could not get this to compile with Xcode 12 otherwise).

Tested on 10.15.7 with xcode command line tools 12.2. Compiles and passes tests with "-m".

Maintainer is @akhansen.