### PR TITLE
New package cppy-py as build dependency for kiwisolver; update to upstream 1.3.1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/cppy-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/cppy-py.info
@@ -1,0 +1,37 @@
+Info2: <<
+Package: cppy-py%type_pkg[python]
+Version: 1.1.0
+Revision: 1
+Description: C++ headers for C extension development
+License: BSD
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+Type: python (2.7 3.5 3.6 3.7 3.8)
+Depends: python%type_pkg[python]
+BuildDepends: setuptools-tng-py%type_pkg[python]
+
+Source: https://files.pythonhosted.org/packages/source/c/cppy/cppy-%v.tar.gz
+Source-Checksum: SHA256(4eda6f1952054a270f32dc11df7c5e24b259a09fddf7bfaa5f33df9fb4a29642)
+
+GCC: 4.0
+CompileScript: <<
+	%p/bin/python%type_raw[python] setup.py build
+<<
+
+InfoTest: <<
+	TestDepends: pytest-py%type_pkg[python]
+	TestScript: %p/bin/python%type_raw[python] -Bm pytest || exit 2
+<<
+
+InstallScript: <<
+	%p/bin/python%type_raw[python] setup.py install --root %d
+<<
+
+DocFiles: LICENSE PKG-INFO releasenotes.rst README.rst docs/source/*.rst
+Homepage: https://github.com/nucleic/cppy
+DescDetail: <<
+A small C++ header library which makes it easier to write Python extension
+modules. The primary feature is a PyObject smart pointer which automatically
+handles reference counting and provides convenience methods for performing
+common object operations.
+<<
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/kiwisolver-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/kiwisolver-py.info
@@ -1,40 +1,38 @@
 Info2: <<
 Package: kiwisolver-py%type_pkg[python]
-Version: 1.2.0
+Version: 1.3.1
 Revision: 1
 Description: Fast Cassowary constraint solver
 License: BSD
 # Free to modify, update, and take over
-Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
 Type: python (3.5 3.6 3.7 3.8)
 Depends: <<
 	python%type_pkg[python]
 <<
 BuildDepends: <<
-	setuptools-tng-py%type_pkg[python]
+	setuptools-tng-py%type_pkg[python],
+	cppy-py%type_pkg[python]
 <<
+
 Source: https://files.pythonhosted.org/packages/source/k/kiwisolver/kiwisolver-%v.tar.gz
-Source-Checksum: SHA256(247800260cd38160c362d211dcaf4ed0f7816afb5efe56544748b21d6ad6d17f)
-PatchScript: <<
-	# fix mismatched input and expected type
-	perl -pi -e 's|assert \"str\" in|assert "int" in|g' py/tests/test_constraint.py
-<<
+Source-Checksum: SHA256(950a199911a8d94683a6b10321f9345d5a3a8433ec58b217ace979e18f16e248)
+
 GCC: 4.0
 CompileScript: <<
 	%p/bin/python%type_raw[python] setup.py build
 <<
 
 InfoTest: <<
-	TestDepends: <<
-		pytest-py%type_pkg[python]
-	<<
+	TestDepends: pytest-py%type_pkg[python]
 	TestScript: PYTHONPATH=$(ls -d %b/build/lib.macosx-*-%type_raw[python]) %p/bin/python%type_raw[python] -m pytest py/tests || exit 2
 <<
 
 InstallScript: <<
 	%p/bin/python%type_raw[python] setup.py install --root %d
 <<
-DocFiles: LICENSE releasenotes.rst README.rst
+
+DocFiles: LICENSE PKG-INFO releasenotes.rst README.rst docs/source/basis docs/source/use_cases
 Homepage: https://github.com/nucleic/kiwi
 DescDetail: <<
 Kiwi is an efficient C++ implementation of the Cassowary constraint
@@ -44,5 +42,9 @@ solver. Kiwi has been designed from the ground up to be lightweight and
 fast. Kiwi ranges from 10x to 500x faster than the original Cassowary
 solver with typical use cases gaining a 40x improvement. Memory savings
 are consistently > 5x.
+<<
+DescPort: <<
+Post-1.1.0 versions are Python 3 only; officially only supporting 3.6+,
+but 1.3.1 still builds and passes tests with 3.5.
 <<
 <<


### PR DESCRIPTION
I found that the kiwisolver 1.2.0 build fails if pip is not installed, and that it pip-installs a dependency `cppy` during the build phase, if it is. I think this goes against packaging rules, so I have added that package as `BuildDepends` (I checked that the tests are still running successfully after cppy has been removed).
Updated to the latest upstream along the way and also removed a patch to the tests that no longer seems required.