### PR TITLE
Bioconductor 20201211

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-affy-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-affy-r.info
@@ -28,7 +28,7 @@ Source: mirror:custom:affy_%v.tar.gz
 Source-MD5: be0bf944c76571002c49bf9fb722870d
 SourceDirectory: affy
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/affy/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-affy-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-affy-r.info
@@ -18,20 +18,24 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 1.64.0
+Version: 1.68.0
 Revision: 1
 Description: Methods for Affymetrix Oligonucleotide Arrays
 Homepage: https://bioconductor.org/packages/affy/
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/affy_%v.tar.gz
-Source-MD5: edf0f0d94650dd988e8d795ded9982f7
+Source: mirror:custom:affy_%v.tar.gz
+Source-MD5: be0bf944c76571002c49bf9fb722870d
 SourceDirectory: affy
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/affy/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
-	bioconductor-affyio-r%type_pkg[rversion] (>= 1.13.3),
-	bioconductor-biobase-r%type_pkg[rversion] (>= 2.5.5),
-	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.1.12),
+	bioconductor-affyio-r%type_pkg[rversion] (>= 1.13.3-1),
+	bioconductor-biobase-r%type_pkg[rversion] (>= 2.5.5-1),
+	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.1.12-1),
 	bioconductor-preprocesscore-r%type_pkg[rversion],
 	bioconductor-zlibbioc-r%type_pkg[rversion],
 	cran-biocmanager-r%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-affyio-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-affyio-r.info
@@ -28,7 +28,7 @@ Source: mirror:custom:affyio_%v.tar.gz
 Source-MD5: fed8be49f728011047085c7f117d37c0
 SourceDirectory: affyio
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/affyio/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-affyio-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-affyio-r.info
@@ -18,15 +18,19 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 1.56.0
+Version: 1.60.0
 Revision: 1
 Description: Tools for parsing Affymetrix data files
 Homepage: https://bioconductor.org/packages/affyio/
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/affyio_%v.tar.gz
-Source-MD5: e8a56137b02d9ec691b75ee7b6bb34e7
+Source: mirror:custom:affyio_%v.tar.gz
+Source-MD5: fed8be49f728011047085c7f117d37c0
 SourceDirectory: affyio
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/affyio/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	bioconductor-zlibbioc-r%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-annotate-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-annotate-r.info
@@ -18,22 +18,26 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 1.64.0
+Version: 1.68.0
 Revision: 1
 Description: Annotation for microarrays
 Homepage: https://bioconductor.org/packages/annotate/
 License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/annotate_%v.tar.gz
-Source-MD5: d32f547fd75a4e4c5b9420957b2aca17
+Source: mirror:custom:annotate_%v.tar.gz
+Source-MD5: c06830f9bcfc0ae87023bfe03acb319e
 SourceDirectory: annotate
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/annotate/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
-	bioconductor-annotationdbi-r%type_pkg[rversion] (>= 1.27.5),
+	bioconductor-annotationdbi-r%type_pkg[rversion] (>= 1.27.5-1),
 	bioconductor-biobase-r%type_pkg[rversion],
-	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.13.8),
+	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.13.8-1),
 	cran-dbi-r%type_pkg[rversion],
-	cran-rcurl-r%type_pkg[rversion],
+	cran-httr-r%type_pkg[rversion],
 	cran-xml-r%type_pkg[rversion],
 	cran-xtable-r%type_pkg[rversion]
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biobase-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biobase-r.info
@@ -28,7 +28,7 @@ Source: mirror:custom:Biobase_%v.tar.gz
 Source-MD5: fc0fb1f68f2aed8b314c8347afb2257c
 SourceDirectory: Biobase
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/Biobase/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biobase-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biobase-r.info
@@ -18,18 +18,22 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 2.46.0
+Version: 2.50.0
 Revision: 1
 Description: Base functions for Bioconductor
 Homepage: https://bioconductor.org/packages/Biobase/
 License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/Biobase_%v.tar.gz
