### PR TITLE
FreePascal and Lazarus update to new upstream versions.

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/avr-embedded-binutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/avr-embedded-binutils.info
@@ -1,0 +1,44 @@
+Info2: <<
+Package: avr-embedded-binutils
+Version: 2.36.1
+Revision: 1
+Description: GNU binutils for avr-embedded
+License: LGPL
+# .xz archive needs a newer fink
+Depends: fink (>= 0.32)
+
+Source: mirror:gnu:binutils/binutils-%v.tar.xz
+Source-MD5: 628d490d976d8957279bbbff06cf29d4
+#PatchFile: %n.patch
+#PatchFile-MD5: c904483a2bd3f1377a4d847a9d02d926 
+
+SourceDirectory: binutils-%v
+
+ConfigureParams: <<
+  --target=avr-unknown-elf                                         \
+  --prefix=%p/lib/avr-embedded                                  \
+  --bindir=%p/bin --mandir=%p/share/man --infodir=%p/share/info \
+  --program-prefix=avr-embedded-                                \
+  --disable-werror --disable-nls
+<<
+
+InstallScript: <<
+#!/bin/sh -ev
+  make install DESTDIR=%d
+  rm -fr %i/lib/avr-embedded/lib/
+  rm -fr %i/share/info
+<<
+
+DocFiles: README COPYING* MAINTAINERS
+
+DescPort: <<
+Like 'avr-binutils' package, lib & include folders have been moved to 
+/sw/lib/avr-embedded and the binaries are put into /sw/bin.
+All xxx.info files are removed to avoid clashes with other potential
+toolchains.
+<<
+
+Homepage: http://www.gnu.org/software/binutils/
+
+Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>
+<<

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-doc.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-doc.info
@@ -1,14 +1,14 @@
 Package: lazarus-doc
-Version: 2.0.8
+Version: 2.0.12
 Revision: 1
 Enhances: lazarus-aqua, lazarus-cocoa, lazarus-gtk2, lazarus-qt4, lazarus-qt5
 Recommends: xchm
 
 License: GPL/LGPL
-Source: mirror:sourceforge:lazarus/Lazarus%%20Documentation/Lazarus%%20%v/doc-chm-fpc3.0.4-laz%v.zip
-Source-MD5: fefa6ca46de2f9b62bab7059db932d0e
+Source: mirror:sourceforge:lazarus/Lazarus%%20Documentation/Lazarus%%20%v/doc-chm-fpc3.2.0-laz%v.zip
+Source-MD5: 4347c866420616b0a06a813abfcfc960
 
-SourceDirectory: chm
+SourceDirectory: lazarus-docs-chm
 
 CompileScript: echo "Nothing to compile."
 
@@ -25,7 +25,7 @@ component library (fcl) and the FreePascal runtime library (rtl) as chm
 files. Use a chm file reader like Chmox or xchm.
 <<
 
-DescUsage: Files are in %p/share/doc/lazarus-doc-%v
+DescUsage: Files are in %p/share/doc/lazarus-docs-%v
 
 Homepage: https://wiki.freepascal.org/Main_Page
 Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-carbon.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-carbon.info
@@ -1,12 +1,13 @@
 Package: lazarus-lcl-carbon
-Version: 2.0.8
+Version: 2.0.12
 Revision: 1
 License: GPL/LGPL
+Distribution: 10.9 10.10 10.11 10.12 10.13 10.14
 
 Depends: <<
   lazarus-cocoa (>= 2.0) | lazarus-gtk2 (>= 2.0) |
   lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
-  fpc-cross-i386-darwin (>= 3.0.4)
+  fpc-cross-i386-darwin (>= 3.2.2)
 <<
 
 Conflicts: lazarus-aqua
@@ -15,7 +16,7 @@ Replaces:  lazarus-aqua
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 4479133eb1b3cfa678b9526408c2356f
+Source-MD5: 309eb59f83bbcb3976b835d4363b2968
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-cocoa-32bit.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-cocoa-32bit.info
@@ -1,18 +1,19 @@
 Package: lazarus-lcl-cocoa-32bit
-Version: 2.0.8
+Version: 2.0.12
 Revision: 1
 License: GPL/LGPL
+Distribution: 10.9 10.10 10.11 10.12 10.13 10.14
 
 Depends: <<
   lazarus-aqua (>= 2.0) | lazarus-cocoa (>= 2.0) | lazarus-gtk2 (>= 2.0) | 
   lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
-  fpc-cross-i386-darwin (>= 3.0.4)
+  fpc-cross-i386-darwin (>= 3.2.2)
 <<
 
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 4479133eb1b3cfa678b9526408c2356f
+Source-MD5: 309eb59f83bbcb3976b835d4363b2968
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-cocoa.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-cocoa.info
@@ -1,12 +1,12 @@
 Package: lazarus-lcl-cocoa
-Version: 2.0.8
+Version: 2.0.12
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
   lazarus-aqua (>= 2.0) | lazarus-gtk2 (>= 2.0) | 
   lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
-  fpc (>= 3.0.4)
+  fpc (>= 3.2.2)
 <<
 
 Conflicts: lazarus-cocoa
@@ -15,7 +15,7 @@ Replaces:  lazarus-cocoa
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 4479133eb1b3cfa678b9526408c2356f
+Source-MD5: 309eb59f83bbcb3976b835d4363b2968
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-gtk2.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-gtk2.info
@@ -1,12 +1,12 @@
 Package: lazarus-lcl-gtk2
-Version: 2.0.8
+Version: 2.0.12
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
   lazarus-aqua (>= 2.0) | lazarus-cocoa (>= 2.0) | 
   lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
-  fpc (>= 3.0.4),
+  fpc (>= 3.2.2),
   gtk+2-shlibs,
   glib2-shlibs,
   cairo-shlibs
