### PR TITLE
Gdal3 - and a few updates to packages that depend on it

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/postgis.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgis.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: postgis%type_pkg[postgresql]
 Version: 3.1.0
-Revision: 1
+Revision: 2
 Description: PostgreSQL geographic object support
 
 # This version only supports postgresql >=9.6 (upstream has a moving
@@ -15,8 +15,8 @@ License: BSD
 Maintainer: Benjamin Reed <postgis@fink.raccoonfink.com>
 
 Depends: <<
-	gdal2-shlibs,
-	json-c-shlibs,
+	gdal3-shlibs,
+	json-c5-shlibs,
 	libgeos3.6.1-shlibs,
 	libgettext8-shlibs,
 	libiconv,
@@ -29,9 +29,9 @@ BuildDepends: <<
 	cunit1,
 	dblatex,
 	fink-package-precedence,
-	gdal2-dev,
+	gdal3-dev,
 	imagemagick,
-	json-c,
+	json-c5,
 	libgeos3.6.1,
 	libgettext8-dev,
 	libiconv-dev,

--- a/10.9-libcxx/stable/main/finkinfo/libs/gdal3.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/gdal3.info
@@ -1,0 +1,247 @@
+Info3: <<
+Package: gdal3
+Version: 3.2.0
+Revision: 1
+
+Depends: %n-shlibs (= %v-%r)
+
+Conflicts: gdal, gdal-pgsql, gdal2
+Replaces: gdal, gdal-pgsql, gdal2
+
+BuildConflicts: hdf5.9, hdf5.9-bin
+BuildDepends: <<
+  bash-completion,
+  expat1,
+  fink (>= 0.32),
+  fink-package-precedence,
+  giflib7,
+  hdf5.100.v1.10 (>= 1.10.0-4),
+  ilmbase24-dev,
+  json-c5,
+  libcfitsio8-dev,
+  libcryptopp5-dev,
+  libcurl4,
+  libdap11,
+  libfreexl1-dev,
+  libgeos3.6.1,
+  libgeotiff5,
+  libheif1-dev,
+  libiconv-dev,
+  libjasper.1,
+  libjpeg9,
+  libodbc3-dev,
+  libogdi4,
+  libopenexr24-dev,
+  libopenjp2.7,
+  libpcre1,
+  libpng16,
+  libproj19,
+  libspatialite7,
+  libtiff5,
+  libwebp7,
+  libxml2 (>= 2.9.1-1),
+  netcdf-bin,
+  netcdf-c18,
+  pkgconfig,
+  postgresql12-dev,
+  qhull6.3.1-dev,
+  sqlite3-dev,
+  xerces-c31-dev
+<<
+
+GCC: 4.0
+
+# UseMaxBuildJobs: 1
+Source: http://download.osgeo.org/gdal/%v/gdal-%v.tar.xz
+# SourceDirectory: gdal-%v
+Source-MD5: 6c573e09acce89cef7853ca58789871c
+
+# -MD for automatic header dependency tracking (not sure no standard
+# libtool --enable-dependency-tracking flag for this feature) --dmacks
+SetCPPFLAGS: -MD -Wno-deprecated-declarations
+
+PatchScript: <<
+  # Address https://trac.osgeo.org/gdal/ticket/6607
+  # (installation location of bash-completions)
+  perl -pi -e 's|-rs \$\(DESTDIR\)\$\(INST_BASH_COMPLETION\)/gdalinfo|-s gdalinfo|' scripts/GNUmakefile
+  perl -pi -e 's|-ldap\+\+ -lpthread -lrx|-ldap -ldapclient|' configure
+<<
+
+ConfigureParams: <<
+  --libdir=%p/lib --includedir=%p/include/gdal3 \
+  --mandir=%p/share \
+  --disable-static \
+  --with-local=%p \
+  --with-libz=%p \
+  --with-libiconv-prefix=%p \
+  --with-bash-completion=`pkg-config --variable=compatdir bash-completion` \
+  --with-libtiff=%p \
+  --with-curl=%p/bin/curl-config \
+  --with-sqlite3=%p \
+  --with-proj=%p \
+  --with-spatialite=%p \
+  --with-liblzma=yes \
+  --with-zstd=no \
+  --with-pg=yes \
+  PQ_CFLAGS=-I%p/opt/postgresql-12/include \
+  PQ_LIBS="-L%p/opt/postgresql-12/lib -lpq" \
+  --with-grass=no \
+  --with-cfitsio=%p \
+  --with-pcraster=no \
+  --with-png=%p \
+  --with-dds=no \
+  --with-gta=no \
+  --with-pcidsk=internal \
+  --with-geotiff=%p \
+  --with-jpeg=%p \
+  --without-charls \
+  --with-gif=%p \
+  --with-ogdi=%p \
+  --with-fme=no \
+  --with-sosi=no \
+  --with-mongocxx=no \
+  --with-hdf4=no \
+  --with-hdf5=%p/opt/hdf5.v1.10 \
+  --without-kea \
+  --with-netcdf=%p \
+  --with-jasper=%p \
+  --with-fgdb=no \
+  --with-ecw=no \
+  --with-kakadu=no \
+  --with-mrsid=no \
+  --with-jp2lura=no \
+  --with-msg=no \
+  --with-oci=no \
+  --with-xerces=%p \
+  --with-expat=%p \
+  --with-libkml=no \
+  --with-odbc=%p \
+  --with-dods-root=%p/opt/libdap11 \
+  --with-xml2=yes \
+  --with-webp=%p \
+  --with-geos=%p/opt/libgeos3.6.1/bin/geos-config \
+  --without-sfcgal \
+  --with-qhull=yes \
+  --with-opencl=no \
+  --with-freexl=%p \
+  --with-libjson-c=%p \
+  --without-perl \
+  --without-python
+<<
+
+CompileScript: <<
+  ./configure %c
+  # silly hand-coded autoconf tests put %p not just %p/{include,lib}
+  #perl -pi -e 's,-[IL]%p ,,g' GDALmake.opt
+  make
+  fink-package-precedence --depfile-ext='\.d' --prohibit-bdep=%n-dev .
+<<
+
+
+InstallScript: <<
+  make install DESTDIR=%d
+  make install-man DESTDIR=%d INST_MAN=%p/share/man
+
+  # The license file will be brought to %i/share/doc/%n by DocFiles
+  rm -f %i/share/gdal/LICENSE.TXT
+<<
+
+DocFiles: <<
+  LICENSE.TXT
+  NEWS
+  PROVENANCE.TXT
+  HOWTO-RELEASE
+  COMMITTERS
+  MIGRATION_GUIDE.TXT
+<<
+
+SplitOff: <<
+  Package: %N-shlibs
+  Description: GDAL/OGR shared libraries
+  Depends: <<
+    expat1-shlibs,
+    giflib7-shlibs,
+    hdf5.100.v1.10-shlibs,
+    ilmbase24-shlibs,
+    json-c5-shlibs,
+    libcfitsio8-shlibs,
+    libcryptopp5-shlibs,
+    libcurl4-shlibs,
+    libdap11-shlibs,
+    libfreexl1-shlibs,
+    libgeos3.6.1-shlibs,
+    libgeotiff5-shlibs,
+    libheif1-shlibs,
+    libiconv,
+    libjasper.1-shlibs,
+    libjpeg9-shlibs,
+    liblzma5-shlibs,
+    libodbc3-shlibs,
+    libogdi4-shlibs,
+    libopenexr24-shlibs,
+    libopenjp2.7-shlibs,
+    libpcre1-shlibs,
+    libpng16-shlibs,
+    libproj19-shlibs,
+    libspatialite7-shlibs,
+    libtiff5-shlibs,
+    libwebp7-shlibs,
+    libxml2-shlibs (>= 2.9.1-1),
+    netcdf-c18-shlibs,
+    postgresql12-shlibs,
+    qhull6.3.1-shlibs,
+    sqlite3-shlibs,
+    xerces-c31-shlibs,
+  <<
+
+  Files: lib/libgdal.*.dylib
+  Shlibs: %p/lib/libgdal.28.dylib 29.0.0 %n (>= 3.2.0-1)
+  DocFiles: LICENSE.TXT
+<<
+
+SplitOff2: <<
+  Package: %N-dev
+  Description: GDAL/OGR development headers
+  Conflicts: gdal-dev, gdal-pgsql-dev, gdal2-dev
+  Replaces: gdal-dev, gdal-pgsql-dev, gdal2 (<< 2.3.1-2), gdal2-dev
+  Depends: %N-shlibs (= %v-%r)
+  BuildDependsOnly: true
+  Files: <<
+    bin/gdal-config
+    include
+    lib/libgdal.{dylib,la}
+    lib/pkgconfig
+  <<
+  DocFiles: LICENSE.TXT
+<<
+
+Description: Raster/Vector Geospatial Format Translator
+License: BSD
+Homepage: http://www.gdal.org
+Maintainer: None <fink-devel@lists.sourceforge.net>
+DescDetail: <<
+GDAL is a translator library for raster geospatial data formats. As a library,
+it presents a single abstract data model to the calling application for all
+supported formats.
+
+Current translators include GeoTIFF, ESRI .BIL, .aux labelled raw,
+DTED, SDTS DEM, CEOS, JPEG, PNG, Geosoft GXF, Arc/Info Binary Grid,
+FITS, netCDF, GIF, and more.
+
+GDAL comes with the related OGR library (which lives within the GDAL
+source tree) provides a similar capability for simple features vector
+data.  The OGR Simple Features Library is a C++ open source library
+(and commandline tools) providing read (and sometimes write) access to
+a variety of vector file formats including ESRI Shapefiles, S-57,
+SDTS, PostGIS, Oracle Spatial, and Mapinfo mid/mif and TAB formats.
+<<
+
+DescUsage: <<
+Packages that need GDAL/OGR libraries should builddepend on gdal-dev and
+depend on gdal-shlibs.  Make sure that configure finds the gdal-config
+script in %p/bin, which tells that the headers are
+in %p/include/gdal1/ and the libraries are in %p/lib/.
+<<
+
+# End of Info3
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/gdal3.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/gdal3.info
@@ -65,6 +65,10 @@ PatchScript: <<
   # (installation location of bash-completions)
   perl -pi -e 's|-rs \$\(DESTDIR\)\$\(INST_BASH_COMPLETION\)/gdalinfo|-s gdalinfo|' scripts/GNUmakefile
   perl -pi -e 's|-ldap\+\+ -lpthread -lrx|-ldap -ldapclient|' configure
