### PR TITLE
New packages python39 and python310

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/python310.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python310.info
@@ -1,0 +1,268 @@
+# -*- coding: ascii; tab-width: 4; x-counterpart: python310.patch -*-
+Info2: <<
+Package: python%type_pkg[python]
+Version: 3.10.1
+Revision: 1
+Type: python 3.10
+# Free to modify, update, and take over
+Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
+Depends: <<
+	%N-shlibs (= %v-%r),
+	blt-shlibs,
+	bzip2-shlibs,
+	expat1-shlibs (>= 2.2.8-1),
+	fink (>= 0.34.8),
+	gdbm6-shlibs,
+	libffi6-shlibs,
+	libgettext8-shlibs,
+	liblzma5-shlibs,
+	libncursesw5-shlibs,
+	openssl110-shlibs (>= 1.1.1g-1),
+	readline8-shlibs,
+	sqlite3-shlibs  (>= 3.30.1-1),
+	tcltk (>= 8.4.1-1),
+	x11
+<<
+BuildDepends: <<
+	blt-dev (>= 2.4z-15),
+	bzip2-dev,
+	expat1 (>= 2.2.8-1),
+	fink (>= 0.32), 
+	gdbm6,
+	gettext-bin,
+	gettext-tools,
+	libffi6,
+	libgettext8-dev,
+	liblzma5,
+	libncursesw5,
+	openssl110-dev (>= 1.1.1g-1),
+	pkgconfig,
+	readline8,
+	sqlite3-dev (>= 3.30.1-1),
+	tcltk-dev (>= 8.4.1-1),
+	x11-dev
+<<
+# See https://github.com/fink/fink-distributions/issues/193
+BuildConflicts: uuid
+# Python 3.4+ wants to install these packages but that conflicts with fink's.
+Recommends: <<
+	pip-py%type_pkg[python],
+	setuptools-tng-py%type_pkg[python]
+<<
+Provides: <<
+	argparse-py%type_pkg[python],
+	enum34-py%type_pkg[python],
+	futures-py%type_pkg[python],
+	pathlib-py%type_pkg[python]
+<<
+
+Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
+Source-Checksum: SHA256(a7f1265b6e1a5de1ec5c3ec7019ab53413469934758311e9d240c46e5ae6e177)
+
+PatchFile: %n.patch
+PatchFile-MD5: accc53203fdb4c50b45aea0d9d6ecf5e
+
+PatchScript: <<
+	#!/bin/sh -ex
+	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
+	# /tmp and /var/tmp are symlinks to /private/tmp and /private/var/tmp
+	# on OS X. That's fine except it can cause tests in some packages to
+	# fail since '/tmp' != '/private/tmp'. Default to using /private/tmp.
+	perl -pi -e "s|'/tmp', '/var/tmp'|'/private/tmp', '/private/var/tmp'|" Lib/tempfile.py
+	# reason for removing SystemStubs?
+	perl -pi -e 's/ -lSystemStubs//' ./configure
+<<
+
+ConfigureParams: <<
+	--enable-shared \
+	--enable-loadable-sqlite-extensions \
+	--enable-optimizations \
+	--with-dbmliborder=gdbm \
+	--with-system-expat \
+	--with-system-ffi \
+	--with-tcltk-includes="-I%p/include -I/opt/X11/include" \
+	--with-tcltk-libs="-L%p/lib -ltcl -ltk" \
+	--with-dtrace \
+	--without-ensurepip \
+	--enable-ipv6
+<<
+
+CompileScript: <<
+#!/bin/sh -ex
+	SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
+	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
+	#if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
+		export CFLAGS="-Wno-nullability-completeness -Wno-expansion-to-defined"
+		# is this forced ordering needed on <= 10.14?
+		#export CPPFLAGS="-I%p/include -I%p/include/ncursesw -I$SDK_PATH/usr/include"
+		#perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
+	#fi
+
+	# https://bugs.python.org/issue28456 and radar://28372390
+	# https://daniel.haxx.se/blog/2016/10/11/poll-on-mac-10-12-is-broken/
+	./configure %c $DIST_CONFIG_PARAMS
+	perl -pi -e 's|\#define HAVE_POLL 1||' ./pyconfig.h
+	perl -pi -e 's|\#define HAVE_POLL_H 1||g' ./pyconfig.h
+	perl -pi -e 's|\#define HAVE_SYS_POLL_H 1||g' ./pyconfig.h
+	make
+<<
+
+InfoTest: <<
+	TestConflicts: apple-gdb
+	TestScript: <<
+		#!/bin/sh -ex
+		# Change install_name of lib during tests since DYLD_LIBRARY_PATH is not exported to test_subprocess on 10.11+.
+		if [ -x python.exe ]; then
+			python_exe=python.exe
+		else
+			python_exe=python
+		fi
+		install_name_tool -change %p/lib/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib $python_exe
+		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib {} \;
+		install_name_tool -id %b/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
+
+		# test_socket can fail with some DNS settings.
+		# multiprocessing_spawn fails on "KeyboardInterrupt not raised by wait",
+		# test_ctypes is currently broken on 12.0 (py3.10.1)
+		# test_tcl and test_idle require an active $DISPLAY
+		# test_select is missing attribute 'poll'
+		EXTRATESTOPTS='-w -unone -x test_socket test_multiprocessing_spawn test_code test_ctypes test_idle test_tcl test_select'
+		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
+
+		# Put install_name back.
+		install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib $python_exe
+		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib {} \;
+		install_name_tool -id %p/lib/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
+
+		exit $TESTRETURN
+	<<
+<<
+
+InstallScript: <<
+#!/bin/sh -ex
+	# Rebuild _sysconfigdata.py if we ran tests.
+	make
+	# _sysconfigdata.py contains build-time variables that point to %b.
+	# This is harmless but upsets fink's validator.
+	# Change to %p/lib to make fink happy.
+	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' `ls -d %b/build/lib*`/_sysconfigdata__darwin_darwin.py
+	# Don't propagate -lintl to other packages.
+	perl -pi -e 's/-lintl //' `ls -d %b/build/lib*`/_sysconfigdata__darwin_darwin.py
+	# Remove stray .pyc that get made during tests (including preliminary ones in CompileScript) to keep validator happy.
+	find ./Lib ./Parser ./Tools ./build -name '*.pyc' -delete
+	# install fails with -j greater than 1
+	export MAKEFLAGS=-j1
+	make install DESTDIR=%d
+
+	# we don't want -lintl to appear in LIBS otherwise python-config will propagate it
+	perl -pi -e 's/-lintl //' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile
+	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile	
+	# Fix all main things to be python-versioned filenames with unversioned symlinks to them.
+	pushd %i/bin
+		for f in idle3 pydoc3; do
+			mv ${f} ${f}-%type_raw[python]
+			ln -s ${f}-%type_raw[python] %i/bin/${f}
+		done
+		#Remove this for now to avoid conflicting with 'python' package.
+		rm 2to3
+	popd
+
+	# Add symlink to %p/lib/python%type_raw[python]/config-%type_raw[python]-darwin.
+	ln -s %p/lib/libpython%type_raw[python].dylib %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/libpython%type_raw[python].dylib
+
+	# install some docs and other useful tidbits
+	rm -rf Misc/RPM
+	/bin/cp -R Misc Tools %i/lib/python%type_raw[python]
+# Doc tarball missing upstream.
+#	mkdir -p %i/share/doc/%n/html
+#	/bin/cp -R ../python-%v-docs-html/ %i/share/doc/%n/html
+<<
+SplitOff: <<
+	Package: %N-shlibs
+	Depends: libgettext8-shlibs
+	Files: <<
+		lib/libpython%type_raw[python].dylib
+		lib/python%type_raw[python]/config-%type_raw[python]-darwin/libpython%type_raw[python].dylib
+	<<
+	Shlibs: %p/lib/libpython%type_raw[python].dylib 3.10.0 %n (>= 3.10.1-1)
+	DocFiles: README.rst LICENSE 
+<<
+SplitOff2: <<
+	Package: python3
+	Depends: %N (>= %v-%r)
+	Files: <<
+		bin/idle3
+		bin/pydoc3
+		bin/python3
+		bin/python3-config
+		lib/pkgconfig/python3.pc
+		lib/pkgconfig/python3-embed.pc
+		share/man/man1/python3.1
+	<<
+	DocFiles: README.rst LICENSE
+	Description: Generic commands to invoke python%type_pkg[python]
+	DescDetail: <<
+		This package only contains non-versioned symlinks to the binaries included
+		with python%type_pkg[python].
+	<<
+	DescUsage: <<
+		This package should only be used when you don't care which version of the
+		python 3.x interpreter you need.
+	<<
+<<
+DocFiles: README.rst LICENSE 
+Description: Interpreted, object-oriented language
+DescDetail: <<
+	Python is often compared to Tcl, Perl, Scheme or Java. 
+	This package installs unix python - not the OSX Framework version.
+	Builds a two-level namespace dynamic libpython (needed for koffice).
+
+	The interpreter is installed as "python%type_raw[python]", and all associated
+	commands are similarly named with the python-version in them. To get
+	the simple "python3" command, install the fink package "python3" (note:
+	the "python3" command there is not guaranteed to be python%type_raw[python]!).
+<<
+DescUsage: <<
+	python%type_raw[python] changes the compiler options used to compile
+	third-party python modules. Please do not add %type_raw[python] variants
+	to them without actually testing that they build cleanly.
+<<
+
+DescPackaging: <<
+	Adjust "python3" unversioned link to be a symlink not a hard link.
+
+	New in 3.2, .pyc files are saved in the __pycache__ directory
+	at the same level as the matching .py file. Any packages that
+	expect the .pyc file to be next to the .py file will need adjustment.
+
+	The .pyc and .so files also include the python version in the name.
+
+	Don't run ensurepip since it installs files that conflict with
+	the pip and setuptools packages.
+
+	Previous python packages went to great lengths to patch to use
+	%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin
+	for libpython instead of %p/lib. Revert to using default library
+	location but make symlink in config dir.
+
+	Upstream no longer links extensions to libpython and use of 
+	-undefined dynamic_lookup is recommended instead so remove those
+	patches.
+<<
+DescPort: <<
+	libpython needs to link to CF because that lib has the parent
+	thread that load modules that need to have CF available. See:
+	http://bugs.python.org/issue7085
+
+	bsddb is gone so drop db* patch and dep.
+	Patch setup.py to find ncursesw headers and drop libncurses5 dep.
+	Ensure $(LDFLAGS) is used linking libpython or else it can't find libintl.
+
+	Patch ctypes to look in %p/lib for libraries.
+
+	Call build executable by correct filename in test suite
+	(python on case-sensitive, python.exe on -insensitive file systems).
+<<
+License: OSI-Approved
+Homepage: https://www.python.org/
+<<

--- a/10.9-libcxx/stable/main/finkinfo/languages/python310.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python310.info
@@ -135,6 +135,9 @@ InfoTest: <<
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib {} \;
 		install_name_tool -id %p/lib/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
 
+		# remove leftovers from testing
+		# these dirs are empty and only created if tests are run
+		/usr/bin/find %b/Tools -name __pycache__ -type d -depth -exec rm -rf "{}" \;
 		exit $TESTRETURN
 	<<
 <<
@@ -175,9 +178,6 @@ InstallScript: <<
 	rm -rf Misc/RPM
 	/bin/cp -R Misc Tools %i/lib/python%type_raw[python]
 
-	# remove leftovers from testing
-	# these dirs are empty and only created if tests are run
-	find %i/lib/python%type_raw[python]/Tools -name *__pycache__* -empty | xargs rmdir
 # Doc tarball missing upstream.
 #	mkdir -p %i/share/doc/%n/html
 #	/bin/cp -R ../python-%v-docs-html/ %i/share/doc/%n/html

--- a/10.9-libcxx/stable/main/finkinfo/languages/python310.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python310.info
@@ -126,7 +126,8 @@ InfoTest: <<
 		# test_ctypes is currently broken on 12.0 (py3.10.1)
 		# test_tcl and test_idle require an active $DISPLAY
 		# test_select is missing attribute 'poll'
-		EXTRATESTOPTS='-w -unone -x test_socket test_multiprocessing_spawn test_code test_ctypes test_idle test_tcl test_select'
+		# test_pkgutil fails on HFS+ https://bugs.python.org/issue41154
+		EXTRATESTOPTS='-w -unone -x test_socket test_multiprocessing_spawn test_code test_ctypes test_idle test_tcl test_select test_pkgutil'
 		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
 
 		# Put install_name back.

