### PR TITLE
libaudiofile 0.3.6

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libaudiofile1.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libaudiofile1.info
@@ -1,17 +1,49 @@
 Package: libaudiofile1
-Version: 0.3.4
-Revision: 2
+Version: 0.3.6
+Revision: 1
 Epoch: 1
 ###
 Depends: %N-shlibs (= %e:%v-%r)
+BuildDepends: <<
+  fink (>= 0.32.0),
+  fink-package-precedence,
+  libflac8-dev
+<<
 BuildDependsOnly: true
 Replaces: audiofile
 Conflicts: audiofile
 ###
-Source: http://www.68k.org/~michael/audiofile/audiofile-%v.tar.gz
-Source-MD5: 2ed06d64ee552a2ce490f54351b86ccd
+Source: https://audiofile.68k.org/audiofile-%v.tar.gz
+Source-MD5: 2731d79bec0acef3d30d2fc86b0b72fd
+Source2: http://archive.ubuntu.com/ubuntu/pool/universe/a/audiofile/audiofile_%v-5build1.debian.tar.xz
+Source2-MD5: 12d30c0079fee14350ef19601c93bf96
 ###
-ConfigureParams: --with-pic --enable-shared --enable-static --mandir=%i/share/man --infodir=%p/share/info --libexecdir=%p/lib
+PatchScript: <<
+	patch -p1 < ../debian/patches/03_CVE-2015-7747.patch
+	patch -p1 < ../debian/patches/04_clamp-index-values-to-fix-index-overflow-in-IMA.cpp.patch
+	patch -p1 < ../debian/patches/05_Always-check-the-number-of-coefficients.patch
+	patch -p1 < ../debian/patches/06_Check-for-multiplication-overflow-in-MSADPCM-decodeSam.patch
+	patch -p1 < ../debian/patches/07_Check-for-multiplication-overflow-in-sfconvert.patch
+	patch -p1 < ../debian/patches/08_Fix-signature-of-multiplyCheckOverflow.-It-returns-a-b.patch
+	patch -p1 < ../debian/patches/09_Actually-fail-when-error-occurs-in-parseFormat.patch
+	patch -p1 < ../debian/patches/10_Check-for-division-by-zero-in-BlockCodec-runPull.patch
+	patch -p1 < ../debian/patches/11_CVE-2018-13440.patch
+	patch -p1 < ../debian/patches/12_CVE-2018-17095.patch
+<<
+GCC: 4.0
+ConfigureParams: <<
+	--with-pic \
+	--enable-shared \
+	--enable-static \
+	--mandir=%i/share/man \
+	--infodir=%p/share/info \
+	--libexecdir=%p/lib \
+	--enable-dependency-tracking
+<<
+CompileScript: <<
+	%{default_script}
+	fink-package-precedence --prohibit-bdep=libaudiofile1 .
+<<
 ###
 InfoTest: TestScript: make check || exit 2
 ###
@@ -22,6 +54,7 @@ SetCXXFLAGS: -DGTEST_USE_OWN_TR1_TUPLE=1
 ###
 SplitOff: <<
   Package: %N-shlibs
+  Depends: libflac8
   Suggests: audiofile-bin
   Files: <<
     lib/libaudiofile.*.dylib
@@ -34,7 +67,7 @@ SplitOff: <<
 <<
 SplitOff2: <<
   Package: audiofile-bin
-  Depends: %N-shlibs (= %e:%v-%r)
+  Depends: %N-shlibs (= %e:%v-%r), libflac8
   Files: <<
     bin/sfconvert
     bin/sfinfo
@@ -50,7 +83,11 @@ DescDetail: <<
   accessing standard digital audio file formats, such as AIFF/AIFF-C,
   WAVE, and NeXT/Sun .snd/.au. 
 <<
+DescPackaging: <<
+  static library needed to run the test suite
+  https://github.com/mpruett/audiofile/issues/15
+<<
 ###
 License: LGPL
 Maintainer: Justin F. Hallett <thesin@users.sourceforge.net>
-Homepage: http://www.68k.org/~michael/audiofile/
+Homepage: https://audiofile.68k.org/


### PR DESCRIPTION
update to latest libaudiofile (from 2013).
Adds Ubuntu's patches which contain several fixes for CVEs