### PR TITLE
PostgreSQL updates 12.8, 11.13, 10.18, 9.6.23

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql10.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 10.17
+Version: 10.18
 Revision: 1
 Type: postgresql 10
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 06b20fcdcab6b4ad54621daaff941ab5
-Source-Checksum: SHA256(5af28071606c9cd82212c19ba584657a9d240e1c4c2da28fc1f3998a2754b26c)
+Source-MD5: 5da5ca531e8d47f7c8fb9959bbef693a
+Source-Checksum: SHA256(57477c2edc82c3f86a74747707b3babc1f301f389315ae14e819e025c0ba3801)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql11.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql11.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 11.12
+Version: 11.13
 Revision: 1
 Type: postgresql 11
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 3746c96a0e8f546f5503ef7b50abd2ff
-Source-Checksum: SHA256(87f9d8b16b2b8ef71586f2ec76beac844819f64734b07fa33986755c2f53cb04)
+Source-MD5: a2f6254597794afac144ddeec9af85f6
+Source-Checksum: SHA256(a0c3689ff7f565288002cbc138779d5121d74831a5e8341aea7aa86e99b6bc48)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql12.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql12.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 12.7
+Version: 12.8
 Revision: 1
 Type: postgresql 12
 Description: PostgreSQL open-source database
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: d6eb2d115871195665e1020b8ef123c4
-Source-Checksum: SHA256(8490741f47c88edc8b6624af009ce19fda4dc9b31c4469ce2551d84075d5d995)
+Source-MD5: 2f37bc7efbe4ed38768a167148876746
+Source-Checksum: SHA256(e26401e090c34ccb15ffb33a111f340833833535a7b7c5cd11cd88ab57d9c62a)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql96.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 9.6.22
+Version: 9.6.23
 Revision: 1
 Epoch: 1
 Type: postgresql 9.6
@@ -33,8 +33,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: f4aca4bd2f0541fb5612f9c8cabaa242
-Source-Checksum: SHA256(3d32cd101025a0556813397c69feff3df3d63736adb8adeaf365c522f39f2930)
+Source-MD5: 2345beeb56a0dff20e2d4f23f901d0a5
+Source-Checksum: SHA256(a849f798401ab8c6dfa653ebbcd853b43f2200b4e3bc1ea3cb5bec9a691947b9)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1


### PR DESCRIPTION
PostgreSQL updates to latest upstream version

The upstream updates contains a fix for security issue [CVE-2021-3677](https://www.postgresql.org/support/security/CVE-2021-3677/) Memory disclosure in certain queries