-Source-MD5: 961d26c6399e94de8c7c816b4f6967e9
+Source: mirror:custom:Biobase_%v.tar.gz
+Source-MD5: fc0fb1f68f2aed8b314c8347afb2257c
 SourceDirectory: Biobase
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/Biobase/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
-	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.27.1),
+	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.27.1-1),
 	libgettext8-shlibs
 <<
 BuildDepends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biocgenerics-r-0.28.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biocgenerics-r-0.28.0.info
@@ -1,0 +1,46 @@
+Info2: <<
+
+Package: bioconductor-biocgenerics-r%type_pkg[rversion]
+Type: rversion (3.6 3.5 3.4)
+Version: 0.28.0
+Revision: 1
+Description: S4 generic functions for Bioconductor
+Homepage: http://bioconductor.org/packages/3.8/bioc/html/BiocGenerics.html
+License: Artistic
+Maintainer: None <fink-devel@lists.sourceforge.net>
+Source: mirror:custom:BiocGenerics_%v.tar.gz
+Source-MD5: 39b4dfb1f9526c64ddcb9b994130a7c0
+SourceDirectory: BiocGenerics
+CustomMirror: <<
+        Primary: http://bioconductor.org/packages/3.8/bioc/src/contrib/
+        Secondary: https://bioconductor.riken.jp/packages/3.8/bioc/src/contrib/
+<<
+Depends: <<
+	r-base%type_pkg[rversion]
+<<
+BuildDepends: <<
+	r-base%type_pkg[rversion]-dev
+<<
+CompileScript: <<
+  #!/bin/bash -ev
+  export TMPDIR=%b/tmp
+  BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
+  
+  pushd ..
+  $BIN_R --verbose CMD build --no-build-vignettes BiocGenerics
+<<
+InstallScript: <<
+  #!/bin/sh -ev
+  BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
+  
+  mkdir -p %i/lib/R/%type_raw[rversion]/site-library
+  pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library BiocGenerics
+<<
+DescDetail: <<
+S4 generic functions needed by many Bioconductor packages.
+<<
+DescPackaging: <<
+This is an older version for R 3.4, 3.5 and 3.6.
+<<
+
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biocgenerics-r-0.34.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biocgenerics-r-0.34.0.info
@@ -1,0 +1,46 @@
+Info2: <<
+
+Package: bioconductor-biocgenerics-r%type_pkg[rversion]
+Type: rversion (3.6)
+Version: 0.34.0
+Revision: 1
+Description: S4 generic functions for Bioconductor
+Homepage: http://bioconductor.org/packages/3.11/bioc/html/BiocGenerics.html
+License: Artistic
+Maintainer: None <fink-devel@lists.sourceforge.net>
+Source: mirror:custom:BiocGenerics_%v.tar.gz
+Source-MD5: 39b4dfb1f9526c64ddcb9b994130a7c0
+SourceDirectory: BiocGenerics
+CustomMirror: <<
+        Primary: http://bioconductor.org/packages/3.11/bioc/src/contrib/
+        Secondary: https://bioconductor.riken.jp/packages/3.11/bioc/src/contrib/
+<<
+Depends: <<
+	r-base%type_pkg[rversion]
+<<
+BuildDepends: <<
+	r-base%type_pkg[rversion]-dev
+<<
+CompileScript: <<
+  #!/bin/bash -ev
+  export TMPDIR=%b/tmp
+  BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
+  
+  pushd ..
+  $BIN_R --verbose CMD build --no-build-vignettes BiocGenerics
+<<
+InstallScript: <<
+  #!/bin/sh -ev
+  BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
+  
+  mkdir -p %i/lib/R/%type_raw[rversion]/site-library
+  pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library BiocGenerics
+<<
+DescDetail: <<
+S4 generic functions needed by many Bioconductor packages.
+<<
+DescPackaging: <<
+This is an older version for R 3.6.
+<<
+
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biocgenerics-r-0.34.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biocgenerics-r-0.34.0.info
@@ -9,7 +9,7 @@ Homepage: http://bioconductor.org/packages/3.11/bioc/html/BiocGenerics.html
 License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:BiocGenerics_%v.tar.gz
-Source-MD5: 39b4dfb1f9526c64ddcb9b994130a7c0
+Source-MD5: 35705627c6003a3ef6672f6f3117066f
 SourceDirectory: BiocGenerics
 CustomMirror: <<
         Primary: http://bioconductor.org/packages/3.11/bioc/src/contrib/