@@ -20,7 +20,7 @@ Replaces:  lazarus-gtk2
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 4479133eb1b3cfa678b9526408c2356f
+Source-MD5: 309eb59f83bbcb3976b835d4363b2968
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-qt4.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-qt4.info
@@ -1,5 +1,5 @@
 Package: lazarus-lcl-qt4
-Version: 2.0.8
+Version: 2.0.12
 Revision: 1
 License: GPL/LGPL
 
@@ -15,7 +15,7 @@ Replaces:  lazarus-qt4
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 4479133eb1b3cfa678b9526408c2356f
+Source-MD5: 309eb59f83bbcb3976b835d4363b2968
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-qt5.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-qt5.info
@@ -1,5 +1,5 @@
 Package: lazarus-lcl-qt5
-Version: 2.0.8
+Version: 2.0.12
 Revision: 1
 License: GPL/LGPL
 
@@ -15,13 +15,11 @@ Replaces:  lazarus-qt5
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 4479133eb1b3cfa678b9526408c2356f
+Source-MD5: 309eb59f83bbcb3976b835d4363b2968
 
 SourceDirectory: lazarus
 
 UseMaxBuildJobs: false
-
-BuildDependsOnly: false
 
 CompileScript: <<
 #!/bin/sh -ev

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-win32.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-win32.info
@@ -1,18 +1,18 @@
 Package: lazarus-lcl-win32
-Version: 2.0.8
+Version: 2.0.12
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
   lazarus-aqua (>= 2.0) | lazarus-cocoa (>= 2.0) | lazarus-gtk2 (>= 2.0) | 
   lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
-  fpc-cross-i386-win32 (>= 3.0.4)
+  fpc-cross-i386-win32 (>= 3.2.2)
 <<
 
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 4479133eb1b3cfa678b9526408c2356f
+Source-MD5: 309eb59f83bbcb3976b835d4363b2968
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-win64.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-win64.info
@@ -1,18 +1,18 @@
 Package: lazarus-lcl-win64
-Version: 2.0.8
+Version: 2.0.12
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
   lazarus-aqua (>= 2.0) | lazarus-cocoa (>= 2.0) | lazarus-gtk2 (>= 2.0) | 
   lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
-  fpc-cross-x86-64-win64 (>= 3.0.4)
+  fpc-cross-x86-64-win64 (>= 3.2.2)
 <<
 
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 4479133eb1b3cfa678b9526408c2356f
+Source-MD5: 309eb59f83bbcb3976b835d4363b2968
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-wince-arm.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-wince-arm.info
@@ -1,18 +1,18 @@
 Package: lazarus-lcl-wince-arm
-Version: 2.0.8
+Version: 2.0.12
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
   lazarus-aqua (>= 2.0) | lazarus-cocoa (>= 2.0) | lazarus-gtk2 (>= 2.0) | 
   lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
-  fpc-cross-arm-wince (>= 3.0.4)
+  fpc-cross-arm-wince (>= 3.2.2)
 <<
 
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 4479133eb1b3cfa678b9526408c2356f
+Source-MD5: 309eb59f83bbcb3976b835d4363b2968
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-wince-i386.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus-lcl-wince-i386.info
@@ -1,18 +1,18 @@
 Package: lazarus-lcl-wince-i386
-Version: 2.0.8
+Version: 2.0.12
 Revision: 1
 License: GPL/LGPL
 
 Depends: <<
   lazarus-aqua (>= 2.0) | lazarus-cocoa (>= 2.0) | lazarus-gtk2 (>= 2.0) | 
   lazarus-qt4 (>= 2.0) | lazarus-qt5 (>= 2.0),
-  fpc-cross-i386-wince (>= 3.0.4)
+  fpc-cross-i386-wince (>= 3.2.2)
 <<
 
 Recommends: fpc-doc, lazarus-doc
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 4479133eb1b3cfa678b9526408c2356f
+Source-MD5: 309eb59f83bbcb3976b835d4363b2968
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/lazarus.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/lazarus.info
@@ -1,26 +1,34 @@
 Info2: <<
 Package: lazarus%type_pkg[uitype]
 Type: uitype (-aqua -cocoa -gtk2 -qt4 -qt5)
-Version: 2.0.8
+Version: 2.0.12
 Revision: 1
 License: GPL/LGPL
+Distribution: <<
+  10.9, 10.10, 10.11, 10.12, 10.13, 10.14,
+  (%type_pkg[uitype] != -aqua) 10.15,
+  (%type_pkg[uitype] != -aqua) 11.0,
+  (%type_pkg[uitype] != -aqua) 11.1,
+  (%type_pkg[uitype] != -aqua) 11.2,
+  (%type_pkg[uitype] != -aqua) 11.3
+<<
 
 Recommends: fpc-doc, lazarus-doc, apple-gdb, gdb
 
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 4479133eb1b3cfa678b9526408c2356f
+Source-MD5: 208dfeb20c528649d2598cc0eb341309
 
 SourceDirectory: lazarus
 
 Depends: <<
-  fpc (>= 3.0.4),
-  fpc-sources (>= 3.0.4),
-  fpc-cross-i386-darwin (>= 3.0.4),
+  fpc (>= 3.2.2),
+  fpc-sources (>= 3.2.2),
+  fpc-cross-i386-darwin (>= 3.2.2),
   (%type_pkg[uitype] = -gtk2) gtk+2-shlibs,
   (%type_pkg[uitype] = -gtk2) glib2-shlibs,
   (%type_pkg[uitype] = -gtk2) cairo-shlibs,
-  (%type_pkg[uitype] = -qt4)  qt4pas (>= 2.5-3),
-  (%type_pkg[uitype] = -qt5)  qt5pas (>= 1.8.2)
+  (%type_pkg[uitype] = -qt4)  qt4pas (>= 2.5-4),
+  (%type_pkg[uitype] = -qt5)  qt5pas (>= 2.0.12)
 <<
  
 Builddepends: <<
