### PR TITLE
Cppunit upgrade

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libe-book01-dev.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libe-book01-dev.info
@@ -1,17 +1,16 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: libe-book01-dev
-Version: 0.1.2
-Revision: 2
+Version: 0.1.3
+Revision: 1
 Description: Library to import ebook files
 # Mozilla Public License 2.0
 License: OSI-Approved
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 
-#Does not build with boost1.63.
 Depends: libe-book01-shlibs (= %v-%r)
 BuildDepends: <<
-	boost1.58-nopython,
+	boost1.68-nopython,
 	doxygen,
 	fink-package-precedence,
 	libiconv-dev,
@@ -24,12 +23,12 @@ BuildDependsOnly: true
 GCC: 4.0
 
 Source: mirror:sourceforge:libebook/libe-book-%v/libe-book-%v.tar.bz2
-Source-MD5: 6b48eda57914e6343efebc9381027b78
+Source-MD5: 2a2593e1f70d4eecd8517b9e328db0fd
 
 PatchScript: perl -pi -e 's/Requires\.private.*$//' libe-book.pc.in
 
 SetLDFLAGS: -Wl,-dead_strip_dylibs
-SetCPPFLAGS: -I%p/opt/boost-1_58/include
+SetCPPFLAGS: -I%p/opt/boost-1_68/include
 
 ConfigureParams: <<
 	--enable-dependency-tracking \
@@ -42,7 +41,7 @@ CompileScript: <<
 <<
 
 InfoTest: <<
-	TestDepends: cppunit1.12.1
+	TestDepends: cppunit1.15.1
 	TestScript: make check || exit 2
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/libepubgen0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libepubgen0.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: libepubgen0
 Version: 0.0.0
-Revision: 2
+Revision: 3
 Description: EPUB generator library
 # Mozilla Public License 2.0
 License: OSI-Approved
@@ -23,6 +23,7 @@ Source: mirror:sourceforge:libepubgen/libepubgen-%v.tar.bz2
 Source-MD5: 6caa290d664f54ce5d1d9f1d43273cd2
 
 SetCPPFLAGS: -I%p/opt/boost-1_63/include
+SetCXXFLAGS: -std=c++11
 SetLDFLAGS: -L%p/opt/boost-1_63/lib -Wl,-dead_strip_dylibs
 ConfigureParams: <<
 	--docdir='${datarootdir}/doc/%{n}' \
@@ -36,7 +37,7 @@ CompileScript: <<
 <<
 
 InfoTest: <<
-	TestDepends: cppunit1.12.1
+	TestDepends: cppunit1.15.1
 	TestScript: make check || exit 2
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/librvngabw0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/librvngabw0.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: librvngabw0
-Version: 0.0.1
+Version: 0.0.3
 Revision: 1
 Description: AbiWord v3 export library
 # Mozilla Public License 2.0 and LGPL 2.1
@@ -18,7 +18,7 @@ BuildDependsOnly: true
 GCC: 4.0
 
 Source: mirror:sourceforge:librvngabw/librvngabw-%v.tar.bz2
-Source-MD5: 2d66fbce0ce60b243020f19c57ce9e93
+Source-MD5: fa1b517b2aa5cedebf60f2d57573209d
 
 SetLDFLAGS: -Wl,-dead_strip_dylibs
 ConfigureParams: <<
@@ -33,7 +33,7 @@ CompileScript: <<
 <<
 
 InfoTest: <<
-	TestDepends: cppunit1.12.1
+	TestDepends: cppunit1.15.1
 	TestConfigureParams: --enable-test
 	TestScript: make check || exit 2
 <<


### PR DESCRIPTION
Bump packages using cppunit1.12.1 to cppunit1.15.1.  cppunit1.12.1 doesn't build on Big Sur.

After this, `libetonyek` is the only package left using the old cppunit1.12.1, and that's failing tests with either version of cppunit. There's newer `libetonyek`, but it requires an upgrade to a new libN of `mdds`.