### PR TITLE
patched configure and R.m4 to include <stdlib.h> and <string.h> to av…

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base36.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base36.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: r-base36
 Version: 3.6.3
-Revision: 1
+Revision: 3
 Description: R Framework
 Type: rversion (3.6)
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
@@ -39,7 +39,7 @@ BuildDepends: <<
 Source: http://cran.r-project.org/src/base/R-3/R-%v.tar.gz
 Source-MD5: 506c9576ba33e1262ad5b5624db9d96a
 PatchFile: %n.patch
-PatchFile-MD5: 873c0e3f7a06d0434c4ff2846bd74c4c
+PatchFile-MD5: 9f638c0d775d06e163c023ccd87949b8
 PatchScript: <<
   #!/bin/sh -ev
   #sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base36.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base36.patch
@@ -1,6 +1,6 @@
-diff -ruN R-3.6.1-orig/Makefile.fw R-3.6.1/Makefile.fw
---- R-3.6.1-orig/Makefile.fw	2019-10-01 08:46:02.000000000 +0900
-+++ R-3.6.1/Makefile.fw	2019-10-01 09:09:49.000000000 +0900
+diff -ruN R-3.6.3-orig/Makefile.fw R-3.6.3/Makefile.fw
+--- R-3.6.3-orig/Makefile.fw	2018-09-25 04:47:00.000000000 -0400
++++ R-3.6.3/Makefile.fw	2021-01-13 11:12:28.000000000 -0500
 @@ -8,7 +8,7 @@
  
  install install-strip: install-R-framework