@@ -28,8 +36,8 @@ Builddepends: <<
   (%type_pkg[uitype] = -gtk2) gtk+2-dev,
   (%type_pkg[uitype] = -gtk2) glib2-dev,
   (%type_pkg[uitype] = -gtk2) cairo,
-  (%type_pkg[uitype] = -qt4)  qt4pas     (>= 2.5-3),
-  (%type_pkg[uitype] = -qt4)  qt4pas-dev (>= 2.5-3)
+  (%type_pkg[uitype] = -qt4)  qt4pas     (>= 2.5-4),
+  (%type_pkg[uitype] = -qt4)  qt4pas-dev (>= 2.5-4)
 <<
 
 Conflicts: <<
@@ -80,7 +88,7 @@ Patchscript: <<
   sed -i.tmp 's|<DebuggerFilename Value="/usr/bin/lldb"/>|<DebuggerFilename Value="/usr/bin/lldb"> <History Count="4"> <Item1 Value="/usr/bin/lldb"/> <Item2 Value="/usr/bin/gdb"/> <Item3 Value="%p/bin/fsf-gdb"/> <Item4 Value="%p/bin/gdb"/> </History> </DebuggerFilename>|g'  tools/install/macosx/environmentoptions.xml
 
 # fix path to X11
-  sed -i.tmp 's|-Fl/usr/X11R6/lib -Fl%p/lib|"-Fl%p/lib -Fl%p/lib/pango-ft219/lib -Fl/opt/X11/lib"|g' ide/Makefile
+  sed -i.tmp 's|-Fl/usr/X11R6/lib -Fl.../lib|"-Fl%p/lib -Fl%p/lib/pango-ft219/lib -Fl/opt/X11/lib"|g' ide/Makefile
 
 # fix compilation of bigidecomponents with LCL_PLATFORM=nogui (LCLnogui)
 # with osprinters.pas the line number needs to be given
@@ -127,31 +135,28 @@ CompileScript: <<
 
   if   [ "%type_raw[uitype]" == "-aqua" ]; then
     make bigide    LCL_PLATFORM=carbon OPT="$debug_options" $carbon_arch
-    # 64 bit nogui units
-    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options"
   elif [ "%type_raw[uitype]" == "-cocoa" ]; then
     make bigide    LCL_PLATFORM=cocoa  OPT="$debug_options"
-    # 32 bit nogui units
-    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options" $carbon_arch
   elif [ "%type_raw[uitype]" == "-gtk2" ]; then
     make bigide    LCL_PLATFORM=gtk2   OPT="$debug_options -dHasX \
          -FfApplicationServices \
          -k-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib \
          -k-L/opt/X11/lib -k-L%p/lib -k-L%p/lib/pango-ft219/lib "
-    # 32 bit nogui units
-    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options" $carbon_arch
   elif [ "%type_raw[uitype]" == "-qt4" ]; then
     make bigide    LCL_PLATFORM=qt     OPT="$debug_options"
-    # 32 bit nogui units
-    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options" $carbon_arch
   elif [ "%type_raw[uitype]" == "-qt5" ]; then
     # build lazarus
     make bigide    LCL_PLATFORM=qt5 OPT="$debug_options -Ff%p/lib/qt5-mac/lib"
     install_name_tool -change Qt5Pas.framework/Versions/1/Qt5Pas %p/lib/qt5-mac/lib/Qt5Pas.framework/Versions/1/Qt5Pas lazarus
+  fi
+
+  if   [ "%type_raw[uitype]" == "-aqua" ]; then
+    # 64 bit nogui units
+    make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options"
+  elif [[ `uname -r | cut -d. -f1` -le 14 ]]; then
     # 32 bit nogui units
     make $AllUnits LCL_PLATFORM=nogui  OPT="$debug_options" $carbon_arch
   fi
-
 # ** Finish compiling Lazarus **
 <<
 
