### PR TITLE
Misc librtmp build-fixes

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/net/librtmp1-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/librtmp1-shlibs.info
@@ -15,7 +15,7 @@ DescDetail: <<
 	Plain rtmp, as well as tunneled and encrypted sessions are supported.
 <<
 DescPackaging: <<
-* FTBFS with openssl110
+* FTBFS with openssl110 (gentoo has a patch)
 * no more tarballs after 2.3 release.
 * The 2.4-20190330 tarball was created on 2020-07-12 with these
 commands, that correspond to commit hash
@@ -31,7 +31,7 @@ Source: mirror:sourceforge:fink/rtmpdump-%v.tar.bz2
 Source-MD5: 1a149d66063529e2066a9456d2e73d75
 
 PatchFile: %{ni}.patch
-PatchFile-MD5: 0b9dce6b398762311b77918255af5ef9
+PatchFile-MD5: 455e4e201914f203ff57ad3ec175d167
 
 BuildDepends: <<
 	fink-package-precedence,
@@ -46,9 +46,11 @@ Depends: <<
 	nettle7-shlibs
 <<
 
+SetCPPFLAGS: -MD
+SetLDFLAGS: -L%p/lib/gnutls30
 CompileScript: <<
-	make SYS=darwin prefix=%p INC="-MD -I%p/include" XLDFLAGS="-L%b/librtmp -L%p/lib/gnutls30 -L%p/lib"
-	fink-package-precedence --depfile-ext='\.d' .
+	make SYS=darwin prefix=%p XLDFLAGS="$LDFLAGS"
+	fink-package-precedence --depfile-ext='\.d' --prohibit-bdep=librtmp1 .
 <<
 
 InstallScript: make -j1 install SYS=darwin prefix=%p DESTDIR=%d

--- a/10.9-libcxx/stable/main/finkinfo/net/librtmp1-shlibs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/net/librtmp1-shlibs.patch
@@ -22,6 +22,15 @@ diff -ruN rtmpdump-2.4-20190330-orig/Makefile rtmpdump-2.4-20190330/Makefile
  
  BINDIR=$(DESTDIR)$(bindir)
  SBINDIR=$(DESTDIR)$(sbindir)
+@@ -35,7 +35,7 @@
+ LIBS_posix=
+ LIBS_darwin=
+ LIBS_mingw=-lws2_32 -lwinmm -lgdi32
+-LIB_RTMP=-Llibrtmp -lrtmp
++LIB_RTMP=librtmp/librtmp.dylib
+ LIBS=$(LIB_RTMP) $(CRYPTO_LIB) $(LIBS_$(SYS)) $(XLIBS)
+ 
+ THREADLIB_posix=-lpthread
 diff -ruN rtmpdump-2.4-20190330-orig/librtmp/Makefile rtmpdump-2.4-20190330/librtmp/Makefile
 --- rtmpdump-2.4-20190330-orig/librtmp/Makefile	2020-07-12 06:06:19.000000000 -0500
 +++ rtmpdump-2.4-20190330/librtmp/Makefile	2020-07-12 06:21:44.000000000 -0500
@@ -45,6 +54,15 @@ diff -ruN rtmpdump-2.4-20190330-orig/librtmp/Makefile rtmpdump-2.4-20190330/libr
  DEF_POLARSSL=-DUSE_POLARSSL
  DEF_OPENSSL=-DUSE_OPENSSL
  DEF_GNUTLS=-DUSE_GNUTLS
+@@ -54,7 +54,7 @@
+ SODIR=$(SODIR_$(SYS))
+ 
+ SO_LDFLAGS_posix=-shared -Wl,-soname,$@
+-SO_LDFLAGS_darwin=-dynamiclib -twolevel_namespace -undefined dynamic_lookup \
++SO_LDFLAGS_darwin=-dynamiclib -twolevel_namespace \
+ 	-fno-common -headerpad_max_install_names -install_name $(libdir)/$@
+ SO_LDFLAGS_mingw=-shared -Wl,--out-implib,librtmp.dll.a
+ SO_LDFLAGS=$(SO_LDFLAGS_$(SYS))
 diff -ruN rtmpdump-2.4-20190330-orig/librtmp/hashswf.c rtmpdump-2.4-20190330/librtmp/hashswf.c
 --- rtmpdump-2.4-20190330-orig/librtmp/hashswf.c	2020-07-12 06:06:19.000000000 -0500
 +++ rtmpdump-2.4-20190330/librtmp/hashswf.c	2020-07-12 06:38:24.000000000 -0500


### PR DESCRIPTION
Trying to address:
* [Fink-users] problem compiling librtmp1-shlibs-2.4-20190330-2
* [Fink-users] "librtmp1: library not found for -lgnutls" 10.14.6, xcode 10.3

These changes might not solve it, but should make it fail harder sooner rather than deferring until after the original failure began to occur.