### PR TITLE
root5: Dep upgrades

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/root5.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/root5.info
@@ -1,7 +1,7 @@
 Info3: <<
 Package: root5%type_pkg[-x11]%type_pkg[-cernlib]%type_pkg[-pythia]
 Version: 5.34.38
-Revision: 1
+Revision: 2
 Distribution: 10.9, 10.10, 10.11, 10.12, 10.13
 Type: <<
  -x11 (boolean),
@@ -18,23 +18,24 @@ Depends: <<
  (%type_pkg[-x11]) x11
 <<
 BuildDepends: <<
- cfitsio,
  expat1,
  fftw3,
  fink (>= 0.28),
- glew1.13,
- libgraphviz238-dev,
+ glew2.0,
  gsl,
+ libcfitsio8-dev,
  libftgl2-dev,
+ libgraphviz238-dev,
  liblzma5,
  libodbc3-dev,
  libpcre1,
+ libxxhash0-dev,
  mysql-unified-dev,
  pkgconfig,
- postgresql94-dev,
+ postgresql12-dev,
  sqlite3-dev,
  xrootd4-dev (>= 4.5.0),
- (%type_pkg[-x11]) freetype219 (>= 2.6-1),
+ (%type_pkg[-x11]) freetype219 (>= 2.10.2-1),
  (%type_pkg[-x11]) libjpeg9,
  (%type_pkg[-x11]) libpng16,
  (%type_pkg[-x11]) libtiff5,
@@ -69,7 +70,7 @@ Source: https://root.cern.ch/download/root_v%v.source.tar.gz
 Source-MD5: c0e3a2ddd7dfab17db4a8e8dc042a579
 SourceDirectory: root
 PatchFile: %{ni}.patch
-PatchFile-MD5: a691bfbcaeeb0910749df573fe66c0bc
+PatchFile-MD5: c37ec291d2ab942216bb802f74dcb425
 PatchScript: <<
  patch -p1 < %{PatchFile}
  /usr/bin/sed -i '.bak' -e 's:python :%p/bin/python2.7 :' bindings/pyroot/Module.mk cint/cintex/Module.mk
@@ -78,6 +79,8 @@ PatchScript: <<
  /bin/rm -f bindings/pyroot/Module.mk.bak cint/cintex/Module.mk.bak config/genreflex.in.bak config/roots.in.bak
  perl -pi.bak -e 's,/usr/X11/(include|lib),$& /opt/X11/$1,g' configure
 <<
+# * Don't specify anything about mysql, so autodetection finds and
+#   uses mysql_config properly.
 ConfigureParams: <<
  --etcdir=%p/etc/root \
  --docdir=%p/share/doc/%n \
@@ -88,7 +91,6 @@ ConfigureParams: <<
  --with-gviz-incdir=%p/include --with-gviz-libdir=%p/lib/graphviz-2.38 \
  --with-gsl-incdir=%p/include --with-gsl-libdir=%p/lib \
  --with-ldap-incdir=/usr/include --with-ldap-libdir=/usr/lib \
- --with-mysql-incdir=%p/include/mysql --with-mysql-libdir=%p/lib/mysql \
  --with-odbc-incdir=%p/include --with-odbc-libdir=%p/lib \
  --with-glew-incdir=%p/include --with-glew-libdir=%p/lib \
 (%type_pkg[-x11]) --with-opengl-incdir=%p/include/mesa \
@@ -96,7 +98,7 @@ ConfigureParams: <<
 (%type_raw[-x11] = .) --with-opengl-incdir=/System/Library/Frameworks/OpenGL.framework/Headers \
 (%type_raw[-x11] = .) --with-opengl-libdir=/System/Library/Frameworks/OpenGL.framework/Libraries \
  --with-sqlite-incdir=%p/include --with-sqlite-libdir=%p/lib \
- --with-pgsql-incdir=%p/opt/postgresql-9.4/include --with-pgsql-libdir=%p/opt/postgresql-9.4/lib \
+ --with-pgsql-incdir=%p/opt/postgresql-12/include --with-pgsql-libdir=%p/opt/postgresql-12/lib \
  --with-python-incdir=%p/include/python2.7 --with-python-libdir=%p/lib/python2.7/config \
  --with-xml-incdir=/usr/include/libxml2 --with-xml-libdir=/usr/lib \
  --with-xrootd=%p --with-finkdir=%p \
@@ -105,6 +107,7 @@ ConfigureParams: <<
  --disable-builtin-freetype \
  --disable-builtin-glew \
  --disable-builtin-lzma \
