### PR TITLE
Libzip overhaul

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libzip2.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libzip2.info
@@ -1,6 +1,6 @@
 Package: libzip2
 Version: 0.11.2
-Revision: 2
+Revision: 3
 Description: Library for handling zip archives
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Homepage: http://www.nih.at/libzip/
@@ -17,7 +17,7 @@ Source-MD5: c5437df15e4825d40cdc3ec8b9b7516c
 
 Depends: %N-shlibs (= %v-%r)
 BuildDepends: <<
-	fink (>= 0.26.2),
+	fink (>= 0.32),
 	fink-package-precedence
 <<
 BuildDependsOnly: True
@@ -50,11 +50,23 @@ SplitOff: <<
 <<
 
 SplitOff2: <<
-	Package: %N-bin
-	Depends: %N-shlibs (= %v-%r)
-	Conflicts: libzip1-bin, libzip2-bin, libzip5-bin
+	Package: libzip-bin
+	Depends: %N-shlibs (>= %v-%r)
 	Replaces: libzip1-bin, libzip2-bin, libzip5-bin
 
 	Files: bin share/man/man1
 	DocFiles: AUTHORS LICENSE NEWS README THANKS TODO
+<<
+
+SplitOff3: <<
+	Package: %N-bin
+	Description: OBSOLETE: use libzip-bin instead
+	RuntimeDepends: <<
+		fink-obsolete-packages,
+		libzip-bin (>= %v-%r)
+	<<
+	InstallScript: <<
+		mkdir -p %i/share/doc/installed-packages
+		touch %i/share/doc/installed-packages/%n
+	<<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/libzip2.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libzip2.info
@@ -1,4 +1,3 @@
-Info4: <<
 Package: libzip2
 Version: 0.11.2
 Revision: 2
@@ -17,17 +16,22 @@ Source: http://www.nih.at/libzip/libzip-%v.tar.gz
 Source-MD5: c5437df15e4825d40cdc3ec8b9b7516c
 
 Depends: %N-shlibs (= %v-%r)
-BuildDepends: fink (>= 0.26.2)
+BuildDepends: <<
+	fink (>= 0.26.2),
+	fink-package-precedence
+<<
 BuildDependsOnly: True
 Conflicts: libzip1, libzip2, libzip5
 Replaces: libzip1, libzip2, libzip5
 
-NoSetCPPFLAGS: True
-NoSetLDFLAGS: True
 SetCFLAGS: -Os
 UseMaxBuildJobs: True
 
-ConfigureParams: --disable-dependency-tracking --disable-static
+ConfigureParams: --disable-static
+CompileScript: <<
+	%{default_script}
+	fink-package-precedence --prohibit-bdep=%n .
+<<
 
 InfoTest: TestScript: make check || exit 2
 
@@ -35,11 +39,11 @@ InstallScript: <<
   make install DESTDIR=%d
 <<
 
-DocFiles: AUTHORS LICENSE NEWS README THANKS TODO 
+DocFiles: AUTHORS LICENSE NEWS README THANKS TODO
 
 SplitOff: <<
 	Package: %N-shlibs
-	
+
 	Files: lib/libzip.2*dylib
 	Shlibs: %p/lib/libzip.2.dylib 4.0.0 %n (>= 0.10-1)
 	DocFiles: AUTHORS LICENSE NEWS README THANKS TODO
@@ -53,5 +57,4 @@ SplitOff2: <<
 
 	Files: bin share/man/man1
 	DocFiles: AUTHORS LICENSE NEWS README THANKS TODO
-<<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/libzip5.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libzip5.info
@@ -1,7 +1,7 @@
 Package: libzip5
 # 1.3.2 is the last release to use autotools. Newer versions move to cmake
 Version: 1.3.2
-Revision: 2
+Revision: 3
 Description: Library for handling zip archives
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Homepage: https://libzip.org/
@@ -56,14 +56,26 @@ SplitOff: <<
 <<
 
 SplitOff2: <<
