### PR TITLE
automake bumps and libtinyxml2 compensation

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/caca-doxygen.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/caca-doxygen.patch
@@ -1,21 +1,22 @@
 Description: Don't mess with Doxygen's output
 Author: Balint Reczey <balint@balintreczey.hu>
-Index: libcaca-0.99.beta19/doc/Makefile.am
+Daniel Macks converted the Makefile.am segment to do Makefile.in instead
+Index: libcaca-0.99.beta19/doc/Makefile.in
 ===================================================================
---- libcaca-0.99.beta19.orig/doc/Makefile.am
-+++ libcaca-0.99.beta19/doc/Makefile.am
-@@ -28,10 +28,7 @@ stamp-latex: stamp-doxygen
- if BUILD_DOCUMENTATION
- if USE_LATEX
- 	rm -f latex/libcaca.tex latex/libcaca.pdf
--	mv latex/refman.tex latex/libcaca.tex
--	sed 's/setlength{/renewcommand{/' latex/libcaca.tex \
--	  | sed 's/.*usepackage.*times.*//' > latex/refman.tex
--	cd latex && $(MAKE) $(AM_CFLAGS) refman.pdf || (cat refman.log; exit 1)
-+	(cd latex &&  pdflatex refman ; makeindex refman.idx ; pdflatex refman ; pdflatex refman ; pdflatex refman ; pdflatex refman ; pdflatex refman; echo "pdflatex exit code: $$?")
- 	mv latex/refman.pdf latex/libcaca.pdf
- 	touch stamp-latex
- endif
+--- libcaca-0.99.beta19.orig/doc/Makefile.in
++++ libcaca-0.99.beta19/doc/Makefile.in
+@@ -635,10 +635,7 @@
+ 
+ stamp-latex: stamp-doxygen
+ @BUILD_DOCUMENTATION_TRUE@@USE_LATEX_TRUE@	rm -f latex/libcaca.tex latex/libcaca.pdf
+-@BUILD_DOCUMENTATION_TRUE@@USE_LATEX_TRUE@	mv latex/refman.tex latex/libcaca.tex
+-@BUILD_DOCUMENTATION_TRUE@@USE_LATEX_TRUE@	sed 's/setlength{/renewcommand{/' latex/libcaca.tex \
+-@BUILD_DOCUMENTATION_TRUE@@USE_LATEX_TRUE@	  | sed 's/.*usepackage.*times.*//' > latex/refman.tex
+-@BUILD_DOCUMENTATION_TRUE@@USE_LATEX_TRUE@	cd latex && $(MAKE) $(AM_CFLAGS) refman.pdf || (cat refman.log; exit 1)
++@BUILD_DOCUMENTATION_TRUE@@USE_LATEX_TRUE@	(cd latex &&  pdflatex refman ; makeindex refman.idx ; pdflatex refman ; pdflatex refman ; pdflatex refman ; pdflatex refman ; pdflatex refman; echo "pdflatex exit code: $$?")
+ @BUILD_DOCUMENTATION_TRUE@@USE_LATEX_TRUE@	mv latex/refman.pdf latex/libcaca.pdf
+ @BUILD_DOCUMENTATION_TRUE@@USE_LATEX_TRUE@	touch stamp-latex
+ 
 Index: libcaca-0.99.beta19/doc/doxygen.cfg.in
 ===================================================================
 --- libcaca-0.99.beta19.orig/doc/doxygen.cfg.in

--- a/10.9-libcxx/stable/main/finkinfo/libs/caca.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/caca.info
@@ -9,7 +9,6 @@ Depends: <<
 	slang2-shlibs
 <<
 Builddepends: <<
-	automake1.14-core,
 	cairo (>= 1.12.8-3),
 	doxygen (>= 1.8.9.1),
 	fink (>= 0.30.0),
@@ -35,7 +34,7 @@ Source-MD5: a3d4441cdef488099f4a92f4c6c1da00
 PatchFile: %n.patch
 PatchFile-MD5: 772e23de1319128e782df88b52985fd1
 PatchFile2: %n-doxygen.patch
-PatchFile2-MD5: ede3b655dec3ed7871be00382819730d
+PatchFile2-MD5: 4984f4fd7da609cdd40a87be16287a81
 PatchScript: <<
   %{default_script}
   #patch -p1 < %{PatchFile2}

--- a/10.9-libcxx/stable/main/finkinfo/libs/hermes.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/hermes.info
@@ -6,7 +6,7 @@ Source: http://www.clanlib.org/download/files/Hermes-%v.tar.bz2
 Source-MD5: 1b99f623169cf62b70f3de081a633d14
 ###
 Depends: %N-shlibs (= %v-%r)
