### PR TITLE
new version: mupdf

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/text/mupdf.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/mupdf.info
@@ -44,13 +44,16 @@ PatchScript: <<
 	# Make extra sure not to see bundled libs that we instead want
 	# to use as externals.
 	mv thirdparty ../thirdparty_HIDDEN
+	# Note: need to hack around a darwin 'ar' incompatibility when
+	# *all* support libs are external. See:
+	# https://bugs.ghostscript.com/show_bug.cgi?id=703328
 <<
 CompileScript: <<
-	make verbose=yes USE_SYSTEM_LIBS=yes THIRD_LIB= prefix=%p
+	make verbose=yes USE_SYSTEM_LIBS=yes prefix=%p
 	fink-package-precedence --depfile-ext='\.d' .
 <<
 InstallScript: <<
-	make verbose=yes USE_SYSTEM_LIBS=yes THIRD_LIB= prefix=%p DESTDIR=%d install
+	make verbose=yes USE_SYSTEM_LIBS=yes prefix=%p DESTDIR=%d install
 	ln -s mupdf-x11 %i/bin/mupdf
 <<
 SplitOff: <<

--- a/10.9-libcxx/stable/main/finkinfo/text/mupdf.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/mupdf.info
@@ -1,9 +1,10 @@
 Package: mupdf
 Version: 1.18.0
-Revision: 1
+Revision: 2
 
 Depends: <<
 	freetype219-shlibs (>= 2.6-1),
+	lcms2mt2-shlibs,
 	libcurl4-shlibs,
 	libgumbo1-shlibs,
 	libharfbuzz0-shlibs,
@@ -18,6 +19,7 @@ BuildDepends: <<
 	fink-package-precedence,
 	flag-sort,
 	freetype219 (>= 2.6-1),
+	lcms2mt2 (>= 2.10-2),
 	libcurl4,
 	libgumbo1-dev,
 	libharfbuzz0-dev,
@@ -35,25 +37,21 @@ Source-MD5: 3135391b027cdbedf915db1787b4ea05
 License: OSI-Approved
 
 PatchFile: %n.patch
-PatchFile-MD5: 5ce5846d8d695f410e99da57ea15a104
+PatchFile-MD5: 67acfdbddb32bc976af4302a17e4a487
 PatchScript: <<
 	%{default_script}
 
 	# Make extra sure not to see bundled libs that we instead want
 	# to use as externals.
 	mv thirdparty ../thirdparty_HIDDEN
-	mkdir thirdparty
-	mv ../thirdparty_HIDDEN/lcms2 thirdparty
 <<
 CompileScript: <<
-	make verbose=yes USE_SYSTEM_LIBS=yes prefix=%p
+	make verbose=yes USE_SYSTEM_LIBS=yes THIRD_LIB= prefix=%p
 	fink-package-precedence --depfile-ext='\.d' .
 <<
 InstallScript: <<
-	make verbose=yes USE_SYSTEM_LIBS=yes prefix=%p DESTDIR=%d install
+	make verbose=yes USE_SYSTEM_LIBS=yes THIRD_LIB= prefix=%p DESTDIR=%d install
 	ln -s mupdf-x11 %i/bin/mupdf
-	mkdir -p %i/share/doc/%n/lcms2-fork
-	install -m644 thirdparty/lcms2/{AUTHORS,COPYING,ChangeLog,README.1ST,doc/WhyThisFork.txt} %i/share/doc/%n/lcms2-fork
 <<
 SplitOff: <<
 	Package: %N-dev
@@ -75,6 +73,10 @@ DescPackaging: <<
 	dmacks: Build system mixes included and externally supplied
 	flavors of several libs, which gives an unreliable build and
 	unpredictable result. Use externals exclusively.
+
+	dmacks: Hack the heck out of lcms external support (slightly
+	higher BDep of lcms2mt2 to avoid a broken lcms2mt.pc that was
+	transiently in fink)
 <<
 Description: Lightweight PDF and XPS viewer
 Maintainer: Stefan Bruda <fink@bruda.ca>

