### PR TITLE
cmake 3.19.1 - new upstream

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/cmake.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/cmake.info
@@ -1,8 +1,8 @@
 Package: cmake
-Version: 3.16.2
+Version: 3.19.1
 Revision: 1
-Source: http://www.cmake.org/files/v3.16/%n-%v.tar.gz
-Source-MD5: 78f418efd94f9c3364559d7f5d03c7b9
+Source: https://github.com/Kitware/CMake/releases/download/v%v/%n-%v.tar.gz
+Source-MD5: f2969ca3cf90a647c6c9f55b949f6cc1
 License: BSD
 BuildDepends: libidn2.0-dev
 Depends: libidn2.0-shlibs
@@ -37,4 +37,4 @@ DescPort: <<
  Earlier versions by Sylvain Cuaz.
 <<
 Maintainer: Martin Costabel <costabel@wanadoo.fr>
-Homepage: http://www.cmake.org
+Homepage: https://cmake.org


### PR DESCRIPTION
New upstream version of cmake. Same patches as before. Updated source URL to Github, and website URL to https. Compiles with "-m" using xcode 12.3 on 10.15.7 and appears to work correctly. Maintainer is @costabel.