### PR TITLE
Spatialite update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/libspatialite2-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/libspatialite2-shlibs.info
@@ -1,7 +1,7 @@
 Info3: <<
-Package: libspatialite2
+Package: libspatialite2-shlibs
 Version: 3.0.1
-Revision: 7
+Revision: 8
 Description: GIS extensions and tools to SQLite
 License: OSI-Approved
 Homepage: http://www.gaia-gis.it/spatialite/
@@ -17,16 +17,18 @@ BuildConflicts: <<
 	libspatialite7
 <<
 Conflicts: <<
-	libspatialite5,
-	libspatialite7
+	libspatialite2 (<< 3.0.1-8)
 <<
 Replaces: <<
-	libspatialite5,
-	libspatialite7
+	libspatialite2 (<< 3.0.1-8)
 <<
 
 Depends: <<
-  %n-shlibs (=%v-%r)
+    libiconv,
+    sqlite3-shlibs,
+    libproj9-shlibs,
+    libgeos3.5.0-shlibs,
+    libfreexl1-shlibs
 <<
 BuildDepends: <<
   fink (>= 0.32), 
@@ -48,7 +50,8 @@ SetCPPFLAGS: -Os
 SetLDFLAGS: -lcharset -L%p/opt/libgeos3.5.0/lib
 ConfigureParams: <<
 	--target=macosx \
-	--enable-dependency-tracking
+	--enable-dependency-tracking \
+	--disable-static
 <<
 
 CompileScript: <<
@@ -71,27 +74,14 @@ InstallScript: <<
 #!/bin/sh -xe
   # Install Libraries
   make install prefix=%i
+
+  rm -r %i/include
+  rm -r %i/lib/pkgconfig
+  rm %i/lib/libspatialite.{dylib,la}
 <<
 DocFiles: AUTHORS COPYING INSTALL README
-
-SplitOff: <<
-  Package: %N-shlibs
-  Description: Shared libraries for %N package
-  Depends: <<
-    libiconv,
-    sqlite3-shlibs,
-    libproj9-shlibs,
-    libgeos3.5.0-shlibs,
-    libfreexl1-shlibs
-  <<  
-  Files: <<
-    lib/libspatialite.2.dylib
-  <<
-  Shlibs: <<
-    %p/lib/libspatialite.2.dylib  5.0.0 %n (>= 3.0.1-1)
-  <<
-  DocFiles: AUTHORS COPYING INSTALL README
-# End of SplitOff
+Shlibs: <<
+  %p/lib/libspatialite.2.dylib  5.0.0 %n (>= 3.0.1-1)
 <<
 
 # End of Info3

--- a/10.9-libcxx/stable/main/finkinfo/database/libspatialite2-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/libspatialite2-shlibs.info
@@ -1,7 +1,7 @@
 Info3: <<
 Package: libspatialite2-shlibs
 Version: 3.0.1
-Revision: 8
+Revision: 9
 Description: GIS extensions and tools to SQLite
 License: OSI-Approved
 Homepage: http://www.gaia-gis.it/spatialite/
@@ -10,11 +10,6 @@ DescDetail: <<
   The SpatiaLite extension enables SQLite to support 
 spatial data too [aka GEOMETRY], in a way conformant 
 to OpenGIS specifications.
-<<
-BuildConflicts: <<
-	libspatialite2,
-	libspatialite5,
-	libspatialite7
 <<
 Conflicts: <<
 	libspatialite2 (<< 3.0.1-8)
@@ -26,8 +21,8 @@ Replaces: <<
 Depends: <<
     libiconv,
     sqlite3-shlibs,
-    libproj9-shlibs,
-    libgeos3.5.0-shlibs,
+    libproj19-shlibs,
+    libgeos3.6.1-shlibs,
     libfreexl1-shlibs
 <<
 BuildDepends: <<
@@ -35,7 +30,7 @@ BuildDepends: <<
   fink-package-precedence,
   libiconv-dev,
   sqlite3-dev,
-  libproj9, libgeos3.5.0,
+  libproj19, libgeos3.6.1,
   libfreexl1-dev
 <<
 BuildDependsOnly: True