-	Package: %N-bin
+	Package: libzip-bin
 	Depends: <<
-		%N-shlibs (= %v-%r),
+		%N-shlibs (>= %v-%r),
 		bzip2-shlibs
 	<<
-	Conflicts: libzip1-bin, libzip2-bin, libzip5-bin
 	Replaces: libzip1-bin, libzip2-bin, libzip5-bin
 
 	Files: bin share/man/man1
 	DocFiles: AUTHORS LICENSE NEWS.md README.md THANKS TODO.md
+<<
+
+SplitOff3: <<
+	Package: %N-bin
+	Description: OBSOLETE: use libzip-bin instead
+	RuntimeDepends: <<
+		fink-obsolete-packages,
+		libzip-bin (>= %v-%r)
+	<<
+	InstallScript: <<
+		mkdir -p %i/share/doc/installed-packages
+		touch %i/share/doc/installed-packages/%n
+	<<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/libzip5.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libzip5.info
@@ -1,8 +1,7 @@
-Info4: <<
 Package: libzip5
 # 1.3.2 is the last release to use autotools. Newer versions move to cmake
 Version: 1.3.2
-Revision: 1
+Revision: 2
 Description: Library for handling zip archives
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Homepage: https://libzip.org/
@@ -16,19 +15,28 @@ DescPackaging: <<
 
 Source: https://libzip.org/download/libzip-%v.tar.gz
 Source-Checksum: SHA256(ab4c34eb6c3a08b678cd0f2450a6c57a13e9618b1ba34ee45d00eb5327316457)
+PatchScript: <<
+	perl -pi -e 's/-module/-no-undefined -module/' regress/Makefile.in
+<<
 
 Depends: %N-shlibs (= %v-%r)
-BuildDepends: fink (>= 0.32.0)
+BuildDepends: <<
+	bzip2-dev,
+	fink (>= 0.32.0),
+	fink-package-precedence
+<<
 BuildDependsOnly: True
 Conflicts: libzip1, libzip2, libzip5
 Replaces: libzip1, libzip2, libzip5
 
-NoSetCPPFLAGS: True
-NoSetLDFLAGS: True
 SetCFLAGS: -Os
 UseMaxBuildJobs: True
 
-ConfigureParams: --disable-dependency-tracking --disable-static
+ConfigureParams: --disable-static
+CompileScript: <<
+	%{default_script}
+	fink-package-precedence --prohibit-bdep=%n .
+<<
 
 InfoTest: TestScript: make check || exit 2
 
@@ -40,7 +48,8 @@ DocFiles: AUTHORS LICENSE NEWS.md README.md THANKS TODO.md
 
 SplitOff: <<
 	Package: %N-shlibs
-	
+	Depends: bzip2-shlibs
+
 	Files: lib/libzip.5*dylib
 	Shlibs: %p/lib/libzip.5.dylib 6.0.0 %n (>= 1.2.0-1)
 	DocFiles: AUTHORS LICENSE NEWS.md README.md THANKS TODO.md
@@ -48,11 +57,13 @@ SplitOff: <<
 
 SplitOff2: <<
 	Package: %N-bin
-	Depends: %N-shlibs (= %v-%r)
+	Depends: <<
+		%N-shlibs (= %v-%r),
+		bzip2-shlibs
+	<<
 	Conflicts: libzip1-bin, libzip2-bin, libzip5-bin
 	Replaces: libzip1-bin, libzip2-bin, libzip5-bin
 
 	Files: bin share/man/man1
 	DocFiles: AUTHORS LICENSE NEWS.md README.md THANKS TODO.md
-<<
 <<


### PR DESCRIPTION
Main functional change is that the userland binaries package (zimcmp, zipmerge, ziptool) is now not lib-versioned and uses ">=" not "=" on -shlibs (avoids several deadlock situations). Is "libzip-bin" the best name (was libzipN-bin), or should it instead be "zip-bin" or "zip"? Debian has a separate package for each of the three binaries, which seems excessive to me.