### PR TITLE
lua53: update to upstream version 5.3.6

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/lua53.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/lua53.info
@@ -1,5 +1,5 @@
 Package: lua53
-Version: 5.3.5
+Version: 5.3.6
 Revision: 1
 Description: Small and fast embeddable scripting language
 License: BSD
@@ -11,8 +11,8 @@ Replaces:  lua (<< 1:5.0.4-0)
 Recommends: luarocks
 
 # Unpack Phase:
-Source: http://www.lua.org/ftp/lua-%v.tar.gz
-Source-MD5: 4f4b4f323fd3514a68e0ab3da8ce3455 
+Source: https://www.lua.org/ftp/lua-%v.tar.gz
+Source-MD5: 83f23dbd5230140a3770d5f54076948d 
 
 Patchscript: <<
 #!/bin/sh -ev
@@ -95,7 +95,7 @@ InstallScript: <<
 <<
 
 DocFiles: <<
-  doc/contents.html doc/logo.gif doc/lua.css doc/manual.css
+  doc/contents.html doc/logo.gif doc/index.css doc/lua.css doc/manual.css
   doc/manual.html doc/osi-certified-72x60.png doc/readme.html README
 <<
 
@@ -216,9 +216,9 @@ DocFiles: README
 
 DescDetail: <<
   For details about Lua/C API:
-  http://www.lua.org/manual/5.3/manual.html#3
+  https://www.lua.org/manual/5.3/manual.html#3
 <<
 <<
 
-Homepage: http://www.lua.org
+Homepage: https://www.lua.org
 Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>


### PR DESCRIPTION
- change from http to https
- add missing doc/index.css