### PR TITLE
binutils: update to upstream version 2.36.1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/aarch64-binutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/aarch64-binutils.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: aarch64-%type_pkg[platform]-binutils
-Version: 2.35
+Version: 2.36.1
 Revision: 1
 Type: platform (linux )
 # tried, but not yet working or needed:
@@ -11,7 +11,7 @@ License: LGPL
 Depends: fink (>= 0.32)
 
 Source: mirror:gnu:binutils/binutils-%v.tar.xz
-Source-MD5: fc8d55e2f6096de8ff8171173b6f5087
+Source-MD5: 628d490d976d8957279bbbff06cf29d4
 
 SourceDirectory: binutils-%v
 
@@ -56,3 +56,4 @@ Homepage: http://www.gnu.org/software/binutils/
 
 Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
 <<
+

--- a/10.9-libcxx/stable/main/finkinfo/devel/arm-binutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/arm-binutils.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: arm-%type_pkg[platform]-binutils
-Version: 2.35
+Version: 2.36.1
 Revision: 1
 Type: platform (linux embedded freebsd freertos gba nds netbsd none-gnueabi wince)
 # tried, but not yet working or needed:
@@ -11,7 +11,7 @@ License: LGPL
 Depends: fink (>= 0.32)
 
 Source: mirror:gnu:binutils/binutils-%v.tar.xz
-Source-MD5: fc8d55e2f6096de8ff8171173b6f5087
+Source-MD5: 628d490d976d8957279bbbff06cf29d4
 
 SourceDirectory: binutils-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/binutils-docs.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/binutils-docs.info
@@ -1,11 +1,11 @@
 Package: binutils-docs
-Version: 2.35
+Version: 2.36.1
 Revision: 1
 Description: Documentation for the GNU binutils
 License: LGPL
 
 Source: mirror:gnu:binutils/binutils-%v.tar.xz
-Source-MD5: fc8d55e2f6096de8ff8171173b6f5087
+Source-MD5: 628d490d976d8957279bbbff06cf29d4
 
 SourceDirectory: binutils-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/i386-binutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/i386-binutils.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: i386-%type_pkg[platform]-binutils
 Version: 2.36.1
 Revision: 1
-Type: platform (linux aros beos darwin embedded freebsd go32v2 msdosdjgpp netbsd solaris win32 wince)
+Type: platform (linux aros beos darwin embedded freebsd go32v2 msdosdjgpp solaris win32 wince)
 # tried, but not yet working or needed:
 # emx haiku netwlibc openbsd qnx symbian watcom wdosx
 Description: GNU binutils for 32 bit %type_pkg[platform]

--- a/10.9-libcxx/stable/main/finkinfo/devel/i386-binutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/i386-binutils.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: i386-%type_pkg[platform]-binutils
-Version: 2.35
+Version: 2.36.1
 Revision: 1
 Type: platform (linux aros beos darwin embedded freebsd go32v2 msdosdjgpp netbsd solaris win32 wince)
 # tried, but not yet working or needed:
@@ -11,7 +11,7 @@ License: LGPL
 Depends: fink (>= 0.32)
 
 Source: mirror:gnu:binutils/binutils-%v.tar.xz
-Source-MD5: fc8d55e2f6096de8ff8171173b6f5087
+Source-MD5: 628d490d976d8957279bbbff06cf29d4
 
 SourceDirectory: binutils-%v
 
@@ -67,3 +67,4 @@ Homepage: http://www.gnu.org/software/binutils/
 
 Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
 <<
+

--- a/10.9-libcxx/stable/main/finkinfo/devel/m68k-binutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/m68k-binutils.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: m68k-%type_pkg[platform]-binutils
-Version: 2.35
+Version: 2.36.1
 Revision: 1
 Type: platform (linux embedded netbsd)
 # tried, but not yet working or needed: 
@@ -11,7 +11,7 @@ License: LGPL
 Depends: fink (>= 0.32)
 
 Source: mirror:gnu:binutils/binutils-%v.tar.xz
-Source-MD5: fc8d55e2f6096de8ff8171173b6f5087
+Source-MD5: 628d490d976d8957279bbbff06cf29d4
 
 SourceDirectory: binutils-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/mipsel-binutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/mipsel-binutils.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: mipsel-%type_pkg[platform]-binutils
