### PR TITLE
Update openblas to 0.3.19 and build with gcc11

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
@@ -1,9 +1,9 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: openblas
-Version: 0.3.10
+Version: 0.3.19
 Revision: 1
-Type: gcc (10)
+Type: gcc (11)
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
 
 BuildDependsOnly: true
@@ -11,10 +11,10 @@ BuildDepends: fink (>= 0.30.0), gcc%type_raw[gcc]-compiler
 Depends: %N-shlibs (= %v-%r)
 
 Source: https://github.com/xianyi/OpenBLAS/archive/v%v.tar.gz
-Source-MD5: 4727a1333a380b67c8d7c7787a3d9c9a
+Source-Checksum: SHA256(947f51bfe50c2a0749304fbe373e00e7637600b0a47b78a51382aeb30ca08562)
 SourceRename: OpenBLAS-%v.tar.gz
 PatchFile: %n.patch
-PatchFile-MD5: 38268179357f21681e208c3467e6869c
+PatchFile-MD5: e9d16e8a2772758bbd37e29e3c25c0f8
 
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 
@@ -23,6 +23,8 @@ SetCC: gcc-fsf-%type_raw[gcc]
 CompileScript: <<
 	#!/bin/sh -ev
 	perl -pi -e 's|(^# )(DYNAMIC_ARCH = 1)|$2|;' Makefile.rule
+	# remove excessive truncating of $hostarch https://github.com/xianyi/OpenBLAS/commit/00ce353
+	perl -pi -e 's|;chop..hostarch.;|;|' c_check
 	# set arch to minimum model supported in OS version
 	darwin_vers=$(uname -r | cut -d. -f1)
 	if [ "$darwin_vers" -ge 18 ]; then
@@ -35,11 +37,15 @@ CompileScript: <<
 	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 libs netlib shared
 	cd benchmark
 	mkdir -m 755 bin
-	# 6 tests require clock_gettime, disable if missing (on 10.11)
+	mv Makefile Makefile.orig
+	# 6 tests require clock_gettime, disable if missing (on 10.11); *axpby seems not provided by (some) Accelerate versions
 	if [ "$darwin_vers" -lt 16 ]; then
-		mv Makefile Makefile.orig
 		egrep -v 'saxpy.*daxpy.*.caxpy\.|scopy.*dcopy.*ccopy\.|st[pr][ms]v.*dt[pr][ms]v.*ct[pr][ms]v\.' Makefile.orig > Makefile
+	else
+		egrep -v 'saxpy\.veclib.*daxpy\.veclib.*.caxpy\.veclib' Makefile.orig > Makefile
 	fi
+	# For some reason #define RETURN_BY_STACK 1 is not properly recognised in zdot-intel.c...
+	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp LIBSUFFIX=dylib CFLAGS+=-DRETURN_BY_STACK=1 {c,z}dot-intel.o
 	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp LIBSUFFIX=dylib veclib goto smallscaling
 	for x in smallscaling *.goto; do
 		install_name_tool -change %b/exports/../libopenblas.0.dylib %p/lib/libopenblas.0.dylib $x
@@ -58,7 +64,7 @@ InfoTest: <<
 	TestScript: <<
 		#!/bin/sh -ev
 		make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 tests | tee tests.log
-		grep -i fail tests.log
+		grep -il fail tests.log && grep -i fail tests.log
 		grep -c PASSED tests.log
 		cd benchmark
 		make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp atlas

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
@@ -1,7 +1,7 @@
 diff -uNr a/Makefile.system b/Makefile.system
 --- a/Makefile.system	2020-02-09 23:16:28.000000000 +0100
 +++ b/Makefile.system	2020-02-20 18:06:14.000000000 +0100
-@@ -490,8 +490,10 @@
+@@ -550,8 +550,10 @@
  endif
  
  ifeq ($(C_COMPILER), CLANG)
@@ -12,7 +12,7 @@ diff -uNr a/Makefile.system b/Makefile.system
  
  ifeq ($(C_COMPILER), INTEL)
  CCOMMON_OPT    += -fopenmp
-@@ -1258,8 +1260,8 @@
+@@ -1438,8 +1440,8 @@
  endif
 
 
@@ -22,7 +22,7 @@ diff -uNr a/Makefile.system b/Makefile.system
 
  ifeq ($(DEBUG), 1)
  COMMON_OPT += -g
-@@ -1328,19 +1330,19 @@
+@@ -1512,19 +1514,19 @@
  
  ifneq ($(DYNAMIC_ARCH), 1)
  ifndef SMP
@@ -126,7 +126,7 @@ diff -uNr a/benchmark/smallscaling.c b/benchmark/smallscaling.c
 diff -uNr a/Makefile b/Makefile
 --- a/Makefile		2019-08-11 23:23:27.000000000 +0100
 +++ b/Makefile		2019-11-06 19:18:15.000000000 +0100
-@@ -124,8 +124,10 @@
+@@ -130,8 +130,10 @@
  ifeq ($(OSNAME), Darwin)
 	@$(MAKE) -C exports dyn
 	@ln -fs $(LIBDYNNAME) $(LIBPREFIX).dylib
@@ -140,7 +140,7 @@ diff -uNr a/Makefile b/Makefile
 diff -uNr a/Makefile.install b/Makefile.install
 --- a/Makefile.install	2019-08-11 23:23:27.000000000 +0100
 +++ b/Makefile.install	2019-11-06 2019-11-06 20:13:02.000000000 +0100
-@@ -84,8 +84,7 @@
+@@ -107,8 +107,7 @@
 	@-cp $(LIBDYNNAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
 	@-install_name_tool -id "$(OPENBLAS_LIBRARY_DIR)/$(LIBPREFIX).$(MAJOR_VERSION).dylib" "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)/$(LIBDYNNAME)"
 	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \


### PR DESCRIPTION
Current upstream release; tested to build with gcc11 on 10.13 and 10.14 – don't know if it needs to be versioned for others.