### PR TITLE
Sensible-Utils upstream version update and link to gzip tarball so no…

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/base/sensible-utils.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/sensible-utils.info
@@ -1,31 +1,30 @@
 Package: sensible-utils
-Version: 0.0.7
-Revision: 4
+Version: 0.0.14
+Revision: 1
 Essential: true
 Maintainer: Fink Core Group <fink-core@lists.sourceforge.net>
-## Remove po4a
 BuildDepends: fink (>= 0.24.12-1)
 Replaces: debianutils (<= 2.32.3)
-CustomMirror: <<
-	Primary: http://ftp.debian.org/debian/pool/main/s/%n/
-	Secondary: http://downloads.sourceforge.net/fink/
-<<
-Source: mirror:custom:%n-%v.tar.gz
-Source-MD5: 9a208cceb0e9c5cc1d2aa4d53d7d2baa
-SourceDirectory: %n-%v
+Source: https://salsa.debian.org/debian/%n/-/archive/debian/%v/%n-debian-%v.tar.gz
+Source-MD5: 61621ccf9b29c1249cdb17496dc613ab
+SourceRename: %n-%v.tar.gz
+SourceDirectory: %n-debian-%v
+
 PatchScript: <<
-#cd po4a && po4a --no-backups po4a.conf
 perl -pi -e 's,SUBDIRS = po4a,SUBDIRS = ,g' Makefile.in
 perl -pi -e 's,Makefile po4a/Makefile po4a/de/Makefile po4a/es/Makefile po4a/fr/Makefile po4a/it/Makefile po4a/ja/Makefile po4a/pl/Makefile,Makefile,g' configure
 
 perl -pi -e 's,/usr,%p,g' debian/mime
 perl -pi -e 's,/usr,%p,g' sensible-browser
 <<
+
 ConfigureParams: --mandir=%p/share/man
+
 CompileScript: <<
 SENSIBLE_UTILS_VERSION="%v" ./configure %c
 make
 <<
+
 InstallScript: <<
 #!/bin/sh -ev
 
@@ -36,23 +35,9 @@ install -d -m 0755 %d/DEBIAN \
 	           %i/share/doc/%n
 make install DESTDIR=%d INSTALL_PROGRAM="install -m 0755"
 
-ln -s sensible-editor.1 %i/share/man/man1/sensible-pager.1
-ln -s sensible-editor.1 %i/share/man/man1/sensible-browser.1
-#ln -s sensible-editor.1 %i/share/man/fr/man1/sensible-pager.1
-#ln -s sensible-editor.1 %i/share/man/fr/man1/sensible-browser.1
-#ln -s sensible-editor.1 %i/share/man/pl/man1/sensible-pager.1
-#ln -s sensible-editor.1 %i/share/man/pl/man1/sensible-browser.1
-#ln -s sensible-editor.1 %i/share/man/es/man1/sensible-pager.1
-#ln -s sensible-editor.1 %i/share/man/es/man1/sensible-browser.1
-#ln -s sensible-editor.1 %i/share/man/de/man1/sensible-pager.1
-#ln -s sensible-editor.1 %i/share/man/de/man1/sensible-browser.1
-#ln -s sensible-editor.1 %i/share/man/ja/man1/sensible-pager.1
-#ln -s sensible-editor.1 %i/share/man/ja/man1/sensible-browser.1
-#ln -s sensible-editor.1 %i/share/man/it/man1/sensible-pager.1
-#ln -s sensible-editor.1 %i/share/man/it/man1/sensible-browser.1
-
 install -m 0644 debian/mime %i/lib/mime/packages/sensible-utils
 <<
+
 PostInstScript: <<
 if [ configure = "$1" ]; then
     if which update-mime >/dev/null;
@@ -61,6 +46,7 @@ if [ configure = "$1" ]; then
     fi
 fi
 <<
+
 PostRmScript: <<
 if [ remove = "$1" -o disappear = "$1" ]; then
     if which update-mime >/dev/null;
@@ -69,8 +55,10 @@ if [ remove = "$1" -o disappear = "$1" ]; then
     fi
 fi
 <<
+
 DocFiles: debian/changelog debian/copyright
 Description: Utilities for sensible alternative selection
+
 DescDetail: <<
 This package provides a number of small utilities which are used by programs
 to sensibly select and spawn an appropriate browser, editor, or pager.
@@ -78,5 +66,6 @@ to sensibly select and spawn an appropriate browser, editor, or pager.
 The specific utilities included are: sensible-browser sensible-editor
 sensible-pager
 <<
+
 Homepage: http://packages.debian.org/unstable/sensible-utils
 License: GPL


### PR DESCRIPTION
The link to source code was out of date and no longer active.
Updated to latest upstream version (0.0.14)
Link to repository gzip file to avoid gymnastics to deal with .xz file during installation
Passes build with -m option and validates.