### PR TITLE
cernlib2006: fix FTBFS: no bin/makedepend or libXp.dylib in xquartz-2.8.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
@@ -2,7 +2,7 @@ Info3: <<
 Package: cernlib2006
 Type: gcc (9)
 Version: 2006b
-Revision: 30
+Revision: 31
 Description: Paw and other basic executables
 Depends: <<
   gcc%type_pkg[gcc]-shlibs,
@@ -10,7 +10,7 @@ Depends: <<
 <<
 BuildDepends: <<
   fink-package-precedence (>=0.31-1),
-  freetype219 (>= 2.4.11-1),
+  freetype219 (>= 2.10.2-1),
   gcc%type_pkg[gcc],
   libxt-flat (>=1.1.5-2),
   openmotif4 (>= 2.3.4-13),
@@ -23,7 +23,7 @@ Provides: cernlib
 Source: http://cernlib.web.cern.ch/cernlib/download/%v_source/tar/2006_src.tar.gz
 SourceRename: cernlib-%v.tar.gz
 Source-MD5: 750c4804a2366ccd8e80c45a055f8ac5
-Source2: http://cern.ch/~mommsen/fink/%f.patch.gz
+Source2: http://cern.ch/~mommsen/fink/%n-%v-30.patch.gz
 Source2-MD5: 45ae1b9450ee432639000a5beae1462d
 SourceDirectory: 2006/src
 PatchScript: <<
@@ -32,7 +32,7 @@ PatchScript: <<
     "i386")    ARCH="I386" ;;
     "x86_64")  ARCH="QMLXIA64" ;;
   esac
-  gunzip -c ../../%f.patch.gz | \
+  gunzip -c ../../%n-%v-30.patch.gz | \
     /usr/bin/sed -e "{
       s|@PREFIX@|%p|g ;
       s|@ARCH@|${ARCH}|g ;
@@ -41,6 +41,9 @@ PatchScript: <<
       s|g++-6|g++-%type_pkg[gcc]|g;
     }" | patch -p1
   perl -pi -e 's|-lXt|%p/lib/libXt-flat/libXt.6.dylib|g' scripts/cernlib
+
+  # XQuartz-2.8.0 dropped libXp compile-time files
+  perl -pi -e 's/ -lXp / /g' scripts/cernlib
 <<
 UseMaxBuildJobs: false
 CompileScript: <<
@@ -56,6 +59,14 @@ CompileScript: <<
   export CVSCOSRC=%b
   export HAVE_MOTIF=yes
   ${CVSCOSRC}/config/imake_boot
+
+  # XQuartz-2.8.0 dropped bin/makedepend. There is no flag to control
+  # generation/use of dependency-tracking, so we just create blank .d
+  # files. That means we cannot use f-p-p to track BuildDepends and
+  # there is a possible risk of parallel-build breakage, but at least
+  # it compiles.
+  export MAKEDEPEND=/usr/bin/true
+
   make tree
   make install.include CERN_INCLUDEDIR=${CERN_ROOT}/include
   pushd packlib/kuip/programs/kuipc
@@ -105,6 +116,9 @@ InfoTest: <<
     export CERN_ROOT=${CERN}/${CERN_LEVEL}
     export PATH=${CERN_ROOT}/bin:%p/lib/xmkmf/bin:${PATH}
     export CVSCOSRC=%b
+
+    export MAKEDEPEND=/usr/bin/true
+
     cd packlib
     ( make test 2>&1 | /usr/bin/tee %b/test.log ) || exit 2
     cd ../mathlib


### PR DESCRIPTION
So disable header-tracking and avoid linking against a lib that isn't directly used anyway.