### PR TITLE
mbsystem: bump to proj19

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/mbsystem.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/mbsystem.info
@@ -1,6 +1,6 @@
 Package: mbsystem
 Version: 5.7.6
-Revision: 1
+Revision: 2
 
 Source: https://github.com/dwcaress/MB-System/archive/%v.tar.gz
 SourceRename: %n-%v.tar.gz
@@ -12,7 +12,7 @@ BuildDepends: <<
   openmotif4,
   netcdf-c18,
   x11-dev,
-  libproj9,
+  libproj19,
   fftw3,
   gdal2-dev
 <<
@@ -22,8 +22,8 @@ Depends: <<
   netcdf-c18-shlibs,
   x11,
   gv,
-  proj-bin (>= 4.9.2),
-  libproj9-shlibs,
+  proj-bin (>= 7.2.0),
+  libproj19-shlibs,
   gdal2-shlibs,
   parallel-forkmanager-pm5182 | parallel-forkmanager-pm5184
 <<


### PR DESCRIPTION
Bumped to latest libproj19. Compiles with "-m" and appears to work correctly.