### PR TITLE
Postgresql updates

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 10.14
+Version: 10.15
 Revision: 1
 Type: postgresql 10
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: b3943822ebbf46f791c72f48ff0d5128
-Source-Checksum: SHA256(381cd8f491d8f77db2f4326974542a50095b5fa7709f24d7c5b760be2518b23b)
+Source-MD5: 8db86062be525c7cdb73ce50202b2ad9
+Source-Checksum: SHA256(5956bce0becffa77883c41594c95a23110b94f10cd66a1157e373c3575921f7e)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql11.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql11.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 11.9
+Version: 11.10
 Revision: 1
 Type: postgresql 11
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 2d20502cbce1c7531bb69e56f5c5c65a
-Source-Checksum: SHA256(35618aa72e0372091f923c42389c6febd07513157b4fbb9408371706afbb6635)
+Source-MD5: c9dbf5ae42a08b937d1b6cf7921e4669
+Source-Checksum: SHA256(13e6d2f80662fe463bc7718cdf0de6a9ec67fc78afcc7a3ae66b9ea19bb97899)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql12.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql12.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 12.4
+Version: 12.5
 Revision: 1
 Type: postgresql 12
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 80ebbf0e55193b123760e5f8e48c6cff
-Source-Checksum: SHA256(bee93fbe2c32f59419cb162bcc0145c58da9a8644ee154a30b9a5ce47de606cc)
+Source-MD5: f19e48090bbd59ea81826b5fd99e7e97
+Source-Checksum: SHA256(bd0d25341d9578b5473c9506300022de26370879581f5fddd243a886ce79ff95)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql94-implicit-declarations.patch
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql94-implicit-declarations.patch
@@ -1,0 +1,53 @@
+diff -ruN postgresql-9.4.26-orig/configure postgresql-9.4.26/configure
+--- postgresql-9.4.26-orig/configure	2020-02-10 16:25:31.000000000 -0600
++++ postgresql-9.4.26/configure	2021-01-22 19:50:25.000000000 -0600
+@@ -11540,6 +11540,7 @@
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <xlocale.h>
+ #include <time.h>
+ #ifndef tzname /* For SGI.  */
+ extern char *tzname[]; /* RS6000 and others reject char **tzname.  */
+@@ -12607,7 +12608,6 @@
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-
+ int
+ main ()
+ {
+@@ -13713,7 +13713,7 @@
+ # trust that the arithmetic works.
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -13734,6 +13734,7 @@
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <stdlib.h>
+ typedef long int ac_int64;
+ 
+ /*
+@@ -13795,7 +13796,7 @@
+ # trust that the arithmetic works.
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -13816,6 +13817,7 @@
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <stdlib.h>
+ typedef long long int ac_int64;
+ 
+ /*

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql94.info
@@ -19,6 +19,7 @@ Depends: <<
 <<
 BuildDepends: <<
 	bison,
+	fink (>= 0.30.0),
 	fink-mirrors (>= 0.28.7.1-2),
 	libxml2,
 	libxslt,
@@ -37,6 +38,7 @@ Source-Checksum: SHA256(f5c014fc4a5c94e8cf11314cbadcade4d84213cfcc82081c9123e1b8
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
+	patch -p1 < %{PatchFile2}
 
 	# Use xcrun instead of xcodebuild to support Xcode Command Line Tools only (so not the full Xcode).
 	sed -i.orig -e 's|xcodebuild -version -sdk macosx Path|xcrun --sdk macosx --show-sdk-path|g' src/template/darwin
@@ -51,7 +53,8 @@ PatchScript: <<
 <<
 PatchFile: %n.patch
 PatchFile-MD5: 76ee3710f431eda1a9c7de2441c60054
-
+PatchFile2: %n-implicit-declarations.patch
+PatchFile2-MD5: 9079f3ff064f0bf98a3fb6b985c8ead0
 SetCPPFLAGS: -DHAVE_OPTRESET -fno-common
 SetLDFLAGS: -F/System/Library/Frameworks
 CompileScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql95-implicit-declarations.patch
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql95-implicit-declarations.patch
@@ -1,0 +1,36 @@
+diff -ruN postgresql-9.5.24-orig/configure postgresql-9.5.24/configure
+--- postgresql-9.5.24-orig/configure	2020-11-09 16:34:09.000000000 -0600
++++ postgresql-9.5.24/configure	2021-01-23 05:45:01.000000000 -0600
+@@ -11642,6 +11642,7 @@
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <stdlib.h>
+ #include <time.h>
+ #ifndef tzname /* For SGI.  */
+ extern char *tzname[]; /* RS6000 and others reject char **tzname.  */
+@@ -13761,7 +13762,7 @@
+ # trust that the arithmetic works.
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -13782,6 +13783,7 @@
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <stdlib.h>
+ typedef long int ac_int64;
+ 
+ /*
+@@ -13845,6 +13847,7 @@
+ # trust that the arithmetic works.
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <stdlib.h>
+ 
+ int
+ main ()

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql95.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.5.21
+Version: 9.5.24
 Revision: 1
 Epoch: 1
 Type: postgresql 9.5
@@ -19,6 +19,7 @@ Depends: <<
 <<
 BuildDepends: <<
 	bison,
+	fink (>= 0.30.0),
 	fink-mirrors (>= 0.28.7.1-2),
 	libxml2,
 	libxslt,
@@ -32,11 +33,12 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: ec5c7dc5ade389be5eb0bc7c564e7796
-Source-Checksum: SHA256(7eb56e4fa877243c2df78adc5a0ef02f851060c282682b4bb97b854100fb732c)
+Source-MD5: 3e86e1016baefe6581b6d136367589a4
+Source-Checksum: SHA256(065cfd3db9f5aca84e794e73e71a797c984b2e728e760f4f4226a9162a99c22a)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
+	patch -p1 < %{PatchFile2}
 	
 	# Use xcrun instead of xcodebuild to support Xcode Command Line Tools only (so not the full Xcode).
 	sed -i.orig -e 's|xcodebuild -version -sdk macosx Path|xcrun --sdk macosx --show-sdk-path|g' src/template/darwin
@@ -51,6 +53,8 @@ PatchScript: <<
 <<
 PatchFile: %n.patch
 PatchFile-MD5: 0f6a310cf6fba539fa9d1e3e12e98088
+PatchFile2: %n-implicit-declarations.patch
+PatchFile2-MD5: 44d69aaa14e525b9b4b1c07f4b41969c
 
 SetCPPFLAGS: -DHAVE_OPTRESET -fno-common
 SetLDFLAGS: -F/System/Library/Frameworks

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql96-implicit-declarations.patch
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql96-implicit-declarations.patch
@@ -1,0 +1,35 @@
+diff -ruN postgresql-9.6.20-orig/configure postgresql-9.6.20/configure
+--- postgresql-9.6.20-orig/configure	2020-11-09 16:32:22.000000000 -0600
++++ postgresql-9.6.20/configure	2021-01-23 06:01:25.000000000 -0600
+@@ -11723,6 +11723,7 @@
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <stdlib.h>
+ #include <time.h>
+ #ifndef tzname /* For SGI.  */
+ extern char *tzname[]; /* RS6000 and others reject char **tzname.  */
+@@ -13809,6 +13810,7 @@
+ # trust that the arithmetic works.
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <stdlib.h>
+ 
+ int
+ main ()
+@@ -13830,6 +13832,7 @@
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <stdlib.h>
+ typedef long int ac_int64;
+ 
+ /*
+@@ -13893,6 +13896,7 @@
+ # trust that the arithmetic works.
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <stdlib.h>
+ 
+ int
+ main ()

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.6.19
+Version: 9.6.20
 Revision: 1
 Epoch: 1
 Type: postgresql 9.6
@@ -19,6 +19,7 @@ Depends: <<
 <<
 BuildDepends: <<
 	bison,
+	fink (>= 0.30.0),
 	fink-mirrors (>= 0.28.7.1-2),
 	libxml2,
 	libxslt,
@@ -32,11 +33,12 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 96d5f5f8e78eea6cada9d2e02718cc28
-Source-Checksum: SHA256(61f93a94ccddbe0b2d1afaf03f04ba605d8af5b774ff9b830e5adeb50ab55cb0)
+Source-MD5: 652f2c5eb1a3b0368000717a0e7c36f0
+Source-Checksum: SHA256(3d08cba409d45ab62d42b24431a0d55e7537bcd1db2d979f5f2eefe34d487bb6)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
+	patch -p1 < %{PatchFile2}
 	
 	# Use xcrun instead of xcodebuild to support Xcode Command Line Tools only (so not the full Xcode).
 	sed -i.orig -e 's|xcodebuild -version -sdk macosx Path|xcrun --sdk macosx --show-sdk-path|g' src/template/darwin
@@ -51,6 +53,8 @@ PatchScript: <<
 <<
 PatchFile: %n.patch
 PatchFile-MD5: b0b4aedbd5f4cc686755b087acaa7b76
+PatchFile2: %n-implicit-declarations.patch
+PatchFile2-MD5: 6649c9df8c5cb71192ba121f4b862c93
 
 SetCPPFLAGS: -DHAVE_OPTRESET -fno-common
 SetLDFLAGS: -F/System/Library/Frameworks


### PR DESCRIPTION
@wodev 
Updates for postgresql packages

For postgresql9X, had to patch configure to successfully build when using Xcode12 and it's implicit-declaration enforcements.

For postgresql1X, simple version bumps that contain a fix for a test in earlier releases that failed when not in daylight savings time.