### PR TITLE
icon: new version, switch to 64-bit arch

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/icon.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/icon.info
@@ -2,7 +2,7 @@ Package: icon
 Version: 9.5.20i
 Revision: 1
 Depends: x11
-BuildDepends: x11-dev
+BuildDepends: fink-package-precedence, x11-dev
 #Source: http://www.cs.arizona.edu/icon/ftp/packages/unix/icon-v951src.tgz
 #Source: https://www2.cs.arizona.edu/icon/ftp/historic/v951.tgz
 Source: https://github.com/gtownsend/icon/archive/refs/tags/v%v.tar.gz
@@ -10,11 +10,16 @@ SourceRename: icon-%v.tar.gz
 Source-MD5: 2c8803b42ae0512981855e9147738efd
 PatchFile: %n.patch
 PatchFile-MD5: 1c4cfa5acbdab87c88bae50eb1480fbf
+PatchScript: <<
+	%{default_script}
+	find . -name Make\* | xargs perl -pi -e 's/ -O/ -O -MD/'
+<<
 UseMaxBuildJobs: false
 CompileScript:<<
 make X-Configure name=macintosh
 ln -s . lib/icon
 make All
+fink-package-precedence --depfile-ext='\.d' .
 <<
 InstallScript:<<
 make Install dest=%i

--- a/10.9-libcxx/stable/main/finkinfo/languages/icon.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/icon.info
@@ -1,22 +1,25 @@
 Package: icon
-Version: 9.5.1
+Version: 9.5.20i
 Revision: 1
-Depends: readline6-shlibs, x11
-BuildDepends: fink (>= 0.24.12-1), readline6, x11-dev
-Source: http://www.cs.arizona.edu/icon/ftp/packages/unix/icon-v951src.tgz
-Source-MD5: 8fdeb7c5408d9d9bf06bc5e7f4f54498
+Depends: readline8-shlibs, x11
+BuildDepends: readline8, x11-dev
+#Source: http://www.cs.arizona.edu/icon/ftp/packages/unix/icon-v951src.tgz
+#Source: https://www2.cs.arizona.edu/icon/ftp/historic/v951.tgz
+Source: https://github.com/gtownsend/icon/archive/refs/tags/v%v.tar.gz
+SourceRename: icon-%v.tar.gz
+Source-MD5: 2c8803b42ae0512981855e9147738efd
 PatchFile: %n.patch
-PatchFile-MD5: 79578310448491541a9113d753e4f5e0
+PatchFile-MD5: 1c4cfa5acbdab87c88bae50eb1480fbf
 UseMaxBuildJobs: false
 CompileScript:<<
-make X-Configure name=mac386
+make X-Configure name=macintosh
 ln -s . lib/icon
 make All
 <<
 InstallScript:<<
 make Install dest=%i
 <<
