### PR TITLE
nmap: New upstream.

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/net/nmap.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/nmap.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: nmap
-Version: 7.70
+Version: 7.91
 Revision: 1
 GCC: 4.0
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
@@ -25,8 +25,8 @@ Replaces: nmap-nox (<< 4.76-2), nmap (<< 4.76-2)
 Recommends: zenmap, nmap-update
 
 Source: http://nmap.org/dist/%n-%{v}.tar.bz2
-Source-MD5: 84eb6fbe788e0d4918c2b1e39421bf79
-Source-Checksum: SHA256(847b068955f792f4cc247593aca6dc3dc4aae12976169873247488de147a6e18)
+Source-MD5: 239cef725863ab454590a1bb8793b72b
+Source-Checksum: SHA256(18cc4b5070511c51eb243cdd2b0b30ff9b2c4dc4544c6312f75ce3a67a593300)
 SourceDirectory: %n-%{v}
 
 PatchScript: <<
@@ -55,29 +55,29 @@ ConfigureParams: <<
 <<
 CompileScript: <<
 	./configure %c PYTHON=%p/bin/python%type_raw[python] CC="flag-sort -r gcc" CXX="flag-sort -r g++"
-	
+
 	make
 <<
 InstallScript: <<
 	make install DESTDIR=%d
 <<
 
-DocFiles: CHANGELOG COPYING HACKING docs/README docs/*.txt
+DocFiles: CHANGELOG HACKING docs/README docs/*.txt
 Description: Network exploration utility
 DescDetail: <<
 	nmap, a utility for network exploration or auditing, supporting ping scanning,
 	port scanning and TCP/IP fingerprinting. It also offers decoy scanning, sunRPC
 	scanning, reverse-identd scanning and others.
-	
+
 	This package also contains:
 		nping: Network packet generation tool / ping utility
 		ncat:  Concatenate and redirect sockets
 		ndiff: Utility to compare the results of Nmap scans
-	
+
 	Version 3.46 thanks to Alex Barclay <prozac@utulsa.edu>.
-	
+
 	The GUI is now included in the 'zenmap' package.
-	
+
 	6.00 introduces the 'nmap-update' command which allows one to download
 	the latest scripts and OS-fingerprints from an official svn repo.
 	The 'nmap-update' tool has been moved to its own package.
@@ -85,12 +85,12 @@ DescDetail: <<
 DescPackaging: <<
 	Use Fink-installed libpcre instead of building our own.
 	Now scriptable with lua!
-	
+
 	Switch to included libdnet and libpcap as they're newer and have
 	nmap-specific patches.
-	
+
 	Switch to included lua because fink's is too old.
-	
+
 	Previously maintained by Jeremy Higgs <fink@higgs-family.net>
 <<
 License: GPL2


### PR DESCRIPTION
Newer nmap is required to run on Big Sur.