@@ -19,9 +19,9 @@ diff -ruN R-3.6.1-orig/Makefile.fw R-3.6.1/Makefile.fw
  	@( otool=otool ; if otool -D "$(DESTDIR)$(Rexeclibdir)/libR.dylib"|grep 'not an object'>/dev/null; then otool=otool64; fi; \
  	   for lib in Rlapack Rblas R; do \
  	   if test -e "$(DESTDIR)$(Rexeclibdir)/lib$${lib}.dylib"; then $(ECHO) "  lib$${lib}"; \
-diff -ruN R-3.6.1-orig/configure R-3.6.1/configure
---- R-3.6.1-orig/configure	2019-10-01 08:46:02.000000000 +0900
-+++ R-3.6.1/configure	2019-10-01 09:14:34.000000000 +0900
+diff -ruN R-3.6.3-orig/configure R-3.6.3/configure
+--- R-3.6.3-orig/configure	2020-02-21 18:16:00.000000000 -0500
++++ R-3.6.3/configure	2021-01-13 12:22:29.000000000 -0500
 @@ -3874,8 +3874,8 @@
  
  ## As from R 3.2.0 split up -L... and -lR
@@ -33,7 +33,7 @@ diff -ruN R-3.6.1-orig/configure R-3.6.1/configure
  else
    LIBR0=
    LIBR1=
-@@ -38712,7 +38712,7 @@
+@@ -38938,7 +38938,7 @@
  
  if test "${use_blas_shlib}" = yes; then
    ## set BLAS_LIBS to point at local version
@@ -42,7 +42,7 @@ diff -ruN R-3.6.1-orig/configure R-3.6.1/configure
  fi
  
   if test "x${use_veclib_g95fix}" = xyes; then
-@@ -38877,7 +38877,7 @@
+@@ -39103,7 +39103,7 @@
  
  fi
  if test "${acx_lapack_ok}" != "yes"; then
@@ -51,9 +51,46 @@ diff -ruN R-3.6.1-orig/configure R-3.6.1/configure
  fi
  
   if test "${acx_lapack_ok}" = "yes"; then
-diff -ruN R-3.6.1-orig/src/extra/intl/vasnprintf.c R-3.6.1/src/extra/intl/vasnprintf.c
---- R-3.6.1-orig/src/extra/intl/vasnprintf.c	2019-10-01 08:46:02.000000000 +0900
-+++ R-3.6.1/src/extra/intl/vasnprintf.c	2019-10-01 08:46:29.000000000 +0900
+@@ -42238,6 +42238,8 @@
+ /* end confdefs.h.  */
+ 
+ #ifdef HAVE_BZLIB_H
++#include <stdlib.h> // for exit
++#include <string.h> // for strcmp
+ #include <bzlib.h>
+ #endif
+ int main() {
+@@ -42946,6 +42948,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <string.h>
+ #include <curl/curl.h>
+ int main()
+diff -ruN R-3.6.3-orig/m4/R.m4 R-3.6.3/m4/R.m4
+--- R-3.6.3-orig/m4/R.m4	2019-09-06 18:15:02.000000000 -0400
++++ R-3.6.3/m4/R.m4	2021-01-13 12:18:38.000000000 -0500
+@@ -3189,6 +3189,8 @@
+ LIBS="-lbz2 ${LIBS}"
+ AC_RUN_IFELSE([AC_LANG_SOURCE([[
+ #ifdef HAVE_BZLIB_H
++#include <stdlib.h> // for exit
++#include <string.h> // for strcmp
+ #include <bzlib.h>
+ #endif
+ int main() {
+@@ -4184,6 +4186,7 @@
+ if test "x${have_libcurl}" = "xyes"; then
+ AC_CACHE_CHECK([if libcurl supports https], [r_cv_have_curl_https],
+ [AC_RUN_IFELSE([AC_LANG_SOURCE([[
++#include <stdlib.h>
+ #include <string.h>
+ #include <curl/curl.h>
+ int main()
+diff -ruN R-3.6.3-orig/src/extra/intl/vasnprintf.c R-3.6.3/src/extra/intl/vasnprintf.c
+--- R-3.6.3-orig/src/extra/intl/vasnprintf.c	2018-09-25 04:46:48.000000000 -0400
++++ R-3.6.3/src/extra/intl/vasnprintf.c	2021-01-13 11:12:28.000000000 -0500
 @@ -4006,7 +4006,7 @@
  #endif
  		  *fbp = dp->conversion;
@@ -63,9 +100,9 @@ diff -ruN R-3.6.1-orig/src/extra/intl/vasnprintf.c R-3.6.1/src/extra/intl/vasnpr
  		fbp[1] = '%';
  		fbp[2] = 'n';
  		fbp[3] = '\0';
-diff -ruN R-3.6.1-orig/src/main/Makefile.in R-3.6.1/src/main/Makefile.in
---- R-3.6.1-orig/src/main/Makefile.in	2019-10-01 08:46:03.000000000 +0900
-+++ R-3.6.1/src/main/Makefile.in	2019-10-01 08:46:29.000000000 +0900
+diff -ruN R-3.6.3-orig/src/main/Makefile.in R-3.6.3/src/main/Makefile.in
+--- R-3.6.3-orig/src/main/Makefile.in	2019-03-28 19:02:31.000000000 -0400
++++ R-3.6.3/src/main/Makefile.in	2021-01-13 11:12:28.000000000 -0500
 @@ -101,7 +101,7 @@
  R_bin_OBJECTS = Rmain.o @WANT_R_SHLIB_FALSE@$(OBJECTS)
  @WANT_R_SHLIB_FALSE@R_bin_LDADD = $(MAIN_OBJS) $(EXTRA_STATIC_LIBS) $(EXTRA_LIBS)
@@ -75,9 +112,9 @@ diff -ruN R-3.6.1-orig/src/main/Makefile.in R-3.6.1/src/main/Makefile.in
  @BUILD_LTO_FALSE@R_bin_DEPENDENCIES =@WANT_R_SHLIB_FALSE@ libR.a @USE_EXPORTFILES_TRUE@ $(top_builddir)/etc/R.exp
  
  libR_la = libR$(R_DYLIB_EXT)
-diff -ruN R-3.6.1-orig/src/nmath/standalone/Makefile.in R-3.6.1/src/nmath/standalone/Makefile.in
---- R-3.6.1-orig/src/nmath/standalone/Makefile.in	2019-10-01 08:46:04.000000000 +0900
-+++ R-3.6.1/src/nmath/standalone/Makefile.in	2019-10-01 08:46:29.000000000 +0900
+diff -ruN R-3.6.3-orig/src/nmath/standalone/Makefile.in R-3.6.3/src/nmath/standalone/Makefile.in
+--- R-3.6.3-orig/src/nmath/standalone/Makefile.in	2019-03-28 19:02:35.000000000 -0400
++++ R-3.6.3/src/nmath/standalone/Makefile.in	2021-01-13 11:12:28.000000000 -0500
 @@ -131,7 +131,7 @@
  
  test: $(srcdir)/test.c


### PR DESCRIPTION
patched configure and R.m4 to include <stdlib.h> and <string.h> to avoid implicit declaration no longer allowed by compiler in Xcode 12.3.
Updated patch file for R-base 3.6.3 and updated MD5 hash in .info file