@@ -45,9 +40,8 @@ BuildDependsOnly: True
 Source: http://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-%v.tar.gz
 Source-MD5: 450d1a0d9da1bd9f770b7db3f2509f69
 
-SetCFLAGS: -I%p/opt/libgeos3.5.0/include 
-SetCPPFLAGS: -Os
-SetLDFLAGS: -lcharset -L%p/opt/libgeos3.5.0/lib
+SetCPPFLAGS: -Os -I%p/opt/libgeos3.6.1/include -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+SetLDFLAGS: -lcharset -L%p/opt/libgeos3.6.1/lib
 ConfigureParams: <<
 	--target=macosx \
 	--enable-dependency-tracking \

--- a/10.9-libcxx/stable/main/finkinfo/database/libspatialite2.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/libspatialite2.info
@@ -1,8 +1,8 @@
 Info3: <<
 Package: libspatialite2
 Version: 3.0.1
-Revision: 6
-Description: OBSOLETE use 'libspatialite7' instead
+Revision: 7
+Description: GIS extensions and tools to SQLite
 License: OSI-Approved
 Homepage: http://www.gaia-gis.it/spatialite/
 Maintainer: BABA Yoshihiko <babayoshihiko@mac.com>
@@ -28,7 +28,6 @@ Replaces: <<
 Depends: <<
   %n-shlibs (=%v-%r)
 <<
-RuntimeDepends: fink-obsolete-packages
 BuildDepends: <<
   fink (>= 0.32), 
   fink-package-precedence,
@@ -59,10 +58,10 @@ CompileScript: <<
 
   # Set up Libraries
   ./configure %c
-
-  perl -pi -e "s|SUBDIRS = src test examples|SUBDIRS = src test|" Makefile
   
   # 4.0.0
+  perl -pi -e "s|SUBDIRS = src test examples|SUBDIRS = src test|" Makefile
+  
   make
   fink-package-precedence --prohibit-bdep=%N .
 <<
@@ -77,7 +76,7 @@ DocFiles: AUTHORS COPYING INSTALL README
 
 SplitOff: <<
   Package: %N-shlibs
-  Description: OBSOLETE use 'libspatialite7-shlibs' instead
+  Description: Shared libraries for %N package
   Depends: <<
     libiconv,
     sqlite3-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/database/libspatialite5-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/libspatialite5-shlibs.info
@@ -1,7 +1,7 @@
 Info3: <<
-Package: libspatialite5
+Package: libspatialite5-shlibs
 Version: 4.1.1
-Revision: 5
+Revision: 6
 Description: GIS extensions and tools to SQLite
 License: OSI-Approved
 Homepage: http://www.gaia-gis.it/spatialite/
@@ -11,29 +11,26 @@ DescDetail: <<
 spatial data too [aka GEOMETRY], in a way conformant 
 to OpenGIS specifications.
 <<
-BuildConflicts: <<
-	libspatialite2,
-	libspatialite5,
-	libspatialite7
-<<
 Conflicts: <<
-	libspatialite2,
-	libspatialite7
+	libspatialite5 (<< 4.1.1-6)
 <<
 Replaces: <<
-	libspatialite2,
-	libspatialite7
+	libspatialite5 (<< 4.1.1-6)
 <<
 
 Depends: <<
-  %n-shlibs (=%v-%r)
+    libiconv,
+    sqlite3-shlibs,
+    libproj19-shlibs,
+    libgeos3.6.1-shlibs,
+    libfreexl1-shlibs
 <<
 BuildDepends: <<
   fink (>= 0.28), 
   fink-package-precedence,
   libiconv-dev,
   sqlite3-dev,
-  libproj9, libgeos3.5.0,
+  libproj19, libgeos3.6.1,
   libfreexl1-dev
 <<
 BuildDependsOnly: True
@@ -43,12 +40,20 @@ BuildDependsOnly: True
 Source: http://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-%v.tar.gz
 Source-MD5: 356e0b18de0d382e27da578dc227a7b0
 
