### PR TITLE
Gettext 0.20.2

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/base/dpkg.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/dpkg.info
@@ -1,11 +1,11 @@
 Package: dpkg
 Version: 1.10.21
-Revision: 1250
+Revision: 1251
 GCC: 4.0
 BuildDepends: fink (>= 0.30.0)
 Depends: <<
 	gzip,
-	libgettext8-shlibs (>= 0.20.1-1),
+	libgettext8-shlibs (>= 0.20.2-1),
 	libiconv (>= 1.14-6),
 	libncurses5-shlibs (>= 5.4-20041023-1006)
 <<
@@ -16,20 +16,19 @@ Maintainer: Fink Core Group <fink-core@lists.sourceforge.net>
 Source: mirror:sourceforge:fink/dpkg_%v.tar.gz
 SourceDirectory: dpkg-%v
 Source-MD5: a9f6c43891db74d727beab7dfc0ee663
-Source2: mirror:sourceforge:fink/gettext-0.20.1.tar.gz
-#Source2: mirror:gnu:gettext/gettext-0.20.1.tar.gz
-Source2-MD5: bb5b0c0caa028105f3ca1905ddc306e2
+Source2: mirror:sourceforge:fink/gettext-0.20.2.tar.gz
+#Source2: mirror:gnu:gettext/gettext-0.20.2.tar.gz
+Source2-MD5: 30fec34a895fab4c02584449c500aac2
 PatchFile: %n.patch
 PatchFile-MD5: 4619ec40a935795c705fbd60b258cf5a
 PatchFile2: libgettext8-shlibs.patch
-PatchFile2-MD5: 925a8d897cd72f6dd0c89bea4dfa868a
+PatchFile2-MD5: 8ebf1b7c276059b0d3a334f60a2f705e
 PatchFile3: %n-xcode12.patch
 PatchFile3-MD5: 04c17928d17ca1e2320258f142a4093a
 PatchScript: <<
  cd %b/..; sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p0
  cd %b/..; sed 's|@PREFIX@|%p|g' < %{PatchFile2} | patch -p0
  patch -p1 < %{PatchFile3}
- cd %b/../gettext-0.20.1/build-aux; perl -pi -e 's/.*chmod.*777.*$//g' ltmain.sh
  cd optlib; perl -pi -e 's/(getopt|getopt1).c//g' Makefile.in; rm getopt*
  echo "x86_64-darwin           darwin-x86_64   darwin-x86_64" >> %b/archtable
 <<
@@ -43,11 +42,11 @@ CompileScript: <<
 	### match the new package parameters (except build static only here).
 	### Not necessary, but will avoid unforeseen consequences.
 	%p/bin/fink -y install gettext-bin libgettext8-dev libiconv-dev libncurses5
-	# gettext-tools >= 0.20.1 needs libtextstyle
-	cd %b/../gettext-0.20.1/libtextstyle
+	# gettext-tools >= 0.20.2 needs libtextstyle
+	cd %b/../gettext-0.20.2/libtextstyle
 	env EMACS=no JAVA=/usr/bin/java PATH=../bin:$PATH ./configure --prefix=%b/localtree --enable-shared=no ac_cv_prog_AWK=/usr/bin/awk ac_cv_path_GREP=/usr/bin/grep ac_cv_path_SED=/usr/bin/sed
 	/usr/bin/make -w
-	cd %b/../gettext-0.20.1/gettext-tools
+	cd %b/../gettext-0.20.2/gettext-tools
 	env EMACS=no JAVA=/usr/bin/java GCJ=/usr/bin/javac ./configure \
 		--prefix="%b/../_inst%p" \
 		--infodir='${prefix}/share/info' \
@@ -114,6 +113,9 @@ DescPackaging: <<
  actual libs themselves.
 <<
 DescPort: <<
+1.10.21-1251
+- Bump to libgettext-0.20.2
+
 1.10.21-1250
 - Bump to libgettext-0.20.1
 

--- a/10.9-libcxx/stable/main/finkinfo/base/gettext-tools.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/gettext-tools.info
@@ -1,20 +1,19 @@
 Package: gettext-tools
