### PR TITLE
e2fsprogs: update to 1.46.2, add testsuite

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/utils/e2fsprogs.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/e2fsprogs.info
@@ -1,6 +1,6 @@
 Package: e2fsprogs
-Version: 1.42.13
-Revision: 2
+Version: 1.46.2
+Revision: 1
 ###
 BuildDepends: <<
 	fink-package-precedence,
@@ -19,7 +19,7 @@ Depends: <<
 <<
 ###
 Source: mirror:sourceforge:e2fsprogs/%n-%v.tar.gz
-Source-MD5: bc759fc62666786f5436e2075beb3265
+Source-MD5: e8ef5fa3b72557be5e9fe564a25da6eb
 ###
 # TheSin: fix pathnames for darwin
 # dmacks: Self-consistent ordering of CPPFLAGS vs INCLUDES (external
@@ -27,7 +27,7 @@ Source-MD5: bc759fc62666786f5436e2075beb3265
 # dmacks: avoid fink's libuuid, which wasn't being used correctly
 #         anyway (OS X has it)
 PatchFile: %n.patch
-PatchFile-MD5: afd321fb3adef77e49f699b00325ca55
+PatchFile-MD5: c7321f40b7e8499c79e4400f7aa1b16d
 ###
 SetCPPFLAGS: -MD
 ConfigureParams: <<
@@ -49,13 +49,17 @@ CompileScript: <<
 	fink-package-precedence --depfile-ext='\.d' --prohibit-bdep=e2fslibs-dev,comerr-dev,ss-dev,libblkid-dev .
 <<
 ###
+InfoTest: <<
+TestScript: make check || exit 2
+<<
+###
 InstallScript: <<
 	make install DESTDIR=%d
 	make install-libs DESTDIR=%d
 <<
 ###
 ConfFiles: %p/etc/mke2fs.conf
-DocFiles: COPYING README RELEASE-NOTES
+DocFiles: NOTICE README RELEASE-NOTES
 ###
 Description: Utilities for ext2/ext3/ext4 file system
 DescDetail: <<
@@ -78,7 +82,7 @@ SplitOff: <<
 		%p/lib/libe2p.2.dylib		1.0.0	%n (>= 1.42.13-1)
 		%p/lib/libext2fs.2.dylib	1.0.0	%n (>= 1.42.13-1)
 	<<
-	DocFiles: COPYING
+	DocFiles: NOTICE
 	Description: Libraries for ext2/ext3/ext4 file system
 	DescDetail: <<
 The ext2, ext3 and ext4 file systems are successors of the original ext
@@ -106,7 +110,7 @@ SplitOff2: <<
 		include/ext2fs
 		share/info
 	<<
-	DocFiles: COPYING
+	DocFiles: NOTICE
 	InfoDocs: libext2fs.info
 	Description: Development for ext2/ext3/ext4 file system
 	DescDetail: <<
@@ -126,7 +130,7 @@ SplitOff3: <<
 	Shlibs: <<
 		%p/lib/libcom_err.2.dylib	1.0.0	%n (>= 1.42.13-1)
 	<<
-	DocFiles: COPYING
+	DocFiles: NOTICE
 	Description: Common error description library
 	DescDetail: <<
 libcomerr is an attempt to present a common error-handling mechanism to
@@ -150,7 +154,7 @@ SplitOff4: <<
 		share/man/man1/compile_et.1
 		share/man/man3/com_err.3
 	<<
-	DocFiles: COPYING
+	DocFiles: NOTICE
 	Description: Common error description development
 	DescDetail: <<
 libcomerr is an attempt to present a common error-handling mechanism to
@@ -171,7 +175,7 @@ SplitOff5: <<
 	Shlibs: <<
 		%p/lib/libss.2.dylib		1.0.0	%n (>= 1.42.13-1)
 	<<
-	DocFiles: COPYING
+	DocFiles: NOTICE
 	Description: Command-line interface parsing library
 	DescDetail: <<
 libss provides a simple command-line interface parser which will accept input