@@ -23,6 +23,7 @@ BuildDepends: <<
 <<
 CompileScript: <<
   #!/bin/bash -ev
+  
   export TMPDIR=%b/tmp
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biocparallel-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biocparallel-r.info
@@ -28,7 +28,7 @@ Source: mirror:custom:BiocParallel_%v.tar.gz
 Source-MD5: e4c72f1bb1b4592cc2a013b8f14c9e85
 SourceDirectory: BiocParallel
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/BiocParallel/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biocparallel-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-biocparallel-r.info
@@ -18,15 +18,19 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 1.20.0
+Version: 1.24.1
 Revision: 1
 Description: Facilities for parallel evaluation
 Homepage: https://bioconductor.org/packages/BiocParallel/
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/BiocParallel_%v.tar.gz
-Source-MD5: da39b52c27a29b961fcedd371aa96d4b
+Source: mirror:custom:BiocParallel_%v.tar.gz
+Source-MD5: e4c72f1bb1b4592cc2a013b8f14c9e85
 SourceDirectory: BiocParallel
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/BiocParallel/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	cran-bh-r%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-graph-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-graph-r.info
@@ -18,18 +18,22 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 1.64.0
+Version: 1.68.0
 Revision: 1
 Description: Package to handle graph data structures
 Homepage: https://bioconductor.org/packages/graph/
 License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/graph_%v.tar.gz
-Source-MD5: 31f92dbe60c8a6972cf4885ec71a98cd
+Source: mirror:custom:graph_%v.tar.gz
+Source-MD5: ea86a5c8f2abff7d293ff02db2283b20
 SourceDirectory: graph
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/graph/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
-	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.13.11),
+	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.13.11-1),
 	libgettext8-shlibs
 <<
 BuildDepends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-graph-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-graph-r.info
@@ -28,7 +28,7 @@ Source: mirror:custom:graph_%v.tar.gz
 Source-MD5: ea86a5c8f2abff7d293ff02db2283b20
 SourceDirectory: graph
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/graph/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-impute-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-impute-r.info
@@ -18,15 +18,19 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 1.60.0
+Version: 1.64.0
 Revision: 1
 Description: Imputation for microarray data
 Homepage: https://bioconductor.org/packages/impute/
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/impute_%v.tar.gz
-Source-MD5: 7dbfa72a7ea02da1ddd4bb8e302acd1c
+Source: mirror:custom:impute_%v.tar.gz
+Source-MD5: 659f0e29d6f9d8325bd89918a06a2698
 SourceDirectory: impute
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/impute/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	(%type_raw[rversion] << 3.6) gcc5-shlibs | (%type_raw[rversion] >= 3.6) gcc9-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-impute-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-impute-r.info
@@ -28,7 +28,7 @@ Source: mirror:custom:impute_%v.tar.gz
 Source-MD5: 659f0e29d6f9d8325bd89918a06a2698
 SourceDirectory: impute
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/impute/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-kegggraph-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-kegggraph-r.info
@@ -43,7 +43,7 @@ Source: mirror:custom:KEGGgraph_%v.tar.gz
 Source-MD5: d891d5e728179f324ab2e3992db40eaf
 SourceDirectory: KEGGgraph
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/KEGGgraph/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-kegggraph-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-kegggraph-r.info
@@ -33,20 +33,24 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.46.0
+Version: 1.50.0
 Revision: 1
 Description: Graph approach to KEGG PATHWAY in R
 Homepage: https://bioconductor.org/packages/KEGGgraph/
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/KEGGgraph_%v.tar.gz
-Source-MD5: 7a13f83e3d434d9245089897f3c28d1a
+Source: mirror:custom:KEGGgraph_%v.tar.gz
+Source-MD5: d891d5e728179f324ab2e3992db40eaf
 SourceDirectory: KEGGgraph
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/KEGGgraph/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	bioconductor-graph-r%type_pkg[rversion],
 	cran-rcurl-r%type_pkg[rversion],