-Version: 0.20.1
-Revision: 2
+Version: 0.20.2
+Revision: 1
 CustomMirror: <<
 	Primary: http://ftpmirror.gnu.org/gettext/
 	Secondary: http://downloads.sourceforge.net/fink/
 <<
 Source: mirror:custom:gettext-%v.tar.gz
-Source-MD5: bb5b0c0caa028105f3ca1905ddc306e2
+Source-MD5: 30fec34a895fab4c02584449c500aac2
 PatchFile: libgettext8-shlibs.patch
-PatchFile-MD5: 925a8d897cd72f6dd0c89bea4dfa868a
+PatchFile-MD5: 8ebf1b7c276059b0d3a334f60a2f705e
 PatchFile2: gettext-tools-tests.patch
 PatchFile2-MD5: 6051a92acfc5ba9bf2274c258dbd6c7e
 PatchScript: <<
  patch -p1 < %{PatchFile}
  sed 's|@FINKPREFIX@|%p|g' < %{PatchFile2} | patch -p1
- perl -pi -e 's/.*chmod.*777.*$//g' build-aux/ltmain.sh
 <<
 Depends: <<
 	expat1-shlibs (>= 2.0.1-1),
@@ -90,8 +89,8 @@ InstallScript: <<
 DocFiles: README* AUTHORS COPYING* NEWS THANKS ChangeLog* 
 InfoDocs: gettext.info
 Shlibs: <<
-  !%p/lib/libgettextlib-0.20.1.dylib
-  !%p/lib/libgettextsrc-0.20.1.dylib
+  !%p/lib/libgettextlib-0.20.2.dylib
+  !%p/lib/libgettextsrc-0.20.2.dylib
 <<
 Description: GNU Internationalization utils
 

--- a/10.9-libcxx/stable/main/finkinfo/base/libgettext8-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/libgettext8-shlibs.info
@@ -1,19 +1,18 @@
 Package: libgettext8-shlibs
-Version: 0.20.1
+Version: 0.20.2
 Revision: 1
 CustomMirror: <<
 	Primary: http://ftpmirror.gnu.org/gettext/
 	Secondary: http://downloads.sourceforge.net/fink/
 <<
 Source: mirror:custom:gettext-%v.tar.gz
-Source-MD5: bb5b0c0caa028105f3ca1905ddc306e2
+Source-MD5: 30fec34a895fab4c02584449c500aac2
 # libgettext8-shlibs.patch must be regenerated for every update since
 # dpkg uses it and needs the correct full file headers for patch -p0 
 PatchFile: %n.patch
-PatchFile-MD5: 925a8d897cd72f6dd0c89bea4dfa868a
+PatchFile-MD5: 8ebf1b7c276059b0d3a334f60a2f705e
 PatchScript: <<
  patch -p1 < %{PatchFile}
- cd build-aux; perl -pi -e 's/.*chmod.*777.*$//g' ltmain.sh
 <<
 Essential: yes
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/base/libgettext8-shlibs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/base/libgettext8-shlibs.patch
@@ -1,7 +1,7 @@
-diff -ruN gettext-0.20.1-orig/gettext-runtime/libasprintf/Makefile.in gettext-0.20.1/gettext-runtime/libasprintf/Makefile.in
---- gettext-0.20.1-orig/gettext-runtime/libasprintf/Makefile.in	2019-05-12 10:08:31.000000000 -0500
-+++ gettext-0.20.1/gettext-runtime/libasprintf/Makefile.in	2019-05-13 06:44:58.000000000 -0500
-@@ -566,7 +566,7 @@
+diff -ruN gettext-0.20.2-orig/gettext-runtime/libasprintf/Makefile.in gettext-0.20.2/gettext-runtime/libasprintf/Makefile.in
+--- gettext-0.20.2-orig/gettext-runtime/libasprintf/Makefile.in	2020-04-13 23:45:32.000000000 -0500
++++ gettext-0.20.2/gettext-runtime/libasprintf/Makefile.in	2021-01-01 06:21:30.000000000 -0600
+@@ -574,7 +574,7 @@
  # How to build libasprintf.
  # With libtool 1.5.14, on some platforms, like BeOS, "libtool --tag=CXX" fails
  # to create a shared library, however "libtool --tag=CC" succeeds.
