### PR TITLE
build fixes and cleanup for r-base3[3-6]

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base33.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base33.info
@@ -2,6 +2,7 @@ Info2: <<
 Package: r-base33
 Version: 3.3.3
 Revision: 3
+Distribution: 10.9, 10.10, 10.11, 10.12, 10.13, 10.14, 10.14.5
 Description: R Framework
 Type: rversion (3.3)
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base33.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base33.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: r-base33
 Version: 3.3.3
-Revision: 3
+Revision: 4
 Distribution: 10.9, 10.10, 10.11, 10.12, 10.13, 10.14, 10.14.5
 Description: R Framework
 Type: rversion (3.3)
@@ -26,6 +26,7 @@ BuildDepends: <<
 	liblzma5,
 	libpng16,
 	libtiff5,
+	libxt,
 	pango1-xft2-ft219-dev (>= 1.24.5-4),
 	libpcre1,
 	pkgconfig,
@@ -200,6 +201,7 @@ SplitOff: <<
 	liblzma5-shlibs,
 	libpng16-shlibs,
 	libtiff5-shlibs,
+	libxt-shlibs,
 	pango1-xft2-ft219-shlibs (>= 1.24.5-4),
 	libpcre1-shlibs,
 	readline6-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base34.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base34.info
@@ -2,6 +2,7 @@ Info2: <<
 Package: r-base34
 Version: 3.4.4
 Revision: 1
+Distribution: 10.9, 10.10, 10.11, 10.12, 10.13, 10.14, 10.14.5
 Description: R Framework
 Type: rversion (3.4)
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base34.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base34.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: r-base34
 Version: 3.4.4
-Revision: 1
+Revision: 2
 Distribution: 10.9, 10.10, 10.11, 10.12, 10.13, 10.14, 10.14.5
 Description: R Framework
 Type: rversion (3.4)
@@ -26,6 +26,7 @@ BuildDepends: <<
 	liblzma5,
 	libpng16,
 	libtiff5,
+	libxt,
 	pango1-xft2-ft219-dev (>= 1.24.5-4),
 	libpcre1,
 	pkgconfig,
@@ -200,6 +201,7 @@ SplitOff: <<
 	liblzma5-shlibs,
 	libpng16-shlibs,
 	libtiff5-shlibs,
+	libxt-shlibs,
 	pango1-xft2-ft219-shlibs (>= 1.24.5-4),
 	libpcre1-shlibs,
 	readline6-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base35.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base35.info
@@ -2,6 +2,7 @@ Info2: <<
 Package: r-base35
 Version: 3.5.3
 Revision: 2
+Distribution: 10.9, 10.10, 10.11, 10.12, 10.13, 10.14, 10.14.5
 Description: R Framework
 Type: rversion (3.5)
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base35.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base35.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: r-base35
 Version: 3.5.3
-Revision: 2
+Revision: 3
 Distribution: 10.9, 10.10, 10.11, 10.12, 10.13, 10.14, 10.14.5
 Description: R Framework
 Type: rversion (3.5)
@@ -26,6 +26,7 @@ BuildDepends: <<
 	liblzma5,
 	libpng16,
 	libtiff5,
+	libxt,
 	pango1-xft2-ft219-dev (>= 1.24.5-4),
 	libpcre1, libpcre2,
 	pkgconfig,
@@ -200,6 +201,7 @@ SplitOff: <<
 	liblzma5-shlibs,
 	libpng16-shlibs,
 	libtiff5-shlibs,
+	libxt-shlibs,
 	pango1-xft2-ft219-shlibs (>= 1.24.5-4),
 	libpcre1-shlibs, libpcre2-shlibs,
 	readline6-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base36-implicit-declarations.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base36-implicit-declarations.patch