--- a/10.9-libcxx/stable/main/finkinfo/text/mupdf.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/mupdf.info
@@ -1,64 +1,67 @@
 Package: mupdf
-# OPENSSL110 FTBFS; upstream reportedly fixes it https://bugs.ghostscript.com/show_bug.cgi?id=697494
-# debian omits openssl, loses a feature https://www.mail-archive.com/arch-dev-public@archlinux.org/msg25102.html
-Version: 1.6
-Revision: 3
+Version: 1.18.0
+Revision: 1
 
 Depends: <<
 	freetype219-shlibs (>= 2.6-1),
 	libcurl4-shlibs,
+	libgumbo1-shlibs,
+	libharfbuzz0-shlibs,
 	libjbig2dec-shlibs,
 	libjpeg9-shlibs,
+	libmujs1-shlibs,
 	libopenjp2.7-shlibs,
-	openssl100-shlibs,
 	x11
 <<
 BuildDepends: <<
+	fink (>= 0.32),
 	fink-package-precedence,
+	flag-sort,
 	freetype219 (>= 2.6-1),
 	libcurl4,
+	libgumbo1-dev,
+	libharfbuzz0-dev,
 	libjbig2dec-dev,
 	libjpeg9,
+	libmujs1-dev,
 	libopenjp2.7,
-	openssl100-dev,
 	pkgconfig,
 	x11-dev
 <<
 
-Source: http://www.mupdf.com/downloads/%n-%v-source.tar.gz
-Source-MD5: 8d69db41ae9e0b6807b76bb6ed70dc2f
-License: GPL/OpenSSL
+Source: http://www.mupdf.com/downloads/archive/%n-%v-source.tar.xz
+Source-MD5: 3135391b027cdbedf915db1787b4ea05
+# AGPL is GPL-derived but not exactly GPL?
+License: OSI-Approved
 
 PatchFile: %n.patch
-PatchFile-MD5: bb61ab9b4e1340a9e22a388ea22186c4
+PatchFile-MD5: 5ce5846d8d695f410e99da57ea15a104
 PatchScript: <<
 	%{default_script}
-	sed -i~ -e 's,/usr/local,%p,' Makefile
 
-	# autodetect what's available instead of hardcoding paths (we
-	# do have pkg-config, despite what Makerules says)...
-	sed -i~ -e 's,OS:Darwin=MACOS,OS:Darwin=Linux,' Makerules
-	# ...but scrap actual linux-ish details
-	sed -i~ -e 's,-lrt,,' Makerules
-	# build system defaults to bundled libs if it autodetects the
-	# bundled ones present, so hide them to enable system ones
-	mv thirdparty thirdparty_HIDDEN
+	# Make extra sure not to see bundled libs that we instead want
+	# to use as externals.
+	mv thirdparty ../thirdparty_HIDDEN
+	mkdir thirdparty
+	mv ../thirdparty_HIDDEN/lcms2 thirdparty
 <<
 CompileScript: <<
-	make XCFLAGS=-MD verbose=yes
+	make verbose=yes USE_SYSTEM_LIBS=yes prefix=%p
 	fink-package-precedence --depfile-ext='\.d' .
 <<
 InstallScript: <<
-	make install DESTDIR=%d XCFLAGS=-MD
-	cd %i/bin && ln -s mupdf-x11 mupdf
+	make verbose=yes USE_SYSTEM_LIBS=yes prefix=%p DESTDIR=%d install
+	ln -s mupdf-x11 %i/bin/mupdf
+	mkdir -p %i/share/doc/%n/lcms2-fork
+	install -m644 thirdparty/lcms2/{AUTHORS,COPYING,ChangeLog,README.1ST,doc/WhyThisFork.txt} %i/share/doc/%n/lcms2-fork
 <<
 SplitOff: <<
 	Package: %N-dev
 	Depends: %N
 	BuildDependsOnly: true
 	Files: <<
