### PR TITLE
pasdoc: update to upstream version 0.16.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/pasdoc-gui.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/pasdoc-gui.info
@@ -14,7 +14,7 @@ Source-MD5: c35a88c27d53903734259947d67c1c4f
 Source2: http://michael-ep3.physik.uni-halle.de/fink-sources/PasDoc.icns
 Source2-MD5: 76a6786674c625df120dfc49a60a25ab
 
-SourceDirectory: pasdoc-%v
+SourceRename: pasdoc-%v.tar.gz
 
 # Compile Phase
 Compilescript: <<

--- a/10.9-libcxx/stable/main/finkinfo/devel/pasdoc-gui.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/pasdoc-gui.info
@@ -1,35 +1,39 @@
 Package: pasdoc-gui
-Version: 0.15.0
+Version: 0.16.0
 Revision: 1
 Description: Documentation tool for Pascal source code
 License: GPL
 
-BuildDepends: lazarus-aqua | lazarus-gtk2 | lazarus-qt4
+BuildDepends: lazarus-cocoa
+
+Suggests: graphviz
 
 # Unpack Phase
-Source: mirror:sourceforge:/pasdoc/PasDoc%%20Source/%v/pasdoc-%v-src.tar.gz
-Source-MD5: 6ba14091637a2eb4f9cd77f711cccd24
+Source: https://github.com/%n/%n/archive/refs/tags/v%v.tar.gz
+Source-MD5: c35a88c27d53903734259947d67c1c4f
 Source2: http://michael-ep3.physik.uni-halle.de/fink-sources/PasDoc.icns
 Source2-MD5: 76a6786674c625df120dfc49a60a25ab
 
-SourceDirectory: pasdoc
+SourceDirectory: pasdoc-%v
 
 # Compile Phase
 Compilescript: <<
 #!/bin/sh -ev
-  lazbuild --cpu=i386 --ws=carbon source/packages/lazarus/pasdoc_package.lpk
-  lazbuild --cpu=i386 --ws=carbon source/gui/pasdoc_gui.lpi
+  lazbuild --cpu=x86_64 --ws=cocoa source/packages/lazarus/pasdoc_package.lpk
+  lazbuild --cpu=x86_64 --ws=cocoa source/gui/pasdoc_gui.lpi
+  cd source/gui
+  macos/create_bundle.sh %v
 # move and rename binary
-  rm source/gui/pasdoc_gui.app/Contents/MacOS/pasdoc_gui
-  mv source/gui/pasdoc_gui source/gui/pasdoc_gui.app/Contents/MacOS/PasDoc
+  rm pasdoc_gui.app/Contents/MacOS/pasdoc_gui
+  mv pasdoc_gui pasdoc_gui.app/Contents/MacOS/PasDoc
 # rename app bundle
-  mv source/gui/pasdoc_gui.app source/gui/PasDoc.app
-  sed -i.bak 's|pasdoc_gui|PasDoc|g' source/gui/PasDoc.app/Contents/Info.plist
-  rm source/gui/PasDoc.app/Contents/Info.plist.bak
+  mv pasdoc_gui.app PasDoc.app
+  sed -i.bak 's|pasdoc_gui|PasDoc|g' PasDoc.app/Contents/Info.plist
+  rm PasDoc.app/Contents/Info.plist.bak
 # move icon file and add it to Info.plist
-  mv ../PasDoc.icns source/gui/PasDoc.app/Contents/Resources
-  sed -i.bak 's|<dict>|<dict> <key>CFBundleIconFile</key> <string>PasDoc</string>|g' source/gui/PasDoc.app/Contents/Info.plist
-  rm source/gui/PasDoc.app/Contents/Info.plist.bak
+  mv ../../../PasDoc.icns PasDoc.app/Contents/Resources
+  sed -i.bak 's|<dict>|<dict> <key>CFBundleIconFile</key> <string>PasDoc</string>|g' PasDoc.app/Contents/Info.plist
+  rm PasDoc.app/Contents/Info.plist.bak
 <<
 
 # Install Phase
@@ -52,7 +56,7 @@ PostRmScript: rm -f /Applications/Fink/PasDoc.app
 #AppBundles: source/gui/PasDoc.app
 
 # Documentation
-DocFiles: LICENSE README.md old_docs/pasdoc.pdf old_docs/pasdoc.html old_docs/pasdoc.css
+DocFiles: LICENSE *.md old_docs/pasdoc.pdf old_docs/pasdoc.html old_docs/pasdoc.css
 
 # Additional Info
 DescDetail: <<
@@ -61,15 +65,6 @@ DescDetail: <<
   Available output formats are HTML, HtmlHelp, LaTeX, latex2rtf, simplexml.
   Type "pasdoc --help" to get a better feeling for how PasDoc works.
   Also, see the web page for more information about PasDoc.
-<<
-
-DescPort: <<
-  Warnings: Font and Fontsize is not found:
-  CarbonFontIDToFontName Error: ATSUFindFontName Length failed with result -8905
-  FindCarbonFontID Error: ATSUFindFontFromName  failed with result -8796
-
-  Todo:
-  check for dependencies. graphviz is mentioned. 
 <<
 
 Homepage: https://github.com/pasdoc/pasdoc/wiki

--- a/10.9-libcxx/stable/main/finkinfo/devel/pasdoc.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/pasdoc.info
@@ -9,7 +9,7 @@ BuildDepends: fpc
 # Unpack Phase
 Source: https://github.com/%n/%n/archive/refs/tags/v%v.tar.gz
 Source-MD5: c35a88c27d53903734259947d67c1c4f
-SourceDirectory: %n-%v
+SourceRename: %n-%v.tar.gz
 
 # Compile Phase
 Compilescript: <<

--- a/10.9-libcxx/stable/main/finkinfo/devel/pasdoc.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/pasdoc.info
@@ -1,5 +1,5 @@
 Package: pasdoc
-Version: 0.15.0
+Version: 0.16.0
 Revision: 1
 Description: Documentation tool for Pascal source code
 License: GPL
@@ -7,9 +7,9 @@ License: GPL
 BuildDepends: fpc
 
 # Unpack Phase
-Source: mirror:sourceforge:/%n/PasDoc Source/%n-%v-src.tar.gz
-Source-MD5: 6ba14091637a2eb4f9cd77f711cccd24
-SourceDirectory: pasdoc
+Source: https://github.com/%n/%n/archive/refs/tags/v%v.tar.gz
+Source-MD5: c35a88c27d53903734259947d67c1c4f
+SourceDirectory: %n-%v
 
 # Compile Phase
 Compilescript: <<
@@ -23,7 +23,7 @@ Installscript: <<
 <<
 
 # Documentation
-DocFiles: LICENSE README.md old_docs/pasdoc.pdf old_docs/pasdoc.html old_docs/pasdoc.css
+DocFiles: LICENSE *.md old_docs/pasdoc.pdf old_docs/pasdoc.html old_docs/pasdoc.css
 
 # Additional Info
 DescDetail: <<


### PR DESCRIPTION
pasdoc-gui: use lazarus-cocoa and the included script to create the app-bundle.