### PR TITLE
python37 - fix build on 10.15

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -52,7 +52,7 @@ Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
 Source-Checksum: SHA256(91923007b05005b5f9bd46f3b9172248aea5abc1543e8a636d59e629c3331b01)
 
 PatchFile: %n.patch
-PatchFile-MD5: b6d661336ee8d56ad6adf6d64b00ff61
+PatchFile-MD5: c0e637d6b2cd5ecff8c88691d66d68e2
 PatchScript: <<
 	#!/bin/sh -ex
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: python%type_pkg[python]
 Version: 3.7.9
-Revision: 1
+Revision: 2
 Type: python 3.7
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Depends: <<
@@ -52,7 +52,7 @@ Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
 Source-Checksum: SHA256(91923007b05005b5f9bd46f3b9172248aea5abc1543e8a636d59e629c3331b01)
 
 PatchFile: %n.patch
-PatchFile-MD5: 2d47c28843a13238bbe9495c42c8b910
+PatchFile-MD5: b6d661336ee8d56ad6adf6d64b00ff61
 PatchScript: <<
 	#!/bin/sh -ex
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.patch
@@ -81,7 +81,6 @@ diff -ru Python-3.7.9.orig/Makefile.pre.in Python-3.7.9/Makefile.pre.in
  		fi; \
  	else	true; \
  	fi
-Only in Python-3.7.9: Makefile.pre.in.orig
 diff -ru Python-3.7.9.orig/Misc/python-config.in Python-3.7.9/Misc/python-config.in
 --- Python-3.7.9.orig/Misc/python-config.in	2020-08-15 06:20:16.000000000 +0100
 +++ Python-3.7.9/Misc/python-config.in	2020-12-27 19:08:54.000000000 +0000
@@ -199,7 +198,6 @@ diff -ru Python-3.7.9.orig/configure Python-3.7.9/configure
  fi
  
  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for %zd printf() format support" >&5