-DocFiles: README doc/*
+DocFiles: README
 Description: Very high level programming language
 DescDetail: <<
 Icon is a high-level, general-purpose programming language with a
@@ -24,6 +27,14 @@ large repertoire of features for processing data structures and
 character strings. Icon is an imperative, procedural language with a
 syntax reminiscent of C and Pascal, but with semantics at a much
 higher level.
+<<
+DescPackaging: <<
+	dmacks: Remove whitespace between "-I" and its path because it
+	is not portable to some compilers (not per spec at all). Also
+	robustify the linking against build-dir library.
+
+	Upstream PR for using X11's libXpm:
+	https://github.com/gtownsend/icon/pull/2
 <<
 License: Public Domain
 Maintainer: Matthias Neeracher <neeracher@mac.com>

--- a/10.9-libcxx/stable/main/finkinfo/languages/icon.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/icon.info
@@ -1,8 +1,8 @@
 Package: icon
 Version: 9.5.20i
 Revision: 1
-Depends: readline8-shlibs, x11
-BuildDepends: readline8, x11-dev
+Depends: x11
+BuildDepends: x11-dev
 #Source: http://www.cs.arizona.edu/icon/ftp/packages/unix/icon-v951src.tgz
 #Source: https://www2.cs.arizona.edu/icon/ftp/historic/v951.tgz
 Source: https://github.com/gtownsend/icon/archive/refs/tags/v%v.tar.gz

--- a/10.9-libcxx/stable/main/finkinfo/languages/icon.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/icon.patch
@@ -1,14 +1,14 @@
-diff -ru icon.v942src-orig/Makefile icon.v942src/Makefile
---- icon.v942src-orig/Makefile	Sun Nov  2 15:47:32 2003
-+++ icon.v942src/Makefile	Sun Nov  2 16:09:12 2003
-@@ -97,16 +97,13 @@
+diff -Nurd icon-9.5.20i.orig/Makefile icon-9.5.20i/Makefile
+--- icon-9.5.20i.orig/Makefile	2020-08-13 12:50:45.000000000 -0400
++++ icon-9.5.20i/Makefile	2021-06-18 09:28:37.000000000 -0400
+@@ -85,16 +85,14 @@
  
  D=$(dest)
  Install:
 -		mkdir $D
 -		mkdir $D/bin $D/lib $D/doc $D/man $D/man/man1
 -		cp README $D
-+		mkdir -p $D/bin $D/lib/icon $D/share/man/man1
++		mkdir -p $D/bin $D/lib/icon $D/share/doc/icon $D/share/man/man1
  		cp bin/[cflpvwx]* $D/bin
  		cp bin/icon[tx]* $D/bin
  		rm -f $D/bin/libI*
@@ -17,17 +17,51 @@ diff -ru icon.v942src-orig/Makefile icon.v942src/Makefile
 -		cp doc/*.* $D/doc
 -		cp man/man1/*.* $D/man/man1
 +		cp lib/*.* $D/lib/icon
++		cp doc/*.* $D/share/doc/icon
 +		cp man/man1/*.* $D/share/man/man1
  
  
  # Bundle up for binary distribution.
-Only in icon.v942src: Makefile.orig
-Only in icon.v942src: Makefile.rej
-Only in icon.v942src: Makefile~
-diff -ru icon.v942src-orig/src/icont/tunix.c icon.v942src/src/icont/tunix.c
---- icon.v942src-orig/src/icont/tunix.c	Sun Nov  2 15:47:32 2003
-+++ icon.v942src/src/icont/tunix.c	Sun Nov  2 15:47:58 2003
-@@ -301,7 +301,7 @@
+diff -Nurd icon-9.5.20i.orig/config/mac386/Makedefs icon-9.5.20i/config/mac386/Makedefs
+--- icon-9.5.20i.orig/config/mac386/Makedefs	2020-08-13 12:50:45.000000000 -0400
++++ icon-9.5.20i/config/mac386/Makedefs	2021-06-18 09:46:41.000000000 -0400
+@@ -10,7 +10,7 @@
+ #  SFLAGS   flags for stripping iconx
+ 
+ CC = cc -arch i386
+-CFLAGS = -I /opt/X11/include
++CFLAGS = -I/opt/X11/include
+ CFDYN =
+ RLINK = -dynamic
+ RLIBS = -lm
+diff -Nurd icon-9.5.20i.orig/config/macintosh/Makedefs icon-9.5.20i/config/macintosh/Makedefs
+--- icon-9.5.20i.orig/config/macintosh/Makedefs	2020-08-13 12:50:45.000000000 -0400
++++ icon-9.5.20i/config/macintosh/Makedefs	2021-06-18 09:46:38.000000000 -0400
+@@ -10,7 +10,7 @@
+ #  SFLAGS   flags for stripping iconx
+ 
+ CC = cc
+-CFLAGS = -O -I /opt/X11/include
++CFLAGS = -O -I/opt/X11/include
+ CFDYN =
+ RLINK = -dynamic
+ RLIBS = -lm
+diff -Nurd icon-9.5.20i.orig/config/setup.sh icon-9.5.20i/config/setup.sh
+--- icon-9.5.20i.orig/config/setup.sh	2020-08-13 12:50:45.000000000 -0400
++++ icon-9.5.20i/config/setup.sh	2021-06-18 09:49:47.000000000 -0400
+@@ -11,7 +11,7 @@
+ 
+ # check parameters
+ case "$GPX" in
+-   Graphics)	XL='-L../../bin -lIgpx $(XLIBS)';;
++   Graphics)	XL='../../bin/libIgpx.a $(XLIBS)';;
+    NoGraphics)	XL= ;;
+    *)		echo "$USAGE" 1>&2; exit 1;;
+ esac
+diff -Nurd icon-9.5.20i.orig/src/icont/tunix.c icon-9.5.20i/src/icont/tunix.c
+--- icon-9.5.20i.orig/src/icont/tunix.c	2020-08-13 12:50:45.000000000 -0400
++++ icon-9.5.20i/src/icont/tunix.c	2021-06-18 09:24:51.000000000 -0400
+@@ -300,7 +300,7 @@
     else
        strcpy(buf, ".");
     strcat(buf, ":");
@@ -36,4 +70,3 @@ diff -ru icon.v942src-orig/src/icont/tunix.c icon.v942src/src/icont/tunix.c
     return salloc(buf);
     }
  
-Only in icon.v942src/src/icont: tunix.c.orig


### PR DESCRIPTION
The .so is built flat installed in bin/ as in previous versions; I
have no idea how this file might get used so I don't know if the
location and/or binary library flags are correct.