### PR TITLE
xtide 2.15.3, libtcd 2.2.7-r3, xtide-harmonics-us 20191229

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/libtcd.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/libtcd.info
@@ -33,17 +33,17 @@ PARTICULAR PURPOSE.
 
 For additional background, see Jan Depner, "Format for the Oceanographic and 
 Atmospheric Master Library (OAML) Tide Constituent Database," rev. 2003-06-06.
-( ftp://ftp.flaterco.com/xtide/TCD.pdf )
+( https://flaterco.com/files/xtide/TCD.pdf )
 <<
 License: Public Domain
-Homepage:  http://www.flaterco.com/xtide/
+Homepage:  https://flaterco.com/xtide/
 Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 
 BuildDepends: fink (>= 0.32)
 Depends: %N-shlibs (= %v-%r)
 BuildDependsOnly: true
 
-Source: ftp://ftp.flaterco.com/xtide/%n-%v.tar.xz
+Source: https://flaterco.com/files/xtide/%n-%v.tar.xz
 Source-MD5: 10447a33c6aba87ee9e67cd5178fbc69
 Source-Checksum: SHA1(db78363df75d5c9df7c05541aacd4c79ba1ba33f)
 SourceDirectory: %n-2.2.7

--- a/10.9-libcxx/stable/main/finkinfo/sci/libtcd.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/libtcd.info
@@ -1,5 +1,5 @@
 Package: libtcd
-Version: 2.2.7-r2
+Version: 2.2.7-r3
 Revision: 1
 Description: API to read/write TCD files (dev. files)
 DescDetail: <<
@@ -39,13 +39,13 @@ License: Public Domain
 Homepage:  http://www.flaterco.com/xtide/
 Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 
-
+BuildDepends: fink (>= 0.32)
 Depends: %N-shlibs (= %v-%r)
 BuildDependsOnly: true
 
-Source: ftp://ftp.flaterco.com/xtide/%n-%v.tar.bz2
-Source-MD5: 5dbdc144c0e00886252ef880fc765d2e
-Source-Checksum: SHA1(800cec12db681f60670a060cc69a9f44f46be4cf)
+Source: ftp://ftp.flaterco.com/xtide/%n-%v.tar.xz
+Source-MD5: 10447a33c6aba87ee9e67cd5178fbc69
+Source-Checksum: SHA1(db78363df75d5c9df7c05541aacd4c79ba1ba33f)
 SourceDirectory: %n-2.2.7
 
 PatchScript: perl -pi -e 's/(10\.\[012\])\*/\1\,.\*/' configure

--- a/10.9-libcxx/stable/main/finkinfo/sci/libtcd.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/libtcd.info
@@ -48,11 +48,14 @@ Source-MD5: 10447a33c6aba87ee9e67cd5178fbc69
 Source-Checksum: SHA1(db78363df75d5c9df7c05541aacd4c79ba1ba33f)
 SourceDirectory: %n-2.2.7
 
-PatchScript: perl -pi -e 's/(10\.\[012\])\*/\1\,.\*/' configure
+PatchScript: <<
+perl -pi -e 's/(10\.\[012\])\*/\1\,.\*/' configure
+perl -pi -e 's/libtcd.html//' Makefile.*
+<<
 
 InstallScript: make install DESTDIR=%d 
 
-DocFiles: AUTHORS COPYING NEWS README
+DocFiles: AUTHORS COPYING NEWS README libtcd.html
 
 DescPort: <<
 	Patch to avoid flat namespace linkage on Yosemite and later.
@@ -63,5 +66,5 @@ Splitoff: <<
 	Files: lib/libtcd.1.dylib
 	Shlibs: %p/lib/libtcd.1.dylib 2.0.0 %n (>=2.2.5-1)
 	Description: API to read/write TCD files (shared libs)
-	DocFiles: AUTHORS COPYING NEWS README
+	DocFiles: AUTHORS COPYING NEWS README libtcd.html
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide-coastline.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide-coastline.info
@@ -21,10 +21,10 @@ DescUsage: <<
 	this package.
 <<
 License: Public Domain
-Homepage:  http://www.flaterco.com/xtide/
+Homepage:  https://flaterco.com/xtide/
 Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 
-Source: ftp://ftp.flaterco.com/xtide/wvs.tar.bz2
+Source: https://flaterco.com/files/xtide/wvs.tar.bz2
 Source-MD5: 56325c8105c7137ced73396f2f2d8221
 NoSourceDirectory: true
 

--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide-harmonics-us.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide-harmonics-us.info
@@ -13,12 +13,12 @@ DescUsage: <<
 	this change after installing/removing this package.
 <<
 License: Public Domain
-Homepage: http://www.flaterco.com/xtide/
+Homepage: https://flaterco.com/xtide/
 Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 
 BuildDepends: fink (>= 0.32)
 
-Source: ftp://ftp.flaterco.com/xtide/harmonics-dwf-%v-free.tar.xz
+Source: https://flaterco.com/files/xtide/harmonics-dwf-%v-free.tar.xz
 Source-MD5: dd0229543b5a02bf45a317de12099afc
 Source-Checksum: SHA1(76fc49bba68aae7def461f3963f7f16b0053cca7)
 SourceDirectory: harmonics-dwf-%v

--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide-harmonics-us.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide-harmonics-us.info
@@ -1,5 +1,5 @@
 Package: xtide-harmonics-us
-Version: 20190620
+Version: 20191229
 Revision: 1
 Description: US harmonic data for XTide
 DescDetail: <<
@@ -16,9 +16,11 @@ License: Public Domain
 Homepage: http://www.flaterco.com/xtide/
 Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 
-Source: ftp://ftp.flaterco.com/xtide/harmonics-dwf-%v-free.tar.bz2
-Source-MD5: ffde40b6fadccefa99fae500ae28e176
-Source-Checksum: SHA1(63c41d37c4e36c402ab0a07ff3371a1189ec4cae)
+BuildDepends: fink (>= 0.32)
+
+Source: ftp://ftp.flaterco.com/xtide/harmonics-dwf-%v-free.tar.xz
+Source-MD5: dd0229543b5a02bf45a317de12099afc
+Source-Checksum: SHA1(76fc49bba68aae7def461f3963f7f16b0053cca7)
 SourceDirectory: harmonics-dwf-%v
 
 CompileScript: printf "No compiling needed.\n" 

--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: xtide
-Version: 2.15.2
+Version: 2.15.3
 Revision: 1
-Type: harm (20190620)
+Type: harm (20191229)
 
 Description: Tide and current prediction software
 License: Public Domain
@@ -13,6 +13,7 @@ BuildConflicts: libxt, libxt-flat
 BuildDepends: <<
 	autoconf2.6,
 	automake1.15,
+	fink (>= 0.32),
 	fink-package-precedence (>= 0.34-1),
 	flag-sort,
 	fontconfig2-dev,
@@ -37,9 +38,9 @@ Depends: <<
 
 Recommends: xtide-coastline (>= 20110414-2)
 
-Source: ftp://ftp.flaterco.com/%n/%n-%v.tar.bz2
-Source-MD5: 3d4bd4ef4152809deff9a3b48330fe9d
-Source-Checksum: SHA1(0684d72df6e463822ac36016e248eaea07228340)
+Source: ftp://ftp.flaterco.com/%n/%n-%v.tar.xz
+Source-MD5: 0381904d2d623685c4971efd2f54c7ba
+Source-Checksum: SHA1(333ca9fa42afd62868d722d9f1627e9447f78c19)
 
 PatchScript: <<
 	perl -pi -e 's,(/etc/xtide\.conf),%p\1,g' libxtide/Global.cc README tide.1 xtide.1 xttpd.8

--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
@@ -6,7 +6,7 @@ Type: harm (20191229)
 
 Description: Tide and current prediction software
 License: Public Domain
-Homepage: http://www.flaterco.com/xtide/
+Homepage: https://flaterco.com/xtide/
 Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 
 BuildConflicts: libxt, libxt-flat
@@ -38,7 +38,7 @@ Depends: <<
 
 Recommends: xtide-coastline (>= 20110414-2)
 
-Source: ftp://ftp.flaterco.com/%n/%n-%v.tar.xz
+Source: https://flaterco.com/files/xtide/%n-%v.tar.xz
 Source-MD5: 0381904d2d623685c4971efd2f54c7ba
 Source-Checksum: SHA1(333ca9fa42afd62868d722d9f1627e9447f78c19)
 
@@ -120,7 +120,7 @@ tide clocks that can be bought in novelty stores.  However, it takes more to
 predict tides accurately than just a spiffy algorithm--you also need some 
 special data for each and every location for which you want to predict tides.  
 XTide reads these data from harmonics files.  See 
-http://www.flaterco.com/xtide/files.html for details on where to get one.
+https://flaterco.com/xtide/files.html for details on where to get one.
 
 Ultimately, XTide's predictions can only be as good as the available harmonics
 data.  Due to issues of data availability and of compatibility with non-U.S.


### PR DESCRIPTION
Trivial updates to xtide packages. Latest upstream (minor) versions, tarballs changed from .bz2 to .xz (requiring a BuildDepend for fink >= 0.32).

Maintainer is @akhansen. 