@@ -210,14 +215,14 @@ DocFiles: docs/*.txt docs/*.pdf
 Description: Free Pascal IDE
 
 DescDetail: <<
-Lazarus is an open-source development system that builds on the Free Pascal 
-compiler by adding an integrated development environment (IDE). 
-It includes a syntax-highlighting code editor and a visual form designer, 
-as well as a component library that is highly compatible with Delphi's 
-Visual Component Library (VCL).  The Lazarus Component Library (LCL) 
-includes  equivalents for many of the familiar VCL controls such as 
-forms, buttons, text boxes and so on, which are used to create 
-applications with a graphical user interface (GUI).
+Lazarus is an open-source development system that builds on the Free Pascal
+compiler by adding an integrated development environment (IDE).  It
+includes a syntax-highlighting code editor and a visual form designer, as
+well as a component library that is highly compatible with Delphi's Visual
+Component Library (VCL).  The Lazarus Component Library (LCL) includes
+equivalents for many of the familiar VCL controls such as forms, buttons,
+text boxes and so on, which are used to create applications with a
+graphical user interface (GUI).
 
 Release Notes:
   https://wiki.freepascal.org/Lazarus_2.0.0_release_notes
@@ -231,8 +236,8 @@ DescUsage: <<
 <<
 
 DescPort: <<
-Available versions of the lcl: carbon, cocoa-32bit, cocoa, gtk2, qt4, qt5 and 
-nogui.
+Available versions of the lcl: carbon, cocoa-32bit, cocoa, gtk2, qt4, qt5,
+and nogui.
 Crosscompilation is available for:
   i386-win32
   x86_64-win64

--- a/10.9-libcxx/stable/main/finkinfo/devel/qt4pas.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/qt4pas.info
@@ -1,9 +1,9 @@
 Package: qt4pas
 Version: 2.5
-Revision: 3
+Revision: 4
 Description: Pascal wrapper for Qt4
-BuildDepends: fpc (>= 3.0.2), qt4-base-mac
-Depends: fpc (>= 3.0.2), qt4-base-mac-qtcore-shlibs, %n-shlibs (= %v-%r)
+BuildDepends: fpc (>= 3.2.2), qt4-base-mac
+Depends: fpc (>= 3.2.2), qt4-base-mac-qtcore-shlibs, %n-shlibs (= %v-%r)
 License: GPL
 
 # Unpack Phase:

--- a/10.9-libcxx/stable/main/finkinfo/devel/qt5pas.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/qt5pas.info
@@ -1,5 +1,5 @@
 Package: qt5pas
-Version: 2.0.2
+Version: 2.0.12
 Revision: 1
 Description: Pascal wrapper for Qt5
 BuildDepends: qt5-mac-qtbase, qt5-mac-qtbase-dev-tools
@@ -8,7 +8,7 @@ License: GPL
 
 # Unpack Phase:
 Source: mirror:sourceforge:lazarus/lazarus-%v.tar.gz
-Source-MD5: 23dd868959c5d57091ce82504ef34e45
+Source-MD5: 208dfeb20c528649d2598cc0eb341309
 
 SourceDirectory: lazarus
 

--- a/10.9-libcxx/stable/main/finkinfo/devel/xdev-toolkit.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/xdev-toolkit.info
@@ -1,18 +1,18 @@
 Package: xdev-toolkit
-Version: 2015-4264
-Revision: 3
+Version: 2016-5024
+Revision: 1
 Description: Delphi -> Lazarus/FPC conversion tools
 Depends: <<
-  fpc (>=3.0.2), 
-  lazarus-gtk2 (>=1.6) | lazarus-qt4 (>=1.6) | lazarus-lcl-gtk2 (>=1.6) | lazarus-lcl-qt4 (>=1.6)
+  fpc (>=3.2.2), 
+  lazarus-gtk2 (>=2.0.12) | lazarus-qt4 (>=2.0.12) | lazarus-qt5 (>=2.0.12) | lazarus-cocoa (>=2.0.12) | lazarus-lcl-gtk2 (>=2.0.12) | lazarus-lcl-qt4 (>=2.0.12) | lazarus-lcl-qt5 (>=2.0.12)
 <<
 License: LGPL
 
 # Unpack Phase:
-Source: http://michael-ep3.physik.uni-halle.de/fink-sources/lazarus-ccr-xdev_toolkit-%v.zip
-Source-MD5: c368ebc29ad293d82266e620f352e0da
+Source: http://michael-ep3.physik.uni-halle.de/fink-sources/lazarus-ccr-%n-%v.zip
+Source-MD5: 7e8c07e3a98db88c85d6862357b9f786
 
-SourceDirectory: xdev_toolkit
+SourceDirectory: %n-%v
 
 # Patch Phase
 PatchScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-aarch64.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-aarch64.info
@@ -1,22 +1,21 @@
 Info2: <<
 Package: fpc-cross-aarch64-%type_pkg[platform]
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
 Type: platform (linux)
 Depends: <<
-  fpc-cross-common (>= 3.2.0-1),
+  fpc-cross-common (>= 3.2.2-1),
   aarch64-%type_pkg[platform]-binutils
 <<
 Recommends: fpc-doc
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 Source: mirror:custom:/dist/%v/source/fpc-%v.source.tar.gz
-Source-MD5: fd386c89ba1324f157bb5c875d23622d
+Source-MD5: e7649ad0fc9230fdd9493a7fcabbd426
 
 SourceDirectory: fpc-%v
 
@@ -87,7 +86,8 @@ http://wiki.freepascal.org/User_Changes_%v also lists changes in fpc.
 <<
 
 DescUsage: <<
- This Pascal crosscompiler produces aarch64 executables for %type_pkg[platform].
+ This Pascal crosscompiler produces aarch64 executables for
+ %type_pkg[platform].
 
  get help with: fpc -h
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-arm-embedded.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-arm-embedded.info
@@ -1,11 +1,11 @@
 Info2: <<
 Package: fpc-cross-arm%type_pkg[subarch]-embedded
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
 Type: subarch (v4 v4t v6m v7a v7m v7em)
 # For arm-embedded binutils are needed. 
 Depends: <<
-  fpc-cross-common (>= 3.2.0-1),
+  fpc-cross-common (>= 3.2.2-1),
   arm-embedded-binutils
 <<
 Conflicts: <<
@@ -28,13 +28,12 @@ fpc-cross-armv7em-embedded
 Recommends: fpc-doc
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 Source: mirror:custom:/dist/%v/source/fpc-%v.source.tar.gz
-Source-MD5: fd386c89ba1324f157bb5c875d23622d
+Source-MD5: e7649ad0fc9230fdd9493a7fcabbd426
 
 SourceDirectory: fpc-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-arm.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-arm.info
@@ -1,24 +1,23 @@
 Info2: <<
 Package: fpc-cross-arm-%type_pkg[platform]
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
-Type: platform (linux wince)
+Type: platform (linux gba nds wince)
 # tried, but not yet working or needed: PalmOS, Symbian
 Depends: <<
-  fpc-cross-common (>= 3.2.0-1),
+  fpc-cross-common (>= 3.2.2-1),
   arm-%type_pkg[platform]-binutils
 <<
 Replaces: fpc-arm-cross
 Recommends: fpc-doc
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 Source: mirror:custom:/dist/%v/source/fpc-%v.source.tar.gz
-Source-MD5: fd386c89ba1324f157bb5c875d23622d
+Source-MD5: e7649ad0fc9230fdd9493a7fcabbd426
 
 SourceDirectory: fpc-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-avr-embedded.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-avr-embedded.info
@@ -1,11 +1,11 @@
 Info2: <<
 Package: fpc-cross-avr%type_pkg[subarch]-embedded
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
 Type: subarch (25 35 4 5 51 6)
 Depends: <<
-  fpc-cross-common (>= 3.2.0-1),
-  avr-binutils
+  fpc-cross-common (>= 3.2.2-1),
+  avr-embedded-binutils
 <<
 Conflicts: <<
 fpc-cross-avr25-embedded,
@@ -26,13 +26,12 @@ fpc-cross-avr6-embedded
 Recommends: fpc-doc
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 Source: mirror:custom:/dist/%v/source/fpc-%v.source.tar.gz
-Source-MD5: fd386c89ba1324f157bb5c875d23622d
+Source-MD5: e7649ad0fc9230fdd9493a7fcabbd426
 
 SourceDirectory: fpc-%v
 
@@ -115,7 +114,7 @@ DescUsage: <<
 <<
 
 DescPort: <<
-  Possibly have to wait for 3.2.0.
+  Possibly have to wait for 3.2.2.
   Please report if it works for you.
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-i386-darwin.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-i386-darwin.info
@@ -1,17 +1,16 @@
 Package: fpc-cross-i386-darwin
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
-Depends: fpc-cross-common (>= 3.2.0-1)
+Depends: fpc-cross-common (>= 3.2.2-1)
 Recommends: fpc-doc
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 Source: mirror:custom:/dist/%v/source/fpc-%v.source.tar.gz
-Source-MD5: fd386c89ba1324f157bb5c875d23622d
+Source-MD5: e7649ad0fc9230fdd9493a7fcabbd426
 
 SourceDirectory: fpc-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-i386.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-i386.info
@@ -1,24 +1,23 @@
 Info2: <<
 Package: fpc-cross-i386-%type_pkg[platform]
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
 Type: platform (linux freebsd netbsd win32 wince go32v2 nativent solaris)
 # tried, but not yet working or needed: beos haiku os2 symbian openbsd qnx netware wdosx emx watcom netwlibc
 Depends: <<
-  fpc-cross-common (>= 3.2.0-1),
+  fpc-cross-common (>= 3.2.2-1),
   (%type_pkg[platform] != nativent) i386-%type_pkg[platform]-binutils
 <<
 Replaces: fpc-win, fpc-i386-linux
 Recommends: fpc-doc
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 Source: mirror:custom:/dist/%v/source/fpc-%v.source.tar.gz
-Source-MD5: fd386c89ba1324f157bb5c875d23622d
+Source-MD5: e7649ad0fc9230fdd9493a7fcabbd426
 
 SourceDirectory: fpc-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-i8086.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-i8086.info
@@ -1,11 +1,11 @@
 Info2: <<
-Package: fpc-cross-jvm-%type_pkg[platform]
+Package: fpc-cross-i8086-%type_pkg[platform]
 Version: 3.2.2
 Revision: 1
-Type: platform (java android)
+Type: platform (msdos)
 Depends: <<
   fpc-cross-common (>= 3.2.2-1),
-  jasmin
+  msdos-nasm
 <<
 Recommends: fpc-doc
 
@@ -26,8 +26,8 @@ CompileScript: <<
 # Yosemite fix
   if [ "$(uname -r | cut -d. -f1)" -ge 14 ]; then export MACOSX_DEPLOYMENT_TARGET=10.9 ; fi
 
-# compile rtl and packages for jvm
-  make rtl OPT="-ap" CPU_TARGET=jvm OS_TARGET=%type_pkg[platform]
+# compile rtl and packages for i8086
+  make rtl packages OPT="-ap" CPU_TARGET=i8086 CROSSOPT="-Anasm" OS_TARGET=%type_pkg[platform]
 <<
 
 InstallScript: <<
@@ -36,14 +36,14 @@ InstallScript: <<
   if [ "$(uname -r | cut -d. -f1)" -ge 14 ]; then export MACOSX_DEPLOYMENT_TARGET=10.9 ; fi
 
 # install all units from the rtl and packages
-  make rtl_install OS_TARGET=%type_pkg[platform] CPU_TARGET=jvm INSTALL_PREFIX=%i CROSSINSTALL=1
+  make rtl_install packages_install OS_TARGET=%type_pkg[platform] CPU_TARGET=i8086 INSTALL_PREFIX=%i CROSSINSTALL=1
 
 # remove duplicate doc files
-# not needed yet.  rm %i/share/doc/fpc-%v/*/*.txt
+#  rm -rf %i/share/doc/fpc-%v/*/*.txt
 #  rm -rf %i/share/doc/fpc-%v/ide/*.ide
 
 # remove duplicate bin files