+
+  # fink's libdap11 headers and libs are a special opt/ subdir, but
+  # bin/dap-config is in main bin/ (not private subdir).
+  perl -pi.bak -e 's|\$\{DODS_BIN\}/dap-config|%p/bin/dap-config|;s|\$DODS_BIN/dap-config|%p/bin/dap-config|' configure
 <<
 
 ConfigureParams: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/gdal3.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/gdal3.info
@@ -16,7 +16,7 @@ BuildDepends: <<
   fink-package-precedence,
   giflib7,
   hdf5.100.v1.10 (>= 1.10.0-4),
-  ilmbase24-dev,
+  ilmbase24-dev (>= 2.4.2-2),
   json-c5,
   libcfitsio8-dev,
   libcryptopp5-dev,
@@ -31,7 +31,7 @@ BuildDepends: <<
   libjpeg9,
   libodbc3-dev,
   libogdi4,
-  libopenexr24-dev,
+  libopenexr24-dev (>= 2.4.2-2),
   libopenjp2.7,
   libpcre1,
   libpng16,
@@ -131,8 +131,6 @@ ConfigureParams: <<
 
 CompileScript: <<
   ./configure %c
-  # silly hand-coded autoconf tests put %p not just %p/{include,lib}
-  #perl -pi -e 's,-[IL]%p ,,g' GDALmake.opt
   make
   fink-package-precedence --depfile-ext='\.d' --prohibit-bdep=%n-dev .
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/gdal-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/gdal-py.info
@@ -1,27 +1,27 @@
 Info2: <<
 
 Package: gdal-py%type_pkg[python]