+ --disable-builtin-lz4 \
  --disable-builtin-pcre \
  --disable-builtin-zlib \
  --disable-builtin_ftgl \
@@ -265,19 +268,21 @@ SplitOff: <<
    Depends: <<
     expat1-shlibs,
     fftw3-shlibs,
-    glew1.13-shlibs,
-    libgraphviz238-shlibs,
+    glew2.0-shlibs,
     gsl-shlibs,
+    libcfitsio8-shlibs,
     libftgl2-shlibs,
+    libgraphviz238-shlibs,
     liblzma5-shlibs,
     libodbc3-shlibs,
     libpcre1-shlibs,
+    libxxhash0-shlibs,
     mysql-unified-shlibs,
-    postgresql94-shlibs,
+    postgresql12-shlibs,
     python27-shlibs,
     sqlite3-shlibs,
     xrootd4 (>= 4.5.0),
-    (%type_pkg[-x11]) freetype219-shlibs (>= 2.6-1),
+    (%type_pkg[-x11]) freetype219-shlibs (>= 2.10.2-1),
     (%type_pkg[-x11]) libjpeg9-shlibs,
     (%type_pkg[-x11]) libpng16-shlibs,
     (%type_pkg[-x11]) libtiff5-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/sci/root5.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/root5.patch
@@ -106,11 +106,10 @@ index 8ee0d8b..2513ef7 100644
  
  # System libraries:
  SYSLIBS       = -lm $(OSTHREADLIBDIR) \
-diff --git a/configure b/configure
-index d2cb00f..33f413c 100755
---- a/configure
-+++ b/configure
-@@ -2671,8 +2671,8 @@ if test "x$enable_cocoa" = "xyes"; then
+diff -Nurd root.orig/configure root/configure
+--- root.orig/configure	2018-03-12 10:48:57.000000000 -0400
++++ root/configure	2021-01-17 22:32:34.000000000 -0500
+@@ -2680,8 +2680,8 @@
          message "Checking for system OSX SDK"
          osxsdk=""
      fi
@@ -121,7 +120,7 @@ index d2cb00f..33f413c 100755
      if [ -d $openglincdir ] && [ -d $opengllibdir ]; then
          result "yes"
      else
-@@ -2783,12 +2783,6 @@ if test ! "x$enable_x11" = "xno" ; then
+@@ -2792,12 +2792,6 @@
          result "See http://root.cern.ch/drupal/content/build-prerequisites"
          exit 1
      fi
@@ -131,10 +130,10 @@ index d2cb00f..33f413c 100755
 -        result "For consistency they should be in the same directory"
 -        exit 1
 -    fi
-
+ 
      check_library "libXext" "$enable_shared" "$xextlibdir" \
          ${finkdir:+$finkdir/lib} \
-@@ -2801,12 +2795,6 @@ if test ! "x$enable_x11" = "xno" ; then
+@@ -2810,12 +2804,6 @@
          result "See http://root.cern.ch/drupal/content/build-prerequisites"
          exit 1
      fi
@@ -147,17 +146,26 @@ index d2cb00f..33f413c 100755
  else
      x11libdir=""
      xpmlibdir=""
-@@ -3127,7 +3115,7 @@ if test ! "x$enable_opengl" = "xno" && test ! "x$platform" = "xwin32" ; then
+@@ -3108,7 +3096,7 @@
+         enable_builtin_lz4=yes
+     else
+         lz4inc=$found_hdr
+-        lz4incdir+=$lz4incdir:$xxhashincdir
++        lz4incdir="$lz4incdir $xxhashincdir"
+     fi
+ 
+     check_library "liblz4" "$enable_shared" "" \
+@@ -3200,7 +3188,7 @@
          glewinc="$found_hdr"
          glewincdir="$found_dir"
-
+ 
 -        check_library "libGLEW" "$enable_shared" "$keep" $opengllibdirs
 +        check_library "libGLEW" "$enable_shared" "$glewlibdir" $opengllibdirs
          glewlib="$found_lib"
          glewlibdir=$found_dir
          glewlibs="$glewlib"
-@@ -3957,7 +3945,7 @@ if test ! "x$enable_fftw3" = "xno"; then
-
+@@ -4031,7 +4019,7 @@
+ 
      # At this time, libfftw3.a should always be prefered over .so,
      # to avoid forcing users to install fftw3.
 -    check_library "libfftw3 libfftw3-3" "no" "$fftw3libdir" \


### PR DESCRIPTION
Especially important here is a switch to using external libxxhash/lv4 (fink package dep), to avoid build-time
downloading of sources.