### PR TITLE
libplist: Update to upstream version 2.2.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libplist-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libplist-py.info
@@ -1,84 +1,54 @@
 Info2: <<
 Package: libplist-py%type_pkg[python]
-Type: python (2.7)
-Version: 1.10
-Revision: 2
+Type: python (2.7 3.4 3.5 3.6 3.7 3.8)
+Version: 2.2.0
+Revision: 1
 Description: Python bindings for libplist
 License: GPL/LGPL
 
 # Dependencies:
 BuildDepends: <<
   fink (>= 0.24.12),
-  cmake, 
-  pkgconfig (>= 0.9.0-1), 
-  libxml2 (>= 2.6.32-1),
-  swig,
   cython-py%type_pkg[python],
-  libplist1 (>= %v-1)
+  libplist7 (>= %v-1)
 <<
-Depends: python%type_pkg[python], libplist1-shlibs (>= %v-1)
+Depends: python%type_pkg[python], libplist7-shlibs (>= %v-1)
+
 GCC: 4.0
 
 # Unpack Phase:
-Source: http://www.libimobiledevice.org/downloads/libplist-%v.tar.bz2
-Source-MD5: fe642d0c8602d70c408994555c330dd1
-
-UseMaxBuildJobs: false
-
-# Patch Phase: (fix building on Mavericks. It is already commmited to git 
-# and should be included in  version 1.11.)
-PatchScript: <<
-#!/bin/sh -ev
-  sed -i.bak 's|iterator(NULL);|iterator(this->_map.end());|g' src/Dictionary.cpp
-<<
+Source: https://github.com/libimobiledevice/libplist/releases/download/%v/libplist-%v.tar.bz2
+Source-MD5: 63cc49401521662c94cd4107898c744c
 
 # Compile Phase:
 CompileScript: <<
 #!/bin/sh -ev
-  mkdir build
-  cd build
-  cmake ..                                                     \
-    -DCMAKE_INSTALL_PREFIX=%p                                  \
-    -DCYTHON_EXECUTABLE=%p/bin/cython-py%type_pkg[python]      \
-    -DPYTHON_EXECUTABLE=%p/bin/python%type_raw[python]         \
-    -DPYTHON_INCLUDE_DIR=%p/include/python%type_raw[python]    \
-    -DCMAKE_OSX_SYSROOT:STRING=/ -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING="" \
-    -DPYTHON_LIBRARY=%p/lib/python%type_raw[python]/config/libpython%type_raw[python].dylib
-  make
+  ./configure %c PYTHON=%p/bin/python%type_raw[python]
+  make CFLAGS='-Wno-missing-field-initializers -Wno-deprecated-declarations'
 <<
 
 # Install Phase:
 InstallScript: <<
 #!/bin/sh -ev
-  SWIGLIB_PATH=`%p/bin/swig -swiglib | cut -d / -f 3-5`
-  mkdir -p -m 755 %i/$SWIGLIB_PATH
-  cp swig/plist.i %i/$SWIGLIB_PATH
-  cd build
-  make -C swig   install DESTDIR=%d
-  make -C cython install DESTDIR=%d
+  cd cython
+  make install DESTDIR=%d
 <<
-DocFiles: AUTHORS COPYING* README
+
+DocFiles: AUTHORS COPYING* NEWS README.md
 
 SplitOff: <<
   Package: %N-dev
   BuildDependsOnly: true
   Depends: %N
-  Conflicts: libplist-py25-dev, libplist-py26-dev, libplist-py27-dev 
-  Replaces:  libplist-py25-dev, libplist-py26-dev, libplist-py27-dev
-  Files: include share/swig
+  Conflicts: libplist-py27-dev, libplist-py34-dev, libplist-py35-dev, libplist-py36-dev, libplist-py37-dev, libplist-py38-dev
+  Replaces:  libplist-py27-dev, libplist-py34-dev, libplist-py35-dev, libplist-py36-dev, libplist-py37-dev, libplist-py38-dev
+  Files: <<
+    include/plist/cython/plist.pxd
+  <<
 <<
 
 # Additional Info
 
-DescPort: <<
-The automatic detection of python does not work. It easily returns a mix of 
-system and fink paths of the python executable, the include and the lib folder.
-Cython is only available for python2.6 and 2.7
-
-This fixes not finding the SDK:
--DCMAKE_OSX_SYSROOT:STRING=/ -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=""
-<<
-
-Homepage: http://www.libimobiledevice.org/
+Homepage: https://libimobiledevice.org/
 Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/libplist7.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libplist7.info
@@ -1,0 +1,69 @@
+Package: libplist7
+Version: 2.2.0
+Revision: 1
+Description: Library to handle Apple Property List files
+License: GPL/LGPL
+
+# Dependencies:
+BuildDependsOnly: true
+BuildDepends: <<
+  fink (>= 0.24.12),
+  pkgconfig (>= 0.9.0-1),
+  fink-package-precedence
+<<
+Depends:   %N-shlibs (>= 2.2.0-1)
+Conflicts: libplist, libplist1
+Replaces:  libplist, libplist1
+
+GCC: 4.0
+
+# Unpack Phase:
+Source: https://github.com/libimobiledevice/libplist/releases/download/%v/libplist-%v.tar.bz2
+Source-MD5: 63cc49401521662c94cd4107898c744c
+
+ConfigureParams: --without-cython
+
+# Compile Phase:
+CompileScript: <<
+#!/bin/sh -ev
+  ./configure %c
+  make
+  fink-package-precedence .
+<<
+
+# Install Phase:
+InstallScript: <<
+#!/bin/sh -ev
+  make install DESTDIR=%d
+<<
+
+DocFiles: AUTHORS COPYING* NEWS README.md
+
+SplitOff: <<
+  Package: %N-shlibs
+  Files: <<
+    lib/libplist-2.0.3.dylib
+    lib/libplist++-2.0.3.dylib
+  <<
+  Shlibs: <<
+    %p/lib/libplist-2.0.3.dylib   7.0.0 %n (>= 2.2.0-1)
+    %p/lib/libplist++-2.0.3.dylib 7.0.0 %n (>= 2.2.0-1)
+  <<
+  DocFiles: AUTHORS COPYING* NEWS README.md
+<<
+
+Splitoff2: <<
+  Package: libplist-bin
+  Description: Command line tool "plistutil" from libplist
+  Depends: %N-shlibs (>= %v-1)
+  Files: bin
+  DocFiles: AUTHORS COPYING* NEWS README.md
+<<
+
+DescPort: <<
+  Python bindings are pushed to a separate package.
+<<
+
+Homepage: https://libimobiledevice.org
+Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
+


### PR DESCRIPTION
Please test on other systems than mine (11.3).

libusdmux and libimobile will follow.