-Version: 2.4.4
+Version: 3.2.0
 
 Revision: 1
 Homepage: http://www.gdal.org
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Type: python (2.7 3.5 3.6 3.7 3.8)
 Depends: <<
-  gdal2 (>= %v),
+  gdal3 (>= %v),
   numpy-py%type_pkg[python],
   python%type_pkg[python]
 <<
 BuildDepends: <<
   fink (>= 0.32),
-  gdal2-dev (>= %v)
+  gdal3-dev (>= %v)
 <<
 
 GCC: 4.0
 
 SourceDirectory: gdal-%v
 Source: http://download.osgeo.org/gdal/%v/gdal-%v.tar.xz
-Source-MD5: 27b8aedb995109e3bfbc64776028e3a8
+Source-MD5: 6c573e09acce89cef7853ca58789871c
 
 # No -L to builddirs. We are linking to external libgdal and we should
 # always link to builddir files by direct paths anyway.
@@ -34,7 +34,7 @@ PatchScript: <<
   %{default_script}
   perl -pi -e 's|../../apps/gdal-config|%p/bin/gdal-config|g' swig/python/setup.cfg
   perl -pi -e 's|#library_dirs = .*|library_dirs = %p/lib|g' swig/python/setup.cfg
-  perl -pi -e 's|#include_dirs = .*|include_dirs = %p/include:%p/include/gdal2|g' swig/python/setup.cfg
+  perl -pi -e 's|#include_dirs = .*|include_dirs = %p/include:%p/include/gdal3|g' swig/python/setup.cfg
 <<
 
 CompileScript: <<