-# not needed yet.  rm -rf %i/bin
+#  rm -rf %i/bin
 
 <<
 
@@ -55,25 +55,18 @@ InfoTest: <<
 
 cat >HelloWorld.pas <<EOFTEST
   Program HelloWorld;
-
-    uses
-    {\$IFDEF java} jdk15 {\$ELSE} androidr14 {\$ENDIF};
-
-    {\$MACRO on}
-    {\$DEFINE writeln := jlsystem.fout.println}
-
   begin
     writeln ('Hello World!');
   end.
 EOFTEST
 
-fpc -Pjvm -T%type_pkg[platform] -Furtl/units/jvm-%type_pkg[platform] HelloWorld.pas
+fpc  -Pi8086 -T%type_pkg[platform] -Furtl/units/i8086-%type_pkg[platform] -XPi8086-%type_pkg[platform]- HelloWorld.pas
 <<
 <<
 
 License: LGPL
 
-Description: FPC cross-compiler jvm-%type_pkg[platform]
+Description: FPC cross-compiler i8086-%type_pkg[platform]
 
 DescDetail: <<
 Free Pascal (aka FPK Pascal) is a 32 and 64 bit professional Pascal
@@ -93,23 +86,20 @@ http://wiki.freepascal.org/User_Changes_%v also lists changes in fpc.
 <<
 
 DescUsage: <<