@@ -1,0 +1,221 @@
+From d8129c99096a58e526d03e6d780b1ded7e1ed9b8 Mon Sep 17 00:00:00 2001
+From: ripley <ripley@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date: Tue, 24 Nov 2020 05:48:21 +0000
+Subject: [PATCH] add some declarations for
+ -Werror=implicit-function-declaration
+
+git-svn-id: https://svn.r-project.org/R/trunk@79475 00db46b3-68df-0310-9c12-caf00c1e9a41
+---
+ configure               | 81 ++++++++++++++++++++++++++++++++++++++
+ doc/manual/R-admin.texi |  4 +-
+ m4/R.m4                 | 87 ++++++++++++++++++++++++++++++++++++++++-
+ 3 files changed, 167 insertions(+), 5 deletions(-)
+
+diff --git a/configure b/configure
+index 58ac487c2d2..60866435fea 100755
+--- a/configure
++++ b/configure
+@@ -41176,6 +41176,7 @@ $as_echo_n "checking for ${dgemm} in ${BLAS_LIBS}... " >&6; }
+     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ void ${xerbla}(char *srname, int *info){}
++                 void ${dgemm}();
+ #ifdef FC_DUMMY_MAIN
+ #ifndef FC_DUMMY_MAIN_EQ_F77
+ #  ifdef __cplusplus
+@@ -41834,6 +41835,86 @@ else
+ #endif
+ void F77_SYMBOL(xerbla)(char *srname, int *info)
+ {}
++// declare (with empty args) before use.
++  void F77_SYMBOL(dasum)();
++  void F77_SYMBOL(daxpy)();
++  void F77_SYMBOL(dcopy)();
++  void F77_SYMBOL(ddot)();
++  void F77_SYMBOL(dgbmv)();
++  void F77_SYMBOL(dgemm)();
++  void F77_SYMBOL(dgemv)();
++  void F77_SYMBOL(dger)();
++  void F77_SYMBOL(dnrm2)();
++  void F77_SYMBOL(drot)();
++  void F77_SYMBOL(drotg)();
++  void F77_SYMBOL(drotm)();
++  void F77_SYMBOL(drotmg)();
++  void F77_SYMBOL(dsbmv)();
++  void F77_SYMBOL(dscal)();
++  void F77_SYMBOL(dsdot)();
++  void F77_SYMBOL(dspmv)();
++  void F77_SYMBOL(dspr)();
++  void F77_SYMBOL(dspr2)();
++  void F77_SYMBOL(dswap)();
++  void F77_SYMBOL(dsymm)();
++  void F77_SYMBOL(dsymv)();
++  void F77_SYMBOL(dsyr)();
++  void F77_SYMBOL(dsyr2)();
++  void F77_SYMBOL(dsyr2k)();
++  void F77_SYMBOL(dsyrk)();
++  void F77_SYMBOL(dtbmv)();
++  void F77_SYMBOL(dtbsv)();
++  void F77_SYMBOL(dtpmv)();
++  void F77_SYMBOL(dtpsv)();
++  void F77_SYMBOL(dtrmm)();
++  void F77_SYMBOL(dtrmv)();
++  void F77_SYMBOL(dtrsm)();
++  void F77_SYMBOL(dtrsv)();
++  void F77_SYMBOL(idamax)();
++  void F77_SYMBOL(lsame)();
++#ifdef HAVE_FORTRAN_DOUBLE_COMPLEX
++/* cmplxblas */
++  void F77_SYMBOL(dcabs1)();
++  void F77_SYMBOL(dzasum)();
++  void F77_SYMBOL(dznrm2)();
++  void F77_SYMBOL(izamax)();
++  void F77_SYMBOL(zaxpy)();
++  void F77_SYMBOL(zcopy)();
++  void F77_SYMBOL(zdotc)();
++  void F77_SYMBOL(zdotu)();
++  void F77_SYMBOL(zdrot)();
++  void F77_SYMBOL(zdscal)();
++  void F77_SYMBOL(zgbmv)();
++  void F77_SYMBOL(zgemm)();
++  void F77_SYMBOL(zgemv)();
++  void F77_SYMBOL(zgerc)();
++  void F77_SYMBOL(zgeru)();
++  void F77_SYMBOL(zhbmv)();
++  void F77_SYMBOL(zhemm)();
++  void F77_SYMBOL(zhemv)();
++  void F77_SYMBOL(zher)();
++  void F77_SYMBOL(zherk)();
++  void F77_SYMBOL(zher2)();
++  void F77_SYMBOL(zher2k)();
++  void F77_SYMBOL(zhpmv)();
++  void F77_SYMBOL(zhpr)();
++  void F77_SYMBOL(zhpr2)();
++  void F77_SYMBOL(zrotg)();
++  void F77_SYMBOL(zscal)();
++  void F77_SYMBOL(zswap)();
++  void F77_SYMBOL(zsymm)();
++  void F77_SYMBOL(zsyr2k)();
++  void F77_SYMBOL(zsyrk)();
++  void F77_SYMBOL(ztbmv)();
++  void F77_SYMBOL(ztbsv)();
++  void F77_SYMBOL(ztpmv)();
++  void F77_SYMBOL(ztpsv)();
++  void F77_SYMBOL(ztrmm)();
++  void F77_SYMBOL(ztrmv)();
++  void F77_SYMBOL(ztrsm)();
++  void F77_SYMBOL(ztrsv)();
++#endif
++
+ void blas_set () {
+   F77_SYMBOL(dasum)();
+   F77_SYMBOL(daxpy)();
+diff --git a/m4/R.m4 b/m4/R.m4
+index e31f16f632c..83aa7a66b7c 100644
+--- a/m4/R.m4
++++ b/m4/R.m4
+@@ -2570,12 +2570,15 @@ acx_blas_save_LIBS="${LIBS}"
+ LIBS="${FLIBS} ${LIBS}"
+ 
+ dnl First, check BLAS_LIBS environment variable
++dnl Dummy xerbla was added in 2003 for the Goto BLAS.
++dnl Declaration added in 2020 for Apple's -Werror=implicit-function-declaration
+ if test "${acx_blas_ok}" = no; then
+   if test "x${BLAS_LIBS}" != x; then
+     r_save_LIBS="${LIBS}"; LIBS="${BLAS_LIBS} ${LIBS}"
+     AC_MSG_CHECKING([for ${dgemm} in ${BLAS_LIBS}])
+-    AC_TRY_LINK([void ${xerbla}(char *srname, int *info){}], ${dgemm}(),
+-      [acx_blas_ok=yes], [BLAS_LIBS=""])
++    AC_TRY_LINK([void ${xerbla}(char *srname, int *info){}
++                 void ${dgemm}();],
++		${dgemm}(), [acx_blas_ok=yes], [BLAS_LIBS=""])
+     AC_MSG_RESULT([${acx_blas_ok}])
+     LIBS="${r_save_LIBS}"
+   fi
+@@ -2746,6 +2749,86 @@ if test "${acx_blas_ok}" = yes; then
+ #endif
+ void F77_SYMBOL(xerbla)(char *srname, int *info)
+ {}
++// declare (with empty args) before use.
++  void F77_SYMBOL(dasum)();
++  void F77_SYMBOL(daxpy)();
++  void F77_SYMBOL(dcopy)();
++  void F77_SYMBOL(ddot)();
++  void F77_SYMBOL(dgbmv)();
++  void F77_SYMBOL(dgemm)();
++  void F77_SYMBOL(dgemv)();
++  void F77_SYMBOL(dger)();
++  void F77_SYMBOL(dnrm2)();
++  void F77_SYMBOL(drot)();
++  void F77_SYMBOL(drotg)();
++  void F77_SYMBOL(drotm)();
++  void F77_SYMBOL(drotmg)();
++  void F77_SYMBOL(dsbmv)();
++  void F77_SYMBOL(dscal)();
++  void F77_SYMBOL(dsdot)();
++  void F77_SYMBOL(dspmv)();
++  void F77_SYMBOL(dspr)();
++  void F77_SYMBOL(dspr2)();
++  void F77_SYMBOL(dswap)();
++  void F77_SYMBOL(dsymm)();
++  void F77_SYMBOL(dsymv)();
++  void F77_SYMBOL(dsyr)();
++  void F77_SYMBOL(dsyr2)();
++  void F77_SYMBOL(dsyr2k)();
++  void F77_SYMBOL(dsyrk)();
++  void F77_SYMBOL(dtbmv)();
++  void F77_SYMBOL(dtbsv)();
++  void F77_SYMBOL(dtpmv)();
++  void F77_SYMBOL(dtpsv)();
++  void F77_SYMBOL(dtrmm)();
++  void F77_SYMBOL(dtrmv)();
++  void F77_SYMBOL(dtrsm)();
++  void F77_SYMBOL(dtrsv)();
++  void F77_SYMBOL(idamax)();
++  void F77_SYMBOL(lsame)();
++#ifdef HAVE_FORTRAN_DOUBLE_COMPLEX
++/* cmplxblas */
++  void F77_SYMBOL(dcabs1)();
++  void F77_SYMBOL(dzasum)();
++  void F77_SYMBOL(dznrm2)();
++  void F77_SYMBOL(izamax)();
++  void F77_SYMBOL(zaxpy)();
++  void F77_SYMBOL(zcopy)();
++  void F77_SYMBOL(zdotc)();
++  void F77_SYMBOL(zdotu)();
++  void F77_SYMBOL(zdrot)();
++  void F77_SYMBOL(zdscal)();
++  void F77_SYMBOL(zgbmv)();
++  void F77_SYMBOL(zgemm)();
++  void F77_SYMBOL(zgemv)();
++  void F77_SYMBOL(zgerc)();
++  void F77_SYMBOL(zgeru)();
++  void F77_SYMBOL(zhbmv)();
++  void F77_SYMBOL(zhemm)();
++  void F77_SYMBOL(zhemv)();
++  void F77_SYMBOL(zher)();
++  void F77_SYMBOL(zherk)();
++  void F77_SYMBOL(zher2)();
++  void F77_SYMBOL(zher2k)();
++  void F77_SYMBOL(zhpmv)();
++  void F77_SYMBOL(zhpr)();
++  void F77_SYMBOL(zhpr2)();
++  void F77_SYMBOL(zrotg)();
++  void F77_SYMBOL(zscal)();
++  void F77_SYMBOL(zswap)();
++  void F77_SYMBOL(zsymm)();
++  void F77_SYMBOL(zsyr2k)();
++  void F77_SYMBOL(zsyrk)();
++  void F77_SYMBOL(ztbmv)();
++  void F77_SYMBOL(ztbsv)();
++  void F77_SYMBOL(ztpmv)();
++  void F77_SYMBOL(ztpsv)();
++  void F77_SYMBOL(ztrmm)();
++  void F77_SYMBOL(ztrmv)();
++  void F77_SYMBOL(ztrsm)();
++  void F77_SYMBOL(ztrsv)();
++#endif
++
+ void blas_set () {
+   F77_SYMBOL(dasum)();
+   F77_SYMBOL(daxpy)();

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base36.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base36.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: r-base36
 Version: 3.6.3
-Revision: 3
+Revision: 4
 Description: R Framework
 Type: rversion (3.6)
 Maintainer:  BABA Yoshihiko <babayoshihiko@mac.com>
@@ -26,6 +26,7 @@ BuildDepends: <<
 	liblzma5,
 	libpng16,
 	libtiff5,
+	libxt,
 	pango1-xft2-ft219-dev (>= 1.24.5-4),
 	libpcre1, libpcre2,
 	pkgconfig,
@@ -197,6 +198,7 @@ SplitOff: <<
 	liblzma5-shlibs,
 	libpng16-shlibs,
 	libtiff5-shlibs,
+	libxt-shlibs,
 	pango1-xft2-ft219-shlibs (>= 1.24.5-4),
 	libpcre1-shlibs, libpcre2-shlibs,
 	readline7-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/sci/r-base36.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/r-base36.info
@@ -15,6 +15,7 @@ Replaces: <<
 BuildDepends: <<
 	bzip2-dev,
 	cairo (>= 1.12.14-1),
+	fink (>= 0.30.0),
 	glib2-dev (>= 2.22.0-1),
 	gcc9-compiler,
 	libcurl4,
@@ -40,6 +41,8 @@ Source: http://cran.r-project.org/src/base/R-3/R-%v.tar.gz
 Source-MD5: 506c9576ba33e1262ad5b5624db9d96a
 PatchFile: %n.patch
 PatchFile-MD5: 9f638c0d775d06e163c023ccd87949b8
+PatchFile2: %n-implicit-declarations.patch
+PatchFile2-MD5: a7af8dd9f26899bd865f24d92698df76
 PatchScript: <<
   #!/bin/sh -ev
   #sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1


### PR DESCRIPTION
* Add libxt as an explicit dep to avoid using libxt-flat.
* Add upstream patch to fix implicit warning errors during the detection of Accelerate.framework on 10.15. Otherwise, package tries to build libRblas.dylib.
* Restrict r-base[3-5] through Dist=10.14.5 to match what we're already doing for the rmods.