@@ -43,6 +43,30 @@ CompileScript: <<
     python%type_raw[python] setup.py build
   popd
 <<
+
+InfoTest: <<
+  TestSource: https://github.com/OSGeo/gdal/releases/download/v%v/gdalautotest-%v.zip
+  TestSource-MD5: 1f8d25042a9258dba550a47be776d287
+  TestDepends: pytest-py%type_pkg[python], lxml-py%type_pkg[python]
+  TestScript: <<
+    #!/bin/sh -ev
+    pushd swig/python
+      python%type_raw[python] setup.py install --root=../../../gdalautotest-%v/root
+    popd
+    cd ../gdalautotest-%v
+    ln -s gdal-%v ../gdal
+    export PYTHONPATH=`pwd`/root/%p/lib/python%type_raw[python]/site-packages:${PYTHONPATH}
+    export PATH=`pwd`/root/%p/bin:$PATH
+    perl -pi -e"s|pytest|pytest-%type_raw[python]|" GNUmakefile
+    perl -pi -e "s|\xc3\xa9|e|" gcore/test_driver_metadata.py
+    perl -pi -e"s|if sys.platform == 'darwin' and gdal.GetConfigOption\('TRAVIS', None\) is not None:|if sys.platform == 'darwin':|" gcore/cog.py
+    perl -pi -e's|125.64813723085801, abs=0.000001|125.64813723085801, abs=0.000015|' gcore/transformer.py
+    perl -pi -e's|39.869345977927146, abs=0.000001|39.869345977927146, abs=0.00006|' gcore/transformer.py
+    perl -pi -e"s|if sys.platform == 'darwin' and gdal.GetConfigOption\('TRAVIS', None\) is not None:|if sys.platform == 'darwin':|" gdrivers/gdalhttp.py
+    make -j1 test || exit 2
+  <<
+<<
+
 
 InstallScript: <<
   #!/bin/bash -ev

--- a/10.9-libcxx/stable/main/finkinfo/sci/gmt-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gmt-shlibs.info
@@ -1,6 +1,6 @@
 Package: gmt-shlibs
 Version: 4.5.18
-Revision: 4
+Revision: 5
 Source: ftp://ftp.soest.hawaii.edu/gmt/gmt-%v-src.tar.bz2
 Source2: ftp://ftp.soest.hawaii.edu/gmt/gmt-%v-non-gpl-src.tar.bz2
 Source-MD5: b35cf18fddcf4823dc75b1ea32808d71
@@ -10,11 +10,11 @@ SourceDirectory: gmt-%v
 BuildDepends: <<
 	fink (>= 0.32),
 	netcdf-c18,
-	gdal2-dev
+	gdal3-dev
 <<
 Depends: <<
 	netcdf-c18-shlibs,
-	gdal2-shlibs,
+	gdal3-shlibs,
 	gshhg (>= 2.3.0)
 <<
 RuntimeDepends: ghostscript

--- a/10.9-libcxx/stable/main/finkinfo/sci/gmt5-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gmt5-shlibs.info
@@ -1,6 +1,6 @@
 Package: gmt5-shlibs
 Version: 5.4.5
-Revision: 4
+Revision: 5
 Source: ftp://ftp.soest.hawaii.edu/gmt/gmt-%v-src.tar.xz
 Source-MD5: 846c7717ca8a6e2c76cc5538331ff59e
 SourceDirectory: gmt-%v
@@ -10,7 +10,7 @@ BuildDepends: <<
   fftw3 (>= 3.3.3),
   fink (>= 0.32),
   fink-package-precedence,
-  gdal2-dev,
+  gdal3-dev,
   libcurl4,
   libpcre1,
   netcdf-c18
@@ -18,7 +18,7 @@ BuildDepends: <<
 Depends: <<
 	dcw-gmt (>= 1.1.1),
 	fftw3-shlibs (>= 3.3.3),
-	gdal2-shlibs,
+	gdal3-shlibs,
 	gshhg (>= 2.3.4),
 	libcurl4-shlibs,
 	libpcre1-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/sci/gmt6-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gmt6-shlibs.info
@@ -1,6 +1,6 @@
 Package: gmt6-shlibs
 Version: 6.1.1
-Revision: 1
+Revision: 2
 Source: https://github.com/GenericMappingTools/gmt/releases/download/%v/gmt-%v-src.tar.xz
 Source-Checksum: SHA1(591c318cfa1a96fb1f39a1b3df4b1ac4da9f1530)
 SourceDirectory: gmt-%v