-	cran-xml-r%type_pkg[rversion] (>= 2.3-0),
+	cran-xml-r%type_pkg[rversion] (>= 2.3-0-1),
 	libgettext8-shlibs
 <<
 BuildDepends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-limma-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-limma-r.info
@@ -2,15 +2,19 @@ Info2: <<
 
 Package: bioconductor-limma-r%type_pkg[rversion]
 Type: rversion (3.6)
-Version: 3.42.0
+Version: 3.46.0
 Revision: 1
 Description: Linear Models for Microarray Data
 Homepage: https://bioconductor.org/packages/limma/
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/limma_%v.tar.gz
-Source-MD5: 27623f46ed39ec83165e6d1c17bdc69d
+Source: mirror:custom:limma_%v.tar.gz
+Source-MD5: 9cea3df170cedf139a4e158f9f7cd8e5
 SourceDirectory: limma
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/limma/
+<<
 Depends: <<
 	r-base%type_pkg[rversion]
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-limma-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-limma-r.info
@@ -12,7 +12,7 @@ Source: mirror:custom:limma_%v.tar.gz
 Source-MD5: 9cea3df170cedf139a4e158f9f7cd8e5
 SourceDirectory: limma
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/limma/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-massspecwavelet-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-massspecwavelet-r.info
@@ -18,15 +18,19 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 1.52.0
+Version: 1.56.0
 Revision: 1
 Description: Wavelet-based mass spectrum processing
 Homepage: https://bioconductor.org/packages/MassSpecWavelet/
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/MassSpecWavelet_%v.tar.gz
-Source-MD5: 0d8c46f89835f7e6f7ad8990101dc583
+Source: mirror:custom:MassSpecWavelet_%v.tar.gz
+Source-MD5: eb74f0197875143823ca5c61861bafe4
 SourceDirectory: MassSpecWavelet
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/MassSpecWavelet/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	cran-waveslim-r%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-multtest-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-multtest-r.info
@@ -18,15 +18,19 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 2.42.0
+Version: 2.46.0
 Revision: 1
 Description: Resampling-based multiple hypothesis testing
 Homepage: https://bioconductor.org/packages/multtest/
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/multtest_%v.tar.gz
-Source-MD5: 0c1317c032c7c973726464df9211bfc1
+Source: mirror:custom:multtest_%v.tar.gz
+Source-MD5: df4a53716450db2c7eb67da8bb616dc7
 SourceDirectory: multtest
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/multtest/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	bioconductor-biocgenerics-r%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-multtest-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-multtest-r.info
@@ -28,7 +28,7 @@ Source: mirror:custom:multtest_%v.tar.gz
 Source-MD5: df4a53716450db2c7eb67da8bb616dc7
 SourceDirectory: multtest
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/multtest/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-mzid-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-mzid-r.info
@@ -28,7 +28,7 @@ Source: mirror:custom:mzID_%v.tar.gz
 Source-MD5: 2d52a55a972baaa6f23ab16c50df4fd9
 SourceDirectory: mzID
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/mzID/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-mzid-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-mzid-r.info
@@ -18,15 +18,19 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 1.24.0
+Version: 1.28.0
 Revision: 1
 Description: MzIdentML parser for R
 Homepage: https://bioconductor.org/packages/mzID/
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/mzID_%v.tar.gz
-Source-MD5: 71469960bbd2b9fc78aade51bf2a27f0
+Source: mirror:custom:mzID_%v.tar.gz
+Source-MD5: 2d52a55a972baaa6f23ab16c50df4fd9
 SourceDirectory: mzID
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/mzID/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	bioconductor-protgenerics-r%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-mzr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-mzr-r.info
@@ -18,34 +18,40 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 2.20.0
+Version: 2.24.1
 Revision: 1
 Description: Parser for netCDF, mzXML, mzData and mzML 
 Homepage: https://bioconductor.org/packages/mzR/
 License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/mzR_%v.tar.gz