-Only in Python-3.7.9: configure.orig
 diff -ru Python-3.7.9.orig/setup.py Python-3.7.9/setup.py
 --- Python-3.7.9.orig/setup.py	2020-08-15 06:20:16.000000000 +0100
 +++ Python-3.7.9/setup.py	2020-12-27 19:09:49.000000000 +0000

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.patch
@@ -1,6 +1,6 @@
-diff -ru Python-3.7.4.orig/Lib/ctypes/macholib/dyld.py Python-3.7.4/Lib/ctypes/macholib/dyld.py
---- Python-3.7.4.orig/Lib/ctypes/macholib/dyld.py	2019-07-08 14:03:50.000000000 -0400
-+++ Python-3.7.4/Lib/ctypes/macholib/dyld.py	2019-08-15 17:20:01.719186434 -0400
+diff -ru Python-3.7.9.orig/Lib/ctypes/macholib/dyld.py Python-3.7.9/Lib/ctypes/macholib/dyld.py
+--- Python-3.7.9.orig/Lib/ctypes/macholib/dyld.py	2020-08-15 06:20:16.000000000 +0100
++++ Python-3.7.9/Lib/ctypes/macholib/dyld.py	2020-12-27 19:08:54.000000000 +0000
 @@ -23,6 +23,7 @@
  
  DEFAULT_LIBRARY_FALLBACK = [
@@ -9,9 +9,9 @@ diff -ru Python-3.7.4.orig/Lib/ctypes/macholib/dyld.py Python-3.7.4/Lib/ctypes/m
      "/usr/local/lib",
      "/lib",
      "/usr/lib",
-diff -ru Python-3.7.4.orig/Lib/sysconfig.py Python-3.7.4/Lib/sysconfig.py
---- Python-3.7.4.orig/Lib/sysconfig.py	2019-07-08 14:03:50.000000000 -0400
-+++ Python-3.7.4/Lib/sysconfig.py	2019-08-15 17:20:01.719893048 -0400
+diff -ru Python-3.7.9.orig/Lib/sysconfig.py Python-3.7.9/Lib/sysconfig.py
+--- Python-3.7.9.orig/Lib/sysconfig.py	2020-08-15 06:20:16.000000000 +0100
++++ Python-3.7.9/Lib/sysconfig.py	2020-12-27 19:08:54.000000000 +0000
 @@ -375,11 +375,6 @@
          if hasattr(e, "strerror"):
              msg = msg + " (%s)" % e.strerror
@@ -24,9 +24,9 @@ diff -ru Python-3.7.4.orig/Lib/sysconfig.py Python-3.7.4/Lib/sysconfig.py
  
      # There's a chicken-and-egg situation on OS X with regards to the
      # _sysconfigdata module after the changes introduced by #15298:
-diff -ru Python-3.7.4.orig/Lib/test/test_uuid.py Python-3.7.4/Lib/test/test_uuid.py
---- Python-3.7.4.orig/Lib/test/test_uuid.py	2019-07-08 14:03:50.000000000 -0400
-+++ Python-3.7.4/Lib/test/test_uuid.py	2019-08-15 17:20:01.720561934 -0400
+diff -ru Python-3.7.9.orig/Lib/test/test_uuid.py Python-3.7.9/Lib/test/test_uuid.py
+--- Python-3.7.9.orig/Lib/test/test_uuid.py	2020-08-15 06:20:16.000000000 +0100
++++ Python-3.7.9/Lib/test/test_uuid.py	2020-12-27 19:08:54.000000000 +0000
 @@ -684,7 +684,7 @@
          self.assertTrue(0 < node < (1 << 48),
                          "%s is not an RFC 4122 node ID" % hex)
@@ -36,10 +36,10 @@ diff -ru Python-3.7.4.orig/Lib/test/test_uuid.py Python-3.7.4/Lib/test/test_uuid
      def test_ifconfig_getnode(self):
          node = self.uuid._ifconfig_getnode()
          self.check_node(node, 'ifconfig')
-diff -ru Python-3.7.4.orig/Makefile.pre.in Python-3.7.4/Makefile.pre.in
---- Python-3.7.4.orig/Makefile.pre.in	2019-07-08 14:03:50.000000000 -0400
-+++ Python-3.7.4/Makefile.pre.in	2019-08-15 17:20:01.721426111 -0400
-@@ -642,7 +642,7 @@
+diff -ru Python-3.7.9.orig/Makefile.pre.in Python-3.7.9/Makefile.pre.in
+--- Python-3.7.9.orig/Makefile.pre.in	2020-08-15 06:20:16.000000000 +0100
++++ Python-3.7.9/Makefile.pre.in	2020-12-27 19:08:54.000000000 +0000
+@@ -643,7 +643,7 @@
  	$(BLDSHARED) $(NO_AS_NEEDED) -o $@ -Wl,-h$@ $^
  
  libpython$(LDVERSION).dylib: $(LIBRARY_OBJS)
@@ -48,7 +48,7 @@ diff -ru Python-3.7.4.orig/Makefile.pre.in Python-3.7.4/Makefile.pre.in
  
  
  libpython$(VERSION).sl: $(LIBRARY_OBJS)
-@@ -1165,7 +1165,7 @@
+@@ -1174,7 +1174,7 @@
  # Install the interpreter with $(VERSION) affixed
  # This goes into $(exec_prefix)
  altbininstall: $(BUILDPYTHON) @FRAMEWORKPYTHONW@
@@ -57,7 +57,7 @@ diff -ru Python-3.7.4.orig/Makefile.pre.in Python-3.7.4/Makefile.pre.in
  	do \
  		if test ! -d $(DESTDIR)$$i; then \
  			echo "Creating directory $$i"; \
-@@ -1182,19 +1182,19 @@
+@@ -1191,19 +1191,19 @@
  		if test -f $(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE) -o -h $(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE); \
  		then rm -f $(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE); \
  		fi; \
@@ -81,9 +81,10 @@ diff -ru Python-3.7.4.orig/Makefile.pre.in Python-3.7.4/Makefile.pre.in
  		fi; \
  	else	true; \
  	fi
-diff -ru Python-3.7.4.orig/Misc/python-config.in Python-3.7.4/Misc/python-config.in
---- Python-3.7.4.orig/Misc/python-config.in	2019-07-08 14:03:50.000000000 -0400
-+++ Python-3.7.4/Misc/python-config.in	2019-08-15 17:26:26.083901850 -0400
+Only in Python-3.7.9: Makefile.pre.in.orig
+diff -ru Python-3.7.9.orig/Misc/python-config.in Python-3.7.9/Misc/python-config.in
+--- Python-3.7.9.orig/Misc/python-config.in	2020-08-15 06:20:16.000000000 +0100
++++ Python-3.7.9/Misc/python-config.in	2020-12-27 19:08:54.000000000 +0000
 @@ -50,11 +50,10 @@
          libs = ['-lpython' + pyver + sys.abiflags]
          libs += getvar('LIBS').split()
@@ -99,9 +100,9 @@ diff -ru Python-3.7.4.orig/Misc/python-config.in Python-3.7.4/Misc/python-config
          print(' '.join(libs))
  
      elif opt == '--extension-suffix':
-diff -ru Python-3.7.4.orig/Misc/python.pc.in Python-3.7.4/Misc/python.pc.in
---- Python-3.7.4.orig/Misc/python.pc.in	2019-07-08 14:03:50.000000000 -0400
-+++ Python-3.7.4/Misc/python.pc.in	2019-08-15 17:20:01.722696674 -0400
+diff -ru Python-3.7.9.orig/Misc/python.pc.in Python-3.7.9/Misc/python.pc.in
+--- Python-3.7.9.orig/Misc/python.pc.in	2020-08-15 06:20:16.000000000 +0100
++++ Python-3.7.9/Misc/python.pc.in	2020-12-27 19:08:54.000000000 +0000
 @@ -1,7 +1,7 @@
  # See: man pkg-config
  prefix=@prefix@
@@ -111,9 +112,9 @@ diff -ru Python-3.7.4.orig/Misc/python.pc.in Python-3.7.4/Misc/python.pc.in
  includedir=@includedir@
  
  Name: Python
-diff -ru Python-3.7.4.orig/Modules/_dbmmodule.c Python-3.7.4/Modules/_dbmmodule.c
---- Python-3.7.4.orig/Modules/_dbmmodule.c	2019-07-08 14:03:50.000000000 -0400
-+++ Python-3.7.4/Modules/_dbmmodule.c	2019-08-15 17:20:01.723127550 -0400
+diff -ru Python-3.7.9.orig/Modules/_dbmmodule.c Python-3.7.9/Modules/_dbmmodule.c
+--- Python-3.7.9.orig/Modules/_dbmmodule.c	2020-08-15 06:20:16.000000000 +0100
++++ Python-3.7.9/Modules/_dbmmodule.c	2020-12-27 19:08:55.000000000 +0000
 @@ -16,7 +16,7 @@
  #include <ndbm.h>
  static const char which_dbm[] = "GNU gdbm";  /* EMX port of GDBM */
@@ -123,10 +124,10 @@ diff -ru Python-3.7.4.orig/Modules/_dbmmodule.c Python-3.7.4/Modules/_dbmmodule.
  static const char which_dbm[] = "GNU gdbm";
  #elif defined(HAVE_GDBM_DASH_NDBM_H)
  #include <gdbm-ndbm.h>
-diff -ru Python-3.7.4.orig/configure Python-3.7.4/configure
---- Python-3.7.4.orig/configure	2019-07-08 14:03:50.000000000 -0400
-+++ Python-3.7.4/configure	2019-08-15 17:20:01.727293496 -0400
-@@ -5948,7 +5948,7 @@
+diff -ru Python-3.7.9.orig/configure Python-3.7.9/configure
+--- Python-3.7.9.orig/configure	2020-08-15 06:20:16.000000000 +0100
++++ Python-3.7.9/configure	2020-12-27 19:08:55.000000000 +0000
+@@ -5947,7 +5947,7 @@
  	  ;;
      Darwin*)
      	LDLIBRARY='libpython$(LDVERSION).dylib'
