### PR TITLE
Add libsigsegv2-shlibs to the depends list for grep.

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/utils/grep.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/grep.info
@@ -1,6 +1,6 @@
 Package: grep
 Version: 3.6
-Revision: 1
+Revision: 2
 Maintainer: None <fink-devel@lists.sourceforge.net>
 
 BuildDepends: <<
@@ -8,7 +8,7 @@ BuildDepends: <<
   libiconv-dev, libgettextpo2-dev,
   fink (>= 0.32.1)
 <<
-Depends: libpcre1-shlibs, libgettextpo2-shlibs
+Depends: libpcre1-shlibs, libgettextpo2-shlibs, libsigsegv2-shlibs
 
 Source: mirror:gnu:%n/%n-%v.tar.xz
 Source-Checksum: SHA256(667e15e8afe189e93f9f21a7cd3a7b3f776202f417330b248c2ad4f997d9373e)


### PR DESCRIPTION
Should fix lib not found errors:
```
dyld: Library not loaded: /opt/sw/lib/libsigsegv.1.dylib
  Referenced from: /opt/sw/bin/grep
  Reason: image not found

```