-SetCPPFLAGS: -Os
+# Make sure local -I come before external (avoids accidentally seeing
+# already-installed incompatible versions of this lib). Also use
+# direct linking against builddir libs rather than relying on -L
+# (again avoid external mix-in).
+PatchFile: %n.patch
+PatchFile-MD5: 03424eaffa04c0b76337a1a4ecb0ce73
+
+SetCPPFLAGS: -Os -I%p/opt/libgeos3.6.1/include -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H
 SetLDFLAGS: -lcharset
 ConfigureParams: <<
 	--target=macosx \
-	--with-geosconfig=%p/opt/libgeos3.5.0/bin/geos-config \
-	--enable-dependency-tracking
+	--with-geosconfig=%p/opt/libgeos3.6.1/bin/geos-config \
+	--enable-dependency-tracking \
+	--disable-static
 <<
 
 CompileScript: <<
@@ -60,7 +65,7 @@ CompileScript: <<
   ./configure %c
   
   # 4.1.0
-  perl -pi -e "s|SUBDIRS = src test|SUBDIRS = src test #|g" Makefile
+  perl -pi -e "s|SUBDIRS = src test examples|SUBDIRS = src test #|g" Makefile
   
   make
   fink-package-precedence --prohibit-bdep=%N .
@@ -71,27 +76,14 @@ InstallScript: <<
 #!/bin/sh -xe
   # Install Libraries
   make install prefix=%i
+
+  rm -r %i/include
+  rm -r %i/lib/pkgconfig
+  rm %i/lib/libspatialite.{dylib,la}
 <<
 DocFiles: AUTHORS COPYING INSTALL README
-
-SplitOff: <<
-  Package: %N-shlibs
-  Description: Shared libraries for %N package
-  Depends: <<
-    libiconv,
-    sqlite3-shlibs,
-    libproj9-shlibs,
-    libgeos3.5.0-shlibs,
-    libfreexl1-shlibs
-  <<  
-  Files: <<
-    lib/libspatialite.5.dylib
-  <<
-  Shlibs: <<
-    %p/lib/libspatialite.5.dylib  7.0.0 %n (>= 4.1.0-1)
-  <<
-  DocFiles: AUTHORS COPYING INSTALL README
-# End of SplitOff
+Shlibs: <<
+  %p/lib/libspatialite.5.dylib  7.0.0 %n (>= 4.1.0-1)
 <<
 
 # End of Info3