-Version: 2.35
+Version: 2.36.1
 Revision: 1
 Type: platform (linux freebsd netbsd embedded)
 Description: GNU binutils for mipsel-%type_pkg[platform]
@@ -9,7 +9,7 @@ License: LGPL
 Depends: fink (>= 0.32)
 
 Source: mirror:gnu:binutils/binutils-%v.tar.xz
-Source-MD5: fc8d55e2f6096de8ff8171173b6f5087
+Source-MD5: 628d490d976d8957279bbbff06cf29d4
 
 SourceDirectory: binutils-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/powerpc-binutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/powerpc-binutils.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: powerpc-%type_pkg[platform]-binutils
-Version: 2.35
+Version: 2.36.1
 Revision: 1
 Type: platform (linux aix darwin freebsd macos netbsd openbsd wii)
 # tried, but not yet working or needed: 
@@ -12,7 +12,7 @@ License: LGPL
 Depends: fink (>= 0.32)
 
 Source: mirror:gnu:binutils/binutils-%v.tar.xz
-Source-MD5: fc8d55e2f6096de8ff8171173b6f5087
+Source-MD5: 628d490d976d8957279bbbff06cf29d4
 
 SourceDirectory: binutils-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/powerpc64-binutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/powerpc64-binutils.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: powerpc64-%type_pkg[platform]-binutils
-Version: 2.35
+Version: 2.36.1
 Revision: 1
 Type: platform (linux freebsd netbsd openbsd)
 # tried, but not yet working or needed: aix
@@ -12,7 +12,7 @@ License: LGPL
 Depends: fink (>= 0.32)
 
 Source: mirror:gnu:binutils/binutils-%v.tar.xz
-Source-MD5: fc8d55e2f6096de8ff8171173b6f5087
+Source-MD5: 628d490d976d8957279bbbff06cf29d4
 
 SourceDirectory: binutils-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/riscv32-binutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/riscv32-binutils.info
@@ -1,14 +1,14 @@
 Info2: <<
-Package: x86-64-%type_pkg[platform]-binutils
+Package: riscv32-%type_pkg[platform]-binutils
 Version: 2.36.1
 Revision: 1
-Type: platform (linux dragonfly darwin embedded freebsd netbsd openbsd win64)
-Description: GNU binutils for 64 bit %type_pkg[platform]
+Type: platform (linux embedded)
+# tried, but not yet working or needed:
+#
+Description: GNU binutils for riscv32-%type_pkg[platform]
 License: LGPL
 # .xz archive needs a newer fink
 Depends: fink (>= 0.32)
-
-Replaces: x86-64-w64-mingw32-binutils
 
 Source: mirror:gnu:binutils/binutils-%v.tar.xz
 Source-MD5: 628d490d976d8957279bbbff06cf29d4
@@ -16,12 +16,11 @@ Source-MD5: 628d490d976d8957279bbbff06cf29d4
 SourceDirectory: binutils-%v
 
 ConfigureParams: <<
-  --target=x86_64-%type_pkg[platform]                           \
-  (%type_pkg[platform] = embedded) --target=x86_64-unknown-elf  \
-  (%type_pkg[platform] = win64) --target=x86_64-w64-mingw32     \
-  --prefix=%p/lib/x86_64-%type_pkg[platform]                    \
-  --bindir=%p/bin --mandir=%p/share/man --infodir=%p/share/info \
-  --program-prefix=x86_64-%type_pkg[platform]-                  \
+  --target=riscv32-%type_pkg[platform]                           \
+  (%type_pkg[platform] = embedded) --target=riscv32-unknown-elf  \
+  --prefix=%p/lib/riscv32-%type_pkg[platform]                    \
+  --bindir=%p/bin --mandir=%p/share/man --infodir=%p/share/info  \
+  --program-prefix=riscv32-%type_pkg[platform]-                  \
   --disable-werror
 <<
 
@@ -41,19 +40,21 @@ CompileScript: <<
 InstallScript: <<
 #!/bin/sh -ev
   make install DESTDIR=%d
-  rm -fr %i/lib/x86_64-%type_pkg[platform]/lib/
+  rm -fr %i/lib/riscv32-%type_pkg[platform]/lib/
   rm -fr %i/share/info
 <<
 
 DocFiles: README COPYING* MAINTAINERS
 
 DescPort: <<