- This Pascal crosscompiler produces jvm executables for %type_pkg[platform].
+ This Pascal crosscompiler produces i8086 executables for %type_pkg[platform].
 
  get help with: fpc -h
 
  compile and link a Pascal file with:
  
- fpc -Pjvm -T%type_pkg[platform] FILENAME
+ fpc -Pi8086 -T%type_pkg[platform] FILENAME
 
  For more documentation about Free Pascal in HTML and pdf, install fpc-doc.
 <<
 
 DescPort: <<
-  Packages do not build for 3.0.4.
-
-  The example program for the test uses jlsystem.fout.println, since the 
-  system unit in the rtl for the target jvm is still very limited and 
-  does not have IO routines like writeln.
+  Does not work for 2.6.4. Possibly have to wait for 2.8.0.
+  Please report if it works for you.
 <<
 
 Homepage: https://www.freepascal.org

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-m68k.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-m68k.info
@@ -1,22 +1,21 @@
 Info2: <<
 Package: fpc-cross-m68k-%type_pkg[platform]
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
 Type: platform (linux)
 Depends: <<
-  fpc-cross-common (>= 3.2.0-1),
+  fpc-cross-common (>= 3.2.2-1),
   m68k-%type_pkg[platform]-binutils
 <<
 Recommends: fpc-doc
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 Source: mirror:custom:/dist/%v/source/fpc-%v.source.tar.gz
-Source-MD5: fd386c89ba1324f157bb5c875d23622d
+Source-MD5: e7649ad0fc9230fdd9493a7fcabbd426
 
 SourceDirectory: fpc-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-mips.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-mips.info
@@ -1,11 +1,11 @@
 Info2: <<
-Package: fpc-cross-jvm-%type_pkg[platform]
+Package: fpc-cross-mips-%type_pkg[platform]
 Version: 3.2.2
 Revision: 1
-Type: platform (java android)
+Type: platform (linux)
 Depends: <<
   fpc-cross-common (>= 3.2.2-1),
-  jasmin
+  mips-%type_pkg[platform]-binutils
 <<
 Recommends: fpc-doc
 
@@ -26,8 +26,8 @@ CompileScript: <<
 # Yosemite fix
   if [ "$(uname -r | cut -d. -f1)" -ge 14 ]; then export MACOSX_DEPLOYMENT_TARGET=10.9 ; fi
 
-# compile rtl and packages for jvm
-  make rtl OPT="-ap" CPU_TARGET=jvm OS_TARGET=%type_pkg[platform]
+# compile rtl and packages for mips
+  make rtl packages OPT="-ap" CPU_TARGET=mips OS_TARGET=%type_pkg[platform]
 <<
 
 InstallScript: <<
@@ -36,14 +36,14 @@ InstallScript: <<
   if [ "$(uname -r | cut -d. -f1)" -ge 14 ]; then export MACOSX_DEPLOYMENT_TARGET=10.9 ; fi
 
 # install all units from the rtl and packages
-  make rtl_install OS_TARGET=%type_pkg[platform] CPU_TARGET=jvm INSTALL_PREFIX=%i CROSSINSTALL=1
+  make rtl_install packages_install OS_TARGET=%type_pkg[platform] CPU_TARGET=mips INSTALL_PREFIX=%i CROSSINSTALL=1
 
 # remove duplicate doc files
