### PR TITLE
Nieder upgrades (security-related deps)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/mplayer.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/mplayer.info
@@ -1,6 +1,6 @@
 Package: mplayer
 Version: 1.4
-Revision: 2
+Revision: 3
 Description: Unix movie player
 License: GPL
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
@@ -11,10 +11,10 @@ Depends: <<
 	bzip2-shlibs,
 	enca-shlibs,
 	fontconfig2-shlibs (>= 2.10.0-1),
-	freetype219-shlibs (>= 2.6-1),
+	freetype219-shlibs (>= 2.10.2-1),
 	fribidi-shlibs,
 	giflib7-shlibs,
-	gnutls28-shlibs,
+	gnutls30-shlibs,
 	lame-shlibs,
 	libass5-shlibs,
 	libbluray1-shlibs,
@@ -58,10 +58,10 @@ BuildDepends: <<
 	fink (>= 0.34),
 	fink-package-precedence,
 	fontconfig2-dev (>= 2.10.0-1),
-	freetype219 (>= 2.6-1),
+	freetype219 (>= 2.10.2-1),
 	fribidi-dev,
 	giflib7,
-	gnutls28,
+	gnutls30,
 	ladspa-dev,
 	lame-dev,
 	libass5-dev,

--- a/10.9-libcxx/stable/main/finkinfo/kde/kdebase4-runtime.info
+++ b/10.9-libcxx/stable/main/finkinfo/kde/kdebase4-runtime.info
@@ -1,7 +1,7 @@
 Info3: <<
 Package: kdebase4-runtime-%type_pkg[kde]
 Version: 14.12.3
-Revision: 5
+Revision: 6
 Description: KDE4 - Base applications and tools (runtime)
 Type: kde (mac)
 License: GPL/LGPL
@@ -16,7 +16,7 @@ Depends: <<
 	libattica0.4-%type_pkg[kde]-shlibs,
 	libcanberra0-shlibs,
 	libexiv2-0.24-shlibs,
-	libgcrypt-shlibs,
+	libgcrypt20-shlibs,
 	libjpeg9-shlibs,
 	libknotifyplugin4-%type_pkg[kde]-shlibs (>= %v-%r),
 #	libnepomuk4-%type_pkg[kde]-shlibs (>= 4.14.3-1),
@@ -58,7 +58,7 @@ BuildDepends: <<
 	libattica0.4-%type_pkg[kde]-dev,
 	libcanberra0,
 	libexiv2-0.24,
-	libgcrypt,
+	libgcrypt20,
 	libgpg-error,
 	libjpeg9,
 	liblzma5,

--- a/10.9-libcxx/stable/main/finkinfo/kde/libkf5js5-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/kde/libkf5js5-shlibs.info
@@ -15,6 +15,7 @@ BuildDepends: <<
 	fink (>= 0.34),
 	fink-buildenv-modules (>= 0.1.2),
 	fink-package-precedence,
+	kdoctools-dev,
 	libpcre1,
 	pkgconfig,
 	qt5-mac-qtbase

--- a/10.9-libcxx/stable/main/finkinfo/kde/libkf5wallet5-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/kde/libkf5wallet5-shlibs.info
@@ -1,6 +1,6 @@
 Package: libkf5wallet5-shlibs
 Version: 5.8.0
-Revision: 1
+Revision: 2
 Distribution: 10.9, 10.10
 Description: KF5 - Secure container for user passwords
 License: GPL
@@ -23,7 +23,7 @@ BuildDepends: <<
 	fink-package-precedence,
 	gettext-tools,
 	gpgme11,
-	libgcrypt,
+	libgcrypt20,
 	libgpg-error,
 	libkf5archive5-dev (>= %v-1),
 	libkf5auth5-dev (>= %v-1),
@@ -101,7 +101,7 @@ SplitOff3: <<
 	Description: KF5 - Secure container for user passwords
 	Depends: <<
 		%N (>= %v-%r),
-		libgcrypt-shlibs,
+		libgcrypt20-shlibs,
 		libkf5configcore5-shlibs (>= %v-1),
 		libkf5coreaddons5-shlibs (>= %v-1),
 		libkf5dbusaddons5-shlibs (>= %v-1),
@@ -129,7 +129,7 @@ SplitOff4: <<
 	Package: libkf5walletbackend5.5-shlibs
 	Description: KF5 - Secure container for user passwords
 	Depends: <<
-		libgcrypt-shlibs,
+		libgcrypt20-shlibs,
 		libkf5coreaddons5-shlibs (>= %v-1),
 		libkf5i18n5-shlibs (>= %v-1),
 		libkf5notifications5-shlibs (>= %v-1),

--- a/10.9-libcxx/stable/main/finkinfo/kde/libktorrent5-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/kde/libktorrent5-shlibs.info
@@ -1,7 +1,7 @@
 Info3: <<
 Package: libktorrent5-%type_pkg[kde]-shlibs
 Version: 1.3.1
-Revision: 1
+Revision: 2
 Description: KDE4 - Torrent library
 Type: kde (mac)
 License: GPL
@@ -10,7 +10,7 @@ Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
 Depends: <<
 	gmp5-shlibs,
 	kdelibs4-%type_pkg[kde]-shlibs,
-	libgcrypt-shlibs,
+	libgcrypt20-shlibs,
 	qca2-%type_pkg[kde]-shlibs,
 	qt4-base-%type_pkg[kde]-qtcore-shlibs (>= 4.8.5-1),
 	qt4-base-%type_pkg[kde]-qtnetwork-shlibs (>= 4.8.5-1),
@@ -27,7 +27,7 @@ BuildDepends: <<
 	gmp5,
 	kde4-buildenv (>= 4.13.1-1),
 	kdelibs4-%type_pkg[kde]-dev,
-	libgcrypt,
+	libgcrypt20,
 	libgettext8-shlibs,
 	libgpg-error,
 	pkgconfig (>= 0.23-1),
@@ -97,9 +97,8 @@ SplitOff2: <<
 PostInstScript: %p/opt/kde4/%type_pkg[kde]/bin/kde4-postinst.sh || :
 
 DocFiles: ChangeLog COPYING RoadMap
-Homepage: http://ktorrent.pwsp.net/
+Homepage: https://apps.kde.org/en/ktorrent
 DescDetail: <<
 BitTorrent protocol library for the KDE environment.
 <<
 <<
-


### PR DESCRIPTION
Bump deps on libgcrypt and gnutls to their latest libversions.

There are large trees of packages with deps on older gpgme lib, not sure if it's a problem to update them piecemeal, so I did not touch here (or check to see if the ton of BDep without accompanying Dep are even needed). Also not touching boost deps for similar reason.