### PR TITLE
grace: updates for Xcode12

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/grace-implicit-declarations.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/grace-implicit-declarations.patch
@@ -1,0 +1,70 @@
+diff -ruN grace-5.1.25-orig/configure grace-5.1.25/configure
+--- grace-5.1.25-orig/configure	2015-02-14 16:59:46.000000000 -0600
++++ grace-5.1.25/configure	2021-04-16 04:44:02.000000000 -0500
+@@ -4236,6 +4236,7 @@
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <stdlib.h>
+ 
+     int main(void) {
+       static int Array[3];
+@@ -4934,6 +4935,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <stdio.h>
+ #include <string.h>
+ 
+@@ -7802,6 +7804,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <string.h>
+ #include <t1lib.h>
+       int main(void) {
+@@ -8345,6 +8348,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <string.h>
+ #include <zlib.h>
+       int main(void) {
+@@ -8430,6 +8434,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <stdio.h>
+ #include <jpeglib.h>
+       int main(void) {
+@@ -8515,6 +8520,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <string.h>
+ #include <png.h>
+       int main(void) {
+@@ -8602,6 +8608,8 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <string.h>
++#include <stdlib.h>
+ #include <pdflib.h>
+       int main(void) {
+         char *vinc;
+@@ -9552,7 +9560,9 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <Xm/XmAll.h>
++void XmRegisterConverters(void);
+       int main(void) {
+         int vlibn, vincn;
+         vincn = XmVersion;

--- a/10.9-libcxx/stable/main/finkinfo/sci/grace.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/grace.info
@@ -1,6 +1,6 @@
 Package: grace
 Version: 5.1.25
-Revision: 5
+Revision: 6
 
 Source: ftp://plasma-gate.weizmann.ac.il/pub/%N/src/%n5/%n-%v.tar.gz
 Source-MD5: c0482b1f18b113192946a96f5ff35a4d
@@ -11,7 +11,7 @@ Depends: <<
 	libjpeg9-shlibs,
 	libpng16-shlibs,
 	libxt-flat-shlibs (>=1.1.5-2),
-	netcdf-c7-shlibs (>= 4.3.2-2),
+	netcdf-c18-shlibs,
 	openmotif4-shlibs (>= 2.3.4-13),
 	pdflib6-shlibs,
 	t1lib5-nox-shlibs,
@@ -23,7 +23,7 @@ BuildDepends: <<
 	libjpeg9,
 	libpng16,
 	libxt-flat (>=1.1.5-2),
-	netcdf-c7 (>= 4.3.2-2),
+	netcdf-c18,
 	openmotif4 (>=2.3.4-13),
 	pdflib6,
 	t1lib5-nox,
@@ -36,6 +36,8 @@ RuntimeDepends: x11
 
 PatchFile: %n.patch
 PatchFile-MD5: d22e4b882a2d55baad8def3063bacc33
+PatchFile2: %n-implicit-declarations.patch
+PatchFile2-MD5: b720ffd56d1f228d31ac3b9ffd5e8f08
 
 PatchScript: <<
 %{default_script}


### PR DESCRIPTION
Fix implicit declaration errors during configure
bump to netcdf-c18 because -c7 deps on hdf5.10, which doesn't build with Xcode12 (more implicit declarations).