@@ -195,7 +199,7 @@ SplitOff6: <<
 		share/man/man1/mk_cmds.1
 		share/ss
 	<<
-	DocFiles: COPYING
+	DocFiles: NOTICE
 	Description: Command-line interface parsing library
 	DescDetail: <<
 libss provides a simple command-line interface parser which will accept input
@@ -215,7 +219,7 @@ SplitOff7: <<
 	Shlibs: <<
 		%p/lib/libblkid.1.dylib		1.0.0	%n (>= 1.42.13-1)
 	<<
-	DocFiles: COPYING
+	DocFiles: NOTICE
 	Description: Block device id library
 	DescDetail: <<
 The blkid library which allows system programs like fsck and mount to quickly
@@ -235,7 +239,7 @@ SplitOff8: <<
 		lib
 		share/man/man3
 	<<
-	DocFiles: COPYING
+	DocFiles: NOTICE
 	Description: Block device id library development
 	DescDetail: <<
 The blkid library which allows system programs like fsck and mount to quickly

--- a/10.9-libcxx/stable/main/finkinfo/utils/e2fsprogs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/utils/e2fsprogs.patch
@@ -1,7 +1,7 @@
-diff -ruN e2fsprogs-1.42.13.orig/configure e2fsprogs-1.42.13/configure
---- e2fsprogs-1.42.13.orig/configure	2014-11-30 16:34:31.000000000 -0500
-+++ e2fsprogs-1.42.13/configure	2018-07-15 09:39:00.000000000 -0400
-@@ -5296,8 +5296,15 @@
+diff -ruN e2fsprogs-1.46.2.orig/configure e2fsprogs-1.46.2/configure
+--- e2fsprogs-1.46.2.orig/configure	2021-03-01 02:46:44.000000000 +0000
++++ e2fsprogs-1.46.2/configure	2021-04-16 15:17:33.000000000 +0100
+@@ -5335,8 +5335,15 @@
  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_uuid_uuid_generate" >&5
  $as_echo "$ac_cv_lib_uuid_uuid_generate" >&6; }
  if test "x$ac_cv_lib_uuid_uuid_generate" = xyes; then :
@@ -19,8 +19,8 @@ diff -ruN e2fsprogs-1.42.13.orig/configure e2fsprogs-1.42.13/configure
  else
    as_fn_error $? "external uuid library not found" "$LINENO" 5
  fi
-@@ -13410,7 +13417,7 @@
- 
+@@ -12383,7 +12390,7 @@
+ fi
  
  if test $cross_compiling = no; then
 -   BUILD_CFLAGS="$CFLAGS $CPPFLAGS $INCLUDES -DHAVE_CONFIG_H"
@@ -28,21 +28,38 @@ diff -ruN e2fsprogs-1.42.13.orig/configure e2fsprogs-1.42.13/configure
     BUILD_LDFLAGS="$LDFLAGS"
  fi
  
-diff -ruN e2fsprogs-1.42.13.orig/debugfs/Makefile.in e2fsprogs-1.42.13/debugfs/Makefile.in
---- e2fsprogs-1.42.13.orig/debugfs/Makefile.in	2014-07-06 00:13:18.000000000 -0400
-+++ e2fsprogs-1.42.13/debugfs/Makefile.in	2018-07-15 07:12:17.000000000 -0400
-@@ -81,7 +81,7 @@
+diff -ruN e2fsprogs-1.46.2.orig/debugfs/Makefile.in e2fsprogs-1.46.2/debugfs/Makefile.in
+--- e2fsprogs-1.46.2.orig/debugfs/Makefile.in	2021-03-01 02:46:44.000000000 +0000
++++ e2fsprogs-1.46.2/debugfs/Makefile.in	2021-04-16 15:21:44.000000000 +0100
+@@ -96,21 +96,21 @@
  
  e2freefrag.o: $(srcdir)/../misc/e2freefrag.c
  	$(E) "	CC $@"
