### PR TITLE
libaprutil.0: explicitly link to libapr and libaprutil to resolve und…

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libaprutil.0-mysql.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libaprutil.0-mysql.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: libaprutil.0-shlibs.patch -*-
 Package: libaprutil.0-mysql
 Version: 1.6.1
-Revision: 4
+Revision: 5
 
 Depends: <<
 	libaprutil.0-shlibs (>= %v-4),
@@ -12,6 +12,7 @@ Depends: <<
 BuildDepends: <<
 	db60-aes,
 	expat1,
+	fink (>= 0.30.0),
 	fink-package-precedence,
 	gdbm6,
 	libapr.0-dev (>= 1.7.0-1),
@@ -30,6 +31,8 @@ Source-MD5: 8ff5dc36fa39a2a3db1df196d3ed6086
 
 PatchFile: libaprutil.0-shlibs.patch
 PatchFile-MD5: eb4274f2998a4146164237056265fa6e
+PatchFile2: libaprutil.0-shlibs-macos12.patch
+PatchFile2-MD5: 5ee7a42deddbb9b8c1cacbd8ba1f3979
 PatchScript: <<
   ### Fix layout
   perl -pi -e 's,/usr/local,%p,g' config.layout

--- a/10.9-libcxx/stable/main/finkinfo/libs/libaprutil.0-odbc.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libaprutil.0-odbc.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: libaprutil.0-shlibs.patch -*-
 Package: libaprutil.0-odbc
 Version: 1.6.1
-Revision: 4
+Revision: 5
 
 Depends: <<
 	libaprutil.0-shlibs (>= %v-4),
@@ -12,6 +12,7 @@ Depends: <<
 BuildDepends: <<
 	db60-aes,
 	expat1,
+	fink (>= 0.30.0),
 	fink-package-precedence,
 	gdbm6,
 	libapr.0-dev (>= 1.7.0-1),
@@ -30,6 +31,8 @@ Source-MD5: 8ff5dc36fa39a2a3db1df196d3ed6086
 
 PatchFile: libaprutil.0-shlibs.patch
 PatchFile-MD5: eb4274f2998a4146164237056265fa6e
+PatchFile2: libaprutil.0-shlibs-macos12.patch
+PatchFile2-MD5: 5ee7a42deddbb9b8c1cacbd8ba1f3979
 PatchScript: <<
   ### Fix layout
   perl -pi -e 's,/usr/local,%p,g' config.layout

--- a/10.9-libcxx/stable/main/finkinfo/libs/libaprutil.0-postgresql.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libaprutil.0-postgresql.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: libaprutil.0-shlibs.patch -*-
 Package: libaprutil.0-postgresql
 Version: 1.6.1
-Revision: 4
+Revision: 5
 
 Depends: <<
 	libaprutil.0-shlibs (>= %v-4),
@@ -12,6 +12,7 @@ Depends: <<
 BuildDepends: <<
 	db60-aes,
 	expat1,
+	fink (>= 0.30.0),
 	fink-package-precedence,
 	gdbm6,
 	libapr.0-dev (>= 1.7.0-1),
@@ -30,6 +31,8 @@ Source-MD5: 8ff5dc36fa39a2a3db1df196d3ed6086
 
 PatchFile: libaprutil.0-shlibs.patch
 PatchFile-MD5: eb4274f2998a4146164237056265fa6e
+PatchFile2: libaprutil.0-shlibs-macos12.patch
+PatchFile2-MD5: 5ee7a42deddbb9b8c1cacbd8ba1f3979
 PatchScript: <<
   ### Fix layout
   perl -pi -e 's,/usr/local,%p,g' config.layout

