### PR TITLE
Cfitsio upgrade

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/libvips42-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/libvips42-shlibs.info
@@ -1,7 +1,8 @@
 Package: libvips42-shlibs
 # 8.4.0 and higher need glib > 2.28 NEWGLIB24
+# FTBFS with libmagick 7
 Version: 8.3.0
-Revision: 2
+Revision: 3
 Description: VASARI Image Processing System
 License: LGPL
 # Free to update, modify and take over
@@ -9,11 +10,12 @@ Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
 Depends: <<
 	fftw3-shlibs (>= 3.1.2-1),
 	fontconfig2-shlibs (>= 2.10.0-1),
-	freetype219-shlibs (>= 2.6-1),
+	freetype219-shlibs (>= 2.10.2-1),
 	giflib7-shlibs (>= 5.1.4),
 	glib2-shlibs (>= 2.22.0-1),
 	ilmbase12-shlibs,
 	lcms2-shlibs (>= 2.2-2),
+	libcfitsio8-shlibs,
 	libexif12-shlibs (>= 0.6.16-1),
 	libgettext8-shlibs,
 	libjpeg9-shlibs,
@@ -30,17 +32,17 @@ Depends: <<
 BuildDepends: <<
 	autoconf2.6,
 	automake1.15,
-	cfitsio,
 	fftw3 (>= 3.1.2-1),
 	fink (>= 0.32),
 	fink-package-precedence,
 	fontconfig2-dev (>= 2.10.0-1),
-	freetype219 (>= 2.6-1),
+	freetype219 (>= 2.10.2-1),
 	gettext-tools,
 	giflib7 (>= 5.1.4),
 	glib2-dev (>= 2.22.0-1),
 	ilmbase12,
 	lcms2 (>= 2.2-2),
+	libcfitsio8-dev,
 	libexif12 (>= 0.6.16-1),
 	libgettext8-dev,
 	libiconv-dev,
@@ -113,11 +115,12 @@ Splitoff: <<
 		%N (>= %v-%r),
 		fftw3-shlibs (>= 3.1.2-1),
 		fontconfig2-shlibs (>= 2.10.0-1),
-		freetype219-shlibs (>= 2.6-1),
+		freetype219-shlibs (>= 2.10.2-1),
 		giflib7-shlibs (>= 5.1.4),
 		glib2-shlibs (>= 2.22.0-1),
 		ilmbase12-shlibs,
 		lcms2-shlibs (>= 2.2-2),
+		libcfitsio8-shlibs,
 		libexif12-shlibs (>= 0.6.16-1),
 		libgettext8-shlibs,
 		libjpeg9-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/graphics/libvips42-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/libvips42-shlibs.info
@@ -2,7 +2,7 @@ Package: libvips42-shlibs
 # 8.4.0 and higher need glib > 2.28 NEWGLIB24
 # FTBFS with libmagick 7
 Version: 8.3.0
-Revision: 3
+Revision: 4
 Description: VASARI Image Processing System
 License: LGPL
 # Free to update, modify and take over
@@ -68,12 +68,9 @@ Source-Checksum: SHA1(2385069d8e15109406869c94de2afe61c18f5535)
 Source2: http://archive.ubuntu.com/ubuntu/pool/universe/v/vips/vips_%v-3.debian.tar.xz
 Source2-MD5: fbe4c6b3b9ee620a05d8b753b9ec8f1b
 PatchScript: <<
-	# This variable is what's published as vips.pc:Requires
-	# (set to match public API (#include in installed *.h)
-	perl -pi -e 's,PACKAGES_USED="",PACKAGES_USED="glib-2.0 gmodule-2.0 gobject-2.0",' configure
 	# don't publish other internal-implementation details
-	perl -pi -e 's,(PACKAGES_USED="\$PACKAGES_USED),#\1,' configure
-	perl -pi -e 's,\@\S+\@,,g if /^Libs:/' vips.pc.in
+	# (set to match public API (#include in installed *.h)
+	perl -pi -e 's,\@PACKAGES_USED\@,glib-2.0 gmodule-2.0 gobject-2.0,; s,^(Requires:).*,\1,; s,\@EXTRA_LIBS_USED\@,,' vips.pc.in
 	# Fix /usr/share paths in doc files (rather than rebuilding all docs)
 	perl -pi -e 's|\/usr\/share|%p\/share|g' doc/html/{libvips-type,object-tree}.html
 	# Get Ubuntu's giflib-5.0 (giflib7) patches

--- a/10.9-libcxx/stable/main/finkinfo/graphics/nip2.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/nip2.info
@@ -1,7 +1,7 @@
 Package: nip2
 # %v restricted by libvips42 NEWGLIB24
 Version: 8.2
-Revision: 2
+Revision: 3
 Description: Graphical image manipulation tool
 License: LGPL
 # Free to update, modify and take over
@@ -12,13 +12,13 @@ Depends: <<
 	desktop-file-utils,
 	fftw3-shlibs (>= 3.1.2-1),
 	fontconfig2-shlibs (>= 2.10.2-2),
-	freetype219-shlibs (>= 2.6.3-2),
+	freetype219-shlibs (>= 2.10.2-1),
 	glib2-shlibs (>= 2.22.4-9),
 	gtk+2-shlibs (>= 2.18.9-11),
 	libgettext8-shlibs,
 	libgsf1.115-shlibs,
 	libgsl25-shlibs,
-	libvips42-shlibs (>= %v),
+	libvips42-shlibs (>= 8.3.0-4),
 	libxml2-shlibs (>= 2.9.4-1),
 	pango1-xft2-ft219-shlibs (>= 1.24.5-11),
 	shared-mime-info