-Like 'avr-binutils' package, lib & include folders have been moved to 
-/sw/lib/x86_64-%type_pkg[platform] and the binaries are put into /sw/bin.
+Like 'avr-binutils' package, lib & include folders have been moved to
+/sw/lib/riscv32-%type_pkg[platform] and the binaries are put into /sw/bin.
 All xxx.info files are removed to avoid clashes with other potential
 toolchains.
 <<
+
 Homepage: http://www.gnu.org/software/binutils/
 
 Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
 <<
+

--- a/10.9-libcxx/stable/main/finkinfo/devel/riscv64-binutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/riscv64-binutils.info
@@ -1,14 +1,14 @@
 Info2: <<
-Package: x86-64-%type_pkg[platform]-binutils
+Package: riscv64-%type_pkg[platform]-binutils
 Version: 2.36.1
 Revision: 1
-Type: platform (linux dragonfly darwin embedded freebsd netbsd openbsd win64)
-Description: GNU binutils for 64 bit %type_pkg[platform]
+Type: platform (linux embedded)
+# tried, but not yet working or needed:
+#
+Description: GNU binutils for riscv64-%type_pkg[platform]
 License: LGPL
 # .xz archive needs a newer fink
 Depends: fink (>= 0.32)
-
-Replaces: x86-64-w64-mingw32-binutils
 
 Source: mirror:gnu:binutils/binutils-%v.tar.xz
 Source-MD5: 628d490d976d8957279bbbff06cf29d4
@@ -16,12 +16,11 @@ Source-MD5: 628d490d976d8957279bbbff06cf29d4
 SourceDirectory: binutils-%v
 
 ConfigureParams: <<
-  --target=x86_64-%type_pkg[platform]                           \
-  (%type_pkg[platform] = embedded) --target=x86_64-unknown-elf  \
-  (%type_pkg[platform] = win64) --target=x86_64-w64-mingw32     \
-  --prefix=%p/lib/x86_64-%type_pkg[platform]                    \
-  --bindir=%p/bin --mandir=%p/share/man --infodir=%p/share/info \
-  --program-prefix=x86_64-%type_pkg[platform]-                  \
+  --target=riscv64-%type_pkg[platform]                           \
+  (%type_pkg[platform] = embedded) --target=riscv64-unknown-elf  \
+  --prefix=%p/lib/riscv64-%type_pkg[platform]                    \
+  --bindir=%p/bin --mandir=%p/share/man --infodir=%p/share/info  \
+  --program-prefix=riscv64-%type_pkg[platform]-                  \
   --disable-werror
 <<
 
@@ -41,19 +40,21 @@ CompileScript: <<
 InstallScript: <<
 #!/bin/sh -ev
   make install DESTDIR=%d
-  rm -fr %i/lib/x86_64-%type_pkg[platform]/lib/
+  rm -fr %i/lib/riscv64-%type_pkg[platform]/lib/
   rm -fr %i/share/info
 <<
 
 DocFiles: README COPYING* MAINTAINERS
 
 DescPort: <<
-Like 'avr-binutils' package, lib & include folders have been moved to 
-/sw/lib/x86_64-%type_pkg[platform] and the binaries are put into /sw/bin.
+Like 'avr-binutils' package, lib & include folders have been moved to
+/sw/lib/riscv64-%type_pkg[platform] and the binaries are put into /sw/bin.
 All xxx.info files are removed to avoid clashes with other potential
 toolchains.
 <<
+
 Homepage: http://www.gnu.org/software/binutils/
 
 Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
 <<
+

--- a/10.9-libcxx/stable/main/finkinfo/devel/sparc-binutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/sparc-binutils.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: sparc-%type_pkg[platform]-binutils
-Version: 2.35
+Version: 2.36.1
 Revision: 1
 Type: platform (linux netbsd solaris)
 # tried, but not yet working or needed: freebsd embedded openbsd
@@ -10,7 +10,7 @@ License: LGPL
 Depends: fink (>= 0.32)
 
 Source: mirror:gnu:binutils/binutils-%v.tar.xz
-Source-MD5: fc8d55e2f6096de8ff8171173b6f5087
+Source-MD5: 628d490d976d8957279bbbff06cf29d4
 
 SourceDirectory: binutils-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/sparc64-binutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/sparc64-binutils.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: sparc64-%type_pkg[platform]-binutils