-# not needed yet.  rm %i/share/doc/fpc-%v/*/*.txt
-#  rm -rf %i/share/doc/fpc-%v/ide/*.ide
+  rm -rf %i/share/doc/fpc-%v/*/*.txt
+  rm -rf %i/share/doc/fpc-%v/ide/*.ide
 
 # remove duplicate bin files
-# not needed yet.  rm -rf %i/bin
+  rm -rf %i/bin
 
 <<
 
@@ -55,25 +55,18 @@ InfoTest: <<
 
 cat >HelloWorld.pas <<EOFTEST
   Program HelloWorld;
-
-    uses
-    {\$IFDEF java} jdk15 {\$ELSE} androidr14 {\$ENDIF};
-
-    {\$MACRO on}
-    {\$DEFINE writeln := jlsystem.fout.println}
-
   begin
     writeln ('Hello World!');
   end.
 EOFTEST
 
-fpc -Pjvm -T%type_pkg[platform] -Furtl/units/jvm-%type_pkg[platform] HelloWorld.pas
+fpc  -Pmips -T%type_pkg[platform] -Furtl/units/mips-%type_pkg[platform] -XPmips-%type_pkg[platform]- HelloWorld.pas
 <<
 <<
 
 License: LGPL
 
-Description: FPC cross-compiler jvm-%type_pkg[platform]
+Description: FPC cross-compiler mips-%type_pkg[platform]
 
 DescDetail: <<
 Free Pascal (aka FPK Pascal) is a 32 and 64 bit professional Pascal
@@ -93,23 +86,20 @@ http://wiki.freepascal.org/User_Changes_%v also lists changes in fpc.
 <<
 
 DescUsage: <<
- This Pascal crosscompiler produces jvm executables for %type_pkg[platform].
+ This Pascal crosscompiler produces mips executables for %type_pkg[platform].
 
  get help with: fpc -h
 
  compile and link a Pascal file with:
  
- fpc -Pjvm -T%type_pkg[platform] FILENAME
+ fpc -Pmips -T%type_pkg[platform] FILENAME
 
  For more documentation about Free Pascal in HTML and pdf, install fpc-doc.
 <<
 
 DescPort: <<
-  Packages do not build for 3.0.4.
-
-  The example program for the test uses jlsystem.fout.println, since the 
-  system unit in the rtl for the target jvm is still very limited and 
-  does not have IO routines like writeln.
+  Does not work for 2.6.4. Possibly have to wait for 2.8.0.
+  Please report if it works for you.
 <<
 
 Homepage: https://www.freepascal.org

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-mipsel.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-mipsel.info
@@ -1,22 +1,21 @@
 Info2: <<
 Package: fpc-cross-mipsel-%type_pkg[platform]
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
 Type: platform (linux)
 Depends: <<
-  fpc-cross-common (>= 3.2.0-1),
+  fpc-cross-common (>= 3.2.2-1),
   mipsel-%type_pkg[platform]-binutils
 <<
 Recommends: fpc-doc
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 Source: mirror:custom:/dist/%v/source/fpc-%v.source.tar.gz
-Source-MD5: fd386c89ba1324f157bb5c875d23622d
+Source-MD5: e7649ad0fc9230fdd9493a7fcabbd426
 
 SourceDirectory: fpc-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-powerpc.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-powerpc.info
@@ -1,23 +1,22 @@
 Info2: <<
 Package: fpc-cross-powerpc-%type_pkg[platform]
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
 Type: platform (linux)
 # tried, but not yet working or needed: MacOS netbsd MorphOS AmigaOS
 Depends: <<
-  fpc-cross-common (>= 3.2.0-1),
+  fpc-cross-common (>= 3.2.2-1),
   powerpc-%type_pkg[platform]-binutils
 <<
 Recommends: fpc-doc
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 Source: mirror:custom:/dist/%v/source/fpc-%v.source.tar.gz
-Source-MD5: fd386c89ba1324f157bb5c875d23622d
+Source-MD5: e7649ad0fc9230fdd9493a7fcabbd426
 
 SourceDirectory: fpc-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-powerpc64.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-powerpc64.info
@@ -1,23 +1,22 @@
 Info2: <<
 Package: fpc-cross-powerpc64-%type_pkg[platform]
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
 Type: platform (linux)
 # tried, but not yet working or needed: MacOS netbsd MorphOS AmigaOS
 Depends: <<
-  fpc-cross-common (>= 3.2.0-1),
+  fpc-cross-common (>= 3.2.2-1),
   powerpc64-%type_pkg[platform]-binutils
 <<
 Recommends: fpc-doc
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 Source: mirror:custom:/dist/%v/source/fpc-%v.source.tar.gz
-Source-MD5: fd386c89ba1324f157bb5c875d23622d
+Source-MD5: e7649ad0fc9230fdd9493a7fcabbd426
 
 SourceDirectory: fpc-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-sparc.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-sparc.info
@@ -1,23 +1,22 @@
 Info2: <<
 Package: fpc-cross-sparc-%type_pkg[platform]
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
 Type: platform (linux solaris)
 # tried, but not yet working or needed: solaris
 Depends: <<
-  fpc-cross-common (>= 3.2.0-1),
+  fpc-cross-common (>= 3.2.2-1),
   sparc-%type_pkg[platform]-binutils
 <<
 Recommends: fpc-doc
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 Source: mirror:custom:/dist/%v/source/fpc-%v.source.tar.gz
-Source-MD5: fd386c89ba1324f157bb5c875d23622d
+Source-MD5: e7649ad0fc9230fdd9493a7fcabbd426
 
 SourceDirectory: fpc-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-sparc64.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-sparc64.info
@@ -1,23 +1,22 @@
 Info2: <<
 Package: fpc-cross-sparc64-%type_pkg[platform]
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
 Type: platform (linux)
 # tried, but not yet working or needed: solaris
 Depends: <<
-  fpc-cross-common (>= 3.2.0-1),
+  fpc-cross-common (>= 3.2.2-1),
   sparc64-%type_pkg[platform]-binutils
 <<
 Recommends: fpc-doc
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 Source: mirror:custom:/dist/%v/source/fpc-%v.source.tar.gz
-Source-MD5: fd386c89ba1324f157bb5c875d23622d
+Source-MD5: e7649ad0fc9230fdd9493a7fcabbd426
 
 SourceDirectory: fpc-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-x86-64.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-cross-x86-64.info
@@ -1,22 +1,21 @@
 Info2: <<
 Package: fpc-cross-x86-64-%type_pkg[platform]
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
 Type: platform (linux dragonfly freebsd win64)
 Depends: <<
-  fpc (>= 3.2.0-1),
+  fpc (>= 3.2.2-1),
   x86-64-%type_pkg[platform]-binutils
 <<
 Recommends: fpc-doc
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 Source: mirror:custom:/dist/%v/source/fpc-%v.source.tar.gz
-Source-MD5: fd386c89ba1324f157bb5c875d23622d
+Source-MD5: e7649ad0fc9230fdd9493a7fcabbd426
 
 SourceDirectory: fpc-%v
 

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-doc.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-doc.info
@@ -1,20 +1,19 @@
 Package: fpc-doc
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
 Enhances: fpc
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 
 Source: mirror:custom:dist/%v/docs/doc-pdf.tar.gz
-Source-MD5: 541bd3fce950ff0b6041b031de65d3bc
+Source-MD5: f61b6cfee3d8c18f53711cb680c52466
 
 Source2: mirror:custom:dist/%v/docs/doc-html.tar.gz
-Source2-MD5: d19bcdc13d51266405195da6bdbbd821
+Source2-MD5: ba481163cf7fed94faba1eccdbb83483
 
 SourceRename:  %n-%v-pdf.tar.gz
 Source2Rename: %n-%v-html.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc-sources.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc-sources.info
@@ -1,15 +1,14 @@
 Package: fpc-sources
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 Source: mirror:custom:/dist/%v/source/fpc-%v.source.tar.gz
-Source-MD5: fd386c89ba1324f157bb5c875d23622d
+Source-MD5: e7649ad0fc9230fdd9493a7fcabbd426
 
 SourceDirectory: fpc-%v
 
@@ -19,10 +18,12 @@ echo 'Nothing to compile.'
 <<
 
 InstallScript: <<
+  install -m 755 -d %i/share/fpcsrc/compiler
   install -m 755 -d %i/share/fpcsrc/rtl
   install -m 755 -d %i/share/fpcsrc/packages
   install -m 755 -d %i/share/fpcsrc/utils
 
+  mv compiler %i/share/fpcsrc
   mv rtl      %i/share/fpcsrc
   mv packages %i/share/fpcsrc
   mv utils    %i/share/fpcsrc
@@ -34,13 +35,11 @@ License: GPL/LGPL
 Description: Sources of the FreePascal compiler
 
 DescDetail: <<
-Sources of the compiler, the runtime library (rtl) and the packages, 
-installed in %i/share/fpcsrc. Used by lazarus packages.
+Sources of the compiler, the runtime library (rtl), the packages, and
+the utilities installed in %i/share/fpcsrc. Used by lazarus packages.
 <<
 
 DescUsage: Implicitly used by lazarus.
-
-DescPort: Nothing
 
 Homepage: https://www.freepascal.org
 Maintainer: Karl-Michael Schindler <karl-michael.schindler@web.de>

--- a/10.9-libcxx/stable/main/finkinfo/languages/fpc.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/fpc.info
@@ -1,19 +1,18 @@
 Package: fpc
-Version: 3.2.0
+Version: 3.2.2
 Revision: 1
 
-Replaces: fpc-config (<< 3.2.0)
+Replaces: fpc-config (<< 3.2.2)
 Recommends: fpc-doc
 
 CustomMirror: <<
-eur-BE: ftp://ftp.freepascal.org/pub/fpc/
 eur-HU: ftp://ftp.hu.freepascal.org/pub/fpc/
-eur-NL: ftp://freepascal.stack.nl/mirrors/fpc/
+nam-CA: ftp://mirror.freemirror.org/pub/fpc/
 Primary: ftp://ftp.freepascal.org/pub/fpc/
 <<
 
 Source: mirror:custom:/dist/%v/source/fpcbuild-%v.tar.gz
-Source-MD5: 407d998c20c3023a2ee38ab8d3f08170
+Source-MD5: 3681ae4a208be4f64ec65e832a9a702d
 
 Source2: mirror:custom:/dist/3.0.4/bootstrap/x86_64-macosx-10.9-ppcx64.tar.bz2
 Source2-MD5: 05b8dade26a8f2657d54e885395930f5
@@ -31,6 +30,9 @@ Patchscript: <<
   sed -i.bak 's|/usr/local|%p|g' utils/tply/pyacc.y
   sed -i.bak 's|/usr/local|%p|g' utils/tply/pyacc.pas
   sed -i.bak 's|/usr/local|%p|g' utils/tply/plex.pas
+# fixes building of lazarus on older system < 10.11.
+  sed -i.bak 's|{\$linkframework CoreImage}|{linkframework CoreImage}|g' \
+    packages/cocoaint/src/CocoaAll.pas
 <<
 
 CompileScript: <<
@@ -40,8 +42,13 @@ CompileScript: <<
 # Keep in sync with fpc-config
   export MACOSX_DEPLOYMENT_TARGET=10.9
 
+  linkerOptions=""
+  if [ "$(uname -r | cut -d. -f1)" -ge 19 ] ; 
+  then
+    linkerOptions="-XR/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+  fi
 # compile the compiler
-  make all OPT="-ap" PP="%b/../../ppcx64"
+  make all OPT="-ap $linkerOptions" PP="%b/../../ppcx64"
 
 # create the config file
   %b/utils/fpcmkcfg/bin/%m-darwin/fpcmkcfg -d basepath=%p/lib/%n/\$fpcversion -o fpc.cfg
@@ -88,8 +95,10 @@ EOFCFGPATCH
 
 # compile the compiler utilities msgdif and msg2inc
   cd compiler/utils
-  %b/compiler/ppcx64 -Fu%b/rtl/units/%m-darwin msgdif.pp
-  %b/compiler/ppcx64 -Fu%b/rtl/units/%m-darwin msg2inc.pp
+  %b/compiler/ppcx64 $linkerOptions \
+    -Fu%b/rtl/units/%m-darwin msgdif.pp
+  %b/compiler/ppcx64 $linkerOptions \
+    -Fu%b/rtl/units/%m-darwin msg2inc.pp
 <<
 
 InfoTest: <<
@@ -106,10 +115,12 @@ InfoTest: <<
 # If you really want to run the tests uncomment the following line and execute
 # "fink --test rebuild fpc"
 # Make sure there is no other version of fpc installed. 
-# Depending on your path settings you may get errors about the system unit being wrong,
+# Depending on your path settings you may get errors about the system unit
+# being wrong.
 # The tests will take quite some time! You have been warned.
 
-# make full TEST_FPC=%b/compiler/ppcx64 FPC=%b/compiler/ppcx64 OPT=-Fu%b/rtl/units/%m-darwin/ FPCMAKE=%b/utils/fpcm/fpcmake
+# make full TEST_FPC=%b/compiler/ppcx64 FPC=%b/compiler/ppcx64 \
+#   OPT=-Fu%b/rtl/units/%m-darwin/ FPCMAKE=%b/utils/fpcm/fpcmake
 
 <<
 <<
@@ -167,7 +178,7 @@ ISO mode of fpc supports Standard Pascal according to ISO 7185.
 Furthermore, Free Pascal supports function overloading, operator
 overloading, global properties and other modern features.
 
-https://wiki.freepascal.org/User_Changes_3.2.0 also lists changes in fpc.
+https://wiki.freepascal.org/User_Changes_3.2.2 also lists changes in fpc.
 <<
 
 DescUsage: <<


### PR DESCRIPTION
Besides FreePascal and Lazarus it includes
avr-embedded-binutils
qt4pas
qt5pas
xdev-toolkit