### PR TITLE
json-c5: version 0.15

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/json-c.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/json-c.info
@@ -1,13 +1,14 @@
 Package: json-c
 Version: 0.12.1
-Revision: 1
+Revision: 2
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Homepage: https://github.com/json-c/json-c/wiki
 ###
 Depends: %N-shlibs (= %v-%r)
 BuildDependsOnly: true
-Conflicts: libjson
+Conflicts: libjson, json-c5
+Replaces: json-c5
 ###
 Source: https://github.com/%n/%n/archive/%n-%v-20160607.tar.gz
 Source-MD5: 0a2a49a1e89044fdac414f984f3f81a6

--- a/10.9-libcxx/stable/main/finkinfo/libs/json-c5.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/json-c5.info
@@ -1,0 +1,53 @@
+Package: json-c5
+Version: 0.15
+Revision: 1
+License: BSD
+Maintainer: None <fink-devel@lists.sourceforge.net>
+Homepage: https://github.com/json-c/json-c/wiki
+###
+Depends: %N-shlibs (= %v-%r)
+BuildDepends: <<
+	cmake,
+	doxygen
+<<
+BuildDependsOnly: true
+Conflicts: libjson, json-c
+Replaces: json-c
+###
+Source: https://github.com/json-c/json-c/archive/json-c-%v-20200726.tar.gz
+Source-MD5: b3841c9abdca837ea00ce6a5ada4bb2c
+SourceDirectory: json-c-json-c-%v-20200726
+CompileScript: <<
+	cmake -D CMAKE_INSTALL_PREFIX=%i -D BUILD_STATIC_LIBS=OFF .
+	perl -pi -e 's|%i|%p|g' json-c.pc
+	make
+<<
+InstallScript: <<
+	%{default_script}
+	install_name_tool -id %p/lib/libjson-c.5.dylib %i/lib/libjson-c.5.1.0.dylib
+<<
+#ConfigureParams: --disable-static
+DocFiles: AUTHORS COPYING ChangeLog INSTALL NEWS README README.md README.html doc/html
+InfoTest: <<
+	TestScript: make test || exit 2
+<<
+###
+Splitoff: <<
+	Package: %N-shlibs
+	Files: <<
+		lib/libjson-c.5*.dylib
+	<<
+	Shlibs: <<
+		%p/lib/libjson-c.5.dylib 5.0.0 %n (>= 0.15-1)
+	<<
+	DocFiles: AUTHORS COPYING ChangeLog INSTALL NEWS README README.md README.html
+<<
+###
+Description: JSON implementation in C
+DescDetail: <<
+JSON-C implements a reference counting object model that allows you
+to easily construct JSON objects in C, output them as JSON formatted
+strings and parse JSON formatted strings back into the C
+representation of JSON objects.
+<<
+###

--- a/10.9-libcxx/stable/main/finkinfo/libs/json-c5.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/json-c5.info
@@ -29,6 +29,7 @@ InstallScript: <<
 <<
 DocFiles: AUTHORS COPYING ChangeLog INSTALL NEWS README README.md README.html doc/html
 InfoTest: <<
+	TestConflicts: valgrind
 	TestScript: make test || exit 2
 <<
 ###

--- a/10.9-libcxx/stable/main/finkinfo/libs/json-c5.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/json-c5.info
@@ -18,15 +18,15 @@ Source: https://github.com/json-c/json-c/archive/json-c-%v-20200726.tar.gz
 Source-MD5: b3841c9abdca837ea00ce6a5ada4bb2c
 SourceDirectory: json-c-json-c-%v-20200726
 CompileScript: <<
-	cmake -D CMAKE_INSTALL_PREFIX=%i -D BUILD_STATIC_LIBS=OFF .
-	perl -pi -e 's|%i|%p|g' json-c.pc
+	cmake -D CMAKE_INSTALL_PREFIX=%p \
+		-D CMAKE_INSTALL_NAME_DIR=%p/lib \
+		-D CMAKE_VERBOSE_MAKEFILE=ON \
+		-D BUILD_STATIC_LIBS=OFF .
 	make
 <<
 InstallScript: <<
-	%{default_script}
-	install_name_tool -id %p/lib/libjson-c.5.dylib %i/lib/libjson-c.5.1.0.dylib
+	make install DESTDIR=%d
 <<
-#ConfigureParams: --disable-static
 DocFiles: AUTHORS COPYING ChangeLog INSTALL NEWS README README.md README.html doc/html
 InfoTest: <<
 	TestScript: make test || exit 2


### PR DESCRIPTION
New version of json-c, with a library main version bump...

Tested on 10.15.7 with xcode 12.2. Compiles and tests with "-m".

If this is accepted, it might be worth bumping the version in gdal2 (#697).