### PR TITLE
New pkg perl5302 to match system-perl on 11.3

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5302-libperl-t.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5302-libperl-t.patch
@@ -1,0 +1,12 @@
+diff -ruN perl-5.30.2-orig/t/porting/libperl.t perl-5.30.2/t/porting/libperl.t
+--- perl-5.30.2-orig/t/porting/libperl.t	2020-03-14 07:11:40.000000000 -0500
++++ perl-5.30.2/t/porting/libperl.t	2021-05-11 06:40:12.000000000 -0500
+@@ -444,7 +444,7 @@
+         $symbols{data}{common} = $symbols{data}{bss};
+     }
+ 
+-    ok($symbols{data}{common}{PL_hash_seed}{'globals.o'}, "has PL_hash_seed");
++    ok(!$symbols{data}{common}{PL_hash_seed}{'globals.o'}, "has no PL_hash_seed");
+     ok($symbols{data}{data}{PL_ppaddr}{'globals.o'}, "has PL_ppaddr");
+ 
+     # None of the GLOBAL_STRUCT* business here.

--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5302-macos11.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5302-macos11.patch
@@ -1,0 +1,32 @@
+From aadc6422eaec39c22e4b4ce00a1e3ff619c41154 Mon Sep 17 00:00:00 2001
+From: Adam Hartley <git@ahartley.com>
+Date: Mon, 6 Jul 2020 22:59:42 +0100
+Subject: [PATCH] Add 11.x support for darwin.sh
+
+---
+ hints/darwin.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/hints/darwin.sh b/hints/darwin.sh
+index 0a91bc083c0..c0f06de1cab 100644
+--- a/hints/darwin.sh
++++ b/hints/darwin.sh
+@@ -301,7 +301,7 @@ case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
+    # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
+    # capturing its value and adding it to the flags.
+     case "$MACOSX_DEPLOYMENT_TARGET" in
+-    10.*)
++    10.* | 11.*)
+       add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
+       add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
+       ;;
+@@ -327,7 +327,7 @@ EOM
+     # "ProductVersion:    10.11"     "10.11"
+         prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
+     case "$prodvers" in
+-    10.*)
++    10.* | 11.*)
+       add_macosx_version_min ccflags $prodvers
+       add_macosx_version_min ldflags $prodvers
+       ;;
+

