### PR TITLE
opensp5-shlibs: BuildDep

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/text/opensp5-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/opensp5-shlibs.info
@@ -17,7 +17,7 @@ PatchScript: <<
 <<
 BuildDepends: <<
 	autoconf2.6,
-	automake1.15 | automake1.14,
+	automake1.14,
 	fink (>= 0.30.0),
 	fink-package-precedence,
 	gettext-bin (>= 0.14.5-1),


### PR DESCRIPTION
It seems opensp5-shlibs requires automake1.14, not automake1.15.

See [my build log](http://babayoshihiko.ddns.net/fink-build-log/fink-opensp5-shlibs-build.log).