### PR TITLE
Update expat1 to fix Billion Laughs vulnerability

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/base/expat1.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/expat1.info
@@ -1,13 +1,13 @@
 Package: expat1
-Version: 2.4.0
+Version: 2.4.1
 Revision: 1
 BuildDepends: fink (>= 0.32), fink-package-precedence
 Depends: %N-shlibs (= %v-%r)
 Replaces: expat
 Conflicts: expat
 BuildDependsOnly: true
-Source: https://github.com/libexpat/libexpat/releases/download/R_2_4_0/expat-%v.tar.xz
-Source-MD5: 09e275fb11fd530d3d94be8ab70d23cf
+Source: https://github.com/libexpat/libexpat/releases/download/R_2_4_1/expat-%v.tar.xz
+Source-MD5: a4fb91a9441bcaec576d4c4a56fa3aa6
 #PatchFile: %n.patch
 #PatchFile-MD5: 
 #PatchScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/base/expat1.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/expat1.info
@@ -1,13 +1,13 @@
 Package: expat1
-Version: 2.3.0
+Version: 2.4.0
 Revision: 1
-BuildDepends: fink-package-precedence
+BuildDepends: fink (>= 0.32), fink-package-precedence
 Depends: %N-shlibs (= %v-%r)
 Replaces: expat
 Conflicts: expat
 BuildDependsOnly: true
-Source: https://github.com/libexpat/libexpat/releases/download/R_2_3_0/expat-%v.tar.bz2
-Source-MD5: 54ea624caca3f9003cebcab4f0a75c8f
+Source: https://github.com/libexpat/libexpat/releases/download/R_2_4_0/expat-%v.tar.xz
+Source-MD5: 09e275fb11fd530d3d94be8ab70d23cf
 #PatchFile: %n.patch
 #PatchFile-MD5: 
 #PatchScript: <<
@@ -37,7 +37,7 @@ DocFiles: <<
 SplitOff:<<
 	Package: %N-shlibs
 	Files: lib/libexpat.*.dylib
-	Shlibs: %p/lib/libexpat.1.dylib 9.0.0 %n (>= 2.3.0-1)
+	Shlibs: %p/lib/libexpat.1.dylib 10.0.0 %n (>= 2.4.0-1)
 	DocFiles: AUTHORS Changes:changelog COPYING README.md
 <<
 


### PR DESCRIPTION
To fix DNS vulnerability [CVE-2013-0340](https://marc.info/?l=oss-security&m=136580776324285&w=2,) as reported in #831 updates (incrementally) to the upstream versions 2.4.0/2.4.1.
Build otherwise unchanged (except for switch to tar.xz source), passes both tests on Mojave 18.7.0.