-Source-MD5: 721f2e859382e79ff086a0955e55ce2b
+Source: mirror:custom:mzR_%v.tar.gz
+Source-MD5: 7681fb96bb7e8a43cdf7f049b2b70ac3
 SourceDirectory: mzR
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/mzR/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	bioconductor-biobase-r%type_pkg[rversion],
-	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.13.6),
-	bioconductor-protgenerics-r%type_pkg[rversion] (>= 1.17.3),
-	bioconductor-rhdf5lib-r%type_pkg[rversion] (>= 1.1.4),
+	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.13.6-1),
+	bioconductor-protgenerics-r%type_pkg[rversion] (>= 1.17.3-1),
+	bioconductor-rhdf5lib-r%type_pkg[rversion] (>= 1.1.4-1),
 	bioconductor-zlibbioc-r%type_pkg[rversion],
 	cran-ncdf4-r%type_pkg[rversion],
-	cran-rcpp-r%type_pkg[rversion] (>= 0.10.1),
+	cran-rcpp-r%type_pkg[rversion] (>= 0.10.1-1),
 	libgettext8-shlibs,
-	netcdf-c15-shlibs
+	libcurl4-shlibs
 <<
+#	netcdf-c18-shlibs
 BuildDepends: <<
 	r-base%type_pkg[rversion]-dev,
 	cran-rcpp-r%type_pkg[rversion]-dev  (>= 0.10.1),
 	bioconductor-rhdf5lib-r%type_pkg[rversion]-dev (>= 1.1.4),
 	libgettext8-dev,
-	netcdf-c15
+	libcurl4
 <<
+#	netcdf-c18
 CompileScript: <<
   #!/bin/bash -ev
   export TMPDIR=%b/tmp

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-mzr-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-mzr-r.info
@@ -28,7 +28,7 @@ Source: mirror:custom:mzR_%v.tar.gz
 Source-MD5: 7681fb96bb7e8a43cdf7f049b2b70ac3
 SourceDirectory: mzR
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/mzR/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-pcamethods-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-pcamethods-r.info
@@ -28,7 +28,7 @@ Source: mirror:custom:pcaMethods_%v.tar.gz
 Source-MD5: 4b1f1d41ca1b7a881c2de8d974d0f4e6
 SourceDirectory: pcaMethods
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/pcaMethods/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-pcamethods-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-pcamethods-r.info
@@ -18,25 +18,29 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 1.78.0
+Version: 1.82.0
 Revision: 1
 Description: Collection of PCA methods
 Homepage: https://bioconductor.org/packages/pcaMethods/
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/pcaMethods_%v.tar.gz
-Source-MD5: 053352a2282185c49e0ed314a43c783c
+Source: mirror:custom:pcaMethods_%v.tar.gz
+Source-MD5: 4b1f1d41ca1b7a881c2de8d974d0f4e6
 SourceDirectory: pcaMethods
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/pcaMethods/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	bioconductor-biobase-r%type_pkg[rversion],
 	bioconductor-biocgenerics-r%type_pkg[rversion],
 	cran-mass-r%type_pkg[rversion],
-	cran-rcpp-r%type_pkg[rversion] (>= 0.11.3)
+	cran-rcpp-r%type_pkg[rversion] (>= 0.11.3-1)
 <<
 BuildDepends: <<
 	r-base%type_pkg[rversion]-dev,
-	cran-rcpp-r%type_pkg[rversion]-dev (>= 0.11.3)
+	cran-rcpp-r%type_pkg[rversion]-dev (>= 0.11.3-1)
 <<
 CompileScript: <<
   #!/bin/bash -ev

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-preprocesscore-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-preprocesscore-r.info
@@ -28,7 +28,7 @@ Source: mirror:custom:preprocessCore_%v.tar.gz
 Source-MD5: 0b716d154f14a5dd8bf6de1a35cd7f9c
 SourceDirectory: preprocessCore
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/preprocessCore/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-preprocesscore-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-preprocesscore-r.info
@@ -18,15 +18,19 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 1.48.0
+Version: 1.52.0
 Revision: 1
 Description: Collection of pre-processing functions
 Homepage: https://bioconductor.org/packages/preprocessCore/
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/preprocessCore_%v.tar.gz
-Source-MD5: 243e54533ed3425ecf08f727b217517a
+Source: mirror:custom:preprocessCore_%v.tar.gz
+Source-MD5: 0b716d154f14a5dd8bf6de1a35cd7f9c
 SourceDirectory: preprocessCore
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/preprocessCore/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	(%type_raw[rversion] << 3.6) gcc5-shlibs | (%type_raw[rversion] >= 3.6) gcc9-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-protgenerics-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-protgenerics-r.info
@@ -29,15 +29,19 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2)
-Version: 1.18.0
+Version: 1.22.0
 Revision: 1
 Description: S4 generic functions for proteomics
 Homepage: https://bioconductor.org/packages/ProtGenerics/
 License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/ProtGenerics_%v.tar.gz