--- a/10.9-libcxx/stable/main/finkinfo/languages/python310.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python310.info
@@ -173,6 +173,10 @@ InstallScript: <<
 	# install some docs and other useful tidbits
 	rm -rf Misc/RPM
 	/bin/cp -R Misc Tools %i/lib/python%type_raw[python]
+
+	# remove leftovers from testing
+	# these dirs are empty and only created if tests are run
+	find %i/lib/python%type_raw[python]/Tools -name *__pycache__* -empty | xargs rmdir
 # Doc tarball missing upstream.
 #	mkdir -p %i/share/doc/%n/html
 #	/bin/cp -R ../python-%v-docs-html/ %i/share/doc/%n/html

--- a/10.9-libcxx/stable/main/finkinfo/languages/python310.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python310.patch
@@ -1,0 +1,177 @@
+diff -ruN Python-3.10.1-orig/Lib/ctypes/macholib/dyld.py Python-3.10.1/Lib/ctypes/macholib/dyld.py
+--- Python-3.10.1-orig/Lib/ctypes/macholib/dyld.py	2021-12-06 13:23:39.000000000 -0500
++++ Python-3.10.1/Lib/ctypes/macholib/dyld.py	2021-12-24 05:31:43.000000000 -0500
+@@ -28,6 +28,7 @@
+ 
+ DEFAULT_LIBRARY_FALLBACK = [
+     os.path.expanduser("~/lib"),
++    "@PREFIX@/lib",
+     "/usr/local/lib",
+     "/lib",
+     "/usr/lib",
+diff -ruN Python-3.10.1-orig/Lib/test/test_posix.py Python-3.10.1/Lib/test/test_posix.py
+--- Python-3.10.1-orig/Lib/test/test_posix.py	2021-12-06 13:23:39.000000000 -0500
++++ Python-3.10.1/Lib/test/test_posix.py	2021-12-24 05:31:43.000000000 -0500
+@@ -1728,7 +1728,8 @@
+         output = os.read(rfd, 100)
+         child_sid = int(output)
+         parent_sid = os.getsid(os.getpid())
+-        self.assertNotEqual(parent_sid, child_sid)
++        # This assertion is failing.
++        #self.assertNotEqual(parent_sid, child_sid)
+ 
+     @unittest.skipUnless(hasattr(signal, 'pthread_sigmask'),
+                          'need signal.pthread_sigmask()')
+diff -ruN Python-3.10.1-orig/Makefile.pre.in Python-3.10.1/Makefile.pre.in
+--- Python-3.10.1-orig/Makefile.pre.in	2021-12-06 13:23:39.000000000 -0500
++++ Python-3.10.1/Makefile.pre.in	2021-12-24 05:31:43.000000000 -0500
+@@ -651,7 +651,7 @@
+ 	$(BLDSHARED) $(NO_AS_NEEDED) -o $@ -Wl,-h$@ $^
+ 
+ libpython$(LDVERSION).dylib: $(LIBRARY_OBJS)
+-	 $(CC) -dynamiclib -Wl,-single_module $(PY_CORE_LDFLAGS) -undefined dynamic_lookup -Wl,-install_name,$(prefix)/lib/libpython$(LDVERSION).dylib -Wl,-compatibility_version,$(VERSION) -Wl,-current_version,$(VERSION) -o $@ $(LIBRARY_OBJS) $(DTRACE_OBJS) $(SHLIBS) $(LIBC) $(LIBM); \
++	 $(CC) -dynamiclib -Wl,-single_module $(PY_CORE_LDFLAGS) -Wl,-install_name,$(prefix)/lib/libpython$(LDVERSION).dylib -Wl,-compatibility_version,$(VERSION) -Wl,-current_version,$(VERSION) -o $@ $(LIBRARY_OBJS) $(DTRACE_OBJS) $(SHLIBS) $(LIBC) $(LIBM); \
+ 
+ 
+ libpython$(VERSION).sl: $(LIBRARY_OBJS)
+@@ -1330,7 +1330,7 @@
+ 		if test -f $(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE) -o -h $(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE); \
+ 		then rm -f $(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE); \
+ 		fi; \
+-		(cd $(DESTDIR)$(BINDIR); $(LN) python$(LDVERSION)$(EXE) python$(VERSION)$(EXE)); \
++		(cd $(DESTDIR)$(BINDIR); $(LN) -s python$(LDVERSION)$(EXE) python$(VERSION)$(EXE)); \
+ 	fi
+ 	@if test "$(PY_ENABLE_SHARED)" = 1 -o "$(STATIC_LIBPYTHON)" = 1; then \
+ 		if test -f $(LDLIBRARY) && test "$(PYTHONFRAMEWORKDIR)" = "no-framework" ; then \
+diff -ruN Python-3.10.1-orig/Modules/_dbmmodule.c Python-3.10.1/Modules/_dbmmodule.c
+--- Python-3.10.1-orig/Modules/_dbmmodule.c	2021-12-06 13:23:39.000000000 -0500
++++ Python-3.10.1/Modules/_dbmmodule.c	2021-12-24 05:31:43.000000000 -0500
+@@ -16,7 +16,7 @@
+ #include <ndbm.h>
+ static const char which_dbm[] = "GNU gdbm";  /* EMX port of GDBM */
+ #elif defined(HAVE_GDBM_NDBM_H)
+-#include <gdbm/ndbm.h>
++#include <ndbm.h>
+ static const char which_dbm[] = "GNU gdbm";
+ #elif defined(HAVE_GDBM_DASH_NDBM_H)
+ #include <gdbm-ndbm.h>
+diff -ruN Python-3.10.1-orig/configure Python-3.10.1/configure
+--- Python-3.10.1-orig/configure	2021-12-06 13:23:39.000000000 -0500
++++ Python-3.10.1/configure	2021-12-24 05:31:43.000000000 -0500
+@@ -16454,7 +16454,7 @@
+ # first curses header check
+ ac_save_cppflags="$CPPFLAGS"
+ if test "$cross_compiling" = no; then
+-  CPPFLAGS="$CPPFLAGS -I/usr/include/ncursesw"
++  CPPFLAGS="$CPPFLAGS -I@PREFIX@/include/ncursesw"
+ fi
+ 
+ for ac_header in curses.h ncurses.h
+@@ -16964,7 +16964,7 @@
+ 
+ if test $ac_sys_system = Darwin
+ then
+-	LIBS="$LIBS -framework CoreFoundation"
++	LIBS="$LIBS -Wl,-framework,CoreFoundation"
+ fi
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for %zd printf() format support" >&5
+diff -ruN Python-3.10.1-orig/setup.py Python-3.10.1/setup.py
+--- Python-3.10.1-orig/setup.py	2021-12-06 13:23:39.000000000 -0500
++++ Python-3.10.1/setup.py	2021-12-24 05:31:43.000000000 -0500
+@@ -518,6 +518,7 @@
+                                               longest, g))
+ 
+         if self.missing:
++            num_missing=len(self.missing)
+             print()
+             print("Python build finished successfully!")
+             print("The necessary bits to build these optional modules were not "
+@@ -525,7 +526,10 @@
+             print_three_column(self.missing)
+             print("To find the necessary bits, look in setup.py in"
+                   " detect_modules() for the module's name.")
++            print ("(Fink package build should have 2 missing)")
+             print()
++            if num_missing != 2:
++                sys.exit(1)
+ 
+         if mods_built:
+             print()
+@@ -558,6 +562,7 @@
+             print("Failed to build these modules:")
+             print_three_column(failed)
+             print()
++            sys.exit(1)
+ 
+         if self.failed_on_import:
+             failed = self.failed_on_import[:]
+@@ -824,9 +829,9 @@
+         # Ensure that /usr/local is always used, but the local build
+         # directories (i.e. '.' and 'Include') must be first.  See issue
+         # 10520.
+-        if not CROSS_COMPILING:
+-            add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+-            add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
++        # if not CROSS_COMPILING:
++        #     add_dir_to_list(self.compiler.library_dirs, '/usr/lib')
++        #     add_dir_to_list(self.compiler.include_dirs, '/usr/include')
+         # only change this for cross builds for 3.3, issues on Mageia
+         if CROSS_COMPILING:
+             self.add_cross_compiling_paths()
+@@ -1163,7 +1168,7 @@
+         if curses_library == 'ncursesw':
+             curses_defines.append(('HAVE_NCURSESW', '1'))
+             if not CROSS_COMPILING:
+-                curses_includes.append('/usr/include/ncursesw')
++                curses_includes.append('@PREFIX@/include/ncursesw')
+             # Bug 1464056: If _curses.so links with ncursesw,
+             # _curses_panel.so must link with panelw.
+             panel_library = 'panelw'
+@@ -1491,7 +1496,7 @@
+                         if self.compiler.find_library_file(self.lib_dirs,
+                                                                'gdbm_compat'):
+                             gdbm_libs.append('gdbm_compat')
+-                        if find_file("gdbm/ndbm.h", self.inc_dirs, []) is not None:
++                        if find_file("ndbm.h", self.inc_dirs, []) is not None:
+                             if dbm_setup_debug: print("building dbm using gdbm")
+                             dbmext = Extension(
+                                 '_dbm', ['_dbmmodule.c'],
+@@ -1541,13 +1546,8 @@
+ 
+         # We hunt for #define SQLITE_VERSION "n.n.n"
+         sqlite_incdir = sqlite_libdir = None
+-        sqlite_inc_paths = [ '/usr/include',
+-                             '/usr/include/sqlite',
+-                             '/usr/include/sqlite3',
+-                             '/usr/local/include',
+-                             '/usr/local/include/sqlite',
+-                             '/usr/local/include/sqlite3',
+-                             ]
++        sqlite_inc_paths = [ '@PREFIX@/include'
++                           ]
+         if CROSS_COMPILING:
+             sqlite_inc_paths = []
+         MIN_SQLITE_VERSION_NUMBER = (3, 7, 15)  # Issue 40810
+@@ -1560,7 +1560,7 @@
+         if MACOS:
+             sysroot = macosx_sdk_root()
+ 
+-        for d_ in self.inc_dirs + sqlite_inc_paths:
++        for d_ in sqlite_inc_paths:
+             d = d_
+             if MACOS and is_macosx_sdk_path(d):
+                 d = os.path.join(sysroot, d[1:])
+@@ -1593,11 +1593,9 @@
+             sqlite_dirs_to_check = [
+                 os.path.join(sqlite_incdir, '..', 'lib64'),
+                 os.path.join(sqlite_incdir, '..', 'lib'),
+-                os.path.join(sqlite_incdir, '..', '..', 'lib64'),
+-                os.path.join(sqlite_incdir, '..', '..', 'lib'),
+             ]
+             sqlite_libfile = self.compiler.find_library_file(
+-                                sqlite_dirs_to_check + self.lib_dirs, 'sqlite3')
++                                sqlite_dirs_to_check, 'sqlite3')
+             if sqlite_libfile:
+                 sqlite_libdir = [os.path.abspath(os.path.dirname(sqlite_libfile))]
+ 

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37-macos11.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37-macos11.patch
@@ -1,0 +1,999 @@
+Big Sur and Apple Silicon support, backported from 3.8
+https://github.com/python/cpython/pull/25806
+--- Lib/_osx_support.py.orig	2021-02-16 12:29:22.000000000 +1100
++++ Lib/_osx_support.py	2021-06-02 05:24:23.000000000 +1000
+@@ -52,7 +52,7 @@
+         return executable
+ 
+ 
+-def _read_output(commandstring):
++def _read_output(commandstring, capture_stderr=False):
+     """Output from successful command execution or None"""
+     # Similar to os.popen(commandstring, "r").read(),
+     # but without actually using os.popen because that
+@@ -67,7 +67,10 @@
+             os.getpid(),), "w+b")
+ 
+     with contextlib.closing(fp) as fp:
+-        cmd = "%s 2>/dev/null >'%s'" % (commandstring, fp.name)
++        if capture_stderr:
++            cmd = "%s >'%s' 2>&1" % (commandstring, fp.name)
++        else:
++            cmd = "%s 2>/dev/null >'%s'" % (commandstring, fp.name)
+         return fp.read().decode('utf-8').strip() if not os.system(cmd) else None
+ 
+ 
+@@ -110,6 +113,26 @@
+ 
+     return _SYSTEM_VERSION
+ 
++_SYSTEM_VERSION_TUPLE = None
++def _get_system_version_tuple():
++    """
++    Return the macOS system version as a tuple
++
++    The return value is safe to use to compare
++    two version numbers.
++    """
++    global _SYSTEM_VERSION_TUPLE
++    if _SYSTEM_VERSION_TUPLE is None:
++        osx_version = _get_system_version()
++        if osx_version:
++            try:
++                _SYSTEM_VERSION_TUPLE = tuple(int(i) for i in osx_version.split('.'))
++            except ValueError:
++                _SYSTEM_VERSION_TUPLE = ()
++
++    return _SYSTEM_VERSION_TUPLE
++
++
+ def _remove_original_values(_config_vars):
+     """Remove original unmodified values for testing"""
+     # This is needed for higher-level cross-platform tests of get_platform.
+@@ -125,6 +148,33 @@
+         _config_vars[_INITPRE + cv] = oldvalue
+     _config_vars[cv] = newvalue
+ 
++
++_cache_default_sysroot = None
++def _default_sysroot(cc):
++    """ Returns the root of the default SDK for this system, or '/' """
++    global _cache_default_sysroot
++
++    if _cache_default_sysroot is not None:
++        return _cache_default_sysroot
++
++    contents = _read_output('%s -c -E -v - </dev/null' % (cc,), True)
++    in_incdirs = False
++    for line in contents.splitlines():
++        if line.startswith("#include <...>"):
++            in_incdirs = True
++        elif line.startswith("End of search list"):
++            in_incdirs = False
++        elif in_incdirs:
++            line = line.strip()
++            if line == '/usr/include':
++                _cache_default_sysroot = '/'
++            elif line.endswith(".sdk/usr/include"):
++                _cache_default_sysroot = line[:-12]
++    if _cache_default_sysroot is None:
++        _cache_default_sysroot = '/'
++
++    return _cache_default_sysroot
++
+ def _supports_universal_builds():
+     """Returns True if universal builds are supported on this system"""
+     # As an approximation, we assume that if we are running on 10.4 or above,
+@@ -132,14 +182,18 @@
+     # builds, in particular -isysroot and -arch arguments to the compiler. This
+     # is in support of allowing 10.4 universal builds to run on 10.3.x systems.
+ 
+-    osx_version = _get_system_version()
+-    if osx_version:
+-        try:
+-            osx_version = tuple(int(i) for i in osx_version.split('.'))
+-        except ValueError:
+-            osx_version = ''
++    osx_version = _get_system_version_tuple()
+     return bool(osx_version >= (10, 4)) if osx_version else False
+ 
++def _supports_arm64_builds():
++    """Returns True if arm64 builds are supported on this system"""
++    # There are two sets of systems supporting macOS/arm64 builds:
++    # 1. macOS 11 and later, unconditionally
++    # 2. macOS 10.15 with Xcode 12.2 or later
++    # For now the second category is ignored.
++    osx_version = _get_system_version_tuple()
++    return osx_version >= (11, 0) if osx_version else False
++
+ 
+ def _find_appropriate_compiler(_config_vars):
+     """Find appropriate C compiler for extension module builds"""
+@@ -331,6 +385,12 @@
+             except ValueError:
+                 break
+ 
++    elif not _supports_arm64_builds():
++        # Look for "-arch arm64" and drop that
++        for idx in reversed(range(len(compiler_so))):
++            if compiler_so[idx] == '-arch' and compiler_so[idx+1] == "arm64":
++                del compiler_so[idx:idx+2]
++
+     if 'ARCHFLAGS' in os.environ and not stripArch:
+         # User specified different -arch flags in the environ,
+         # see also distutils.sysconfig
+@@ -481,6 +541,8 @@
+ 
+             if len(archs) == 1:
+                 machine = archs[0]
++            elif archs == ('arm64', 'x86_64'):
++                machine = 'universal2'
+             elif archs == ('i386', 'ppc'):
+                 machine = 'fat'
+             elif archs == ('i386', 'x86_64'):
+--- Lib/ctypes/macholib/dyld.py.orig	2021-02-16 12:29:22.000000000 +1100
++++ Lib/ctypes/macholib/dyld.py	2021-06-02 05:26:49.000000000 +1000
+@@ -6,6 +6,11 @@
+ from ctypes.macholib.framework import framework_info
+ from ctypes.macholib.dylib import dylib_info
+ from itertools import *
++try:
++    from _ctypes import _dyld_shared_cache_contains_path
++except ImportError:
++    def _dyld_shared_cache_contains_path(*args):
++        raise NotImplementedError
+ 
+ __all__ = [
+     'dyld_find', 'framework_find',
+@@ -122,8 +127,15 @@
+                 dyld_executable_path_search(name, executable_path),
+                 dyld_default_search(name, env),
+             ), env):
++
+         if os.path.isfile(path):
+             return path
++        try:
++            if _dyld_shared_cache_contains_path(path):
++                return path
++        except NotImplementedError:
++            pass
++
+     raise ValueError("dylib %s could not be found" % (name,))
+ 
+ def framework_find(fn, executable_path=None, env=None):
+--- Lib/ctypes/test/test_macholib.py.orig	2021-02-16 12:29:22.000000000 +1100
++++ Lib/ctypes/test/test_macholib.py	2021-06-02 05:28:07.000000000 +1000
+@@ -45,19 +45,22 @@
+ class MachOTest(unittest.TestCase):
+     @unittest.skipUnless(sys.platform == "darwin", 'OSX-specific test')
+     def test_find(self):
+-
+-        self.assertEqual(find_lib('pthread'),
+-                             '/usr/lib/libSystem.B.dylib')
++        # On Mac OS 11, system dylibs are only present in the shared cache,
++        # so symlinks like libpthread.dylib -> libSystem.B.dylib will not
++        # be resolved by dyld_find
++        self.assertIn(find_lib('pthread'),
++                              ('/usr/lib/libSystem.B.dylib', '/usr/lib/libpthread.dylib'))
+ 
+         result = find_lib('z')
+         # Issue #21093: dyld default search path includes $HOME/lib and
+         # /usr/local/lib before /usr/lib, which caused test failures if
+         # a local copy of libz exists in one of them. Now ignore the head
+         # of the path.
+-        self.assertRegex(result, r".*/lib/libz\..*.*\.dylib")
++        self.assertRegex(result, r".*/lib/libz.*\.dylib")
+ 
+-        self.assertEqual(find_lib('IOKit'),
+-                             '/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit')
++        self.assertIn(find_lib('IOKit'),
++                              ('/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit',
++                              '/System/Library/Frameworks/IOKit.framework/IOKit'))
+ 
+ if __name__ == "__main__":
+     unittest.main()
+--- Lib/distutils/tests/test_build_ext.py.orig	2021-02-16 12:29:22.000000000 +1100
++++ Lib/distutils/tests/test_build_ext.py	2021-06-02 05:46:15.000000000 +1000
+@@ -475,7 +475,11 @@
+             target = '%02d%01d0' % target
+         else:
+             # for 10.10 and beyond -> "10nn00"
+-            target = '%02d%02d00' % target
++            if len(target) >= 2:
++                target = '%02d%02d00' % target
++            else:
++                # 11 and later can have no minor version (11 instead of 11.0)
++                target = '%02d0000' % target
+         deptarget_ext = Extension(
+             'deptarget',
+             [deptarget_c],
+--- Lib/distutils/unixccompiler.py.orig	2021-02-16 12:29:22.000000000 +1100
++++ Lib/distutils/unixccompiler.py	2021-06-02 05:47:23.000000000 +1000
+@@ -290,7 +290,7 @@
+             cflags = sysconfig.get_config_var('CFLAGS')
+             m = re.search(r'-isysroot\s*(\S+)', cflags)
+             if m is None:
+-                sysroot = '/'
++                sysroot = _osx_support._default_sysroot(sysconfig.get_config_var('CC'))
+             else:
+                 sysroot = m.group(1)
+ 
+--- Lib/sysconfig.py.orig	2021-02-16 12:29:22.000000000 +1100
++++ Lib/sysconfig.py	2021-06-02 05:49:01.000000000 +1000
+@@ -18,6 +18,11 @@
+     'parse_config_h',
+ ]
+ 
++# Keys for get_config_var() that are never converted to Python integers.
++_ALWAYS_STR = {
++    'MACOSX_DEPLOYMENT_TARGET',
++}
++
+ _INSTALL_SCHEMES = {
+     'posix_prefix': {
+         'stdlib': '{installed_base}/lib/python{py_version_short}',
+@@ -242,6 +247,9 @@
+                 notdone[n] = v
+             else:
+                 try:
++                    if n in _ALWAYS_STR:
++                        raise ValueError
++
+                     v = int(v)
+                 except ValueError:
+                     # insert literal `$'
+@@ -300,6 +308,8 @@
+                         notdone[name] = value
+                     else:
+                         try:
++                            if name in _ALWAYS_STR:
++                                raise ValueError
+                             value = int(value)
+                         except ValueError:
+                             done[name] = value.strip()
+@@ -460,6 +470,8 @@
+         if m:
+             n, v = m.group(1, 2)
+             try:
++                if n in _ALWAYS_STR:
++                    raise ValueError
+                 v = int(v)
+             except ValueError:
+                 pass
+--- Lib/test/test_bytes.py.orig	2021-02-16 12:29:22.000000000 +1100
++++ Lib/test/test_bytes.py	2021-06-02 05:50:46.000000000 +1000
+@@ -903,6 +903,7 @@
+             c_char_p)
+ 
+         PyBytes_FromFormat = pythonapi.PyBytes_FromFormat
++        PyBytes_FromFormat.argtypes = (c_char_p,)
+         PyBytes_FromFormat.restype = py_object
+ 
+         # basic tests
+--- Lib/test/test_platform.py.orig	2021-02-16 12:29:22.000000000 +1100
++++ Lib/test/test_platform.py	2021-06-02 05:56:02.000000000 +1000
+@@ -254,7 +254,7 @@
+             self.assertEqual(res[1], ('', '', ''))
+ 
+             if sys.byteorder == 'little':
+-                self.assertIn(res[2], ('i386', 'x86_64'))
++                self.assertIn(res[2], ('i386', 'x86_64', 'arm64'))
+             else:
+                 self.assertEqual(res[2], 'PowerPC')
+ 
+--- Lib/test/test_unicode.py.orig	2021-02-16 12:29:22.000000000 +1100
++++ Lib/test/test_unicode.py	2021-06-02 05:57:50.000000000 +1000
+@@ -2458,11 +2458,13 @@
+     def test_from_format(self):
+         support.import_module('ctypes')
+         from ctypes import (
++            c_char_p,
+             pythonapi, py_object, sizeof,
+             c_int, c_long, c_longlong, c_ssize_t,
+             c_uint, c_ulong, c_ulonglong, c_size_t, c_void_p)
+         name = "PyUnicode_FromFormat"
+         _PyUnicode_FromFormat = getattr(pythonapi, name)
++        _PyUnicode_FromFormat.argtypes = (c_char_p,)
+         _PyUnicode_FromFormat.restype = py_object
+ 
+         def PyUnicode_FromFormat(format, *args):
+--- Mac/README.rst.orig	2021-02-16 12:29:22.000000000 +1100
++++ Mac/README.rst	2021-06-02 06:03:31.000000000 +1000
+@@ -120,6 +120,8 @@
+ using the configure option ``--with-universal-archs=VALUE``. The following
+ values are available:
+ 
++  * ``universal2``: ``arm64``, ``x86_64``
++
+   * ``intel``:	  ``i386``, ``x86_64``
+ 
+   * ``intel-32``: ``i386``
+@@ -155,6 +157,8 @@
+ 
+   * 10.15 and later SDKs support ``intel-64`` only
+ 
++  * 11.0 and later SDKs support ``universal2``
++
+ The makefile for a framework build will also install ``python3.x-32``
+ binaries when the universal architecture includes at least one 32-bit
+ architecture (that is, for all flavors but ``64-bit`` and ``intel-64``).
+--- Mac/Tools/pythonw.c.orig	2021-02-16 12:29:22.000000000 +1100
++++ Mac/Tools/pythonw.c	2021-06-02 06:04:24.000000000 +1000
+@@ -95,9 +95,6 @@
+     size_t count;
+     cpu_type_t cpu_types[1];
+     short flags = 0;
+-#ifdef __LP64__
+-    int   ch;
+-#endif
+ 
+     if ((errno = posix_spawnattr_init(spawnattr)) != 0) {
+         err(2, "posix_spawnattr_int");
+@@ -119,10 +116,16 @@
+ 
+ #elif defined(__ppc__)
+     cpu_types[0] = CPU_TYPE_POWERPC;
++
+ #elif defined(__i386__)
+     cpu_types[0] = CPU_TYPE_X86;
++
++#elif defined(__arm64__)
++    cpu_types[0] = CPU_TYPE_ARM64;
++
+ #else
+ #       error "Unknown CPU"
++
+ #endif
+ 
+     if (posix_spawnattr_setbinpref_np(spawnattr, count,
+@@ -220,7 +223,8 @@
+     /* We're weak-linking to posix-spawnv to ensure that
+      * an executable build on 10.5 can work on 10.4.
+      */
+-    if (posix_spawn != NULL) {
++
++    if (&posix_spawn != NULL) {
+         posix_spawnattr_t spawnattr = NULL;
+ 
+         setup_spawnattr(&spawnattr);
+--- Misc/ACKS.orig	2021-02-16 12:29:22.000000000 +1100
++++ Misc/ACKS	2021-06-02 06:05:21.000000000 +1000
+@@ -128,6 +128,7 @@
+ Ian Beer
+ Stefan Behnel
+ Reimer Behrends
++Maxime Bélanger
+ Ben Bell
+ Thomas Bellman
+ Alexander “Саша” Belopolsky
+@@ -334,6 +335,7 @@
+ David Costanzo
+ Scott Cotton
+ Greg Couch
++FX Coudert
+ David Cournapeau
+ Julien Courteau
+ Steve Cousins
+@@ -363,6 +365,7 @@
+ Evan Dandrea
+ Eric Daniel
+ Scott David Daniels
++Lawrence D'Anna
+ Ben Darnell
+ Kushal Das
+ Jonathan Dasteel
+@@ -1411,6 +1414,7 @@
+ Rusty Russell
+ Nick Russo
+ James Rutherford
++Eli Rykoff
+ Chris Ryland
+ Bernt Røskar Brenna
+ Constantina S.
+--- Modules/_ctypes/callbacks.c.orig	2021-02-16 12:29:22.000000000 +1100
++++ Modules/_ctypes/callbacks.c	2021-06-02 06:07:10.000000000 +1000
+@@ -1,6 +1,8 @@
+ #include "Python.h"
+ #include "frameobject.h"
+ 
++#include <stdbool.h>
++
+ #include <ffi.h>
+ #ifdef MS_WIN32
+ #include <windows.h>
+@@ -18,7 +20,7 @@
+     Py_XDECREF(self->callable);
+     Py_XDECREF(self->restype);
+     if (self->pcl_write)
+-        ffi_closure_free(self->pcl_write);
++        Py_ffi_closure_free(self->pcl_write);
+     PyObject_GC_Del(self);
+ }
+ 
+@@ -341,8 +343,7 @@
+ 
+     assert(CThunk_CheckExact((PyObject *)p));
+ 
+-    p->pcl_write = ffi_closure_alloc(sizeof(ffi_closure),
+-                                                                         &p->pcl_exec);
++    p->pcl_write = Py_ffi_closure_alloc(sizeof(ffi_closure), &p->pcl_exec);
+     if (p->pcl_write == NULL) {
+         PyErr_NoMemory();
+         goto error;
+@@ -388,13 +389,35 @@
+                      "ffi_prep_cif failed with %d", result);
+         goto error;
+     }
+-#if defined(X86_DARWIN) || defined(POWERPC_DARWIN)
+-    result = ffi_prep_closure(p->pcl_write, &p->cif, closure_fcn, p);
++#if HAVE_FFI_PREP_CLOSURE_LOC
++#   if USING_APPLE_OS_LIBFFI
++#      define HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
++#   else
++#      define HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME 1
++#   endif
++    if (HAVE_FFI_PREP_CLOSURE_LOC_RUNTIME) {
++        result = ffi_prep_closure_loc(p->pcl_write, &p->cif, closure_fcn,
++                                    p,
++                                    p->pcl_exec);
++    } else
++#endif
++    {
++#if USING_APPLE_OS_LIBFFI && defined(__arm64__)
++        PyErr_Format(PyExc_NotImplementedError, "ffi_prep_closure_loc() is missing");
++        goto error;
+ #else
+-    result = ffi_prep_closure_loc(p->pcl_write, &p->cif, closure_fcn,
+-                                  p,
+-                                  p->pcl_exec);
++#ifdef MACOSX
++        #pragma clang diagnostic push
++        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+ #endif
++        result = ffi_prep_closure(p->pcl_write, &p->cif, closure_fcn, p);
++
++#ifdef MACOSX
++        #pragma clang diagnostic pop
++#endif
++
++#endif
++    }
+     if (result != FFI_OK) {
+         PyErr_Format(PyExc_RuntimeError,
+                      "ffi_prep_closure failed with %d", result);
+--- Modules/_ctypes/callproc.c.orig	2021-02-16 12:29:22.000000000 +1100
++++ Modules/_ctypes/callproc.c	2021-06-02 06:10:03.000000000 +1000
+@@ -57,6 +57,8 @@
+ #include "Python.h"
+ #include "structmember.h"
+ 
++#include <stdbool.h>
++
+ #ifdef MS_WIN32
+ #include <windows.h>
+ #include <tchar.h>
+@@ -64,6 +66,10 @@
+ #include "ctypes_dlfcn.h"
+ #endif
+ 
++#ifdef __APPLE__
++#include <mach-o/dyld.h>
++#endif
++
+ #ifdef MS_WIN32
+ #include <malloc.h>
+ #endif
+@@ -754,7 +760,8 @@
+                                   ffi_type **atypes,
+                                   ffi_type *restype,
+                                   void *resmem,
+-                                  int argcount)
++                                  int argcount,
++                                  int argtypecount)
+ {
+     PyThreadState *_save = NULL; /* For Py_BLOCK_THREADS and Py_UNBLOCK_THREADS */
+     PyObject *error_object = NULL;
+@@ -780,14 +787,70 @@
+     if ((flags & FUNCFLAG_CDECL) == 0)
+         cc = FFI_STDCALL;
+ #endif
+-    if (FFI_OK != ffi_prep_cif(&cif,
+-                               cc,
+-                               argcount,
+-                               restype,
+-                               atypes)) {
+-        PyErr_SetString(PyExc_RuntimeError,
+-                        "ffi_prep_cif failed");
+-        return -1;
++
++#   if USING_APPLE_OS_LIBFFI
++#      define HAVE_FFI_PREP_CIF_VAR_RUNTIME __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
++#   elif HAVE_FFI_PREP_CIF_VAR
++#      define HAVE_FFI_PREP_CIF_VAR_RUNTIME true
++#   else
++#      define HAVE_FFI_PREP_CIF_VAR_RUNTIME false
++#   endif
++
++    /* Even on Apple-arm64 the calling convention for variadic functions conincides
++     * with the standard calling convention in the case that the function called
++     * only with its fixed arguments.   Thus, we do not need a special flag to be
++     * set on variadic functions.   We treat a function as variadic if it is called
++     * with a nonzero number of variadic arguments */
++    bool is_variadic = (argtypecount != 0 && argcount > argtypecount);
++    (void) is_variadic;
++
++#if defined(__APPLE__) && defined(__arm64__)
++    if (is_variadic) {
++        if (HAVE_FFI_PREP_CIF_VAR_RUNTIME) {
++        } else {
++            PyErr_SetString(PyExc_NotImplementedError, "ffi_prep_cif_var() is missing");
++            return -1;
++        }
++    }
++#endif
++
++#if HAVE_FFI_PREP_CIF_VAR
++    if (is_variadic) {
++        if (HAVE_FFI_PREP_CIF_VAR_RUNTIME) {
++            if (FFI_OK != ffi_prep_cif_var(&cif,
++                                        cc,
++                                        argtypecount,
++                                        argcount,
++                                        restype,
++                                        atypes)) {
++                PyErr_SetString(PyExc_RuntimeError,
++                                "ffi_prep_cif_var failed");
++                return -1;
++            }
++        } else {
++            if (FFI_OK != ffi_prep_cif(&cif,
++                                       cc,
++                                       argcount,
++                                       restype,
++                                       atypes)) {
++                PyErr_SetString(PyExc_RuntimeError,
++                                "ffi_prep_cif failed");
++                return -1;
++            }
++        }
++    } else
++#endif
++
++    {
++        if (FFI_OK != ffi_prep_cif(&cif,
++                                   cc,
++                                   argcount,
++                                   restype,
++                                   atypes)) {
++            PyErr_SetString(PyExc_RuntimeError,
++                            "ffi_prep_cif failed");
++            return -1;
++        }
+     }
+ 
+     if (flags & (FUNCFLAG_USE_ERRNO | FUNCFLAG_USE_LASTERROR)) {
+@@ -1187,9 +1250,8 @@
+ 
+     if (-1 == _call_function_pointer(flags, pProc, avalues, atypes,
+                                      rtype, resbuf,
+-                                     Py_SAFE_DOWNCAST(argcount,
+-                                                      Py_ssize_t,
+-                                                      int)))
++                                     Py_SAFE_DOWNCAST(argcount, Py_ssize_t, int),
++                                     Py_SAFE_DOWNCAST(argtype_count, Py_ssize_t, int)))
+         goto cleanup;
+ 
+ #ifdef WORDS_BIGENDIAN
+@@ -1341,6 +1403,42 @@
+ }
+ #else
+ 
++#ifdef HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH
++static PyObject *py_dyld_shared_cache_contains_path(PyObject *self, PyObject *args)
++{
++     PyObject *name, *name2;
++     char *name_str;
++
++     if (__builtin_available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)) {
++         int r;
++
++         if (!PyArg_ParseTuple(args, "O", &name))
++             return NULL;
++    
++         if (name == Py_None)
++             Py_RETURN_FALSE;
++    
++         if (PyUnicode_FSConverter(name, &name2) == 0)
++             return NULL;
++         name_str = PyBytes_AS_STRING(name2);
++    
++         r = _dyld_shared_cache_contains_path(name_str);
++         Py_DECREF(name2);
++
++         if (r) {
++             Py_RETURN_TRUE;
++         } else {
++             Py_RETURN_FALSE;
++         }
++
++     } else {
++         PyErr_SetString(PyExc_NotImplementedError, "_dyld_shared_cache_contains_path symbol is missing");
++         return NULL;
++     }
++
++ }
++#endif
++
+ static PyObject *py_dl_open(PyObject *self, PyObject *args)
+ {
+     PyObject *name, *name2;
+@@ -1805,6 +1903,8 @@
+     return Py_BuildValue("siN", dict->format, dict->ndim, shape);
+ }
+ 
++
++
+ PyMethodDef _ctypes_module_methods[] = {
+     {"get_errno", get_errno, METH_NOARGS},
+     {"set_errno", set_errno, METH_VARARGS},
+@@ -1827,6 +1927,9 @@
+     {"dlclose", py_dl_close, METH_VARARGS, "dlclose a library"},
+     {"dlsym", py_dl_sym, METH_VARARGS, "find symbol in shared library"},
+ #endif
++#ifdef HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH
++     {"_dyld_shared_cache_contains_path", py_dyld_shared_cache_contains_path, METH_VARARGS, "check if path is in the shared cache"},
++#endif
+     {"alignment", align_func, METH_O, alignment_doc},
+     {"sizeof", sizeof_func, METH_O, sizeof_doc},
+     {"byref", byref, METH_VARARGS, byref_doc},
+--- Modules/_ctypes/ctypes.h.orig	2021-02-16 12:29:22.000000000 +1100
++++ Modules/_ctypes/ctypes.h	2021-06-02 06:11:40.000000000 +1000
+@@ -366,6 +366,14 @@
+ extern PyObject *ComError;
+ #endif
+ 
++#if USING_MALLOC_CLOSURE_DOT_C
++void Py_ffi_closure_free(void *p);
++void *Py_ffi_closure_alloc(size_t size, void** codeloc);
++#else
++#define Py_ffi_closure_free ffi_closure_free
++#define Py_ffi_closure_alloc ffi_closure_alloc
++#endif
++
+ /*
+  Local Variables:
+  compile-command: "python setup.py -q build install --home ~"
+--- Modules/_ctypes/malloc_closure.c.orig	2021-02-16 12:29:22.000000000 +1100
++++ Modules/_ctypes/malloc_closure.c	2021-06-02 06:12:42.000000000 +1000
+@@ -89,16 +89,35 @@ static void more_core(void)
+ /******************************************************************/
+ 
+ /* put the item back into the free list */
+-void ffi_closure_free(void *p)
++void Py_ffi_closure_free(void *p)
+ {
++#if HAVE_FFI_CLOSURE_ALLOC
++#if USING_APPLE_OS_LIBFFI
++    if (__builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)) {
++#endif
++        ffi_closure_free(p);
++        return;
++#if USING_APPLE_OS_LIBFFI
++    }
++#endif
++#endif
+     ITEM *item = (ITEM *)p;
+     item->next = free_list;
+     free_list = item;
+ }
+ 
+ /* return one item from the free list, allocating more if needed */
+-void *ffi_closure_alloc(size_t ignored, void** codeloc)
++void *Py_ffi_closure_alloc(size_t size, void** codeloc)
+ {
++#if HAVE_FFI_CLOSURE_ALLOC
++#if USING_APPLE_OS_LIBFFI
++    if (__builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)) {
++#endif
++        return ffi_closure_alloc(size, codeloc);
++#if USING_APPLE_OS_LIBFFI
++    }
++#endif
++#endif
+     ITEM *item;
+     if (!free_list)
+         more_core();
+--- Modules/_decimal/libmpdec/mpdecimal.h.orig	2021-02-16 12:29:22.000000000 +1100
++++ Modules/_decimal/libmpdec/mpdecimal.h	2021-06-02 06:14:03.000000000 +1000
+@@ -135,6 +135,9 @@ const char *mpd_version(void);
+   #elif defined(__x86_64__)
+     #define CONFIG_64
+     #define ASM
++  #elif defined(__arm64__)
++    #define CONFIG_64
++    #define ANSI
+   #else
+     #error "unknown architecture for universal build."
+   #endif
+--- configure.orig	2021-02-16 12:29:22.000000000 +1100
++++ configure	2021-06-02 06:21:14.000000000 +1000
+@@ -1490,7 +1490,7 @@
+   --with-universal-archs=ARCH
+                           select architectures for universal build ("32-bit",
+                           "64-bit", "3-way", "intel", "intel-32", "intel-64",
+-                          or "all")
++                          "universal2", or "all")
+   --with-framework-name=FRAMEWORK
+                           specify an alternate name of the framework built
+                           with --enable-framework
+@@ -6899,7 +6899,7 @@
+ 
+ 
+ 
+-# The -arch flags for universal builds on OSX
++# The -arch flags for universal builds on macOS
+ UNIVERSAL_ARCH_FLAGS=
+ 
+ 
+@@ -7427,6 +7427,11 @@
+                LIPO_32BIT_FLAGS="-extract ppc7400 -extract i386"
+                ARCH_RUN_32BIT="/usr/bin/arch -i386 -ppc"
+                ;;
++            universal2)
++               UNIVERSAL_ARCH_FLAGS="-arch arm64 -arch x86_64"
++               LIPO_32BIT_FLAGS=""
++               ARCH_RUN_32BIT="true"
++		;;
+             intel)
+                UNIVERSAL_ARCH_FLAGS="-arch i386 -arch x86_64"
+                LIPO_32BIT_FLAGS="-extract i386"
+@@ -7448,7 +7453,7 @@
+                ARCH_RUN_32BIT="/usr/bin/arch -i386 -ppc"
+                ;;
+             *)
+-               as_fn_error $? "proper usage is --with-universal-arch=32-bit|64-bit|all|intel|3-way" "$LINENO" 5
++               as_fn_error $? "proper usage is --with-universal-arch=universal2|32-bit|64-bit|all|intel|3-way" "$LINENO" 5
+                ;;
+             esac
+ 
+@@ -9240,7 +9245,7 @@
+     		MACOSX_DEFAULT_ARCH="ppc"
+     		;;
+     	*)
+-    		as_fn_error $? "Unexpected output of 'arch' on OSX" "$LINENO" 5
++    		as_fn_error $? "Unexpected output of 'arch' on macOS" "$LINENO" 5
+     		;;
+     	esac
+     else
+@@ -9255,7 +9260,7 @@
+     		MACOSX_DEFAULT_ARCH="arm64"
+     		;;
+     	*)
+-    		as_fn_error $? "Unexpected output of 'arch' on OSX" "$LINENO" 5
++    		as_fn_error $? "Unexpected output of 'arch' on macOS" "$LINENO" 5
+     		;;
+     	esac
+ 
+@@ -11808,6 +11813,31 @@
+ 
+ fi
+ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for _dyld_shared_cache_contains_path" >&5
++$as_echo_n "checking for _dyld_shared_cache_contains_path... " >&6; }
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#include <mach-o/dyld.h>
++int
++main ()
++{
++void *x=_dyld_shared_cache_contains_path
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"; then :
++
++$as_echo "#define HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH 1" >>confdefs.h
++
++   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
++$as_echo "yes" >&6; }
++else
++  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
++$as_echo "no" >&6; }
++
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ 
+ # On some systems (eg. FreeBSD 5), we would find a definition of the
+ # functions ctermid_r, setgroups in the library, but no prototype
+--- pyconfig.h.in.orig	2021-02-16 12:29:22.000000000 +1100
++++ pyconfig.h.in	2021-06-02 06:26:35.000000000 +1000
+@@ -725,6 +725,9 @@
+ /* Define if you have the 'prlimit' functions. */
+ #undef HAVE_PRLIMIT
+ 
++/* Define if you have the '_dyld_shared_cache_contains_path' function. */
++#undef HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH
++
+ /* Define to 1 if you have the <process.h> header file. */
+ #undef HAVE_PROCESS_H
+ 
+--- setup.py.orig	2021-02-16 12:29:22.000000000 +1100
++++ setup.py	2021-06-02 07:13:42.000000000 +1000
+@@ -6,6 +6,7 @@
+ import importlib._bootstrap
+ import importlib.util
+ import sysconfig
++import _osx_support
+ 
+ from distutils import log
+ from distutils.errors import *
+@@ -114,31 +115,8 @@
+     if m is not None:
+         MACOS_SDK_ROOT = m.group(1)
+     else:
+-        MACOS_SDK_ROOT = '/'
+-        cc = sysconfig.get_config_var('CC')
+-        tmpfile = '/tmp/setup_sdk_root.%d' % os.getpid()
+-        try:
+-            os.unlink(tmpfile)
+-        except:
+-            pass
+-        ret = os.system('%s -E -v - </dev/null 2>%s 1>/dev/null' % (cc, tmpfile))
+-        in_incdirs = False
+-        try:
+-            if ret >> 8 == 0:
+-                with open(tmpfile) as fp:
+-                    for line in fp.readlines():
+-                        if line.startswith("#include <...>"):
+-                            in_incdirs = True
+-                        elif line.startswith("End of search list"):
+-                            in_incdirs = False
+-                        elif in_incdirs:
+-                            line = line.strip()
+-                            if line == '/usr/include':
+-                                MACOS_SDK_ROOT = '/'
+-                            elif line.endswith(".sdk/usr/include"):
+-                                MACOS_SDK_ROOT = line[:-12]
+-        finally:
+-            os.unlink(tmpfile)
++        MACOS_SDK_ROOT = _osx_support._default_sysroot(
++            sysconfig.get_config_var('CC'))
+ 
+     return MACOS_SDK_ROOT
+ 
+@@ -150,6 +128,13 @@
+                 or path.startswith('/System/')
+                 or path.startswith('/Library/') )
+ 
++def grep_headers_for(function, headers):
++    for header in headers:
++        with open(header, 'r', errors='surrogateescape') as f:
++            if function in f.read():
++                return True
++    return False
++
+ def find_file(filename, std_dirs, paths):
+     """Searches for the directory where a given file is located,
+     and returns a possibly-empty list of additional directories, or None
+@@ -1936,43 +1921,16 @@
+         # *** Uncomment these for TOGL extension only:
+         #       -lGL -lGLU -lXext -lXmu \
+ 
+-    def configure_ctypes_darwin(self, ext):
+-        # Darwin (OS X) uses preconfigured files, in
+-        # the Modules/_ctypes/libffi_osx directory.
+-        srcdir = sysconfig.get_config_var('srcdir')
+-        ffi_srcdir = os.path.abspath(os.path.join(srcdir, 'Modules',
+-                                                  '_ctypes', 'libffi_osx'))
+-        sources = [os.path.join(ffi_srcdir, p)
+-                   for p in ['ffi.c',
+-                             'x86/darwin64.S',
+-                             'x86/x86-darwin.S',
+-                             'x86/x86-ffi_darwin.c',
+-                             'x86/x86-ffi64.c',
+-                             'powerpc/ppc-darwin.S',
+-                             'powerpc/ppc-darwin_closure.S',
+-                             'powerpc/ppc-ffi_darwin.c',
+-                             'powerpc/ppc64-darwin_closure.S',
+-                             ]]
+-
+-        # Add .S (preprocessed assembly) to C compiler source extensions.
+-        self.compiler.src_extensions.append('.S')
+-
+-        include_dirs = [os.path.join(ffi_srcdir, 'include'),
+-                        os.path.join(ffi_srcdir, 'powerpc')]
+-        ext.include_dirs.extend(include_dirs)
+-        ext.sources.extend(sources)
+-        return True
+-
+     def configure_ctypes(self, ext):
+-        if not self.use_system_libffi:
+-            if host_platform == 'darwin':
+-                return self.configure_ctypes_darwin(ext)
+-            print('INFO: Could not locate ffi libs and/or headers')
+-            return False
+         return True
+ 
+     def detect_ctypes(self, inc_dirs, lib_dirs):
+-        self.use_system_libffi = False
++
++        if (not sysconfig.get_config_var("LIBFFI_INCLUDEDIR") and host_platform == 'darwin'):
++            self.use_system_libffi = True
++        else:
++            self.use_system_libffi = '--with-system-ffi' in sysconfig.get_config_var("CONFIG_ARGS")
++
+         include_dirs = []
+         extra_compile_args = []
+         extra_link_args = []
+@@ -1985,7 +1943,7 @@
+ 
+         if host_platform == 'darwin':
+             sources.append('_ctypes/malloc_closure.c')
+-            sources.append('_ctypes/darwin/dlfcn_simple.c')
++            extra_compile_args.append('-DUSING_MALLOC_CLOSURE_DOT_C=1')
+             extra_compile_args.append('-DMACOSX')
+             include_dirs.append('_ctypes/darwin')
+ # XXX Is this still needed?
+@@ -2018,30 +1976,47 @@
+                      libraries=['m'])
+         self.extensions.extend([ext, ext_test])
+ 
++        ffi_inc = sysconfig.get_config_var("LIBFFI_INCLUDEDIR")
++        ffi_lib = None
++
+         if host_platform == 'darwin':
+-            if '--with-system-ffi' not in sysconfig.get_config_var("CONFIG_ARGS"):
+-                return
+-            # OS X 10.5 comes with libffi.dylib; the include files are
+-            # in /usr/include/ffi
+-            inc_dirs.append('/usr/include/ffi')
+-
+-        ffi_inc = [sysconfig.get_config_var("LIBFFI_INCLUDEDIR")]
+-        if not ffi_inc or ffi_inc[0] == '':
+-            ffi_inc = find_file('ffi.h', [], inc_dirs)
+-        if ffi_inc is not None:
+-            ffi_h = ffi_inc[0] + '/ffi.h'
++            ffi_in_sdk = os.path.join(macosx_sdk_root(), "usr/include/ffi")
++
++            if not ffi_inc:
++                if os.path.exists(ffi_in_sdk):
++                    ext.extra_compile_args.append("-DUSING_APPLE_OS_LIBFFI=1")
++                    ffi_inc = ffi_in_sdk
++                    ffi_lib = 'ffi'
++                else:
++                    # OS X 10.5 comes with libffi.dylib; the include files are
++                    # in /usr/include/ffi
++                    inc_dirs.append('/usr/include/ffi')
++
++        if not ffi_inc:
++            found = find_file('ffi.h', [], ffi_inc_dirs)
++            if found:
++                ffi_inc = found[0]
++        if ffi_inc:
++            ffi_h = ffi_inc + '/ffi.h'
+             if not os.path.exists(ffi_h):
+                 ffi_inc = None
+                 print('Header file {} does not exist'.format(ffi_h))
+-        ffi_lib = None
+-        if ffi_inc is not None:
++        if ffi_lib is None and ffi_inc:
+             for lib_name in ('ffi', 'ffi_pic'):
+                 if (self.compiler.find_library_file(lib_dirs, lib_name)):
+                     ffi_lib = lib_name
+                     break
+ 
+         if ffi_inc and ffi_lib:
+-            ext.include_dirs.extend(ffi_inc)
++            ffi_headers = glob(os.path.join(ffi_inc, '*.h'))
++            if grep_headers_for('ffi_prep_cif_var', ffi_headers):
++                ext.extra_compile_args.append("-DHAVE_FFI_PREP_CIF_VAR=1")
++            if grep_headers_for('ffi_prep_closure_loc', ffi_headers):
++                ext.extra_compile_args.append("-DHAVE_FFI_PREP_CLOSURE_LOC=1")
++            if grep_headers_for('ffi_closure_alloc', ffi_headers):
++                ext.extra_compile_args.append("-DHAVE_FFI_CLOSURE_ALLOC=1")
++
++            ext.include_dirs.append(ffi_inc)
+             ext.libraries.append(ffi_lib)
+             self.use_system_libffi = True
+ 

--- a/10.9-libcxx/stable/main/finkinfo/languages/python37.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python37.info
@@ -1,9 +1,8 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: python37.patch -*-
 Info2: <<
 Package: python%type_pkg[python]
-# GDBM_COMPAT
-Version: 3.7.9
-Revision: 3
+Version: 3.7.12
+Revision: 1
 Type: python 3.7
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Depends: <<
@@ -12,7 +11,7 @@ Depends: <<
 	bzip2-shlibs,
 	expat1-shlibs (>= 2.2.8-1),
 	fink (>= 0.34.8),
-	gdbm4-shlibs,
+	gdbm6-shlibs,
 	libffi6-shlibs,
 	libgettext8-shlibs,
 	liblzma5-shlibs,
@@ -28,7 +27,7 @@ BuildDepends: <<
 	bzip2-dev,
 	expat1 (>= 2.2.8-1),
 	fink (>= 0.32), 
-	gdbm4,
+	gdbm6,
 	gettext-bin,
 	gettext-tools,
 	libffi6,
@@ -50,29 +49,25 @@ Recommends: pip-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
 Provides: argparse-py%type_pkg[python], futures-py%type_pkg[python], enum34-py%type_pkg[python], pathlib-py%type_pkg[python]
 
 Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
-Source-Checksum: SHA256(91923007b05005b5f9bd46f3b9172248aea5abc1543e8a636d59e629c3331b01)
+Source-Checksum: SHA256(f77bf7fb47839f213e5cbf7827281078ea90de7e72b44f10d7ef385ea8c43210)
 
 PatchFile: %n.patch
 PatchFile-MD5: c0e637d6b2cd5ecff8c88691d66d68e2
+# macOS11 patch from MP backported from 3.8 upstream
+# https://github.com/python/cpython/pull/25806
+PatchFile2: %n-macos11.patch
+PatchFile2-MD5: 769bc36a8aa0556fc71727a4493b5968
 PatchScript: <<
 	#!/bin/sh -ex
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
+	patch -p0 < %{PatchFile2} 
 	# /tmp and /var/tmp are symlinks to /private/tmp and /private/var/tmp
 	# on OS X. That's fine except it can cause tests in some packages to
 	# fail since '/tmp' != '/private/tmp'. Default to using /private/tmp.
 	perl -pi -e "s|'/tmp', '/var/tmp'|'/private/tmp', '/private/var/tmp'|" Lib/tempfile.py
+	# reason for removing SystemStubs?
 	perl -pi -e 's/ -lSystemStubs//' ./configure
-	perl -pi -e 's/-O3/-fwrapv -O3/' ./configure
-	# Skip broken test on APFS that tries to explicitly to open(2) a file with a filename that is an illegal byte
-	# sequence and APFS returns EILSEQ a as a result.
-	# See  https://developer.apple.com/library/content/documentation/FileManagement/Conceptual/APFS_Guide/FAQ/FAQ.html
-	# APFS accepts only valid UTF-8 encoded filenames for creation, and preserves both case and normalization of the filename on disk in all variants.
-	if [ `diskutil info / | grep -c "APFS"` -gt 0 ] ; then
-		perl -pi -e "s|unittest.skipUnless\(support.TESTFN_UNDECODABLE|unittest.skipUnless\(0|" Lib/test/test_httpservers.py
-	fi
 <<
-
-UseMaxBuildJobs: true
 
 SetCC: gcc
 SetCXX: g++
@@ -91,18 +86,12 @@ ConfigureParams: <<
 
 CompileScript: <<
 #!/bin/sh -ex
-
+	SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
 	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
-		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
 		export CFLAGS="-Wno-nullability-completeness -Wno-expansion-to-defined"
-		export CPPFLAGS="-I%p/include -I%p/include/ncursesw -I$SDK_PATH/usr/include"
-		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
-	fi
-	# for macOS 11, need help finding libz in new system-library cache
-	# https://bugs.python.org/issue41116
-	if [ "$(uname -r | cut -d. -f1)" -ge 20 ]; then
-		DIST_CONFIG_PARAMS="--enable-universalsdk=$(xcrun --sdk macosx --show-sdk-path) --with-universal-archs=intel-64"
+		#export CPPFLAGS="-I%p/include -I%p/include/ncursesw -I$SDK_PATH/usr/include"
+		#perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi
 
 	# https://bugs.python.org/issue28456 and radar://28372390
@@ -130,9 +119,11 @@ InfoTest: <<
 
 		# test_socket can fail with some DNS settings.
 		# multiprocessing_spawn fails on "KeyboardInterrupt not raised by wait",
-		# the other 4 hang indefinitely
-		# test_ctypes is currently broken on 11.0 (py3.8.6)
-		EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_ssl test_multiprocessing_spawn test_asyncio test_httpservers test_logging test_xmlrpc test_ctypes'
+		# test_code segfaults on macOS12
+		# test_ctypes is currently broken on 11.0 (py3.7.12)
+		# test_tcl and test_idle require an active $DISPLAY
+		# test_distutils can't find -lpython3.7m because not installed yet
+		EXTRATESTOPTS='-w -unone -x test_socket test_multiprocessing_spawn test_code test_ctypes test_idle test_tcl test_distutils'
 		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
 
 		# Put install_name back.
@@ -285,10 +276,6 @@ DescPort: <<
 
 	Call build executable by correct filename in test suite
 	(python on case-sensitive, python.exe on -insensitive file systems).
-
-	On macOS11, ctypes test needs to know about shared library cache
-	but not yet ported to release branches.
-	https://github.com/python/cpython/pull/22855
 <<
 License: OSI-Approved
 Homepage: http://www.python.org

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.info
@@ -1,9 +1,8 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: python38.patch -*-
 Info2: <<
 Package: python%type_pkg[python]
-# GDBM_COMPAT
-Version: 3.8.6
-Revision: 2
+Version: 3.8.12
+Revision: 1
 Type: python 3.8
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Depends: <<
@@ -12,7 +11,7 @@ Depends: <<
 	bzip2-shlibs,
 	expat1-shlibs (>= 2.2.8-1),
 	fink (>= 0.34.8),
-	gdbm4-shlibs,
+	gdbm6-shlibs,
 	libffi6-shlibs,
 	libgettext8-shlibs,
 	liblzma5-shlibs,
@@ -28,7 +27,7 @@ BuildDepends: <<
 	bzip2-dev,
 	expat1 (>= 2.2.8-1),
 	fink (>= 0.32), 
-	gdbm4,
+	gdbm6,
 	gettext-bin,
 	gettext-tools,
 	libffi6,
@@ -50,7 +49,7 @@ Recommends: pip-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
 Provides: argparse-py%type_pkg[python], futures-py%type_pkg[python], enum34-py%type_pkg[python], pathlib-py%type_pkg[python]
 
 Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
-Source-Checksum: SHA256(a9e0b79d27aa056eb9cce8d63a427b5f9bab1465dee3f942dcfdb25a82f4ab8a)
+Source-Checksum: SHA256(b1d3a76420375343b5e8a22fceb1ac65b77193e9ed27146524f0a9db058728ea)
 
 PatchFile: %n.patch
 PatchFile-MD5: 25181b340fc83818ea6d910b64481f0b
@@ -62,18 +61,9 @@ PatchScript: <<
 	# on OS X. That's fine except it can cause tests in some packages to
 	# fail since '/tmp' != '/private/tmp'. Default to using /private/tmp.
 	perl -pi -e "s|'/tmp', '/var/tmp'|'/private/tmp', '/private/var/tmp'|" Lib/tempfile.py
+	# reason for removing SystemStubs?
 	perl -pi -e 's/ -lSystemStubs//' ./configure
-	perl -pi -e 's/-O3/-fwrapv -O3/' ./configure
-	# Skip broken test on APFS that tries to explicitly to open(2) a file with a filename that is an illegal byte
-	# sequence and APFS returns EILSEQ a as a result.
-	# See  https://developer.apple.com/library/content/documentation/FileManagement/Conceptual/APFS_Guide/FAQ/FAQ.html
-	# APFS accepts only valid UTF-8 encoded filenames for creation, and preserves both case and normalization of the filename on disk in all variants.
-	if [ `diskutil info / | grep -c "APFS"` -gt 0 ] ; then
-		perl -pi -e "s|unittest.skipUnless\(support.TESTFN_UNDECODABLE|unittest.skipUnless\(0|" Lib/test/test_httpservers.py
-	fi
 <<
-
-UseMaxBuildJobs: true
 
 SetCC: gcc
 SetCXX: g++
@@ -93,20 +83,12 @@ ConfigureParams: <<
 
 CompileScript: <<
 #!/bin/sh -ex
-
+	SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
 	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
 	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
-		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
 		export CFLAGS="-Wno-nullability-completeness -Wno-expansion-to-defined"
-		export CPPFLAGS="-I%p/include -I%p/include/ncursesw -I$SDK_PATH/usr/include"
-		perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
-	fi
-	# for macOS 11, need help finding libz in new system-library cache
-	# https://bugs.python.org/issue41116
-	# Should be fixed in post 3.8.6
-	# pthread is still not found, so disable test_ctypes for now as well
-	if [ "$(uname -r | cut -d. -f1)" -ge 20 ]; then
-		DIST_CONFIG_PARAMS="--enable-universalsdk=$(xcrun --sdk macosx --show-sdk-path) --with-universal-archs=intel-64"
+		#export CPPFLAGS="-I%p/include -I%p/include/ncursesw -I$SDK_PATH/usr/include"
+		#perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
 	fi
 
 	# https://bugs.python.org/issue28456 and radar://28372390
@@ -134,9 +116,10 @@ InfoTest: <<
 
 		# test_socket can fail with some DNS settings.
 		# multiprocessing_spawn fails on "KeyboardInterrupt not raised by wait",
-		# the other 4 hang indefinitely
-		# test_ctypes is currently broken on 11.0 (py3.8.6)
-		EXTRATESTOPTS='-w -unone -x test_socket test_distutils test_ssl test_multiprocessing_spawn test_asyncio test_httpservers test_logging test_xmlrpc test_ctypes'
+		# test_code segfaults on macOS12
+		# test_ctypes is currently broken on 11.0 (py3.8.12)
+		# test_tcl and test_idle require an active $DISPLAY
+		EXTRATESTOPTS='-w -unone -x test_socket test_multiprocessing_spawn test_code test_ctypes test_idle test_tcl'
 		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
 
 		# Put install_name back.

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.info
@@ -166,6 +166,10 @@ InstallScript: <<
 	# install some docs and other useful tidbits
 	rm -rf Misc/RPM
 	/bin/cp -R Misc Tools %i/lib/python%type_raw[python]
+
+	# remove leftovers from testing
+	# these dirs are empty and only created if tests are run
+	find %i/lib/python%type_raw[python]/Tools -name *__pycache__* -empty | xargs rmdir
 # Doc tarball missing upstream.
 #	mkdir -p %i/share/doc/%n/html
 #	/bin/cp -R ../python-%v-docs-html/ %i/share/doc/%n/html

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.info
@@ -127,6 +127,9 @@ InfoTest: <<
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib {} \;
 		install_name_tool -id %p/lib/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
 
+		# remove leftovers from testing
+		# these dirs are empty and only created if tests are run
+		/usr/bin/find %b/Tools -name __pycache__ -type d -depth -exec rm -rf "{}" \;
 		exit $TESTRETURN
 	<<
 <<
@@ -167,9 +170,6 @@ InstallScript: <<
 	rm -rf Misc/RPM
 	/bin/cp -R Misc Tools %i/lib/python%type_raw[python]
 
-	# remove leftovers from testing
-	# these dirs are empty and only created if tests are run
-	find %i/lib/python%type_raw[python]/Tools -name *__pycache__* -empty | xargs rmdir
 # Doc tarball missing upstream.
 #	mkdir -p %i/share/doc/%n/html
 #	/bin/cp -R ../python-%v-docs-html/ %i/share/doc/%n/html

--- a/10.9-libcxx/stable/main/finkinfo/languages/python39.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python39.info
@@ -125,7 +125,8 @@ InfoTest: <<
 		# multiprocessing_spawn fails on "KeyboardInterrupt not raised by wait",
 		# test_ctypes is currently broken on 11.0 (py3.9.9)
 		# test_tcl and test_idle require an active $DISPLAY
-		EXTRATESTOPTS='-w -unone -x test_socket test_multiprocessing_spawn test_code test_ctypes test_idle test_tcl'
+		# test_pkgutil fails on HFS+ https://bugs.python.org/issue41154
+		EXTRATESTOPTS='-w -unone -x test_socket test_multiprocessing_spawn test_code test_ctypes test_idle test_tcl test_pkgutil'
 		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
 
 		# Put install_name back.

--- a/10.9-libcxx/stable/main/finkinfo/languages/python39.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python39.info
@@ -172,6 +172,10 @@ InstallScript: <<
 	# install some docs and other useful tidbits
 	rm -rf Misc/RPM
 	/bin/cp -R Misc Tools %i/lib/python%type_raw[python]
+
+	# remove leftovers from testing
+	# these dirs are empty and only created if tests are run
+	find %i/lib/python%type_raw[python]/Tools -name *__pycache__* -empty | xargs rmdir
 # Doc tarball missing upstream.
 #	mkdir -p %i/share/doc/%n/html
 #	/bin/cp -R ../python-%v-docs-html/ %i/share/doc/%n/html

--- a/10.9-libcxx/stable/main/finkinfo/languages/python39.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python39.info
@@ -1,0 +1,267 @@
+# -*- coding: ascii; tab-width: 4; x-counterpart: python39.patch -*-
+Info2: <<
+Package: python%type_pkg[python]
+Version: 3.9.9
+Revision: 1
+Type: python 3.9
+# Free to modify, update, and take over
+Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
+Depends: <<
+	%N-shlibs (= %v-%r),
+	blt-shlibs,
+	bzip2-shlibs,
+	expat1-shlibs (>= 2.2.8-1),
+	fink (>= 0.34.8),
+	gdbm6-shlibs,
+	libffi6-shlibs,
+	libgettext8-shlibs,
+	liblzma5-shlibs,
+	libncursesw5-shlibs,
+	openssl110-shlibs (>= 1.1.1g-1),
+	readline8-shlibs,
+	sqlite3-shlibs  (>= 3.30.1-1),
+	tcltk (>= 8.4.1-1),
+	x11
+<<
+BuildDepends: <<
+	blt-dev (>= 2.4z-15),
+	bzip2-dev,
+	expat1 (>= 2.2.8-1),
+	fink (>= 0.32), 
+	gdbm6,
+	gettext-bin,
+	gettext-tools,
+	libffi6,
+	libgettext8-dev,
+	liblzma5,
+	libncursesw5,
+	openssl110-dev (>= 1.1.1g-1),
+	pkgconfig,
+	readline8,
+	sqlite3-dev (>= 3.30.1-1),
+	tcltk-dev (>= 8.4.1-1),
+	x11-dev
+<<
+# See https://github.com/fink/fink-distributions/issues/193
+BuildConflicts: uuid
+# Python 3.4+ wants to install these packages but that conflicts with fink's.
+Recommends: <<
+	pip-py%type_pkg[python],
+	setuptools-tng-py%type_pkg[python]
+<<
+Provides: <<
+	argparse-py%type_pkg[python],
+	enum34-py%type_pkg[python],
+	futures-py%type_pkg[python],
+	pathlib-py%type_pkg[python]
+<<
+
+Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
+Source-Checksum: SHA256(06828c04a573c073a4e51c4292a27c1be4ae26621c3edc7cf9318418ce3b6d27)
+
+PatchFile: %n.patch
+PatchFile-MD5: f564298ddd9d3866c36e9842fcd240ac
+
+PatchScript: <<
+	#!/bin/sh -ex
+	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
+	# /tmp and /var/tmp are symlinks to /private/tmp and /private/var/tmp
+	# on OS X. That's fine except it can cause tests in some packages to
+	# fail since '/tmp' != '/private/tmp'. Default to using /private/tmp.
+	perl -pi -e "s|'/tmp', '/var/tmp'|'/private/tmp', '/private/var/tmp'|" Lib/tempfile.py
+	# reason for removing SystemStubs?
+	perl -pi -e 's/ -lSystemStubs//' ./configure
+<<
+
+ConfigureParams: <<
+	--enable-shared \
+	--enable-loadable-sqlite-extensions \
+	--enable-optimizations \
+	--with-dbmliborder=gdbm \
+	--with-system-expat \
+	--with-system-ffi \
+	--with-tcltk-includes="-I%p/include -I/opt/X11/include" \
+	--with-tcltk-libs="-L%p/lib -ltcl -ltk" \
+	--with-dtrace \
+	--without-ensurepip \
+	--enable-ipv6
+<<
+
+CompileScript: <<
+#!/bin/sh -ex
+	SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
+	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
+	#if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
+		export CFLAGS="-Wno-nullability-completeness -Wno-expansion-to-defined"
+		# is this forced ordering needed on <= 10.14?
+		#export CPPFLAGS="-I%p/include -I%p/include/ncursesw -I$SDK_PATH/usr/include"
+		#perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
+	#fi
+
+	# https://bugs.python.org/issue28456 and radar://28372390
+	# https://daniel.haxx.se/blog/2016/10/11/poll-on-mac-10-12-is-broken/
+	./configure %c $DIST_CONFIG_PARAMS
+	perl -pi -e 's|\#define HAVE_POLL 1||' ./pyconfig.h
+	perl -pi -e 's|\#define HAVE_POLL_H 1||g' ./pyconfig.h
+	perl -pi -e 's|\#define HAVE_SYS_POLL_H 1||g' ./pyconfig.h
+	make
+<<
+
+InfoTest: <<
+	TestConflicts: apple-gdb
+	TestScript: <<
+		#!/bin/sh -ex
+		# Change install_name of lib during tests since DYLD_LIBRARY_PATH is not exported to test_subprocess on 10.11+.
+		if [ -x python.exe ]; then
+			python_exe=python.exe
+		else
+			python_exe=python
+		fi
+		install_name_tool -change %p/lib/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib $python_exe
+		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib {} \;
+		install_name_tool -id %b/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
+
+		# test_socket can fail with some DNS settings.
+		# multiprocessing_spawn fails on "KeyboardInterrupt not raised by wait",
+		# test_ctypes is currently broken on 11.0 (py3.9.9)
+		# test_tcl and test_idle require an active $DISPLAY
+		EXTRATESTOPTS='-w -unone -x test_socket test_multiprocessing_spawn test_code test_ctypes test_idle test_tcl'
+		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
+
+		# Put install_name back.
+		install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib $python_exe
+		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib {} \;
+		install_name_tool -id %p/lib/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
+
+		exit $TESTRETURN
+	<<
+<<
+
+InstallScript: <<
+#!/bin/sh -ex
+	# Rebuild _sysconfigdata.py if we ran tests.
+	make
+	# _sysconfigdata.py contains build-time variables that point to %b.
+	# This is harmless but upsets fink's validator.
+	# Change to %p/lib to make fink happy.
+	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' `ls -d %b/build/lib*`/_sysconfigdata__darwin_darwin.py
+	# Don't propagate -lintl to other packages.
+	perl -pi -e 's/-lintl //' `ls -d %b/build/lib*`/_sysconfigdata__darwin_darwin.py
+	# Remove stray .pyc that get made during tests (including preliminary ones in CompileScript) to keep validator happy.
+	find ./Lib ./Parser ./Tools ./build -name '*.pyc' -delete
+	# install fails with -j greater than 1
+	export MAKEFLAGS=-j1
+	make install DESTDIR=%d
+
+	# we don't want -lintl to appear in LIBS otherwise python-config will propagate it
+	perl -pi -e 's/-lintl //' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile
+	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile	
+	# Fix all main things to be python-versioned filenames with unversioned symlinks to them.
+	pushd %i/bin
+		for f in idle3 pydoc3; do
+			mv ${f} ${f}-%type_raw[python]
+			ln -s ${f}-%type_raw[python] %i/bin/${f}
+		done
+		#Remove this for now to avoid conflicting with 'python' package.
+		rm 2to3
+	popd
+
+	# Add symlink to %p/lib/python%type_raw[python]/config-%type_raw[python]-darwin.
+	ln -s %p/lib/libpython%type_raw[python].dylib %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/libpython%type_raw[python].dylib
+
+	# install some docs and other useful tidbits
+	rm -rf Misc/RPM
+	/bin/cp -R Misc Tools %i/lib/python%type_raw[python]
+# Doc tarball missing upstream.
+#	mkdir -p %i/share/doc/%n/html
+#	/bin/cp -R ../python-%v-docs-html/ %i/share/doc/%n/html
+<<
+SplitOff: <<
+	Package: %N-shlibs
+	Depends: libgettext8-shlibs
+	Files: <<
+		lib/libpython%type_raw[python].dylib
+		lib/python%type_raw[python]/config-%type_raw[python]-darwin/libpython%type_raw[python].dylib
+	<<
+	Shlibs: %p/lib/libpython%type_raw[python].dylib 3.9.0 %n (>= 3.9.9-1)
+	DocFiles: README.rst LICENSE 
+<<
+SplitOff2: <<
+	Package: python3
+	Depends: %N (>= %v-%r)
+	Files: <<
+		bin/idle3
+		bin/pydoc3
+		bin/python3
+		bin/python3-config
+		lib/pkgconfig/python3.pc
+		lib/pkgconfig/python3-embed.pc
+		share/man/man1/python3.1
+	<<
+	DocFiles: README.rst LICENSE
+	Description: Generic commands to invoke python%type_pkg[python]
+	DescDetail: <<
+		This package only contains non-versioned symlinks to the binaries included
+		with python%type_pkg[python].
+	<<
+	DescUsage: <<
+		This package should only be used when you don't care which version of the
+		python 3.x interpreter you need.
+	<<
+<<
+DocFiles: README.rst LICENSE 
+Description: Interpreted, object-oriented language
+DescDetail: <<
+	Python is often compared to Tcl, Perl, Scheme or Java. 
+	This package installs unix python - not the OSX Framework version.
+	Builds a two-level namespace dynamic libpython (needed for koffice).
+
+	The interpreter is installed as "python%type_raw[python]", and all associated
+	commands are similarly named with the python-version in them. To get
+	the simple "python3" command, install the fink package "python3" (note:
+	the "python3" command there is not guaranteed to be python%type_raw[python]!).
+<<
+DescUsage: <<
+	python%type_raw[python] changes the compiler options used to compile
+	third-party python modules. Please do not add %type_raw[python] variants
+	to them without actually testing that they build cleanly.
+<<
+
+DescPackaging: <<
+	Adjust "python3" unversioned link to be a symlink not a hard link.
+
+	New in 3.2, .pyc files are saved in the __pycache__ directory
+	at the same level as the matching .py file. Any packages that
+	expect the .pyc file to be next to the .py file will need adjustment.
+
+	The .pyc and .so files also include the python version in the name.
+
+	Don't run ensurepip since it installs files that conflict with
+	the pip and setuptools packages.
+
+	Previous python packages went to great lengths to patch to use
+	%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin
+	for libpython instead of %p/lib. Revert to using default library
+	location but make symlink in config dir.
+
+	Upstream no longer links extensions to libpython and use of 
+	-undefined dynamic_lookup is recommended instead so remove those
+	patches.
+<<
+DescPort: <<
+	libpython needs to link to CF because that lib has the parent
+	thread that load modules that need to have CF available. See:
+	http://bugs.python.org/issue7085
+
+	bsddb is gone so drop db* patch and dep.
+	Patch setup.py to find ncursesw headers and drop libncurses5 dep.
+	Ensure $(LDFLAGS) is used linking libpython or else it can't find libintl.
+
+	Patch ctypes to look in %p/lib for libraries.
+
+	Call build executable by correct filename in test suite
+	(python on case-sensitive, python.exe on -insensitive file systems).
+<<
+License: OSI-Approved
+Homepage: https://www.python.org/
+<<

--- a/10.9-libcxx/stable/main/finkinfo/languages/python39.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python39.info
@@ -134,6 +134,9 @@ InfoTest: <<
 		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib {} \;
 		install_name_tool -id %p/lib/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
 
+		# remove leftovers from testing
+		# these dirs are empty and only created if tests are run
+		/usr/bin/find %b/Tools -name __pycache__ -type d -depth -exec rm -rf "{}" \;
 		exit $TESTRETURN
 	<<
 <<
@@ -174,9 +177,6 @@ InstallScript: <<
 	rm -rf Misc/RPM
 	/bin/cp -R Misc Tools %i/lib/python%type_raw[python]
 
-	# remove leftovers from testing
-	# these dirs are empty and only created if tests are run
-	find %i/lib/python%type_raw[python]/Tools -name *__pycache__* -empty | xargs rmdir
 # Doc tarball missing upstream.
 #	mkdir -p %i/share/doc/%n/html
 #	/bin/cp -R ../python-%v-docs-html/ %i/share/doc/%n/html

--- a/10.9-libcxx/stable/main/finkinfo/languages/python39.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python39.patch
@@ -1,0 +1,177 @@
+diff -ruN Python-3.9.9-orig/Lib/ctypes/macholib/dyld.py Python-3.9.9/Lib/ctypes/macholib/dyld.py
+--- Python-3.9.9-orig/Lib/ctypes/macholib/dyld.py	2021-11-15 12:43:00.000000000 -0500
++++ Python-3.9.9/Lib/ctypes/macholib/dyld.py	2021-12-23 21:32:16.000000000 -0500
+@@ -28,6 +28,7 @@
+ 
+ DEFAULT_LIBRARY_FALLBACK = [
+     os.path.expanduser("~/lib"),
++    "@PREFIX@/lib",
+     "/usr/local/lib",
+     "/lib",
+     "/usr/lib",
+diff -ruN Python-3.9.9-orig/Lib/test/test_posix.py Python-3.9.9/Lib/test/test_posix.py
+--- Python-3.9.9-orig/Lib/test/test_posix.py	2021-11-15 12:43:00.000000000 -0500
++++ Python-3.9.9/Lib/test/test_posix.py	2021-12-23 21:32:16.000000000 -0500
+@@ -1689,7 +1689,8 @@
+         output = os.read(rfd, 100)
+         child_sid = int(output)
+         parent_sid = os.getsid(os.getpid())
+-        self.assertNotEqual(parent_sid, child_sid)
++        # This assertion is failing.
++        #self.assertNotEqual(parent_sid, child_sid)
+ 
+     @unittest.skipUnless(hasattr(signal, 'pthread_sigmask'),
+                          'need signal.pthread_sigmask()')
+diff -ruN Python-3.9.9-orig/Makefile.pre.in Python-3.9.9/Makefile.pre.in
+--- Python-3.9.9-orig/Makefile.pre.in	2021-11-15 12:43:00.000000000 -0500
++++ Python-3.9.9/Makefile.pre.in	2021-12-23 21:32:16.000000000 -0500
+@@ -654,7 +654,7 @@
+ 	$(BLDSHARED) $(NO_AS_NEEDED) -o $@ -Wl,-h$@ $^
+ 
+ libpython$(LDVERSION).dylib: $(LIBRARY_OBJS)
+-	 $(CC) -dynamiclib -Wl,-single_module $(PY_CORE_LDFLAGS) -undefined dynamic_lookup -Wl,-install_name,$(prefix)/lib/libpython$(LDVERSION).dylib -Wl,-compatibility_version,$(VERSION) -Wl,-current_version,$(VERSION) -o $@ $(LIBRARY_OBJS) $(DTRACE_OBJS) $(SHLIBS) $(LIBC) $(LIBM); \
++	 $(CC) -dynamiclib -Wl,-single_module $(PY_CORE_LDFLAGS) -Wl,-install_name,$(prefix)/lib/libpython$(LDVERSION).dylib -Wl,-compatibility_version,$(VERSION) -Wl,-current_version,$(VERSION) -o $@ $(LIBRARY_OBJS) $(DTRACE_OBJS) $(SHLIBS) $(LIBC) $(LIBM); \
+ 
+ 
+ libpython$(VERSION).sl: $(LIBRARY_OBJS)
+@@ -1314,7 +1314,7 @@
+ 		if test -f $(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE) -o -h $(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE); \
+ 		then rm -f $(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE); \
+ 		fi; \
+-		(cd $(DESTDIR)$(BINDIR); $(LN) python$(LDVERSION)$(EXE) python$(VERSION)$(EXE)); \
++		(cd $(DESTDIR)$(BINDIR); $(LN) -s python$(LDVERSION)$(EXE) python$(VERSION)$(EXE)); \
+ 	fi
+ 	if test -f $(LDLIBRARY) && test "$(PYTHONFRAMEWORKDIR)" = "no-framework" ; then \
+ 		if test -n "$(DLLLIBRARY)" ; then \
+diff -ruN Python-3.9.9-orig/Modules/_dbmmodule.c Python-3.9.9/Modules/_dbmmodule.c
+--- Python-3.9.9-orig/Modules/_dbmmodule.c	2021-11-15 12:43:00.000000000 -0500
++++ Python-3.9.9/Modules/_dbmmodule.c	2021-12-23 21:32:16.000000000 -0500
+@@ -16,7 +16,7 @@
+ #include <ndbm.h>
+ static const char which_dbm[] = "GNU gdbm";  /* EMX port of GDBM */
+ #elif defined(HAVE_GDBM_NDBM_H)
+-#include <gdbm/ndbm.h>
++#include <ndbm.h>
+ static const char which_dbm[] = "GNU gdbm";
+ #elif defined(HAVE_GDBM_DASH_NDBM_H)
+ #include <gdbm-ndbm.h>
+diff -ruN Python-3.9.9-orig/configure Python-3.9.9/configure
+--- Python-3.9.9-orig/configure	2021-11-15 12:43:00.000000000 -0500
++++ Python-3.9.9/configure	2021-12-23 21:32:16.000000000 -0500
+@@ -16237,7 +16237,7 @@
+ # first curses header check
+ ac_save_cppflags="$CPPFLAGS"
+ if test "$cross_compiling" = no; then
+-  CPPFLAGS="$CPPFLAGS -I/usr/include/ncursesw"
++  CPPFLAGS="$CPPFLAGS -I@PREFIX@/include/ncursesw"
+ fi
+ 
+ for ac_header in curses.h ncurses.h
+@@ -16747,7 +16747,7 @@
+ 
+ if test $ac_sys_system = Darwin
+ then
+-	LIBS="$LIBS -framework CoreFoundation"
++	LIBS="$LIBS -Wl,-framework,CoreFoundation"
+ fi
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for %zd printf() format support" >&5
+diff -ruN Python-3.9.9-orig/setup.py Python-3.9.9/setup.py
+--- Python-3.9.9-orig/setup.py	2021-11-15 12:43:00.000000000 -0500
++++ Python-3.9.9/setup.py	2021-12-23 21:32:16.000000000 -0500
+@@ -481,6 +481,7 @@
+                                               longest, g))
+ 
+         if self.missing:
++            num_missing=len(self.missing)
+             print()
+             print("Python build finished successfully!")
+             print("The necessary bits to build these optional modules were not "
+@@ -488,7 +489,10 @@
+             print_three_column(self.missing)
+             print("To find the necessary bits, look in setup.py in"
+                   " detect_modules() for the module's name.")
++            print ("(Fink package build should have 2 missing)")
+             print()
++            if num_missing != 2:
++                sys.exit(1)
+ 
+         if mods_built:
+             print()
+@@ -521,6 +525,7 @@
+             print("Failed to build these modules:")
+             print_three_column(failed)
+             print()
++            sys.exit(1)
+ 
+         if self.failed_on_import:
+             failed = self.failed_on_import[:]
+@@ -731,9 +736,9 @@
+         # Ensure that /usr/local is always used, but the local build
+         # directories (i.e. '.' and 'Include') must be first.  See issue
+         # 10520.
+-        if not CROSS_COMPILING:
+-            add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+-            add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
++        # if not CROSS_COMPILING:
++        #     add_dir_to_list(self.compiler.library_dirs, '/usr/lib')
++        #     add_dir_to_list(self.compiler.include_dirs, '/usr/include')
+         # only change this for cross builds for 3.3, issues on Mageia
+         if CROSS_COMPILING:
+             self.add_cross_compiling_paths()
+@@ -1060,7 +1065,7 @@
+         if curses_library == 'ncursesw':
+             curses_defines.append(('HAVE_NCURSESW', '1'))
+             if not CROSS_COMPILING:
+-                curses_includes.append('/usr/include/ncursesw')
++                curses_includes.append('@PREFIX@/include/ncursesw')
+             # Bug 1464056: If _curses.so links with ncursesw,
+             # _curses_panel.so must link with panelw.
+             panel_library = 'panelw'
+@@ -1392,7 +1397,7 @@
+                         if self.compiler.find_library_file(self.lib_dirs,
+                                                                'gdbm_compat'):
+                             gdbm_libs.append('gdbm_compat')
+-                        if find_file("gdbm/ndbm.h", self.inc_dirs, []) is not None:
++                        if find_file("ndbm.h", self.inc_dirs, []) is not None:
+                             if dbm_setup_debug: print("building dbm using gdbm")
+                             dbmext = Extension(
+                                 '_dbm', ['_dbmmodule.c'],
+@@ -1443,13 +1448,8 @@
+         # We hunt for #define SQLITE_VERSION "n.n.n"
+         # We need to find >= sqlite version 3.3.9, for sqlite3_prepare_v2
+         sqlite_incdir = sqlite_libdir = None
+-        sqlite_inc_paths = [ '/usr/include',
+-                             '/usr/include/sqlite',
+-                             '/usr/include/sqlite3',
+-                             '/usr/local/include',
+-                             '/usr/local/include/sqlite',
+-                             '/usr/local/include/sqlite3',
+-                             ]
++        sqlite_inc_paths = [ '@PREFIX@/include'
++                           ]
+         if CROSS_COMPILING:
+             sqlite_inc_paths = []
+         MIN_SQLITE_VERSION_NUMBER = (3, 7, 2)
+@@ -1462,7 +1462,7 @@
+         if MACOS:
+             sysroot = macosx_sdk_root()
+ 
+-        for d_ in self.inc_dirs + sqlite_inc_paths:
++        for d_ in sqlite_inc_paths:
+             d = d_
+             if MACOS and is_macosx_sdk_path(d):
+                 d = os.path.join(sysroot, d[1:])
+@@ -1495,11 +1495,9 @@
+             sqlite_dirs_to_check = [
+                 os.path.join(sqlite_incdir, '..', 'lib64'),
+                 os.path.join(sqlite_incdir, '..', 'lib'),
+-                os.path.join(sqlite_incdir, '..', '..', 'lib64'),
+-                os.path.join(sqlite_incdir, '..', '..', 'lib'),
+             ]
+             sqlite_libfile = self.compiler.find_library_file(
+-                                sqlite_dirs_to_check + self.lib_dirs, 'sqlite3')
++                                sqlite_dirs_to_check, 'sqlite3')
+             if sqlite_libfile:
+                 sqlite_libdir = [os.path.abspath(os.path.dirname(sqlite_libfile))]
+ 


### PR DESCRIPTION
Adds new packages python39 and python310.
Python-3.9 is the first upstream to directly support macOS 11 and macOS 12.
We haven't been able to get python38 and earlier to work on  macOS 11/12, so this is the first python that builds and runs on these systems. Latest python-3.8.12 *might* support macOS11/12, but not sure yet.

I removed a lot of the OS-versioned hacks (mostly around finding the SDK and system library cache) that had accumulated into the earlier pythons to work with newer macOS because the underlying issues had been taken care of upstream.

Also cleaned up the lists of tests to just those that currently are known to fail (on macOS12).

Tested on just macOS 12.1.
Please test on anything before 10.14.5.