### PR TITLE
io-compress update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/compress-raw-bzip2-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/compress-raw-bzip2-pm.info
@@ -1,9 +1,9 @@
 Info2: <<
 Package: compress-raw-bzip2-pm%type_pkg[perl]
-Version: 2.074
+Version: 2.101
 Revision: 1
 Source: mirror:cpan:modules/by-module/Compress/Compress-Raw-Bzip2-%v.tar.gz
-Source-MD5: 6609c7cbadeedbb60fa4b057b7dc0ede
+Source-MD5: 3ffb5f313beb810004b185e7e1570349
 Type: perl (5.16.2 5.18.2 5.18.4 5.28.2)
 Distribution: <<
 	(%type_pkg[perl] = 5162) 10.9,

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/compress-raw-lzma-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/compress-raw-lzma-pm.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: compress-raw-lzma-pm%type_pkg[perl]
-Version: 2.087
+Version: 2.101
 Revision: 1
 License: Artistic/GPL
 
@@ -19,7 +19,7 @@ Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Homepage: http://search.cpan.org/dist/Compress-Raw-Lzma/
 
 Source: mirror:cpan:authors/id/P/PM/PMQS/Compress-Raw-Lzma-%v.tar.gz
-Source-Checksum: SHA256(256c076f16538d07c109a3d37a96cf1154d2d1c215e85e81c4ee90ea19557568)
+Source-Checksum: SHA256(bb267fd31981eda11f444038f8a0fca4b94a51ae61b2db71246abf6a4d322a36)
 
 Type: perl (5.16.2 5.18.2 5.18.4 5.28.2)
 Distribution: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/compress-raw-zlib-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/compress-raw-zlib-pm.info
@@ -1,9 +1,9 @@
 Info2: <<
 Package: compress-raw-zlib-pm%type_pkg[perl]
-Version: 2.074
+Version: 2.101
 Revision: 1
 Source: mirror:cpan:modules/by-module/Compress/Compress-Raw-Zlib-%v.tar.gz
-Source-MD5: a648d15ce8bc65111a37a56b3daa4066
+Source-MD5: 681e24fffbb32c1bde808be584489789
 Type: perl (5.16.2 5.18.2 5.18.4 5.28.2)
 Distribution: <<
 	(%type_pkg[perl] = 5162) 10.9,

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/io-compress-lzf-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/io-compress-lzf-pm.info
@@ -1,15 +1,12 @@
 Info2: <<
 Package: io-compress-lzf-pm%type_pkg[perl]
 
-# test failure in 2.074/5.18.2, so not bothering with either new
-# version or new variant. See:
-# https://rt.cpan.org/Public/Bug/Display.html?id=91419
-Version: 2.060
+Version: 2.101
 
 Revision: 1
 Source: mirror:cpan:authors/id/P/PM/PMQS/IO-Compress-Lzf-%v.tar.gz
-Source-MD5: 8b8c153d2e8bcb2f7595aa275438b3ad
-Type: perl (5.16.2)
+Source-MD5: 13b967e7870e5db5a0023d05c0b2fd07
+Type: perl (5.16.2 5.18.2 5.18.4 5.28.2)
 Distribution: <<
 	(%type_pkg[perl] = 5162) 10.9,
 	(%type_pkg[perl] = 5162) 10.10,

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/io-compress-lzma-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/io-compress-lzma-pm.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: io-compress-lzma-pm%type_pkg[perl]
 # Version must be kept in sync with io-compress-pm
-Version: 2.074
+Version: 2.101
 Revision: 1
 License: Artistic/GPL
 
@@ -11,9 +11,9 @@ Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Homepage: http://search.cpan.org/dist/IO-Compress-Lzma/
 
 Source: mirror:cpan:authors/id/P/PM/PMQS/IO-Compress-Lzma-%v.tar.gz