@@ -11,7 +11,7 @@ BuildDepends: <<
   fftw3 (>= 3.3.3),
   fink (>= 0.32),
   fink-package-precedence,
-  gdal2-dev,
+  gdal3-dev,
   gshhg (>= 2.3.7),
   libgeos3.6.1,
   libcurl4,
@@ -21,7 +21,7 @@ BuildDepends: <<
 Depends: <<
 	dcw-gmt (>= 1.1.4),
 	fftw3-shlibs (>= 3.3.3),
-	gdal2-shlibs,
+	gdal3-shlibs,
 	gshhg (>= 2.3.7),
 	libcurl4-shlibs,
 	libpcre1-shlibs,
@@ -49,6 +49,7 @@ CompileScript: <<
 	-DDCW_ROOT=%p/share/gmt/dcw \
 	-DGSHHG_ROOT=%p/share/gmt/gshhg \
 	-DCOPY_GSHHG=FALSE \
+	-DCOPY_DCW=FALSE \
 	-DNETCDF_ROOT=%p \
 	-DCURL_INCLUDE_DIR=%p/include \
 	-DCURL_LIBRARY=%p/lib/libcurl.dylib \
@@ -70,8 +71,8 @@ InstallScript: <<
   cmake -DCMAKE_INSTALL_PREFIX=%i -P cmake_install.cmake
 <<
 Shlibs: <<
-	%p/lib/libgmt.6.dylib 6.0.0 %n (>= 5.4.1-1)
-	%p/lib/libpostscriptlight.6.dylib 6.0.0 %n (>= 5.4.1-1)
+	%p/lib/libgmt.6.dylib 6.0.0 %n (>= 6.1.1-1)
+	%p/lib/libpostscriptlight.6.dylib 6.0.0 %n (>= 6.1.1-1)
 <<
 SplitOff: <<
   Package: gmt6-doc
@@ -114,7 +115,7 @@ SplitOff3: <<
   Depends: %N (= %v-%r), ghostscript
   Recommends: <<
   	gmt6-doc,
-  	gdal2
+  	gdal3
   <<
   Conflicts: <<
     gmt,
@@ -126,9 +127,7 @@ SplitOff3: <<
   <<
   # replaces older -shlibs due to lib/gmt/plugins/supplements.so
   # do not want Conflicts because we also Depend on it
-  # has identical file collision at %p/share/gmt/dcw/dcw-countries.txt from dcw-gmt
   Replaces: <<
-	dcw-gmt,
     gmt,
   	gmt-dev,
   	gmt5,

--- a/10.9-libcxx/stable/main/finkinfo/sci/mbsystem.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/mbsystem.info
@@ -1,6 +1,6 @@
 Package: mbsystem
 Version: 5.7.6
-Revision: 2
+Revision: 3
 
 Source: https://github.com/dwcaress/MB-System/archive/%v.tar.gz
 SourceRename: %n-%v.tar.gz
@@ -14,7 +14,7 @@ BuildDepends: <<
   x11-dev,
   libproj19,
   fftw3,
-  gdal2-dev
+  gdal3-dev
 <<
 Depends: <<
   gmt6 (>= 6.1.0),
@@ -24,7 +24,7 @@ Depends: <<
   gv,
   proj-bin (>= 7.2.0),
   libproj19-shlibs,
-  gdal2-shlibs,
+  gdal3-shlibs,
   parallel-forkmanager-pm5182 | parallel-forkmanager-pm5184
 <<
 ConfigureParams: <<


### PR DESCRIPTION
Here is a new package for gdal version 3.2.0. This PR depends on #712 (for changes to gdal2) and #718 (for bug fixes in openexr24 pkgconfig files, which otherwise break compilation).

gdal-py now includes an extensive suite of tests (for gdal itself and gdal-py)! I've tested these with 2.7 and 3.7. There is one test in the transformations where a slightly larger error margin is required; and two places where there are known issues with MacOS that needed a slight tweak in the test scripts. And one script with a unicode character that causes an error with 2.7 (but not with later versions). In addition, the pytest version needs to be specified in the makefile if more than one type is installed. With these small caveats (four tests out of thousands), the library appears to work correctly and pass its tests.

I have also bumped the gdal dependence of gmt 4, 5, and 6, as well as mbsystem.

In gmt6-shlibs, "-DCOPY_DCW=FALSE" has been also added to the cmake flags, removing the file collision with dcw-gmt (which is a dependence - so the files will be there either way).