### PR TITLE
Cran gitcreds

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gitcreds-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-gitcreds-r.info
@@ -1,6 +1,6 @@
 Info2: <<
 
-Package: cran-gh-r%type_pkg[rversion]
+Package: cran-gitcreds-r%type_pkg[rversion]
 Distribution: <<
 	(%type_pkg[rversion] = 31 ) 10.9,
 	(%type_pkg[rversion] = 31 ) 10.10,
@@ -33,45 +33,45 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.2.1
+Version: 0.1.1
 Revision: 1
-Description: 'GitHub' 'API'
-Homepage: https://cran.r-project.org/package=gh
+Description: Query git Credentials from R
+Homepage: https://cran.r-project.org/package=gitcreds
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: mirror:custom:gh_%v.tar.gz
-Source-MD5: dee4b6613156cdb352831094d9f728f0
-SourceDirectory: gh
+Source: mirror:custom:gitcreds_%v.tar.gz
+Source-MD5: 6d925d510185d9be43ab515c59e57948
+SourceDirectory: gitcreds
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
-	Secondary: https://cran.r-project.org/src/contrib/00Archive/gh
+	Secondary: https://cran.r-project.org/src/contrib/00Archive/gitcreds
 <<
 Depends: <<
-	r-base%type_pkg[rversion],
-	cran-cli-r%type_pkg[rversion] (>= 2.0.1-1),
-	cran-gitcreds-r%type_pkg[rversion],
-	cran-httr-r%type_pkg[rversion] (>= 1.2-1),
-	cran-ini-r%type_pkg[rversion],
-	cran-jsonlite-r%type_pkg[rversion]
+	r-base%type_pkg[rversion]
 <<
-BuildDepends: r-base%type_pkg[rversion]-dev
+BuildDepends: <<
+	fink (>= 0.32),
+	r-base%type_pkg[rversion]-dev
+<<
+RuntimeDepends: <<
+	git
+<<
 CompileScript: <<
   #!/bin/bash -ev
   export TMPDIR=%b/tmp
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
-  $BIN_R --verbose CMD build --no-build-vignettes gh
+  $BIN_R --verbose CMD build --no-build-vignettes gitcreds
 <<
 InstallScript: <<
   #!/bin/sh -ev
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   mkdir -p %i/lib/R/%type_raw[rversion]/site-library
-  pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library gh
+  pushd %b/.. && `which xvfb-run` $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library gitcreds
 <<
 DescDetail: <<
-Minimal client to access the 'GitHub' 'API'.
 <<
 
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pkgload-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-pkgload-r.info
@@ -33,14 +33,14 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
 Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 1.1.0
+Version: 1.2.1
 Revision: 1
 Description: Simulate Package Installation and Attach
 Homepage: https://cran.r-project.org/package=pkgload
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:pkgload_%v.tar.gz
-Source-MD5: 8522b5fdd3fa1d802c3187f10e24ef40
+Source-MD5: e0b0a25d27fcbbdae587e04287e4d4d5
 SourceDirectory: pkgload
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -51,21 +51,17 @@ Depends: <<
 	cran-cli-r%type_pkg[rversion], 
 	cran-crayon-r%type_pkg[rversion], 
 	cran-desc-r%type_pkg[rversion], 
-	cran-pkgbuild-r%type_pkg[rversion], 
 	cran-rlang-r%type_pkg[rversion],
 	cran-rprojroot-r%type_pkg[rversion], 
 	cran-rstudioapi-r%type_pkg[rversion], 
-	cran-withr-r%type_pkg[rversion],
-	libgettext8-shlibs
+	cran-withr-r%type_pkg[rversion]
 <<
 BuildDepends: <<
 	fink (>= 0.27.2),
-	r-base%type_pkg[rversion]-dev,
-	libgettext8-dev
+	r-base%type_pkg[rversion]-dev
 <<
 CompileScript: <<
   #!/bin/bash -ev
-  export TMPDIR=%b/tmp
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..
@@ -77,15 +73,6 @@ InstallScript: <<
   
   mkdir -p %i/lib/R/%type_raw[rversion]/site-library
   pushd %b/.. && $BIN_R --verbose CMD INSTALL --library=%i/lib/R/%type_raw[rversion]/site-library pkgload
-  if [ "%type_num[rversion]" -lt "34" ]; then
-	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/pkgload/libs/pkgload.dylib %i/lib/R/%type_raw[rversion]/site-library/pkgload/libs/pkgload.dylib
-  else
-	  install_name_tool -id %p/lib/R/%type_raw[rversion]/site-library/pkgload/libs/pkgload.so %i/lib/R/%type_raw[rversion]/site-library/pkgload/libs/pkgload.so
-  fi
-<<
-Shlibs: <<
-  ( %type_raw[rversion] >= 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/pkgload/libs/pkgload.so 0.0.0 %n (>= 1.0.2-1)
-  ( %type_raw[rversion] << 3.4 ) %p/lib/R/%type_raw[rversion]/site-library/pkgload/libs/pkgload.dylib 0.0.0 %n (>= 1.0.2-1)
 <<
 DescDetail: <<
 Simulates the process of installing a package and then attaching it.
@@ -94,6 +81,8 @@ iterate while developing a package.
 <<
 DescPackaging: <<
   R (>= 3.1)
+  
+  As of 1.2.1, there no longer is pkgload.so.
 <<
 
 <<


### PR DESCRIPTION
Update cran-gh. The new version requires a new cran packages cran-gitcreds. I have not tested all the functions in gitcreds yet.