@@ -135,7 +136,7 @@ diff -ru Python-3.7.4.orig/configure Python-3.7.4/configure
  	RUNSHARED=DYLD_LIBRARY_PATH=`pwd`${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}
  	;;
      AIX*)
-@@ -9087,7 +9087,7 @@
+@@ -9198,7 +9198,7 @@
      LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -compatibility_version $(VERSION) -current_version $(VERSION)';;
    Darwin/*)
      gcc_version=`gcc -dumpversion`
@@ -144,7 +145,7 @@ diff -ru Python-3.7.4.orig/configure Python-3.7.4/configure
          then
              LIBTOOL_CRUFT="-lcc_dynamic"
          else
-@@ -9284,8 +9284,8 @@
+@@ -9261,8 +9261,8 @@
  
      fi
  
@@ -155,7 +156,7 @@ diff -ru Python-3.7.4.orig/configure Python-3.7.4/configure
      LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -compatibility_version $(VERSION) -current_version $(VERSION)';;
  esac
  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for --enable-framework" >&5
-@@ -9435,9 +9435,9 @@
+@@ -9412,9 +9412,9 @@
  			fi
  		else
  			# building for OS X 10.3 and later
@@ -168,7 +169,7 @@ diff -ru Python-3.7.4.orig/configure Python-3.7.4/configure
  		fi
  		;;
  	Linux*|GNU*|QNX*)
-@@ -9542,11 +9542,6 @@
+@@ -9519,11 +9519,6 @@
  	Darwin/*)
  		LINKFORSHARED="$extra_undefs -framework CoreFoundation"
  
@@ -180,7 +181,7 @@ diff -ru Python-3.7.4.orig/configure Python-3.7.4/configure
  		if test "$enable_framework"
  		then
  			LINKFORSHARED="$LINKFORSHARED "'$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-@@ -15997,7 +15992,7 @@
+@@ -15999,7 +15994,7 @@
  # first curses header check
  ac_save_cppflags="$CPPFLAGS"
  if test "$cross_compiling" = no; then
@@ -189,7 +190,7 @@ diff -ru Python-3.7.4.orig/configure Python-3.7.4/configure
  fi
  
  for ac_header in curses.h ncurses.h
-@@ -16507,7 +16502,7 @@
+@@ -16509,7 +16504,7 @@
  
  if test $ac_sys_system = Darwin
  then
@@ -198,9 +199,10 @@ diff -ru Python-3.7.4.orig/configure Python-3.7.4/configure
  fi
  
  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for %zd printf() format support" >&5
-diff -ru Python-3.7.4.orig/setup.py Python-3.7.4/setup.py
---- Python-3.7.4.orig/setup.py	2019-07-08 14:03:50.000000000 -0400
-+++ Python-3.7.4/setup.py	2019-08-15 17:20:01.729252666 -0400
+Only in Python-3.7.9: configure.orig
+diff -ru Python-3.7.9.orig/setup.py Python-3.7.9/setup.py
+--- Python-3.7.9.orig/setup.py	2020-08-15 06:20:16.000000000 +0100
++++ Python-3.7.9/setup.py	2020-12-27 19:09:49.000000000 +0000
 @@ -366,6 +366,7 @@
                                                longest, g))
  
@@ -228,14 +230,16 @@ diff -ru Python-3.7.4.orig/setup.py Python-3.7.4/setup.py
  
          if self.failed_on_import:
              failed = self.failed_on_import[:]
-@@ -585,8 +590,8 @@
+@@ -584,9 +589,9 @@
+         # Ensure that /usr/local is always used, but the local build
          # directories (i.e. '.' and 'Include') must be first.  See issue
          # 10520.
-         if not cross_compiling:
+-        if not cross_compiling:
 -            add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
 -            add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
-+            add_dir_to_list(self.compiler.library_dirs, '@PREFIX@/lib')
-+            add_dir_to_list(self.compiler.include_dirs, '@PREFIX@/include')
++        # if not cross_compiling:
++        #     add_dir_to_list(self.compiler.library_dirs, '@PREFIX@/lib')
++        #     add_dir_to_list(self.compiler.include_dirs, '@PREFIX@/include')
          # only change this for cross builds for 3.3, issues on Mageia
          if cross_compiling:
              self.add_gcc_paths()


### PR DESCRIPTION
Python37 wasn't building for me on 10.15.7: once it reached the stage where the modules were being compiled, setup.py was moving the system headers ahead of Fink's, causing compilation of the sqlite3 and readline modules to fail.

This fix comments out three offending lines in setup.py. It's been tested on 10.15.7, but should probably also be tested on 11.0 to ensure it doesn't break #682 