### PR TITLE
xtide: use latest harmonic data files

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide-harmonics-us.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide-harmonics-us.info
@@ -1,5 +1,5 @@
 Package: xtide-harmonics-us
-Version: 20191229
+Version: 20210110
 Revision: 1
 Description: US harmonic data for XTide
 DescDetail: <<
@@ -19,8 +19,8 @@ Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 BuildDepends: fink (>= 0.32)
 
 Source: https://flaterco.com/files/xtide/harmonics-dwf-%v-free.tar.xz
-Source-MD5: dd0229543b5a02bf45a317de12099afc
-Source-Checksum: SHA1(76fc49bba68aae7def461f3963f7f16b0053cca7)
+Source-MD5: b14454b1cb477a93bf8311687ade2c79
+Source-Checksum: SHA1(7b2734c879a8ca1ff0fbbad09443103264fc315b)
 SourceDirectory: harmonics-dwf-%v
 
 CompileScript: printf "No compiling needed.\n" 

--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: xtide
 Version: 2.15.3
-Revision: 1
-Type: harm (20191229)
+Revision: 2
+Type: harm (20210110)
 
 Description: Tide and current prediction software
 License: Public Domain


### PR DESCRIPTION
A trivial update to xtide: use the latest data files (released in January). Maintainer is @akhansen 