-BuildDepends: libtool2, autoconf2.6, automake1.14
+BuildDepends: libtool2, autoconf2.6, automake1.15
 BuildDependsOnly: true
 Replaces: %N (<< %v-3)
 ###

--- a/10.9-libcxx/stable/main/finkinfo/libs/libmediainfo0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libmediainfo0.info
@@ -1,8 +1,17 @@
 Package: libmediainfo0
 Version: 0.7.57
-Revision: 1
+Revision: 2
 ###
-BuildDepends: autoconf2.6, automake1.15, libtool2, pkgconfig, libzen0, fink-package-precedence, flag-sort
+BuildDepends: <<
+	autoconf2.6,
+	automake1.15,
+	fink-package-precedence,
+	flag-sort,
+	libtinyxml2.8-dev,
+	libtool2,
+	libzen0,
+	pkgconfig
+<<
 Depends: %N-shlibs (= %v-%r)
 BuildDependsOnly: true
 GCC: 4.0
@@ -11,7 +20,7 @@ Source: mirror:sourceforge:mediainfo/libmediainfo_%v.tar.bz2
 Source-MD5: 6b42fb72c48ca44e65a40495a16e5d26
 SourceDirectory: MediaInfoLib
 ###
-ConfigureParams: --enable-visibility --without-libcurl --without-libmms --enable-dependency-tracking --disable-static --enable-shared --mandir=%p/share/man --infodir=%p/share/info --libexecdir=%p/lib
+ConfigureParams: --enable-visibility --without-libcurl --without-libmms --with-libtinyxml2 --enable-dependency-tracking --disable-static --enable-shared --mandir=%p/share/man --infodir=%p/share/info --libexecdir=%p/lib
 ###
 DocFiles: *.txt *.html
 ###
@@ -61,7 +70,7 @@ install -m 644 %b/Project/GNU/Library/libmediainfo.pc %i/lib/pkgconfig
 ###
 SplitOff: <<
   Package: %N-shlibs
-  Depends: libzen0-shlibs
+  Depends: libtinyxml2.8-shlibs, libzen0-shlibs
   Shlibs: <<
    %p/lib/libmediainfo.0.dylib 1.0.0 libmediainfo0-shlibs (>= 0.7.57-1)
   <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/libmediainfo0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libmediainfo0.info
@@ -2,27 +2,33 @@ Package: libmediainfo0
 Version: 0.7.57
 Revision: 1
 ###
-BuildDepends: autoconf2.6, automake1.14, libtool2, pkgconfig, libzen0
+BuildDepends: autoconf2.6, automake1.15, libtool2, pkgconfig, libzen0, fink-package-precedence, flag-sort
 Depends: %N-shlibs (= %v-%r)
 BuildDependsOnly: true
+GCC: 4.0
 ###
 Source: mirror:sourceforge:mediainfo/libmediainfo_%v.tar.bz2
 Source-MD5: 6b42fb72c48ca44e65a40495a16e5d26
 SourceDirectory: MediaInfoLib
 ###
-ConfigureParams: --enable-visibility --without-libcurl --without-libmms --disable-dependency-tracking --disable-static --enable-shared --mandir=%p/share/man --infodir=%p/share/info --libexecdir=%p/lib
+ConfigureParams: --enable-visibility --without-libcurl --without-libmms --enable-dependency-tracking --disable-static --enable-shared --mandir=%p/share/man --infodir=%p/share/info --libexecdir=%p/lib
 ###
 DocFiles: *.txt *.html
 ###
 PatchScript: <<
 cd Project/GNU/Library && chmod u+x autogen
 perl -pi -e 's,/usr/bin,%p/bin,g' Project/GNU/Library/autogen
+# our libzen0 is via pkgconfig, don't give precedence to anything in
+# /usr/local/bin or elsewhere in PATH
+perl -pi -e 's,(libzen-config),\1.FORCE.NONDETECT,g' Project/GNU/Library/configure.ac
 <<
 ###
+SetCXX: flag-sort -r g++
 CompileScript: <<
 cd Project/GNU/Library && ./autogen
 cd Project/GNU/Library && ./configure %c
 cd Project/GNU/Library && make -j1
+cd Project/GNU/Library && fink-package-precedence --prohibit-bdep=%n .
 <<
 ###
 InstallScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/libzen0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libzen0.info
@@ -2,7 +2,7 @@ Package: libzen0
 Version: 0.4.26
 Revision: 1
 ###
-BuildDepends: autoconf2.6, automake1.14, libtool2
+BuildDepends: autoconf2.6, automake1.15, libtool2
 Depends: %N-shlibs (= %v-%r)
 BuildDependsOnly: true
 GCC: 4.0


### PR DESCRIPTION
Two things here:
- Rooting out the last packages specifically requiring automake1.14.
- Other upgrades to the libmediainfo0 build process.