@@ -10,10 +10,10 @@ diff -ruN gettext-0.20.1-orig/gettext-runtime/libasprintf/Makefile.in gettext-0.
  libgnu_la_SOURCES = size_max.h xsize.h xsize.c
  libgnu_la_LIBADD = $(gl_LTLIBOBJS) @LTALLOCA@
  libgnu_la_DEPENDENCIES = $(gl_LTLIBOBJS) @LTALLOCA@
-diff -ruN gettext-0.20.1-orig/gettext-tools/src/Makefile.in gettext-0.20.1/gettext-tools/src/Makefile.in
---- gettext-0.20.1-orig/gettext-tools/src/Makefile.in	2019-05-12 10:09:17.000000000 -0500
-+++ gettext-0.20.1/gettext-tools/src/Makefile.in	2019-05-13 06:44:58.000000000 -0500
-@@ -3465,10 +3465,10 @@
+diff -ruN gettext-0.20.2-orig/gettext-tools/src/Makefile.in gettext-0.20.2/gettext-tools/src/Makefile.in
+--- gettext-0.20.2-orig/gettext-tools/src/Makefile.in	2020-04-13 23:46:32.000000000 -0500
++++ gettext-0.20.2/gettext-tools/src/Makefile.in	2021-01-01 06:21:30.000000000 -0600
+@@ -3633,10 +3633,10 @@
  	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(urlget_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o urlget-urlget.obj `if test -f 'urlget.c'; then $(CYGPATH_W) 'urlget.c'; else $(CYGPATH_W) '$(srcdir)/urlget.c'; fi`
  
  xgettext-xgettext.o: xgettext.c

--- a/10.9-libcxx/stable/main/finkinfo/base/libiconv.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/libiconv.info
@@ -1,6 +1,6 @@
 Package: libiconv
 Version: 1.16
-Revision: 2
+Revision: 3
 Description: Character set conversion library
 License: LGPL
 Maintainer: Fink Core Group <fink-core@lists.sourceforge.net>
@@ -13,9 +13,9 @@ CustomMirror: <<
 <<
 Source: mirror:custom:libiconv-%v.tar.gz
 Source-MD5: 7d2a800b952942bb2880efb00cfd524c
-Source2: mirror:sourceforge:fink/gettext-0.20.1.tar.gz
-#Source2: mirror:gnu:gettext/gettext-0.20.1.tar.gz
-Source2-MD5: bb5b0c0caa028105f3ca1905ddc306e2
+Source2: mirror:sourceforge:fink/gettext-0.20.2.tar.gz
+#Source2: mirror:gnu:gettext/gettext-0.20.2.tar.gz
+Source2-MD5: 30fec34a895fab4c02584449c500aac2
 Source3: mirror:sourceforge:fink/gperf-3.1.tar.gz
 #Source3: mirror:gnu:gperf/gperf-3.1.tar.gz
 Source3-MD5: 9e251c0a618ad0824b51117d5d9db87e
@@ -40,7 +40,7 @@ make -j1 check || exit 2
 ### If gettext gets updated, make sure these ./configure parameters 
 ### match the new package parameters (except build static only here).
 ### Not necessary, but will avoid unforeseen consequences.
-cd %b/../gettext-0.20.1/gettext-runtime
+cd %b/../gettext-0.20.2/gettext-runtime
 EMACS=no CPPFLAGS="-I%b/../_inst%p/include" LDFLAGS="-L%b/../_inst%p/lib" am_cv_func_iconv=no ./configure \
 	--prefix=%p \
 	--infodir='${prefix}/share/info' \


### PR DESCRIPTION
Update our libgettext to 0.20.2 (including the private versions used by libiconv and dpkg).

This has the potential to fix the annoying build failures that pops up for some people that are using a 'weird' locale/language mix (such as en_AT).
The [release notes](https://savannah.gnu.org/forum/forum.php?forum_id=9430) say this:

> The interpretation of the language preferences on macOS has been improved, especially in the case where a system locale does not exist for the combination of the selected primary language and the selected territory.

On my 10.15 VM, I switched the region to Spain, but kept my language as English. During any build process, I got a lot of warnings about failure to set locale category LC_* to en_ES (but couldn't replicate the failures others were seeing). The warnings happened both during the actual compiling steps as well as while dpkg was creating buildlocks and building debs.
Once I updated my local libgettext8-shlibs 0.20.2, all the locale warnings went away.

I think this is a rather low risk update.