--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5302-timehires.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5302-timehires.patch
@@ -1,0 +1,12 @@
+diff -ruN perl-5.30.2-orig/dist/Time-HiRes/t/clock.t perl-5.30.2/dist/Time-HiRes/t/clock.t
+--- perl-5.30.2-orig/dist/Time-HiRes/t/clock.t	2019-10-24 16:27:56.000000000 -0500
++++ perl-5.30.2/dist/Time-HiRes/t/clock.t	2021-05-11 19:40:46.000000000 -0500
+@@ -70,7 +70,7 @@
+ 
+ SKIP: {
+     skip "no clock_nanosleep", 1
+-	unless &Time::HiRes::d_clock_nanosleep && has_symbol("CLOCK_REALTIME");
++	unless not &Time::HiRes::d_clock_nanosleep && has_symbol("CLOCK_REALTIME");
+     my $s = 1.5e9;
+     my $t = Time::HiRes::clock_nanosleep(&CLOCK_REALTIME, $s);
+     my $r = abs(1 - $t / $s);

--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5302.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5302.info
@@ -1,0 +1,197 @@
+Package: perl5302
+Version: 5.30.2
+Revision: 1
+Distribution: 10.9, 10.10, 10.11, 10.12, 10.13, 10.14, 10.14.5, 10.15, 11.0
+BuildDepends: fink (>= 0.32.0)
+Depends: %n-core (>= %v-%r)
+Conflicts: perl5123, perl5124, perl5162, perl5182, perl5184, perl5282, perl5302
+Replaces: perl5123, perl5124, perl5162, perl5182, perl5184, perl5282, perl5302
+License: Artistic
+Description: The Perl programming language, v. 5.30.2
+DescDetail: <<
+Perl is a high-level programming language with roots in C, sed, awk
+and shell scripting.  Perl is good at handling processes and files,
+and is especially good at handling text.  Perl's hallmarks are
+practicality and efficiency.  While it is used to do a lot of
+different things, Perl's most common applications are system
+administration utilities and web programming.  A large proportion of
+the CGI scripts on the web are written in Perl.
+
+Fink's perl packages retain the perl version subdirectories in the
+lib tree.  Without these, upgrading or downgrading Perl breaks all of
+the binary modules.
+<<
+DescPort: <<
+Because the perl build system is designed to download source files for
+"extra" perlmodules directly from CPAN, we do not include those "extra" 
+perlmodules in this package.  For that reason, the following packages
+which are Provided by Apple's build of perl5.30.2 on 11.3 are not provided
+here:
+  convert-tnef-pm5302, html-parser-pm5302, 
+  perl-objcbridge-pm5302, scalar-list-utils-pm5302, uri-pm5302, 
+  algorithm-diff-pm5302, class-autouse-pm5302, corefoundation-pm5302, 
+  data-hierarcy-pm5302, freezethaw-pm5302, io-pager-pm5302, 
+  locale-maketext-lexicon-pm5302, perlio-eol-pm5302
+
+"be_BY" locales are known broken on Darwin (at least through Darwin 12), so 
+disable testing them.
+http://grokbase.com/t/perl/perl5-porters/1289z1msea/whats-blocking-5-14-3
+perl bug #35895
+radar://4139653 (?)
+
+On macOS11.0, buildtime miniperl is not properly referenced in some Makefiles.
+So we hardcode the relative position for building.
+
+Time::HiRes misidentifies macOS having clock_nanosleep.
+<<
+DescUsage: <<
+Most perl scripts start with #!/usr/bin/perl which will invoke Apple's
+/usr/bin/perl. This package does not alter /usr/bin/perl. If you wish
+to use this version of perl in scripts, the script should begin with
+#!%p/bin/perl5.30.2 instead of #!/usr/bin/perl
+<<
+Source: mirror:cpan:src/5.0/perl-%v.tar.xz
+Source-Checksum: SHA256(a1aa88bd6fbbdc2e82938afbb76c408b0ea847317737b712dc196cc7907a5259)
+PatchFile: %n.patch
+PatchFile-MD5: 0f8c7627076dbe48431f309b2c2a618b
+#PatchFile3: %n-timelocal-y2020.patch
+#PatchFile3-MD5: 0ed67a0840de3869984371db64afc544
+PatchFile4: %n-macos11.patch
+PatchFile4-MD5: 621344203183d47554d394ea539a5adf
+PatchFile5: %n-timehires.patch
+PatchFile5-MD5: 7d3614729a5a8d475315bd7b1a2c5f38
+PatchFile6: %n-libperl-t.patch
+PatchFile6-MD5: 8c54d38628d7a643567995ef9c6f66ba
+PatchScript: <<
+    sed -e 's|@FINK_PREFIX@|%p|g' <  %{PatchFile} | patch -p1
+ #   patch -p1 < %{PatchFile3}
+    patch -p1 < %{PatchFile4}
+    patch -p1 < %{PatchFile5}
+    patch -p1 < %{PatchFile6}
+<<
+CompileScript: <<
+#!/bin/sh -ev
+	if [[ `sw_vers -productVersion | cut -f 1 -d.` -ge 11 ]]; then
+		# race condition on macOS11 causes miniperl to not propagate sometimes
+		ABSPERL=../../miniperl
+		# /usr/lib/libc* no longer exists
+		perl -pi -e 's,win32|vms|openbsd|bitrig|cygwin,$&|darwin,g' ext/DynaLoader/t/DynaLoader.t
+	fi
+	sh Configure \
+	-desr \
+	-Dcc="gcc" \
+	-Dcpp="-gcc -E" \
+	-Dprefix=%p \
+	-Dccflags=-I%p/include \
+	-Dldflags=-L%p/lib \
+	-Dperladmin=none \
+	-Uinstallusrbinperl \
+	-Dprivlib="%p/lib/perl5-core/5.30.2" \
+	-Darchlib="%p/lib/perl5-core/5.30.2/darwin-thread-multi-2level" \
+	-Dman3dir="%p/lib/perl5-core/5.30.2/man/man3" \
+	-Dman3ext=3pm \
+	-Dscriptdir="%p/bin" \
+	-Duseithreads \
+	-Dinc_version_list=none \
+	-Dcf_by="Fink Project" \
+	-Dcf_email="fink-core@lists.sourceforge.net" \
+	-Umydomain \
+	-Dmyhostname="localhost" \
+	-Adefine:startperl="#!%p/bin/perl5.30.2" \
+	-Adefine:perlpath="%p/bin/perl5.30.2"
+	make
+<<
+DocFiles: README Copying
+InfoTest: <<
+	TestScript: <<
+		make test || exit 2
+	<<
+<<
+
+InstallScript: <<
+ make install DESTDIR=%d
+
+ mkdir -p %i/etc/profile.d
+ echo "append_path MANPATH %p/lib/perl5-core/5.30.2/man" >> %i/etc/profile.d/%N-core.csh
+ echo "append_path MANPATH %p/lib/perl5/5.30.2/man" >> %i/etc/profile.d/%N-core.csh
+ echo "append_path MANPATH %p/lib/perl5-core/5.30.2/man" >> %i/etc/profile.d/%N-core.sh
+ echo "append_path MANPATH %p/lib/perl5/5.30.2/man" >> %i/etc/profile.d/%N-core.sh
+ echo "export MANPATH" >> %i/etc/profile.d/%N-core.sh
+ chmod 755 %i/etc/profile.d/%N-core.*
+
+<<
+SplitOff: <<
+ Package: %N-core
+ Conflicts: compress-zlib-pm (<= 1.19-2), crypt-ssleay-pm (<= 0.45-2), dbd-mysql-pm (<= 2.1026-1), dbd-pg-pm (<= 1.21-4), dbd-pg-pm-ssl (<= 1.21-4), dbi-pm (<= 1:1.35-1), digest-md5-pm (<= 2.24-1), digest-sha1-pm (<= 2.02-1), egd (<= 0.8-3), eperl-pm (<= 2.2.14-2), filter-util-pm (<= 1.26-1), fribidi-pm (<= 0.05-2), ftlib-pm (<= 1.2-1), gd-pm (<= 2.06-5), gimp-perl (<= 1.211-4), gtk-perl-pm (<= 0.7008-7), html-parser-pm (<= 3.27-1), http-ghttp-pm (<= 1.07-1), irssi-ssl (<= 0.8.6-3), irssi (<= 0.8.6-2), jcode-pm (<= 0.82-1), libapreq-pm (<= 1.0-1), mac-carbon-pm (<= 0.05-1), macosx-file-pm (<= 0.64-1), mime-base64-pm (<= 2.18-1), net-ssleay-pm (<= 1.22-2), nkf (<= 1.92-1), params-validate-pm (<= 0.57-1), pdl (<= 2.3.2-1), perlmagick-pm (<= 5.5.4-1), pgplot-perl (<= 2.18-4), postgresql-perl (<= 7.3.2-7), postgresql-ssl-perl (<= 7.3.2-7), rrdtool-perl (<= 1.0.41-1), scalar-list-utils-pm (<= 1.11-1), sha-pm (<= 1.2-2), shout-pm (<= 1.0-1), storable-pm (<= 1.0.14-1), string-approx-pm (<= 3.19-1), template-notex-pm (<= 2.08-13), template-pm (<= 2.08-13), term-readkey-pm (<= 2.21-1), term-readline-gnu-pm (<= 1.13-1), text-iconv-pm (<= 1.2-1), time-hires-pm (<= 1.46-1), time-piece-pm (<= 1.08-1), tk-pm (<= 800.024-2), tk-tablematrix-pm (<= 1.01-1), unicode-string-pm (<= 2.07-1), xml-parser-pm (<= 2.31-4), xmms-pm (<= 0.12-2)
+ Provides: <<
+  archive-tar-pm5302,
+  attribute-handlers-pm5302,
+  carp-pm5302,
+  cgi-pm5302,
+  compress-raw-bzip2-pm5302,
+  compress-raw-zlib-pm5302,
+  compress-zlib-pm5302,
+  cpanplus-dist-build-pm5302,
+  cpanplus-pm5302,
+  cpan-meta-requirements-pm5302,
+  data-dumper-pm5302,
+  db-pm5302,
+  devel-peek-pm5302,
+  digest-md5-pm5302,
+  digest-pm5302,
+  digest-sha-pm5302,
+  extutils-cbuilder-pm5302,
+  extutils-makemaker-pm5302,
+  extutils-parsexs-pm5302,
+  file-find-pm5302,
+  file-path-pm5302,
+  file-spec-pm5302,
+  file-temp-pm5302,
+  filter-simple-pm5302,
+  getopt-long-pm5302,
+  http-tiny-pm5302,
+  i18n-langtags-pm5302,
+  io-zlib-pm5302,
+  libnet-pm5302,
+  list-util-pm5302,
+  locale-maketext-pm5302,
+  locale-maketext-simple-pm5302,
+  math-bigint-pm5302,
+  memoize-pm5302,
+  mime-base64-pm5302,
+  module-build-pm5302,
+  module-corelist-pm5302,
+  module-load-conditional-pm5302,
+  module-load-pm5302,
+  module-pluggable-pm5302,
+  package-constants-pm5302,
+  params-check-pm5302,
+  perl-ostype-pm5302,
+  pod-escapes-pm5302,
+  pod-parser-pm5302,
+  pod-simple-pm5302,
+  sys-syslog-pm5302,
+  term-readline-pm5302,
+  test-harness-pm5302,
+  test-simple-pm5302,
+  text-tabs-pm5302,
+  text-wrap-pm5302,
+  time-hires-pm5302,
+  unicode-normalize-pm5302
+ <<
+ Files: bin/perl5.30.2 etc lib/perl5 lib/perl5-core
+ Description: Core files for perl, v. 5.30.2
+ DocFiles: README Copying
+<<
+DescPackaging: <<
+ We split the perl5.30.2 binary and the files in lib/perl5* off as a separate
+ "core" package which does not conflict with other versions of perl.
+ %p/bin/perl and other binaries remain in the perl5302 package, and
+ different versions of perl can be selected by installing a different
+ package instead.
+
+ We now use lib/perl5-core as the main installation directory to avoid
+ conflicts with fink-installed perl modules.
+<<
+Homepage: http://www.cpan.org/
+Maintainer: Fink Core Group <fink-core@lists.sourceforge.net>

--- a/10.9-libcxx/stable/main/finkinfo/languages/perl5302.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/perl5302.patch
@@ -1,0 +1,38 @@
+diff -ruN perl-5.30.2-orig/Configure perl-5.30.2/Configure
+--- perl-5.30.2-orig/Configure	2020-02-29 05:55:22.000000000 -0600
++++ perl-5.30.2/Configure	2021-05-11 06:42:26.000000000 -0500
+@@ -108,8 +108,8 @@
+ fi
+ 
+ : Proper PATH setting
+-paths='/bin /usr/bin /usr/local/bin /usr/ucb /usr/local /usr/lbin'
+-paths="$paths /opt/bin /opt/local/bin /opt/local /opt/lbin"
++paths='/bin /usr/bin /usr/ucb /usr/lbin'
++paths="$paths /opt/bin @FINK_PREFIX@/bin @FINK_PREFIX@ /opt/lbin"
+ paths="$paths /usr/5bin /etc /usr/gnu/bin /usr/new /usr/new/bin /usr/nbin"
+ paths="$paths /opt/gnu/bin /opt/new /opt/new/bin /opt/nbin"
+ paths="$paths /sys5.3/bin /sys5.3/usr/bin /bsd4.3/bin /bsd4.3/usr/ucb"
+@@ -1431,7 +1431,7 @@
+ i_whoami=''
+ : Possible local include directories to search.
+ : Set locincpth to "" in a hint file to defeat local include searches.
+-locincpth="/usr/local/include /opt/local/include /usr/gnu/include"
++locincpth="@FINK_PREFIX@/include /usr/gnu/include"
+ locincpth="$locincpth /opt/gnu/include /usr/GNU/include /opt/GNU/include"
+ :
+ : no include file wanted by default
+@@ -1448,12 +1448,12 @@
+ : change the next line if compiling for Xenix/286 on Xenix/386
+ xlibpth='/usr/lib/386 /lib/386'
+ : Possible local library directories to search.
+-loclibpth="/usr/local/lib /opt/local/lib /usr/gnu/lib"
++loclibpth="@FINK_PREFIX@/lib /usr/gnu/lib"
+ loclibpth="$loclibpth /opt/gnu/lib /usr/GNU/lib /opt/GNU/lib"
+ 
+ : general looking path for locating libraries
+ glibpth="/lib /usr/lib $xlibpth"
+-glibpth="$glibpth /usr/ccs/lib /usr/ucblib /usr/local/lib"
++glibpth="$glibpth /usr/ccs/lib /usr/ucblib"
+ test -f /usr/shlib/libc.so && glibpth="/usr/shlib $glibpth"
+ test -f /shlib/libc.so     && glibpth="/shlib $glibpth"
+ test -d /usr/lib64         && glibpth="$glibpth /lib64 /usr/lib64 /usr/local/lib64"


### PR DESCRIPTION
Tested on 10.14.6 and passes all tests. 
dist/Time-HiRes/t/stat occasionally fails like this:
```
dist/Time-HiRes/t/stat ......................................... #   Failed test at t/stat.t line 35.
#     Structures begin differing at:
#          $got->[8] = '1620781011.01701'
#     $expected->[8] = '1620781010.81523'
# Looks like you failed 1 test of 43.
FAILED at test 27
```
but it is not reproducible.

I've temporarily lost access to my VMs, so please check with other systems, especially macOS 10.12 and macOS11.0/1/2.
