### PR TITLE
Libgeotiff2 update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/libgeotiff2.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/libgeotiff2.info
@@ -1,13 +1,13 @@
 Info2: <<
 Package: libgeotiff2
-Version: 1.4.1
-Revision: 2
+Version: 1.4.3
+Revision: 1
 Description: GeoTIFF handling library
 License: BSD
 Homepage: http://trac.osgeo.org/geotiff/
 Maintainer: BABA Yoshihiko <babayoshihiko@mac.com>
-Source: ftp://ftp.remotesensing.org/pub/geotiff/libgeotiff/libgeotiff-%v.tar.gz
-Source-MD5: 48bdf817e6e7a37671cc1f41b01e10fc
+Source: http://download.osgeo.org/geotiff/libgeotiff/libgeotiff-%v.tar.gz
+Source-MD5: 234bd119b1f2334d44a0ceb0a8e66496
 
 Depends: <<
   %n-shlibs (= %v-%r),
@@ -54,7 +54,7 @@ SplitOff: <<
     share/epsg_csv
   <<
   Shlibs: <<
-    %p/lib/libgeotiff.2.dylib 4.0.0 %n (>= 1.4.0-1)
+    %p/lib/libgeotiff.2.dylib 5.0.0 %n (>= 1.4.3-1)
   <<
   Description: Shared libraries for libgeotiff package
   DocFiles: AUTHORS COPYING ChangeLog INSTALL LICENSE NEWS README README_BIN

--- a/10.9-libcxx/stable/main/finkinfo/graphics/libgeotiff2.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/libgeotiff2.info
@@ -18,8 +18,8 @@ BuildDepends: <<
   flag-sort,
   libjpeg9, libtiff5, libproj9
 <<
-Conflicts: libgeotiff
-Replaces: libgeotiff
+Conflicts: libgeotiff, libgeotiff2, libgeotiff5
+Replaces: libgeotiff, libgeotiff2, libgeotiff5
 BuildDependsOnly: True
 
 SetCC: flag-sort -r gcc


### PR DESCRIPTION
update to libgeotiff2 v1.4.3
This is the last release for the libN=2 series. Latest v1.6.0 is libN=5
Tested to build on 10.13 and 10.15/Xcode12.2