### PR TITLE
libopenexr24 and ilmbase24 - fix pkgconfig files

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/ilmbase24-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/ilmbase24-shlibs.info
@@ -2,7 +2,7 @@ Package: ilmbase24-shlibs
 # 2.5.0 has broken SONAME. 2.5.1 bumps libN=25
 # ilmbase, openexr, pyilmbase-py share same tarball, so keep versions in sync
 Version: 2.4.2
-Revision: 1
+Revision: 2
 Description: Shared libraries for ilmbase
 License: BSD
 # Free to update, modify and take over
@@ -15,6 +15,8 @@ Source: https://github.com/AcademySoftwareFoundation/openexr/archive/v%v.tar.gz
 SourceRename: openexr-%v.tar.gz
 Source-Checksum: SHA256(8e5bfd89f4ae1221f84216a163003edddf0d37b8aac4ee42b46edb55544599b9)
 SourceDirectory: openexr-%v/IlmBase
+PatchFile: %n.patch
+PatchFile-Checksum: SHA256(70ab64a6db792b4a9192eab9adc6d7587dd860200f583c5740d29500603c2b75)
 
 GCC: 4.0
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/graphics/ilmbase24-shlibs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/ilmbase24-shlibs.patch
@@ -1,0 +1,16 @@
+diff -Nurd IlmBase.orig/IlmBase.pc.in IlmBase/IlmBase.pc.in
+--- IlmBase.orig/IlmBase.pc.in	2020-06-14 02:30:34.000000000 +0100
++++ IlmBase/IlmBase.pc.in	2020-12-28 15:51:21.000000000 +0000
+@@ -4,9 +4,9 @@
+ ##
+ 
+ prefix=@prefix@
+-exec_prefix=@exec_prefix@
+-libdir=@libdir@
+-includedir=@includedir@
++exec_prefix=@prefix@/@exec_prefix@
++libdir=@prefix@/@libdir@
++includedir=@prefix@/@includedir@
+ libsuffix=@LIB_SUFFIX_DASH@
+ Name: IlmBase
+ Description: Base math and exception libraries

--- a/10.9-libcxx/stable/main/finkinfo/graphics/libopenexr24-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/libopenexr24-shlibs.info
@@ -2,7 +2,7 @@ Package: libopenexr24-shlibs
 # 2.5.0 has broken SONAME. 2.5.1 bumps libN=25
 # ilmbase, openexr, pyilmbase-py share same tarball, so keep versions in sync
 Version: 2.4.2
-Revision: 1
+Revision: 2
 Description: Shared libraries for OpenEXR
 License: BSD
 # Free to update, modify and take over
@@ -21,6 +21,8 @@ Source: https://github.com/AcademySoftwareFoundation/openexr/archive/v%v.tar.gz
 SourceRename: openexr-%v.tar.gz
 Source-Checksum: SHA256(8e5bfd89f4ae1221f84216a163003edddf0d37b8aac4ee42b46edb55544599b9)
 SourceDirectory: openexr-%v/OpenEXR
+PatchFile: %n.patch
+PatchFile-Checksum: SHA256(633c26914f69c4c62719338770ebdf0261b131617ed296adfe85330c41591322)
 
 GCC: 4.0
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/graphics/libopenexr24-shlibs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/libopenexr24-shlibs.patch
@@ -1,0 +1,18 @@
+diff -Nurd OpenEXR.orig/OpenEXR.pc.in OpenEXR/OpenEXR.pc.in
+--- OpenEXR.orig/OpenEXR.pc.in	2020-06-14 02:30:34.000000000 +0100
++++ OpenEXR/OpenEXR.pc.in	2020-12-28 14:28:49.000000000 +0000
+@@ -4,10 +4,10 @@
+ ##
+ 
+ prefix=@prefix@
+-exec_prefix=@exec_prefix@
+-libdir=@libdir@
+-includedir=@includedir@
+-OpenEXR_includedir=@includedir@/OpenEXR
++exec_prefix=@prefix@/@exec_prefix@
++libdir=@prefix@/@libdir@
++includedir=@prefix@/@includedir@
++OpenEXR_includedir=@prefix@/@includedir@/OpenEXR
+ libsuffix=@LIB_SUFFIX_DASH@
+ 
+ Name: OpenEXR


### PR DESCRIPTION
Bug fixes for OpenEXR and IlmBase 2.4.2: the pkgconfig files omitted the prefix from the include/library paths...

Maintainer is @nieder 