### PR TITLE
unixodbc: version 2.3.9

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/unixodbc.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/unixodbc.info
@@ -1,5 +1,5 @@
 Package: unixodbc
-Version: 2.3.4
+Version: 2.3.9
 Revision: 1
 ###
 Conflicts: unixodbc2 (<< 2.2.12-5), unixodbc2-nox (<< 2.2.12-5)
@@ -19,12 +19,16 @@ Depends: <<
 ###
 CustomMirror: <<
   Primary: http://www.unixodbc.com/
+  Secondary: ftp://ftp.unixodbc.org/pub/unixODBC/
 <<
 ###
 Source: mirror:custom:unixODBC-%v.tar.gz
-Source-MD5: bd25d261ca1808c947cb687e2034be81
+Source-MD5: 06f76e034bb41df5233554abe961a16f
 ###
+PatchFile: %n.patch
+PatchFile-MD5: 5c11da832b8dc46d6582aba42c0e39ab
 PatchScript: <<
+%{default_script}
 ### Fix Drivers, should be unversioned and .so
 for i in `find Drivers -name Makefile.in`; do \
   perl -pi -e 's,-version-info( [1-2]:0:0)?,-avoid-version -module,g' $i; \

--- a/10.9-libcxx/stable/main/finkinfo/database/unixodbc.patch
+++ b/10.9-libcxx/stable/main/finkinfo/database/unixodbc.patch
@@ -1,0 +1,187 @@
+diff -Nurd unixODBC-2.3.9.orig/Drivers/Postgre7.1/misc.h unixODBC-2.3.9/Drivers/Postgre7.1/misc.h
+--- unixODBC-2.3.9.orig/Drivers/Postgre7.1/misc.h	2014-01-06 09:37:01.000000000 +0000
++++ unixODBC-2.3.9/Drivers/Postgre7.1/misc.h	2020-12-06 21:57:20.000000000 +0000
+@@ -106,4 +106,44 @@
+ 
+ int my_strcpy(char *dst, int dst_len, char *src, int src_len);
+ 
++/* declarations for Postgre functions */
++RETCODE SQL_API PG_SQLAllocStmt(
++	HDBC hdbc,
++	HSTMT FAR *phstmt);
++RETCODE SQL_API PG_SQLFreeStmt(
++	HSTMT hstmt,
++	UWORD fOption);
++RETCODE SQL_API PG_SQLFetch(
++	HSTMT hstmt);
++RETCODE SQL_API PG_SQLGetData(
++        HSTMT      hstmt,
++        UWORD      icol,
++        SWORD      fCType,
++        PTR        rgbValue,
++        SDWORD     cbValueMax,
++        SDWORD FAR *pcbValue);
++RETCODE SQL_API PG_SQLExecDirect(
++        HSTMT     hstmt,
++        UCHAR FAR *szSqlStr,
++        SDWORD    cbSqlStr);
++RETCODE SQL_API PG_SQLBindCol(
++        HSTMT      hstmt,
++        UWORD      icol,
++        SWORD      fCType,
++        PTR        rgbValue,
++        SQLLEN     cbValueMax,
++        SQLLEN    *pcbValue);
++RETCODE SQL_API PG_SQLColumns(
++        HSTMT        hstmt,
++        UCHAR FAR *  szTableQualifier,
++        SWORD        cbTableQualifier,
++        UCHAR FAR *  szTableOwner,
++        SWORD        cbTableOwner,
++        UCHAR FAR *  szTableName,
++        SWORD        cbTableName,
++        UCHAR FAR *  szColumnName,
++        SWORD        cbColumnName);
++RETCODE SQL_API PG_SQLExecute(
++	HSTMT   hstmt);
++
+ #endif
+diff -Nurd unixODBC-2.3.9.orig/Drivers/nn/connect.c unixODBC-2.3.9/Drivers/nn/connect.c
+--- unixODBC-2.3.9.orig/Drivers/nn/connect.c	2014-01-06 09:37:01.000000000 +0000
++++ unixODBC-2.3.9/Drivers/nn/connect.c	2020-12-06 22:33:10.000000000 +0000
+@@ -14,6 +14,7 @@
+ **/
+ #include <config.h>
+ #include "driver.h"
++#include <unistd.h>
+ 
+ void*	nnodbc_getenverrstack(void* henv)
+ {
+diff -Nurd unixODBC-2.3.9.orig/Drivers/nn/driver.h unixODBC-2.3.9/Drivers/nn/driver.h
+--- unixODBC-2.3.9.orig/Drivers/nn/driver.h	2014-01-06 09:37:01.000000000 +0000
++++ unixODBC-2.3.9/Drivers/nn/driver.h	2020-12-06 22:40:10.000000000 +0000
+@@ -113,6 +113,38 @@
+ 		char*	value,
+ 		int	size );
+ 
++void	nnodbc_errstkunset(void* stack);
++int	nnodbc_conndialog();
++int	sqlexecute (
++	stmt_t*   pstmt);
++int	sqlputdata (
++		stmt_t* 	pstmt,
++		int		ipar,
++		char*		data );
++RETCODE SQL_API SQLBindParameter(
++	HSTMT hstmt,
++	UWORD ipar,
++	SWORD fParamType,
++	SWORD fCType,
++	SWORD fSqlType,
++	UDWORD   cbColDef,
++	SWORD ibScale,
++	PTR   rgbValue,
++	SDWORD   cbValueMax,
++	SDWORD* pcbValue);
++int	upper_strneq(
++	char*	s1,
++	char*	s2,
++	int	n );
++
++void	nnsql_getrange(void* hstmt, long* pmin, long* pmax);
++int	nnsql_srchtree_evl(void* hstmt);
++int	nnsql_strlike(char* str, char* pattern, char esc, int flag);
++int	nntp_postok( void* hcndes );
++void	nnsql_yyinit( yyenv_t* penv, yystmt_t* yystmt);
++int	nnsql_yyparse (yyenv_t* pyyenv);
++int	nnsql_srchtree_tchk(void* hstmt);
++
+ #endif
+ 
+ 
+diff -Nurd unixODBC-2.3.9.orig/Drivers/nn/nnconfig.h unixODBC-2.3.9/Drivers/nn/nnconfig.h
+--- unixODBC-2.3.9.orig/Drivers/nn/nnconfig.h	2018-05-04 12:25:40.000000000 +0100
++++ unixODBC-2.3.9/Drivers/nn/nnconfig.h	2020-12-06 22:43:06.000000000 +0000
+@@ -104,4 +104,9 @@
+ 
+ # endif /* WINDOWS */
+ 
++int	upper_strneq(
++	char*	s1,
++	char*	s2,
++	int	n );
++
+ #endif
+diff -Nurd unixODBC-2.3.9.orig/Drivers/nn/nntp.c unixODBC-2.3.9/Drivers/nn/nntp.c
+--- unixODBC-2.3.9.orig/Drivers/nn/nntp.c	2014-01-06 09:37:01.000000000 +0000
++++ unixODBC-2.3.9/Drivers/nn/nntp.c	2020-12-06 22:45:02.000000000 +0000
+@@ -35,6 +35,9 @@
+ 
+ #endif
+ 
++#include <arpa/inet.h>
++#include <unistd.h>
++
+ #include	<nntp.h>
+ 
+ typedef struct {
+diff -Nurd unixODBC-2.3.9.orig/Drivers/nn/yylex.c unixODBC-2.3.9/Drivers/nn/yylex.c
+--- unixODBC-2.3.9.orig/Drivers/nn/yylex.c	2018-02-26 14:43:27.000000000 +0000
++++ unixODBC-2.3.9/Drivers/nn/yylex.c	2020-12-06 22:34:25.000000000 +0000
+@@ -27,6 +27,11 @@
+ #include	<stdio.h>
+ #include	<ctype.h>
+ 
++int	upper_strneq(
++	char*	s1,
++	char*	s2,
++	int	n );
++
+ static int	getcmpopidxbyname(char* name)
+ {
+ 	int	i, size;
+diff -Nurd unixODBC-2.3.9.orig/Drivers/nn/yyparse.c unixODBC-2.3.9/Drivers/nn/yyparse.c
+--- unixODBC-2.3.9.orig/Drivers/nn/yyparse.c	2018-05-03 18:48:49.000000000 +0100
++++ unixODBC-2.3.9/Drivers/nn/yyparse.c	2020-12-06 22:33:58.000000000 +0000
+@@ -297,7 +297,7 @@
+ # define YYSTYPE_IS_DECLARED 1
+ #endif
+ 
+-
++int nnsql_yylex(YYSTYPE* pyylval, yyenv_t* penv);
+ 
+ int yyparse (void);
+ 
+diff -Nurd unixODBC-2.3.9.orig/Drivers/nn/yystmt.c unixODBC-2.3.9/Drivers/nn/yystmt.c
+--- unixODBC-2.3.9.orig/Drivers/nn/yystmt.c	2014-01-06 09:37:01.000000000 +0000
++++ unixODBC-2.3.9/Drivers/nn/yystmt.c	2020-12-06 22:40:56.000000000 +0000
+@@ -14,6 +14,7 @@
+ **/
+ #include <config.h>
+ #include "driver.h"
++#include <unistd.h>
+ 
+ static char	sccsid[]
+ 	= "@(#)NNSQL(NetNews SQL) v0.5, Copyright(c) 1995, 1996 by Ke Jin";
+diff -Nurd unixODBC-2.3.9.orig/Drivers/template/driver.h unixODBC-2.3.9/Drivers/template/driver.h
+--- unixODBC-2.3.9.orig/Drivers/template/driver.h	2020-09-03 09:48:58.000000000 +0100
++++ unixODBC-2.3.9/Drivers/template/driver.h	2020-12-06 22:12:46.000000000 +0000
+@@ -87,6 +87,18 @@
+ 
+ } DRVENV, *HDRVENV;
+ 
++SQLRETURN _AllocConnect( SQLHENV    hDrvEnv,
++        SQLHDBC    *phDrvDbc );
++SQLRETURN _AllocEnv( SQLHENV *phDrvEnv );
++SQLRETURN _AllocStmt(   SQLHDBC     hDrvDbc,
++        SQLHSTMT    *phDrvStmt );
++SQLRETURN _FreeResults( HSTMTEXTRAS hStmt );
++SQLRETURN _FreeDbc( SQLHDBC hDrvDbc );
++SQLRETURN _FreeStmt( SQLHSTMT hDrvStmt );
++SQLRETURN _FreeConnect( SQLHDBC hDrvDbc );
++SQLRETURN _FreeEnv( SQLHENV hDrvEnv );
++SQLRETURN _FreeStmtList( SQLHDBC hDrvDbc );
++
+ #endif
+ 
+ 


### PR DESCRIPTION
New upstream version of unixODBC, with a patchfile to fix a whole bunch of implicit declarations.

Builds on 10.15.7 with xcode 12.2. Maintainer is @TheSin-