--	$(Q) $(CC) -c $(ALL_CFLAGS) -I$(srcdir) $< -DDEBUGFS -o $@
-+	$(Q) $(CC) -c -I$(srcdir) $(ALL_CFLAGS) $< -DDEBUGFS -o $@
+-	$(Q) $(CC) -c $(ALL_CFLAGS) -I$(srcdir) $< -o $@
++	$(Q) $(CC) -c -I$(srcdir) $(ALL_CFLAGS) $< -o $@
+ 
+ recovery.o: $(srcdir)/../e2fsck/recovery.c
+ 	$(E) "	CC $@"
+-	$(Q) $(CC) -c $(ALL_CFLAGS) -I$(srcdir) \
++	$(Q) $(CC) -c -I$(srcdir) $(ALL_CFLAGS) \
+ 		$(srcdir)/../e2fsck/recovery.c -o $@
+ 
+ revoke.o: $(srcdir)/../e2fsck/revoke.c
+ 	$(E) "	CC $@"
+-	$(Q) $(CC) -c $(ALL_CFLAGS) -I$(srcdir) \
++	$(Q) $(CC) -c -I$(srcdir) $(ALL_CFLAGS) \
+ 		$(srcdir)/../e2fsck/revoke.c -o $@
+ 
+ create_inode.o: $(srcdir)/../misc/create_inode.c
+ 	$(E) "	CC $@"
+-	$(Q) $(CC) -c $(ALL_CFLAGS) -I$(srcdir) \
++	$(Q) $(CC) -c -I$(srcdir) $(ALL_CFLAGS) \
+ 		 $(srcdir)/../misc/create_inode.c -o $@
  
  debugfs.8: $(DEP_SUBSTITUTE) $(srcdir)/debugfs.8.in
- 	$(E) "	SUBST $@"
-diff -ruN e2fsprogs-1.42.13.orig/lib/Makefile.darwin-lib e2fsprogs-1.42.13/lib/Makefile.darwin-lib
---- e2fsprogs-1.42.13.orig/lib/Makefile.darwin-lib	2011-01-14 13:07:50.000000000 -0500
-+++ e2fsprogs-1.42.13/lib/Makefile.darwin-lib	2018-07-15 06:52:35.000000000 -0400
+diff -ruN e2fsprogs-1.46.2.orig/lib/Makefile.darwin-lib e2fsprogs-1.46.2/lib/Makefile.darwin-lib
+--- e2fsprogs-1.46.2.orig/lib/Makefile.darwin-lib	2021-03-01 02:46:44.000000000 +0000
++++ e2fsprogs-1.46.2/lib/Makefile.darwin-lib	2021-04-16 15:17:33.000000000 +0100
 @@ -16,25 +16,31 @@
  	$(E) "	MKDIR pic"
  	$(Q) mkdir -p pic
@@ -78,3 +95,14 @@ diff -ruN e2fsprogs-1.42.13.orig/lib/Makefile.darwin-lib e2fsprogs-1.42.13/lib/M
  	-$(Q) $(LDCONFIG)
  
  install-strip: install
+diff -ruN e2fsprogs-1.46.2.orig/lib/blkid/probe.c e2fsprogs-1.46.2/lib/blkid/probe.c
+--- e2fsprogs-1.46.2.orig/lib/blkid/probe.c	2021-03-01 02:46:44.000000000 +0000
++++ e2fsprogs-1.46.2/lib/blkid/probe.c	2021-04-16 15:35:18.000000000 +0100
+@@ -33,6 +33,7 @@
+ #ifdef HAVE_ERRNO_H
+ #include <errno.h>
+ #endif
++#include <time.h>
+ #include "blkidP.h"
+ #include "uuid/uuid.h"
+ #include "probe.h"


### PR DESCRIPTION
Here is the latest upstream version of e2fsprogs. Changes include:

- Added `#include <time.h>` to `lib/blkid/probe.c` (fixes implicit declaration error)
- Added the testsuite to the info-file
- Name of license file changed from COPYING to NOTICE
- Library compatibility versions remain the same, so no changes required there.

Builds on 10.15.7, also with `-m`, and all tests pass. Sorry, I haven't upgraded to Big Sur yet... Maintainer is @TheSin- 