### PR TITLE
cran-rjava-r: stable version for older R

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rjava-r.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/rmods/cran-rjava-r.info
@@ -32,15 +32,15 @@ Distribution: <<
 	(%type_pkg[rversion] = 35 ) 10.14,
 	(%type_pkg[rversion] = 35 ) 10.14.5
 <<
-Type: rversion (3.6 3.5 3.4 3.3 3.2 3.1)
-Version: 0.9-8
-Revision: 2
+Type: rversion (4.1 4.0 3.6 3.5 3.4 3.3 3.2 3.1)
+Version: 0.9-13
+Revision: 1
 Description: Low-level R to Java interface
 Homepage: https://cran.r-project.org/package=rJava
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:custom:rJava_%v.tar.gz
-Source-MD5: 51ae0d690ceed056ebe7c4be71fc6c7a
+Source-MD5: 240535398aaa675388bdea4d40e3aba0
 SourceDirectory: rJava
 CustomMirror: <<
 	Primary: https://cran.r-project.org/src/contrib
@@ -58,9 +58,9 @@ BuildDepends: <<
 	libgettext8-dev,
 	system-java-dev
 <<
+
 CompileScript: <<
   #!/bin/bash -ev
-  export TMPDIR=%b/tmp
   BIN_R=%p/Library/Frameworks/R.framework/Versions/%type_raw[rversion]/Resources/bin/R
   
   pushd ..


### PR DESCRIPTION
This version works well. There is a newer version of rJava for R >= 3.6, though.