### PR TITLE
gmt6 6.1.1 - new upstream

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/gmt6.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gmt6.info
@@ -1,10 +1,9 @@
 Package: gmt6
-# 6.1.0 has file collision with dcw-gmt
-Version: 6.0.0
+Version: 6.1.1
 Revision: 1
 Source: https://github.com/GenericMappingTools/gmt/releases/download/%v/gmt-%v-src.tar.xz
-Source-MD5: 2721f3bd7f39eb7c8ea261f644c5c36e
-Source-Checksum: SHA1(3f11da2740402d4d1d98c55b46f4f18e050f76c0)
+Source-MD5: 3024b7f789d5ab38ae0fa92bdab43b5f
+Source-Checksum: SHA1(591c318cfa1a96fb1f39a1b3df4b1ac4da9f1530)
 SourceDirectory: gmt-%v
 
 Conflicts: gmt, gmt5, gmt6
@@ -15,11 +14,17 @@ BuildDepends: <<
   fink (>= 0.32),
   fink-package-precedence,
   gdal2-dev,
+  libgeos3.6.1,
   libcurl4,
   libpcre1,
-  netcdf-c15
+  netcdf-c18,
+  dcw-gmt (>= 1.1.4),
+  gshhg (>= 2.3.7)
 <<
-Depends: %n-shlibs (= %v-%r), ghostscript
+Depends: <<
+  %n-shlibs (= %v-%r),
+  ghostscript
+<<
 Recommends: %n-doc
 NoSetCPPFLAGS: true
 NoSetLDFLAGS: true
@@ -40,12 +45,14 @@ CompileScript: <<
 	-DGMT_DATADIR=share/gmt \
 	-DGMT_MANDIR=share/man \
 	-DDCW_ROOT=%p/share/gmt/dcw \
+	-DCOPY_DCW=FALSE \
 	-DGSHHG_ROOT=%p/share/gmt/gshhg \
-	-DGS_ROOT=%p \
+	-DCOPY_GSHHG=FALSE \
 	-DNETCDF_ROOT=%p \
 	-DCURL_INCLUDE_DIR=%p/include \
 	-DCURL_LIBRARY=%p/lib/libcurl.dylib \
 	-DGDAL_ROOT=%p \
+	-DGEOS_CONFIG=%p/opt/libgeos3.6.1/bin/geos-config \
 	-DPCRE_ROOT=%p \
 	-DFFTW3_ROOT=%p \
 	-DGMT_INSTALL_TRADITIONAL_FOLDERNAMES=off \
@@ -70,15 +77,18 @@ SplitOff: <<
 <<
 SplitOff2: <<
   Package: %N-shlibs
+  Conflicts: gmt-shlibs, gmt5-shlibs, gmt6-shlibs
+  Replaces: gmt-shlibs, gmt5-shlibs, gmt6-shlibs
   Files: lib/*.6.*dylib lib/gmt
   Depends: <<
-    dcw-gmt (>= 1.1.1),
+    dcw-gmt (>= 1.1.4),
     fftw3-shlibs (>= 3.3.3),
     gdal2-shlibs,
+    libgeos3.6.1-shlibs,
     gshhg (>= 2.3.4),
     libcurl4-shlibs,
     libpcre1-shlibs,
-    netcdf-c15-shlibs
+    netcdf-c18-shlibs
   <<
   RuntimeDepends: ghostscript
   Shlibs: <<
@@ -121,4 +131,4 @@ DescPort: <<
 License: GPL, Restrictive/Distributable
 DocFiles: AUTHORS.md COPYING.LESSERv3 COPYINGv3 LICENSE.TXT README.md src/README.TRIANGLE src/TRIANGLE.HOWTO
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Homepage: http://gmt.soest.hawaii.edu/
+Homepage: https://www.generic-mapping-tools.org/


### PR DESCRIPTION
New upstream version of GMT 6.

Depends on #693 for netcdf-c18.

Changes:
- add dependency to libgeos3.6.1
- update NetCDF to netcdf-c18
- add COPY_DCW=FALSE and COPY_GSHHG=FALSE to cmake parameters to avoid clash with dcw-gmt and gshhg packages!
- updated homepage URL

Tested on 10.15.7 with xcode command line tools 12.2. Compiles with "-m".