--- a/10.9-libcxx/stable/main/finkinfo/database/libspatialite5-shlibs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/database/libspatialite5-shlibs.patch
@@ -1,0 +1,66 @@
+diff -Nurd -x'*~' libspatialite-4.1.1.orig/examples/Makefile.in libspatialite-4.1.1/examples/Makefile.in
+--- libspatialite-4.1.1.orig/examples/Makefile.in	2013-06-29 02:53:15.000000000 -0400
++++ libspatialite-4.1.1/examples/Makefile.in	2020-12-20 14:58:40.000000000 -0500
+@@ -238,8 +238,8 @@
+ top_build_prefix = @top_build_prefix@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+-AM_CFLAGS = -I@srcdir@/../src/headers 
+-AM_LDFLAGS = -L../src -lspatialite -lm $(GCOV_FLAGS)
++INCLUDES = -I@srcdir@/../src/headers 
++AM_LDFLAGS = ../src/libspatialite.la -lm $(GCOV_FLAGS)
+ LDADD = @LIBXML2_LIBS@
+ MOSTLYCLEANFILES = *.gcna *.gcno *.gcda
+ EXTRA_DIST = examples.doxy
+diff -Nurd -x'*~' libspatialite-4.1.1.orig/src/gaiageo/Makefile.in libspatialite-4.1.1/src/gaiageo/Makefile.in
+--- libspatialite-4.1.1.orig/src/gaiageo/Makefile.in	2013-06-29 02:53:15.000000000 -0400
++++ libspatialite-4.1.1/src/gaiageo/Makefile.in	2020-12-20 14:50:06.000000000 -0500
+@@ -262,8 +262,8 @@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+ SUBDIRS = flex lemon
+-INCLUDES = @CFLAGS@ @GEOS_CFLAGS@ @LIBXML2_CFLAGS@ \
+-	-I$(top_srcdir)/src/headers
++INCLUDES = @CFLAGS@ \
++	-I$(top_srcdir)/src/headers @GEOS_CFLAGS@ @LIBXML2_CFLAGS@
+ noinst_LTLIBRARIES = libgaiageo.la
+ libgaiageo_la_SOURCES = gg_advanced.c \
+ 	gg_endian.c \
+diff -Nurd -x'*~' libspatialite-4.1.1.orig/src/spatialite/Makefile.in libspatialite-4.1.1/src/spatialite/Makefile.in
+--- libspatialite-4.1.1.orig/src/spatialite/Makefile.in	2013-06-29 02:53:15.000000000 -0400
++++ libspatialite-4.1.1/src/spatialite/Makefile.in	2020-12-20 14:50:28.000000000 -0500
+@@ -229,8 +229,8 @@
+ top_build_prefix = @top_build_prefix@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+-INCLUDES = @CFLAGS@ @GEOS_CFLAGS@ @LIBXML2_CFLAGS@ \
+-	-I$(top_srcdir)/src/headers
++INCLUDES = @CFLAGS@ \
++	-I$(top_srcdir)/src/headers @GEOS_CFLAGS@ @LIBXML2_CFLAGS@
+ noinst_LTLIBRARIES = libsplite.la
+ libsplite_la_SOURCES = mbrcache.c \
+ 	spatialite.c \
+diff -Nurd -x'*~' libspatialite-4.1.1.orig/src/wfs/Makefile.in libspatialite-4.1.1/src/wfs/Makefile.in
+--- libspatialite-4.1.1.orig/src/wfs/Makefile.in	2013-06-29 02:53:15.000000000 -0400
++++ libspatialite-4.1.1/src/wfs/Makefile.in	2020-12-20 14:49:24.000000000 -0500
+@@ -219,7 +219,7 @@
+ top_build_prefix = @top_build_prefix@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+-INCLUDES = @CFLAGS@ @LIBXML2_CFLAGS@ -I$(top_srcdir)/src/headers
++INCLUDES = @CFLAGS@ -I$(top_srcdir)/src/headers @LIBXML2_CFLAGS@
+ noinst_LTLIBRARIES = libwfs.la
+ libwfs_la_SOURCES = wfs_in.c
+ MOSTLYCLEANFILES = *.gcna *.gcno *.gcda
+diff -Nurd -x'*~' libspatialite-4.1.1.orig/test/Makefile.in libspatialite-4.1.1/test/Makefile.in
+--- libspatialite-4.1.1.orig/test/Makefile.in	2013-06-29 02:53:15.000000000 -0400
++++ libspatialite-4.1.1/test/Makefile.in	2020-12-20 14:58:55.000000000 -0500
+@@ -695,7 +695,7 @@
+ top_srcdir = @top_srcdir@
+ INCLUDES = @CFLAGS@ @GEOS_CFLAGS@ @LIBXML2_CFLAGS@
+ AM_CFLAGS = -I@srcdir@/../src/headers -I@srcdir@
+-AM_LDFLAGS = -L../src -lspatialite -lm $(GCOV_FLAGS)
++AM_LDFLAGS = ../src/libspatialite.la -lm $(GCOV_FLAGS)
+ TESTS = $(check_PROGRAMS)
+ MOSTLYCLEANFILES = *.gcna *.gcno *.gcda
+ EXTRA_DIST = asprintf4win.h \

--- a/10.9-libcxx/stable/main/finkinfo/database/spatialite-gui.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/spatialite-gui.info
@@ -1,7 +1,7 @@
 Info3: <<
 Package: spatialite-gui
 Version: 1.7.1
-Revision: 1
+Revision: 2
 Description: User friendly GUI tool to SpatiaLite
 License: GPL
 Homepage: http://www.gaia-gis.it/spatialite