--- a/10.9-libcxx/stable/main/finkinfo/libs/libaprutil.0-shlibs-macos12.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libaprutil.0-shlibs-macos12.patch
@@ -1,0 +1,31 @@
+diff -ruN apr-util-1.6.1-orig/Makefile.in apr-util-1.6.1/Makefile.in
+--- apr-util-1.6.1-orig/Makefile.in	2017-04-02 13:57:23.000000000 -0400
++++ apr-util-1.6.1/Makefile.in	2021-12-30 21:40:03.000000000 -0500
+@@ -30,19 +30,19 @@
+ 
+ EXTRA_OBJECTS = @EXTRA_OBJECTS@
+ 
+-LDADD_dbd_pgsql = @LDADD_dbd_pgsql@
++LDADD_dbd_pgsql = @LDADD_dbd_pgsql@ -lapr -laprutil
+ LDADD_dbd_oracle = @LDADD_dbd_oracle@
+ LDADD_dbd_sqlite2 = @LDADD_dbd_sqlite2@
+-LDADD_dbd_sqlite3 = @LDADD_dbd_sqlite3@
+-LDADD_dbd_mysql = @LDADD_dbd_mysql@
+-LDADD_dbd_odbc = @LDADD_dbd_odbc@
+-LDADD_dbm_db = @LDADD_dbm_db@
+-LDADD_dbm_gdbm = @LDADD_dbm_gdbm@
++LDADD_dbd_sqlite3 = @LDADD_dbd_sqlite3@ -lapr -laprutil
++LDADD_dbd_mysql = @LDADD_dbd_mysql@ -lapr -laprutil
++LDADD_dbd_odbc = @LDADD_dbd_odbc@ -lapr -laprutil
++LDADD_dbm_db = @LDADD_dbm_db@ -lapr libaprutil.la
++LDADD_dbm_gdbm = @LDADD_dbm_gdbm@ -lapr libaprutil.la
+ LDADD_dbm_ndbm = @LDADD_dbm_ndbm@
+-LDADD_ldap = @LDADD_ldap@
++LDADD_ldap = @LDADD_ldap@ -lapr
+ LDADD_crypto_openssl = @LDADD_crypto_openssl@
+ LDADD_crypto_nss = @LDADD_crypto_nss@
+-LDADD_crypto_commoncrypto = @LDADD_crypto_commoncrypto@
++LDADD_crypto_commoncrypto = @LDADD_crypto_commoncrypto@ -lapr libaprutil.la
+ 
+ TARGETS = $(TARGET_LIB) aprutil.exp apu-config.out $(APU_MODULES)
+ 

--- a/10.9-libcxx/stable/main/finkinfo/libs/libaprutil.0-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libaprutil.0-shlibs.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: libaprutil.0-shlibs.patch -*-
 Package: libaprutil.0-shlibs
 Version: 1.6.1
-Revision: 4
+Revision: 5
 # other libaprutil.0-* need to keep in sync with %v (shared tarball)
 
 Depends: <<
@@ -16,6 +16,7 @@ Depends: <<
 BuildDepends: <<
 	db60-aes,
 	expat1,
+	fink (>= 0.30.0),
 	fink-package-precedence,
 	gdbm6,
 	libapr.0-dev (>= 1.7.0-1),
@@ -35,6 +36,8 @@ Source-MD5: 8ff5dc36fa39a2a3db1df196d3ed6086
 
 PatchFile: %n.patch
 PatchFile-MD5: eb4274f2998a4146164237056265fa6e
+PatchFile2: %n-macos12.patch
+PatchFile2-MD5: 5ee7a42deddbb9b8c1cacbd8ba1f3979
 PatchScript: <<
   ### Fix layout
   perl -pi -e 's,/usr/local,%p,g' config.layout

--- a/10.9-libcxx/stable/main/finkinfo/libs/libaprutil.0-sqlite3.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libaprutil.0-sqlite3.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: libaprutil.0-shlibs.patch -*-
 Package: libaprutil.0-sqlite3
 Version: 1.6.1
-Revision: 4
+Revision: 5
 
 Depends: <<
 	libaprutil.0-shlibs (>= %v-4),
@@ -12,6 +12,7 @@ Depends: <<
 BuildDepends: <<
 	db60-aes,
 	expat1,
+	fink (>= 0.30.0),
 	fink-package-precedence,
 	gdbm6,
 	libapr.0-dev (>= 1.7.0-1),
@@ -30,6 +31,8 @@ Source-MD5: 8ff5dc36fa39a2a3db1df196d3ed6086
 
 PatchFile: libaprutil.0-shlibs.patch
 PatchFile-MD5: eb4274f2998a4146164237056265fa6e
+PatchFile2: libaprutil.0-shlibs-macos12.patch
+PatchFile2-MD5: 5ee7a42deddbb9b8c1cacbd8ba1f3979
 PatchScript: <<
   ### Fix layout
   perl -pi -e 's,/usr/local,%p,g' config.layout


### PR DESCRIPTION
…efined symbols in the database drivers

On macOS12, building aprutil.0 and it's various database drivers fails with missing symbols from libapr.dylib and libaprutil.dylib.
The system uses a partly homebuilt autoconf setup, so need to patch directly.

The current solution is to add `-lapr -laprutil` to the LDADD flags for the various database drivers. For the database drivers included in the base package (commoncrypto, dbm_db, dbm_gdbm), I used the .la file from the in source build.

I don't know how this worked in earlier macOS releases. Perhaps there was some level of implicit dynamic lookup (there's no such explicit flag in the code that I can see).

Do these packages build on 10.14 or earlier after the patch?