-	        include/mupdf/*
-	        lib/libmupdf.a
+	        include
+	        lib
 	<<
 	DocFiles: COPYING README
 <<
@@ -71,9 +74,7 @@ DescPackaging: <<
 
 	dmacks: Build system mixes included and externally supplied
 	flavors of several libs, which gives an unreliable build and
-	unpredictable result. Use externals exclusively, with debian
-	patch for openjp2.7:
-	http://sources.debian.net/patches/patch/mupdf/1.7a-1/0003-Fix-build-with-libopenjp2.patch/
+	unpredictable result. Use externals exclusively.
 <<
 Description: Lightweight PDF and XPS viewer
 Maintainer: Stefan Bruda <fink@bruda.ca>

--- a/10.9-libcxx/stable/main/finkinfo/text/mupdf.patch
+++ b/10.9-libcxx/stable/main/finkinfo/text/mupdf.patch
@@ -1,6 +1,30 @@
+diff -Nurd -x'*~' mupdf-1.18.0-source.orig/Makefile mupdf-1.18.0-source/Makefile
+--- mupdf-1.18.0-source.orig/Makefile	2020-10-07 06:35:03.000000000 -0400
++++ mupdf-1.18.0-source/Makefile	2021-01-04 05:15:29.000000000 -0500
+@@ -215,7 +215,11 @@
+ $(MUPDF_LIB) : $(MUPDF_OBJ) $(THIRD_OBJ) $(THREAD_OBJ) $(PKCS7_OBJ)
+ else
+ MUPDF_LIB = $(OUT)/libmupdf.a
++ifneq ($(strip $(THIRD_OBJ)),)
++# only declare this lib to exist if it will have any .o in it
++# (OS X 'ar' cannot create empty archives)
+ THIRD_LIB = $(OUT)/libmupdf-third.a
++endif
+ THREAD_LIB = $(OUT)/libmupdf-threads.a
+ PKCS7_LIB = $(OUT)/libmupdf-pkcs7.a
+ 
 diff -Nurd -x'*~' mupdf-1.18.0-source.orig/Makerules mupdf-1.18.0-source/Makerules
 --- mupdf-1.18.0-source.orig/Makerules	2020-10-07 06:35:03.000000000 -0400
-+++ mupdf-1.18.0-source/Makerules	2020-12-22 15:58:22.000000000 -0500
++++ mupdf-1.18.0-source/Makerules	2021-01-04 04:43:23.000000000 -0500
+@@ -90,7 +90,7 @@
+ SYS_HARFBUZZ_LIBS := -lharfbuzz
+ SYS_JBIG2DEC_LIBS := -ljbig2dec
+ SYS_JPEGXR_LIBS := -ljpegxr
+-SYS_LCMS2_LIBS := -llcms2
++SYS_LCMS2_LIBS := -llcms2mt
+ SYS_LIBJPEG_LIBS := -ljpeg
+ SYS_MUJS_LIBS := -lmujs
+ SYS_OPENJPEG_LIBS := -lopenjp2
 @@ -110,13 +110,11 @@
    HAVE_GLUT := yes
    SYS_GLUT_CFLAGS := -Wno-deprecated-declarations
@@ -16,6 +40,19 @@ diff -Nurd -x'*~' mupdf-1.18.0-source.orig/Makerules mupdf-1.18.0-source/Makerul
  
    ifeq ($(shell pkg-config --exists freetype2 && echo yes),yes)
  	SYS_FREETYPE_CFLAGS := $(shell pkg-config --cflags freetype2)
+@@ -130,9 +128,9 @@
+ 	SYS_HARFBUZZ_CFLAGS := $(shell pkg-config --cflags harfbuzz)
+ 	SYS_HARFBUZZ_LIBS := $(shell pkg-config --libs harfbuzz)
+   endif
+-  ifeq ($(shell pkg-config --exists lcms2 && echo yes),yes)
+-	SYS_LCMS2_CFLAGS := $(shell pkg-config --cflags lcms2)
+-	SYS_LCMS2_LIBS := $(shell pkg-config --libs lcms2)
++  ifeq ($(shell pkg-config --exists lcms2mt && echo yes),yes)
++	SYS_LCMS2_CFLAGS := $(shell pkg-config --cflags lcms2mt)
++	SYS_LCMS2_LIBS := $(shell pkg-config --libs lcms2mt)
+   endif
+   ifeq ($(shell pkg-config --exists libjpeg && echo yes),yes)
+ 	SYS_LIBJPEG_CFLAGS := $(shell pkg-config --cflags libjpeg)
 @@ -165,11 +163,6 @@
  	SYS_CURL_LIBS := $(shell pkg-config --libs libcurl)
    endif
@@ -30,15 +67,27 @@ diff -Nurd -x'*~' mupdf-1.18.0-source.orig/Makerules mupdf-1.18.0-source/Makerul
    ifeq ($(HAVE_X11),yes)
 diff -Nurd -x'*~' mupdf-1.18.0-source.orig/Makethird mupdf-1.18.0-source/Makethird
 --- mupdf-1.18.0-source.orig/Makethird	2020-10-07 06:35:03.000000000 -0400
-+++ mupdf-1.18.0-source/Makethird	2020-12-22 15:59:06.000000000 -0500
-@@ -8,7 +8,7 @@
++++ mupdf-1.18.0-source/Makethird	2021-01-04 04:34:51.000000000 -0500
+@@ -6,9 +6,9 @@
+   USE_SYSTEM_HARFBUZZ := yes
+   USE_SYSTEM_JBIG2DEC := yes
    USE_SYSTEM_JPEGXR := no # not available
-   USE_SYSTEM_LCMS2 := no # lcms2mt is strongly preferred
+-  USE_SYSTEM_LCMS2 := no # lcms2mt is strongly preferred
++  USE_SYSTEM_LCMS2 := yes
    USE_SYSTEM_LIBJPEG := yes
 -  USE_SYSTEM_MUJS := no # not available
 +  USE_SYSTEM_MUJS := yes
    USE_SYSTEM_OPENJPEG := yes
    USE_SYSTEM_ZLIB := yes
    USE_SYSTEM_GLUT := yes
+@@ -278,7 +278,7 @@
+ # --- LCMS2 ---
+ 
+ ifeq ($(USE_SYSTEM_LCMS2),yes)
+-  THIRD_CFLAGS += $(SYS_LCMS2_CFLAGS)
++  THIRD_CFLAGS += $(SYS_LCMS2_CFLAGS) -DHAVE_LCMS2MT
+   THIRD_LIBS += $(SYS_LCMS2_LIBS)
+ else
+ 
 Binary files mupdf-1.18.0-source.orig/thirdparty/lcms2/Projects/mac/LittleCMS/._Info.plist and mupdf-1.18.0-source/thirdparty/lcms2/Projects/mac/LittleCMS/._Info.plist differ
 Binary files mupdf-1.18.0-source.orig/thirdparty/lcms2/Projects/mac/LittleCMS/._LittleCMS.xcodeproj and mupdf-1.18.0-source/thirdparty/lcms2/Projects/mac/LittleCMS/._LittleCMS.xcodeproj differ

--- a/10.9-libcxx/stable/main/finkinfo/text/mupdf.patch
+++ b/10.9-libcxx/stable/main/finkinfo/text/mupdf.patch
@@ -1,26 +1,44 @@
-diff -Nurd -x'*~' mupdf-1.6-source.orig/source/fitz/load-jpx.c mupdf-1.6-source/source/fitz/load-jpx.c
---- mupdf-1.6-source.orig/source/fitz/load-jpx.c	2014-09-30 07:25:12.000000000 -0400
-+++ mupdf-1.6-source/source/fitz/load-jpx.c	2016-01-18 02:44:00.000000000 -0500
-@@ -1,13 +1,5 @@
- #include "mupdf/fitz.h"
+diff -Nurd -x'*~' mupdf-1.18.0-source.orig/Makerules mupdf-1.18.0-source/Makerules
+--- mupdf-1.18.0-source.orig/Makerules	2020-10-07 06:35:03.000000000 -0400
++++ mupdf-1.18.0-source/Makerules	2020-12-22 15:58:22.000000000 -0500
+@@ -110,13 +110,11 @@
+   HAVE_GLUT := yes
+   SYS_GLUT_CFLAGS := -Wno-deprecated-declarations
+   SYS_GLUT_LIBS := -framework GLUT -framework OpenGL
+-  CC = xcrun cc
++  CC = flag-sort cc
+   AR = xcrun ar
+   LD = xcrun ld
+   RANLIB = xcrun ranlib
  
--/* Without the definition of OPJ_STATIC, compilation fails on windows
-- * due to the use of __stdcall. We believe it is required on some
-- * linux toolchains too. */
--#define OPJ_STATIC
--#ifndef _MSC_VER
--#define OPJ_HAVE_STDINT_H
--#endif
--
- #include <openjpeg.h>
+-else ifeq ($(OS),Linux)
+-  HAVE_OBJCOPY := yes
  