-Version: 2.35
+Version: 2.36.1
 Revision: 1
 Type: platform (linux freebsd netbsd openbsd)
 # tried, but not yet working or needed:  embedded
@@ -10,7 +10,7 @@ License: LGPL
 Depends: fink (>= 0.32)
 
 Source: mirror:gnu:binutils/binutils-%v.tar.xz
-Source-MD5: fc8d55e2f6096de8ff8171173b6f5087
+Source-MD5: 628d490d976d8957279bbbff06cf29d4
 
 SourceDirectory: binutils-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/x86-64-binutils-default.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/x86-64-binutils-default.info
@@ -1,5 +1,5 @@
 Package: x86-64-binutils-default
-Version: 2.35
+Version: 2.36.1
 Revision: 1
 Description: GNU binutils, without 'x86_64-darwin' prefix
 License: LGPL

--- a/10.9-libcxx/stable/main/finkinfo/devel/xtensa-binutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/xtensa-binutils.info
@@ -1,0 +1,66 @@
+Info2: <<
+Package: xtensa-%type_pkg[platform]-binutils
+Version: 2.36.1
+Revision: 1
+Type: platform (embedded freertos linux)
+Description: GNU binutils for xtensa-%type_pkg[platform]
+License: LGPL
+# .xz archive needs a newer fink
+Depends: fink (>= 0.32)
+
+Source: mirror:gnu:binutils/binutils-%v.tar.xz
+Source-MD5: 628d490d976d8957279bbbff06cf29d4
+
+SourceDirectory: binutils-%v
+
+ConfigureParams: <<
+  (%type_pkg[platform] = embedded) --target=xtensa-esp32-elf	\
+  (%type_pkg[platform] = freertos) --target=xtensa-freertos-elf	\
+  (%type_pkg[platform] = linux)    --target=xtensa-linux		\
+  --prefix=%p/lib/xtensa-%type_pkg[platform]					\
+  --bindir=%p/bin --mandir=%p/share/man --infodir=%p/share/info	\
+  --program-prefix=xtensa-%type_pkg[platform]-                  \
+  --disable-gdb --disable-sim --disable-readline --disable-libdecnumber \
+  --disable-werror --disable-nls
+<<
+
+Patchscript: <<
+#!/bin/sh -ev
+# set some constants for xtensa-linux
+  cd include
+  sed -i.bak 's|XCHAL_HAVE_BE			1|XCHAL_HAVE_BE			0|g' xtensa-config.h
+  sed -i.bak 's|XCHAL_HAVE_BOOLEANS		0|XCHAL_HAVE_BOOLEANS	1|g' xtensa-config.h
+  sed -i.bak 's|XCHAL_HAVE_FP			0|XCHAL_HAVE_FP			1|g' xtensa-config.h
+  sed -i.bak 's|XCHAL_HAVE_FP_DIV		0|XCHAL_HAVE_FP_DIV		1|g' xtensa-config.h
+  sed -i.bak 's|XCHAL_HAVE_FP_RECIP		0|XCHAL_HAVE_FP_RECIP	1|g' xtensa-config.h
+  sed -i.bak 's|XCHAL_HAVE_FP_SQRT		0|XCHAL_HAVE_FP_SQRT	1|g' xtensa-config.h
+  sed -i.bak 's|XCHAL_HAVE_FP_RSQRT		0|XCHAL_HAVE_FP_RSQRT	1|g' xtensa-config.h
+<<
+
+CompileScript: <<
+#!/bin/sh -ev
+  ./configure %c
+  num_cpu=$(echo `sysctl -n hw.ncpu`)
+  make -j $num_cpu CFLAGS=-Wno-extended-offsetof
+<<
+
+InstallScript: <<
+#!/bin/sh -ev
+  make install DESTDIR=%d
+  rm -fr %i/lib/xtensa-%type_pkg[platform]/lib/
+  rm -fr %i/share/info
+<<
+
+DocFiles: README COPYING* MAINTAINERS
+
+DescPort: <<
+Like 'avr-binutils' package, lib & include folders have been moved to 
+/sw/lib/xtensa-%type_pkg[platform] and the binaries are put into /sw/bin.
+All xxx.info files are removed to avoid clashes with other potential
+toolchains.
+<<
+
+Homepage: http://www.gnu.org/software/binutils/
+
+Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
+<<


### PR DESCRIPTION
Adding binutils for xtensa, risc32, and risc64.