### PR TITLE
Jpeg8 turbo update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/libjpeg8-turbo.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/libjpeg8-turbo.info
@@ -40,7 +40,15 @@ Depends: %n-shlibs (= %v-%r)
 BuildDepends: nasm (>= 2.09-1)
 BuildDependsOnly: true
 
-ConfigureParams: --prefix=%p/lib/%n --disable-dependency-tracking --disable-static \--host=%m-apple-darwin`uname -r` --build=%m-apple-darwin`uname -r` --without-java --with-jpeg8
+ConfigureParams: <<
+	--prefix=%p/lib/%n \
+	--disable-dependency-tracking \
+	--disable-static \
+	--host=%m-apple-darwin`uname -r` \
+	--build=%m-apple-darwin`uname -r` \
+	--without-java \
+	--with-jpeg8
+<<
 
 InfoTest: TestScript: make test || exit 2
 

--- a/10.9-libcxx/stable/main/finkinfo/graphics/libjpeg8-turbo.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/libjpeg8-turbo.info
@@ -1,5 +1,5 @@
 Package: libjpeg8-turbo
-Version: 1.5.2
+Version: 1.5.3
 Revision: 1
 Description: High speed libjpeg for i386 and x86_64
 DescDetail: <<
@@ -29,7 +29,7 @@ Homepage: http://www.libjpeg-turbo.org/
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 
 Source: mirror:sourceforge:libjpeg-turbo/libjpeg-turbo-%v.tar.gz
-Source-MD5: 6b4923e297a7eaa255f08511017a8818
+Source-MD5: 7c82f0f6a3130ec06b8a4d0b321cbca3
 
 PatchScript: <<
 	# Match behavior in <1.2.90 to avoid breaking things.


### PR DESCRIPTION
Update to 1.5.3
This is the last version that uses autotools.
Current upstream is 2.0.6 which is cmake based