### PR TITLE
libcurl4: new version, librtmp upgrade

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/net/libcurl4.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/libcurl4.info
@@ -48,7 +48,6 @@ Depends: %N-shlibs (= %v-%r)
 BuildDepends: <<
 	fink (>= 0.32),
 	fink-package-precedence,
-	gmp5,
 	libbrotli1 (>= 1.0.7-1),
 	libmetalink3 (>= 0.1.3-1),
 	libnghttp2.14 (>= 1.41.0-1),

--- a/10.9-libcxx/stable/main/finkinfo/net/libcurl4.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/libcurl4.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info4: <<
 Package: libcurl4
-Version: 7.71.1
+Version: 7.74.0
 Revision: 1
 Description: Lib. for transferring files with URL syntax
 DescDetail: <<
@@ -42,16 +42,17 @@ License: BSD
 
 Source: http://curl.haxx.se/download/curl-%v.tar.xz
 #Source: mirror:custom:curl-%v.tar.xz
-Source-Checksum: SHA256(40f83eda27cdbeb25cd4da48cefb639af1b9395d6026d2da1825bf059239658c)
+Source-Checksum: SHA256(999d5f2c403cf6e25d58319fdd596611e455dd195208746bc6e6d197a77e878b)
 
 Depends: %N-shlibs (= %v-%r)
 BuildDepends: <<
 	fink (>= 0.32),
 	fink-package-precedence,
+	gmp5,
 	libbrotli1 (>= 1.0.7-1),
 	libmetalink3 (>= 0.1.3-1),
 	libnghttp2.14 (>= 1.41.0-1),
-	librtmp (>= 2.3-8),
+	librtmp1,
 	libssh2.1 (>= 1.9.0-1),
 	pkgconfig (>= 0.20-1)
 <<
@@ -67,13 +68,11 @@ PatchScript: <<
 	perl -pi -e 's,\@LDFLAGS\@,,g; s,\@LIBCURL_LIBS\@,,g' libcurl.pc.in
 	#There is no more libcurl.a so trick curl-config --static-libs into using libcurl.dylib. Fixes building of pycurl.
 	perl -pi -e 's/\@libext\@/dylib/' curl-config.in
-	# Patch configure to not link like Puma on Yosemite
-	perl -pi -e 's|10\.\[012\]\*|10.[012][,.]*|g' configure
 	
 	#Set up to use system's ldap
 	InclPREFIX="/usr/include"
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
-		InclPREFIX="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include" 
+		InclPREFIX="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include"
 	fi
 
 	/bin/cp $InclPREFIX/lber*.h .
@@ -98,6 +97,7 @@ ConfigureParams: <<
 	--with-libmetalink=%p \
 	--with-nghttp2=%p \
 	--with-brotli=%p \
+	--without-zstd \
 	--enable-hidden-symbols \
 	--enable-threaded-resolver \
 	--disable-static \
@@ -129,12 +129,12 @@ SplitOff: <<
 	Depends: <<
 		libbrotli1-shlibs (>= 1.0.7-1),
 		libnghttp2.14-shlibs (>= 1.41.0-1),
-		librtmp-shlibs (>= 2.3-8),
+		librtmp1-shlibs,
 		libssh2.1-shlibs (>= 1.9.0-1)
 	<<
     
 	Files: lib/libcurl.4.*dylib
-	Shlibs: %p/lib/libcurl.4.dylib 11.0.0 %n (>= 7.66.0-1)
+	Shlibs: %p/lib/libcurl.4.dylib 12.0.0 %n (>= 7.74.0-1)
 	DocFiles: CHANGES COPYING README RELEASE-NOTES
 <<
 
@@ -146,7 +146,7 @@ SplitOff2: <<
   Depends: %N-shlibs (= %v-%r), libmetalink3-shlibs (>= 0.1.3-1)
   
   Files: bin/curl share/man/man1/curl.1
-  DocFiles: CHANGES COPYING README RELEASE-NOTES docs/BINDINGS.md docs/BUGS docs/CONTRIBUTE.md docs/FAQ docs/FEATURES docs/HISTORY.md docs/KNOWN_BUGS docs/INTERNALS.md docs/RESOURCES docs/THANKS docs/TODO docs/TheArtOfHttpScripting docs/LICENSE-MIXING.md docs/SSLCERTS.md docs/VERSIONS.md
+  DocFiles: CHANGES COPYING README RELEASE-NOTES docs/BINDINGS.md docs/BUGS.md docs/CONTRIBUTE.md docs/FAQ docs/FEATURES.md docs/HISTORY.md docs/KNOWN_BUGS docs/INTERNALS.md docs/THANKS docs/TODO docs/TheArtOfHttpScripting.md docs/SSLCERTS.md docs/VERSIONS.md
 <<
 
 InfoTest: <<
@@ -159,9 +159,7 @@ InfoTest: <<
     echo '20' >>tests/data/DISABLED
     echo '237' >>tests/data/DISABLED
     echo '507' >>tests/data/DISABLED
-    echo '530' >>tests/data/DISABLED
     echo '534' >>tests/data/DISABLED
-    echo '584' >>tests/data/DISABLED
     
     #This test fails when run as root.
 	echo '1001' >>tests/data/DISABLED
@@ -191,8 +189,6 @@ InfoTest: <<
 	echo '404' >>tests/data/DISABLED
 	
 	echo '1801' >>tests/data/DISABLED
-	echo '1901' >>tests/data/DISABLED
-	echo '1902' >>tests/data/DISABLED
 	
 	# This test started failing with 7.50.0. Looks harmless.
 	echo '506' >>tests/data/DISABLED


### PR DESCRIPTION
Fixes a bunch of CVEs, and also in support of Issue #650