-Source-Checksum: SHA256(7509743fe4dc7a952bd449c0c0c97c3d6bdc9131d7d6e8d10de1892b95046f96)
+Source-Checksum: SHA256(1ae686dbe45dbdcf0c7cccf8a0cd81a579a019601f8e35533db93dcdd8282a90)
 
-Type: perl (5.16.2 5.18.2 5.18.4)
+Type: perl (5.16.2 5.18.2 5.18.4 5.28.2)
 Distribution: <<
 	(%type_pkg[perl] = 5162) 10.9,
 	(%type_pkg[perl] = 5162) 10.10,

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/io-compress-lzop-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/io-compress-lzop-pm.info
@@ -1,10 +1,10 @@
 Info2: <<
 Package: io-compress-lzop-pm%type_pkg[perl]
-Version: 2.074
+Version: 2.101
 Revision: 1
 Source: mirror:cpan:authors/id/P/PM/PMQS/IO-Compress-Lzop-%v.tar.gz
-Source-MD5: f8a67fb13d2ccafeec9c3f36689b817b
-Type: perl (5.16.2 5.18.2 5.18.4)
+Source-MD5: 9029487beebc7caaef4a0ac9f8806d76
+Type: perl (5.16.2 5.18.2 5.18.4 5.28.2)
 Distribution: <<
 	(%type_pkg[perl] = 5162) 10.9,
 	(%type_pkg[perl] = 5162) 10.10,

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/io-compress-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/io-compress-pm.info
@@ -1,9 +1,9 @@
 Info2: <<
 Package: io-compress-pm%type_pkg[perl]
-Version: 2.074
+Version: 2.102
 Revision: 1
 Source: mirror:cpan:modules/by-module/IO/IO-Compress-%v.tar.gz
-Source-MD5: 117232322523b5113f6bfc073d41eb69
+Source-MD5: b79ef532ba8b6c1672dc2a401715f5cf
 Type: perl (5.16.2 5.18.2 5.18.4 5.28.2)
 Distribution: <<
 	(%type_pkg[perl] = 5162) 10.9,
@@ -13,8 +13,8 @@ Distribution: <<
 	(%type_pkg[perl] = 5162) 10.13
 <<
 Depends: <<
-	compress-raw-bzip2-pm%type_pkg[perl] (>= %v-1),
-	compress-raw-zlib-pm%type_pkg[perl] (>= %v-1),
+	compress-raw-bzip2-pm%type_pkg[perl] (>= 2.101-1),
+	compress-raw-zlib-pm%type_pkg[perl] (>= 2.101-1),
 	perl%type_pkg[perl]-core
 <<
 Replaces: <<
@@ -42,11 +42,15 @@ InstallScript: <<
 	%{default_script}
 	mv %i/share/man %i/lib/perl5/%type_raw[perl]
 	/bin/mv %i/bin/zipdetails %i/bin/zipdetails-pm%type_pkg[perl]
+	/bin/mv %i/bin/streamzip %i/bin/streamzip-pm%type_pkg[perl]
 <<
 UpdatePOD: True
 DocFiles: Changes README
 
-PostInstScript: update-alternatives --install %p/bin/zipdetails zipdetails %p/bin/zipdetails-pm%type_pkg[perl] %type_pkg[perl]
+PostInstScript: <<
+update-alternatives --install %p/bin/zipdetails zipdetails %p/bin/zipdetails-pm%type_pkg[perl] %type_pkg[perl] \
+	--slave %p/bin/streamzip streamzip %p/bin/streamzip-%type_pkg[perl]
+<<
 
 PreRmScript: update-alternatives --remove zipdetails %p/bin/zipdetails-pm%type_pkg[perl]
 


### PR DESCRIPTION
update to various compress perlmods
Bump to latest upstreams
Add pm5184 and pm5282 as needed

io-compress-lzf had a note about newer releases failing tests, but I tested on 10.14.6 and all tests passed for all perl variants.