@@ -9,18 +9,26 @@ Maintainer: BABA Yoshihiko <babayoshihiko@mac.com>
 DescUsage: type `spatialite-gui' in Terminal
 
 Depends: <<
-  libspatialite5-shlibs, librasterlite2-shlibs,
+  libspatialite7-shlibs,
+  libfreexl1-shlibs,
   libgaiagraphics1-shlibs,
-  libgettext8-shlibs,
-  libgeos3.4.2-shlibs,
+  libgeos3.6.1-shlibs,
+  libproj19-shlibs,
+  libxml2-shlibs (>= 2.9.1-1),
+  sqlite3-shlibs,
   wxcocoa295-shlibs
 <<
 BuildDepends: <<
   fink (>= 0.28),
-  libspatialite5, librasterlite2,
+  fink-package-precedence,
+  libspatialite7,
+  libfreexl1-dev,
   libgaiagraphics1,
-  libgettext8-dev,
-  libgeos3.4.2,
+  libgeos3.6.1,
+  libproj19,
+  libxml2 (>= 2.9.1-1),
+  pkgconfig,
+  sqlite3,
   wxcocoa295
 <<
 
@@ -29,19 +37,27 @@ BuildDepends: <<
 Source: http://www.gaia-gis.it/gaia-sins/spatialite_gui-%v.tar.gz
 Source-MD5: c917f40810607784528b4db58cd36efb
 
-#PatchFile: %n.patch
-#PatchFile-MD5: 1efaaf631abaff66fef1ca7389739322
-#PatchScript: sed 's|@PREFIX@|%p|g' <%{PatchFile} | patch -p1
+# Includes:
+#   * Alternate fix for missing sqlite3 test (presume that libsqlite3
+#     exists). Will fail later if not, but easier to do it this way
+#     than the whole AC_CHECK_LIB block). See:
+#     Debian spatialite-gui-1.7.1-5 03_link_sqlite3.patch
+#   * Fix underlinking against wx libs. See:
+#     Debian spatialite-gui-1.7.1-5: 04-wx3.0-compat.patch
+PatchFile: %n.patch
+PatchFile-MD5: 9ff97cf51e3c3944b4a7aae725e7a4c4
 
-SetCFLAGS: -I%p/opt/libgeos3.4.2/include
-SetLDFLAGS: -L%p/opt/libgeos3.4.2/lib -lwx_osx_cocoau_aui-2.9 -lxml2 -undefined suppress -flat_namespace
-ConfigureParams: --with-geosconfig=%p/opt/libgeos3.4.2/bin/geos-config
+GCC: 4.0
+SetCPPFLAGS: -I%p/opt/libgeos3.6.1/include -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+SetLDFLAGS: -L%p/opt/libgeos3.6.1/lib
+ConfigureParams: --with-geosconfig=%p/opt/libgeos3.6.1/bin/geos-config
 
 CompileScript: <<
 #!/bin/sh -xe
   ./configure %c
   make
   # make -f Makefile-static-MacOsX
+  fink-package-precedence .
 <<
 
 # Install Phase.

--- a/10.9-libcxx/stable/main/finkinfo/database/spatialite-gui.patch
+++ b/10.9-libcxx/stable/main/finkinfo/database/spatialite-gui.patch
@@ -1,0 +1,20 @@
+diff -Nurd -x'*~' spatialite_gui-1.7.1.orig/configure spatialite_gui-1.7.1/configure
+--- spatialite_gui-1.7.1.orig/configure	2013-06-29 04:29:11.000000000 -0400
++++ spatialite_gui-1.7.1/configure	2020-12-20 13:57:49.000000000 -0500
+@@ -15543,7 +15543,7 @@
+ fi
+ CXXFLAGS="$(wx-config --cxxflags)"
+ AM_CXXFLAGS="$(wx-config --cxxflags)"
+-WX_LIBS="$(wx-config --libs)"
++WX_LIBS="$(wx-config --libs std,aui)"
+ 
+ 
+ # Checks for header files.
+@@ -16271,6 +16271,7 @@
+ fi
+ done
+ 
++LIBS="-lsqlite3 $LIBS"
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pj_init_plus in -lproj" >&5
+ $as_echo_n "checking for pj_init_plus in -lproj... " >&6; }


### PR DESCRIPTION
This set of commits cleans up the builds of libspatialite2 and libspatialite5, converts the remaining users of 5 to use the latest (7), and fixes a bunch of build flaws along the way. With 2 and 5 both no longer used, they are converted to only their -shlibs package.