- static void fz_opj_error_callback(const char *msg, void *client_data)
-@@ -117,7 +109,7 @@
- 	opj_stream_set_read_function(stream, fz_opj_stream_read);
- 	opj_stream_set_skip_function(stream, fz_opj_stream_skip);
- 	opj_stream_set_seek_function(stream, fz_opj_stream_seek);
--	opj_stream_set_user_data(stream, &sb);
-+	opj_stream_set_user_data(stream, &sb, NULL);
- 	/* Set the length to avoid an assert */
- 	opj_stream_set_user_data_length(stream, size);
+   ifeq ($(shell pkg-config --exists freetype2 && echo yes),yes)
+ 	SYS_FREETYPE_CFLAGS := $(shell pkg-config --cflags freetype2)
+@@ -165,11 +163,6 @@
+ 	SYS_CURL_LIBS := $(shell pkg-config --libs libcurl)
+   endif
  
+-  HAVE_GLUT := yes
+-  ifeq ($(HAVE_GLUT),yes)
+-	SYS_GLUT_CFLAGS :=
+-	SYS_GLUT_LIBS := -lglut -lGL
+-  endif
+ 
+   HAVE_X11 := $(shell pkg-config --exists x11 xext && echo yes)
+   ifeq ($(HAVE_X11),yes)
+diff -Nurd -x'*~' mupdf-1.18.0-source.orig/Makethird mupdf-1.18.0-source/Makethird
+--- mupdf-1.18.0-source.orig/Makethird	2020-10-07 06:35:03.000000000 -0400
++++ mupdf-1.18.0-source/Makethird	2020-12-22 15:59:06.000000000 -0500
+@@ -8,7 +8,7 @@
+   USE_SYSTEM_JPEGXR := no # not available
+   USE_SYSTEM_LCMS2 := no # lcms2mt is strongly preferred
+   USE_SYSTEM_LIBJPEG := yes
+-  USE_SYSTEM_MUJS := no # not available
++  USE_SYSTEM_MUJS := yes
+   USE_SYSTEM_OPENJPEG := yes
+   USE_SYSTEM_ZLIB := yes
+   USE_SYSTEM_GLUT := yes
+Binary files mupdf-1.18.0-source.orig/thirdparty/lcms2/Projects/mac/LittleCMS/._Info.plist and mupdf-1.18.0-source/thirdparty/lcms2/Projects/mac/LittleCMS/._Info.plist differ
+Binary files mupdf-1.18.0-source.orig/thirdparty/lcms2/Projects/mac/LittleCMS/._LittleCMS.xcodeproj and mupdf-1.18.0-source/thirdparty/lcms2/Projects/mac/LittleCMS/._LittleCMS.xcodeproj differ


### PR DESCRIPTION
New upstream version of mupdf, which no longer uses openssl