-Source-MD5: d02c7a57034ac815d4e806bfb11e778f
+Source: mirror:custom:ProtGenerics_%v.tar.gz
+Source-MD5: 49d614083211df743116d297a3ff80d0
 SourceDirectory: ProtGenerics
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/ProtGenerics/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	bioconductor-biocgenerics-r%type_pkg[rversion] (>= 0.14.0)

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-protgenerics-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-protgenerics-r.info
@@ -39,7 +39,7 @@ Source: mirror:custom:ProtGenerics_%v.tar.gz
 Source-MD5: 49d614083211df743116d297a3ff80d0
 SourceDirectory: ProtGenerics
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/ProtGenerics/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-qvalue-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-qvalue-r.info
@@ -33,15 +33,19 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 2.18.0
+Version: 2.22.0
 Revision: 1
 Description: Q-value estimation
 Homepage: https://bioconductor.org/packages/qvalue/
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/qvalue_%v.tar.gz
-Source-MD5: 9ece11e073a69fb6633042ec67aca2ac
+Source: mirror:custom:qvalue_%v.tar.gz
+Source-MD5: e7d1ed30c0a0bb7364ddb256f06f610d
 SourceDirectory: qvalue
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/qvalue/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	cran-ggplot2-r%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-qvalue-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-qvalue-r.info
@@ -43,7 +43,7 @@ Source: mirror:custom:qvalue_%v.tar.gz
 Source-MD5: e7d1ed30c0a0bb7364ddb256f06f610d
 SourceDirectory: qvalue
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/qvalue/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-rgraphviz-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-rgraphviz-r.info
@@ -33,15 +33,19 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 2.30.0
+Version: 2.34.0
 Revision: 1
 Description: Plotting capabilities for R graph objects
 Homepage: https://bioconductor.org/packages/Rgraphviz/
 License: OSI-Approved
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/Rgraphviz_%v.tar.gz
-Source-MD5: de619ba8e1c382d060c9ab2ebde50d04
+Source: mirror:custom:Rgraphviz_%v.tar.gz
+Source-MD5: b487eef658cc88ebac4e6ee59c36d036
 SourceDirectory: Rgraphviz
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/Rgraphviz/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	bioconductor-graph-r%type_pkg[rversion],

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-rgraphviz-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-rgraphviz-r.info
@@ -43,7 +43,7 @@ Source: mirror:custom:Rgraphviz_%v.tar.gz
 Source-MD5: b487eef658cc88ebac4e6ee59c36d036
 SourceDirectory: Rgraphviz
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/Rgraphviz/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-rhdf5lib-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-rhdf5lib-r.info
@@ -18,15 +18,19 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 1.8.0
+Version: 1.12.0
 Revision: 1
 Description: Hdf5 library for R
 Homepage: https://bioconductor.org/packages/Rhdf5lib/
-License: GPL
+License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/Rhdf5lib_%v.tar.gz
-Source-MD5: 9c56283a0d64a4717025770593e99c2d
+Source: mirror:custom:Rhdf5lib_%v.tar.gz
+Source-MD5: 29c39041513096f802fc0712bb039ad8
 SourceDirectory: Rhdf5lib
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/Rhdf5lib/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	libgettext8-shlibs

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-rhdf5lib-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-rhdf5lib-r.info
@@ -28,7 +28,7 @@ Source: mirror:custom:Rhdf5lib_%v.tar.gz
 Source-MD5: 29c39041513096f802fc0712bb039ad8
 SourceDirectory: Rhdf5lib
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/Rhdf5lib/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-siggenes-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-siggenes-r.info
@@ -33,20 +33,24 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.60.0
+Version: 1.64.0
 Revision: 1
 Description: Multiple testing using SAM and EBAM
 Homepage: https://bioconductor.org/packages/siggenes/
 License: LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/siggenes_%v.tar.gz