@@ -29,7 +29,7 @@ BuildDepends: <<
 	fftw3 (>= 3.1.2-1),
 	fink-package-precedence,
 	fontconfig2-dev (>= 2.10.2-2),
-	freetype219 (>= 2.6.3-2),
+	freetype219 (>= 2.10.2-1),
 	gettext-tools,
 	glib2-dev (>= 2.22.4-9),
 	gtk+2-dev (>= 2.18.9-11),
@@ -37,7 +37,7 @@ BuildDepends: <<
 	libgsf1.115-dev,
 	libgsl25-dev,
 	libiconv-dev,
-	libvips42-dev (>= %v),
+	libvips42-dev (>= 8.3.0-4),
 	libxml2 (>= 2.9.4-1),
 	pango1-xft2-ft219-dev (>= 1.24.5-11),
 	pkgconfig,

--- a/10.9-libcxx/stable/main/finkinfo/kde/kstars4.info
+++ b/10.9-libcxx/stable/main/finkinfo/kde/kstars4.info
@@ -1,13 +1,14 @@
 Info4: <<
 Package: kstars4-%type_pkg[kde]
 Version: 14.12.3
-Revision: 1
+Revision: 2
 Description: KDE4 - Desktop planetarium
 Type: kde (mac)
 License: GPL
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
 Depends: <<
 	kdelibs4-%type_pkg[kde]-shlibs (>= 4.14.6-1),
+	libcfitsio8-shlibs,
 	oxygen-icons-%type_pkg[kde] (>= %v-1),
 	qt4-base-%type_pkg[kde]-qtcore-shlibs (>= 4.8.5-1),
 	qt4-base-%type_pkg[kde]-qtdbus-shlibs (>= 4.8.5-1),
@@ -19,7 +20,6 @@ Depends: <<
 <<
 BuildDepends: <<
 	automoc-%type_pkg[kde] (>= 0.9.89-0.999999.32),
-	cfitsio,
 	cmake (>= 2.8.10-1),
 	docbook-dtd,
 	docbook-xsl,
@@ -28,6 +28,7 @@ BuildDepends: <<
 	fink-package-precedence,
 	kde4-buildenv (>= 4.13.1-1),
 	kdelibs4-%type_pkg[kde]-dev (>= 4.14.6-1),
+	libcfitsio8-dev,
 	phonon-%type_pkg[kde] (>= 4.5.0-1),
 	pkgconfig (>= 0.23-1),
 	qt4-base-%type_pkg[kde] (>= 4.8.5-1),

--- a/10.9-libcxx/stable/main/finkinfo/libs/octmods/fits-oct.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/octmods/fits-oct.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: fits-oct%type_pkg[oct]
 Version: 1.0.5
 Type: oct (3.6.4 3.8.2), forge (fits), gcc (5)
-Revision: 2
+Revision: 3
 
 Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 Homepage: http://octave.sourceforge.net/general/index.html 
@@ -20,13 +20,14 @@ save_fits_image_multi_ext
 License: GPL3+
 
 BuildDepends: <<
-  cfitsio (>=3.37-1),
+  libcfitsio8-dev,
   liboctave%type_pkg[oct]-dev, 
   fink-octave-scripts (>= 0.3.0-1),
   fftw3, 
   hdf5.9
  <<
 Depends: <<
+  libcfitsio8-shlibs,
   octave%type_pkg[oct]-interpreter
 <<
 Conflicts: octave-forge, octave-forge-%type_raw[forge] (<< 1.0.0-999)

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/astropy-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/astropy-py.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: astropy-py%type_pkg[python]
 Version: 1.3
-Revision: 1
+Revision: 2
 Type: python (2.7 3.4 3.5 3.6)
 Description: Python library for Astronomy
 License: GPL
@@ -9,11 +9,12 @@ Maintainer: Derek Homeier <dhomeie@gwdg.de>
 Depends: <<
   python%type_pkg[python],
   numpy-py%type_pkg[python] (>= 1.6.0-1),
+  libcfitsio8-shlibs,
   expat1-shlibs (>= 2.1.0-1),
   yaml-py%type_pkg[python]
 <<
 BuildDepends: <<
-  cfitsio (>= 3.35-1), expat1 (>= 2.1.0-1), setuptools-tng-py%type_pkg[python]
+  libcfitsio8-dev, expat1 (>= 2.1.0-1), setuptools-tng-py%type_pkg[python]
 <<
 Recommends: <<
   beautifulsoup-py%type_pkg[python],
@@ -64,7 +65,7 @@ PreRmScript: <<
   update-alternatives --remove wcslint %p/bin/wcslint-astropy-py%type_pkg[python]
 <<
 InfoTest: <<
-  TestDepends: pytest-py%type_pkg[python], ca-bundle
+  TestDepends: pytest-py%type_pkg[python], ca-bundle, cython-py%type_pkg[python], h5py-py%type_pkg[python]
   TestScript: <<
     #!/bin/bash -ev
     export PYTHONPATH=$(ls -d %b/build/lib.macosx-*-%type_raw[python])


### PR DESCRIPTION
From static cfitsio to shared libcfitsio8-dev/-shlibs. Along the way, overhaul libvips42's .pc to stop leaking dependencies on internal-use-only libs.

Pinging @nieder (libvips/nip2), @akhansen (fits-oct), @dhomeier (astropy)

There are a few other reverse-dependencies on old cfitsio, but they will involve more substantial updates.