-Source-MD5: bdd9c7b381cfa504b7c13d639b2a27a2
+Source: mirror:custom:siggenes_%v.tar.gz
+Source-MD5: 0431e592232677003db6b90d447d7ad6
 SourceDirectory: siggenes
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/siggenes/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	bioconductor-biobase-r%type_pkg[rversion],
 	bioconductor-multtest-r%type_pkg[rversion],
-	cran-scrime-r%type_pkg[rversion] (>= 1.2.5)
+	cran-scrime-r%type_pkg[rversion] (>= 1.2.5-1)
 <<
 BuildDepends: <<
 	r-base%type_pkg[rversion]-dev

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-siggenes-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-siggenes-r.info
@@ -43,7 +43,7 @@ Source: mirror:custom:siggenes_%v.tar.gz
 Source-MD5: 0431e592232677003db6b90d447d7ad6
 SourceDirectory: siggenes
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/siggenes/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-sspa-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-sspa-r.info
@@ -2,19 +2,23 @@ Info2: <<
 
 Package: bioconductor-sspa-r%type_pkg[rversion]
 Type: rversion (3.6)
-Version: 2.26.0
+Version: 2.30.0
 Revision: 1
 Description: General Sample Size and Power Analysis
 Homepage: https://bioconductor.org/packages/SSPA/
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/SSPA_%v.tar.gz
-Source-MD5: 3151d8e660a5d69b4d5bdabf0b3ff6fe
+Source: mirror:custom:SSPA_%v.tar.gz
+Source-MD5: fb0a35358e78b7caefd919c8a799f214
 SourceDirectory: SSPA
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/SSPA/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
-	bioconductor-limma-r%type_pkg[rversion] (>= 3.24.1),
-	bioconductor-qvalue-r%type_pkg[rversion] (>= 2.0.0),
+	bioconductor-limma-r%type_pkg[rversion],
+	bioconductor-qvalue-r%type_pkg[rversion],
 	cran-lattice-r%type_pkg[rversion]
 <<
 BuildDepends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-sspa-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-sspa-r.info
@@ -12,7 +12,7 @@ Source: mirror:custom:SSPA_%v.tar.gz
 Source-MD5: fb0a35358e78b7caefd919c8a799f214
 SourceDirectory: SSPA
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/SSPA/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-vsn-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-vsn-r.info
@@ -28,7 +28,7 @@ Source: mirror:custom:vsn_%v.tar.gz
 Source-MD5: e943f1c5a77d6d1b4427160e00c167f2
 SourceDirectory: vsn
 CustomMirror: <<
-        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Primary: http://bioconductor.org/packages/3.12/bioc/src/contrib/
         Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/vsn/
 <<
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-vsn-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/bioconductor-vsn-r.info
@@ -18,15 +18,19 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4)
-Version: 3.54.0
+Version: 3.58.0
 Revision: 1
 Description: Variance stabilization for microarray data
 Homepage: https://bioconductor.org/packages/vsn/
 License: Artistic
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: http://www.bioconductor.org/packages/3.10/bioc/src/contrib/vsn_%v.tar.gz
-Source-MD5: 4aa21023b404468ae5246826f49c40ce
+Source: mirror:custom:vsn_%v.tar.gz
+Source-MD5: e943f1c5a77d6d1b4427160e00c167f2
 SourceDirectory: vsn
+CustomMirror: <<
+        Primary: https://www.bioconductor.org/packages/release/bioc/src/contrib/
+        Secondary: http://bioconductor.org/packages/3.12/bioc/src/contrib/Archive/vsn/
+<<
 Depends: <<
 	r-base%type_pkg[rversion],
 	bioconductor-affy-r%type_pkg[rversion],


### PR DESCRIPTION
New upstream versions for bioconductor packages. Biocgenerics has a newer version for r >= 4.0.  Fink packages have not yet privided packages for R >= 4.0.  Some packages depend on Biocgenerics (>=0.27.1) so versioned .info files are added.