### PR TITLE
octave-3.8.2 gcc11 + lapack3 upgrade and openblas

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/arpack-ng.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/arpack-ng.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: arpack-ng%type_pkg[-mpi]%type_pkg[-blas]
 Version: 3.8.0
 Revision: 1
-Type: -blas (-atlas -ref .), gcc (11), -mpi (. -mpi)
+Type: -blas (-atlas -openblas -ref .), gcc (11), -mpi (. -mpi)
 
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Description: Solve large scale eigenvalue problems
@@ -11,16 +11,16 @@ ARPACK is a collection of Fortran77 subroutines designed to solve large scale
 eigenvalue problems.  It began at Rice university:
 http://www.caam.rice.edu/software/ARPACK
 
-The arpack-ng project is a joint project between Debian, Octave and Scilab in 
+The arpack-ng project is a joint project between Debian, Octave and Scilab in
 order to provide a common and maintained version of arpack.
 
-Because no single release has been published by Rice university for the last 
-decade and since many software packages (Octave, Scilab, R, Matlab...) have 
-forked it and implemented their own modifications, arpack-ng aims to tackle 
+Because no single release has been published by Rice university for the last
+decade and since many software packages (Octave, Scilab, R, Matlab...) have
+forked it and implemented their own modifications, arpack-ng aims to tackle
 this issue by providing a common repository and maintained version.
 <<
 DescUsage: <<
-This package contains static libraries, an unversioned dylib, Fortran 
+This package contains static libraries, an unversioned dylib, Fortran
 examples, and documentation.
 <<
 
@@ -38,6 +38,7 @@ BuildDepends: <<
 	autoconf2.6,
 	automake1.15,
 	(%type_raw[-blas] = -atlas) atlas (>= 3.10.2-5),
+	(%type_raw[-blas] = -openblas) openblas,
 	(%type_raw[-blas] = -ref) lapack3,
 	gcc%type_pkg[gcc]-compiler,
 	libtool2,
@@ -47,23 +48,30 @@ BuildDepends: <<
 <<
 Depends: %N-shlibs (= %v-%r )
 Conflicts: <<
-	%{Ni}, 
-	%{Ni}-atlas, 
+	%{Ni},
+	%{Ni}-atlas,
+	%{Ni}-openblas,
 	%{Ni}-ref,
-	%{Ni}-mpi, 
-	%{Ni}-mpi-atlas, 
+	%{Ni}-mpi,
+	%{Ni}-mpi-atlas,
+	%{Ni}-mpi-openblas,
 	%{Ni}-mpi-ref,
-	arpack, 
+	arpack,
 	arpack-atlas
 <<
 Replaces: <<
-	%{Ni}, 
-	%{Ni}-atlas, 
-	%{Ni}-ref, 
-	%{Ni}-mpi, 
-	%{Ni}-mpi-atlas, 
-	%{Ni}-mpi-ref, 
-	arpack, 
+	%{Ni},
+	%{Ni}-atlas,
+	%{Ni}-openblas,
+	%{Ni}-ref,
+	%{Ni}-mpi,
+	%{Ni}-mpi-atlas,
+	%{Ni}-mpi-openblas,
+	%{Ni}-ref,
+	%{Ni}-mpi,
+	%{Ni}-mpi-atlas,
+	%{Ni}-mpi-ref,
+	arpack,
 	arpack-atlas
 <<
 
@@ -73,6 +81,7 @@ PatchScript: <<
 	case "%type_raw[-blas]" in
 		-ref) subst="s|-lblas -latlas|-L%p/lib/lapack -lrefblas -lreflapack|" ;;
 		-atlas) subst="s/-lblas -latlas/-ltatlas/" ;;
+		-openblas) subst="s/-lblas -latlas/-lopenblas/" ;;
 		*) subst="s/-lblas -latlas/-Wl,framework,Accelerate/" ;;
 	esac
 	perl -pi -e "$subst" SRC/arpack.pc.in
@@ -84,6 +93,8 @@ ConfigureParams: <<
 	(%type_raw[-blas] = .) --with-lapack='-Wl,-framework,Accelerate' \
 	(%type_raw[-blas] = -atlas) --with-blas='-ltatlas' \
 	(%type_raw[-blas] = -atlas) --with-lapack='-ltatlas' \
+	(%type_raw[-blas] = -openblas) --with-blas='-lopenblas' \
+	(%type_raw[-blas] = -openblas) --with-lapack='-lopenblas' \
 	(%type_raw[-blas] = -ref) --with-blas='-L%p/lib/lapack -lrefblas' \
 	(%type_raw[-blas] = -ref) --with-lapack='-L%p/lib/lapack -lreflapack' \
 	--libdir=%p/lib/%{Ni}%type_pkg[-blas] \
@@ -102,7 +113,7 @@ CompileScript: <<
 		export LIBS=$libs
 		export LDFLAGS="-L%p/lib/openmpi $LDFLAGS"
 	fi
-	if [ "%type_raw[-blas]" = "." ]  
+	if [ "%type_raw[-blas]" = "." ]
 		then export FFLAGS='-ff2c'
 	fi
 	%{default_script}
@@ -119,8 +130,8 @@ InstallScript:  <<
 	mv arpack-ng%type_pkg[-blas]/pkgconfig .
 	mv arpack-ng%type_pkg[-blas]/*.la .
 	# put in compatibility symlinks
-	ln -s arpack-ng%type_pkg[-blas]/libarpack.dylib 
-	if [ "%type_raw[-mpi]" = "-mpi" ] 
+	ln -s arpack-ng%type_pkg[-blas]/libarpack.dylib
+	if [ "%type_raw[-mpi]" = "-mpi" ]
 	    # For -mpi variant only:
 	    # put in compatibility symlink
 		then ln -s arpack-ng%type_pkg[-blas]/libparpack.dylib
@@ -155,7 +166,8 @@ Splitoff: <<
 		(%type_raw[-mpi] = -mpi) %p/lib/arpack-ng%type_pkg[-blas]/libparpack.2.dylib 4.0.0 %n (>= 3.7.0-1)
 	<<
 	Depends: <<
-		(%type_raw[-blas] = -atlas) atlas-shlibs (>= 3.10.2-5), 
+		(%type_raw[-blas] = -atlas) atlas-shlibs (>= 3.10.2-5),
+		(%type_raw[-blas] = -openblas) openblas-shlibs,
 		(%type_raw[-blas] = -ref) lapack3-shlibs,
 		(%type_raw[-mpi] = -mpi) openmpi-shlibs,
 		gcc%type_pkg[gcc]-shlibs

--- a/10.9-libcxx/stable/main/finkinfo/sci/arpack-ng.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/arpack-ng.info
@@ -1,20 +1,20 @@
 Info2: <<
 Package: arpack-ng%type_pkg[-mpi]%type_pkg[-blas]
 Version: 3.8.0
-Revision: 1
+Revision: 2
 Type: -blas (-atlas -openblas -ref .), gcc (11), -mpi (. -mpi)
 
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Description: Solve large scale eigenvalue problems
 DescDetail: <<
 ARPACK is a collection of Fortran77 subroutines designed to solve large scale
-eigenvalue problems.  It began at Rice university:
+eigenvalue problems.  It began at Rice University:
 http://www.caam.rice.edu/software/ARPACK
 
 The arpack-ng project is a joint project between Debian, Octave and Scilab in
 order to provide a common and maintained version of arpack.
 
-Because no single release has been published by Rice university for the last
+Because no single release has been published by Rice University for the last
 decade and since many software packages (Octave, Scilab, R, Matlab...) have
 forked it and implemented their own modifications, arpack-ng aims to tackle
 this issue by providing a common repository and maintained version.

--- a/10.9-libcxx/stable/main/finkinfo/sci/octave-10.13-3.8.2.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/octave-10.13-3.8.2.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: octave%type_pkg[-blas]%type_pkg[-qtui]
-Type: -blas (. -atlas -ref), oct (3.8.2), gcc (5), lapack (3.5.0), -qtui (. -qtmac -qtx11)
+Type: -blas (. -atlas -openblas -ref), oct (3.8.2), gcc (11), -qtui (. -qtmac -qtx11)
 Version: 3.8.2
-Revision: 104
+Revision: 105
 Distribution: 10.13
 
 Description: MATLAB-like language for computations
@@ -14,19 +14,19 @@ Homepage: https://www.gnu.org/software/octave/
 BuildDepends: <<
 	autoconf2.6,
 	automake1.15,
-	fftw3 (>= 3.1.1-7), 
+	fftw3 (>= 3.1.1-7),
 	fontconfig2-dev,
-	freetype219 (>= 2.5.5-1), 
-	gcc%type_pkg[gcc]-compiler, 
+	freetype219 (>= 2.6-1),
+	gcc%type_pkg[gcc]-compiler,
 	gl2ps-dev,
 	glpk36-dev,
-	graphicsmagick1322-dev, 
-	hdf5.9, 
+	graphicsmagick1322-dev,
+	hdf5.200.v1.12,
 	libcurl4,
 	libpcre1,
 	libtool2,
 	pykg-config,
-	qhull6.3.1-dev, 
+	qhull6.3.1-dev,
 	readline8,
 	sed,
 	suitesparse (>= 4.0.2-2),
@@ -35,20 +35,23 @@ BuildDepends: <<
 	fink-buildenv-modules (>= 0.1.3-1),
 	fink-package-precedence,
 	fltk13-aqua,
-	(%type_raw[-blas] = .) 		arpack-ng (>=3.1.3-3) | (%type_raw[-blas] = .) arpack-ng-mpi (>= 3.1.2-4), 
-	(%type_raw[-blas] = .) 		qrupdate (>= 1.1.2-7),
-	(%type_raw[-blas] = -atlas) atlas (>= 3.10.1-1),
-	(%type_raw[-blas] = -atlas) arpack-ng-atlas (>= 3.1.3-3) | (%type_raw[-blas] = -atlas) arpack-ng-mpi-atlas (>= 3.1.3-3), 
-	(%type_raw[-blas] = -atlas) qrupdate-atlas (>= 1.1.2-7),
-	(%type_raw[-blas] = -ref) 	lapack%type_pkg[lapack], 
-	(%type_raw[-blas] = -ref) 	arpack-ng-ref (>= 3.1.3-3) | (%type_raw[-blas] = -ref) arpack-ng-mpi-ref (>= 3.1.3-3),
-	(%type_raw[-blas] = -ref) 	qrupdate-ref (>= 1.1.2-7),
-	(%type_raw[-qtui] = -qtmac) qt4-base-mac,
-	(%type_raw[-qtui] = -qtmac) qt4-base-mac-linguist,
-	(%type_raw[-qtui] = -qtmac) qscintilla2.11-qt4-mac,
-	(%type_raw[-qtui] = -qtx11) qt4-base-x11,
-	(%type_raw[-qtui] = -qtx11) qt4-base-x11-linguist,
-	(%type_raw[-qtui] = -qtx11) qscintilla2.11-qt4-x11,
+	(%type_raw[-blas] = .)		arpack-ng (>=3.1.3-3) | (%type_raw[-blas] = .) arpack-ng-mpi (>= 3.1.2-4),
+	(%type_raw[-blas] = .)		qrupdate (>= 1.1.2-7),
+	(%type_raw[-blas] = -atlas)	atlas (>= 3.10.1-1),
+	(%type_raw[-blas] = -atlas)	arpack-ng-atlas (>= 3.1.3-3) | (%type_raw[-blas] = -atlas) arpack-ng-mpi-atlas (>= 3.1.3-3),
+	(%type_raw[-blas] = -atlas)	qrupdate-atlas (>= 1.1.2-7),
+	(%type_raw[-blas] = -openblas)	openblas,
+	(%type_raw[-blas] = -openblas)	arpack-ng-openblas (>= 3.7.0-1) | (%type_raw[-blas] = -openblas) arpack-ng-mpi-openblas (>= 3.7.0-1),
+	(%type_raw[-blas] = -openblas)	qrupdate-openblas (>= 1.1.2-11),
+	(%type_raw[-blas] = -ref)	lapack3,
+	(%type_raw[-blas] = -ref)	arpack-ng-ref (>= 3.1.3-3) | (%type_raw[-blas] = -ref) arpack-ng-mpi-ref (>= 3.1.3-3),
+	(%type_raw[-blas] = -ref)	qrupdate-ref (>= 1.1.2-7),
+	(%type_raw[-qtui] = -qtmac)	qt4-base-mac,
+	(%type_raw[-qtui] = -qtmac)	qt4-base-mac-linguist,
+	(%type_raw[-qtui] = -qtmac)	qscintilla2.11-qt4-mac,
+	(%type_raw[-qtui] = -qtx11)	qt4-base-x11,
+	(%type_raw[-qtui] = -qtx11)	qt4-base-x11-linguist,
+	(%type_raw[-qtui] = -qtx11)	qscintilla2.11-qt4-x11,
 	texlive-base | texlive-nox-base
 <<
 Depends: %{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui] (=%v-%r)
@@ -61,51 +64,64 @@ Provides: <<
 (%type_raw[-qtui] = -qtmac)			%{Ni}-interpreter-qtmac,
 (%type_raw[-blas] = -atlas)			%{Ni}-interpreter-newatlas,
 (%type_raw[-blas] = .)				%{Ni}-interpreter-accelerate,
+(%type_raw[-blas] = -openblas)			%{Ni}-interpreter-openblas,
 (%type_raw[-blas] = -ref)			%{Ni}-interpreter-ref
 <<
 Conflicts: <<
-	%{Ni}, 
+	%{Ni},
 	%{Ni}-qtmac,
-	%{Ni}-qtx11, 
-	%{Ni}-x11, 
-	%{Ni}-x11-qtmac, 
-	%{Ni}-x11-qtx11, 
+	%{Ni}-qtx11,
+	%{Ni}-x11,
+	%{Ni}-x11-qtmac,
+	%{Ni}-x11-qtx11,
 	%{Ni}-atlas,
 	%{Ni}-atlas-qtmac,
 	%{Ni}-atlas-qtx11,
 	%{Ni}-atlas-x11,
 	%{Ni}-atlas-x11-qtmac,
 	%{Ni}-atlas-x11-qtx11,
-	%{Ni}-ref, 
-	%{Ni}-ref-qtmac, 
-	%{Ni}-ref-qtx11, 
+	%{Ni}-openblas,
+	%{Ni}-openblas-qtmac,
+	%{Ni}-openblas-qtx11,
+	%{Ni}-openblas-x11,
+	%{Ni}-openblas-x11-qtmac,
+	%{Ni}-openblas-x11-qtx11,
+	%{Ni}-ref,
+	%{Ni}-ref-qtmac,
+	%{Ni}-ref-qtx11,
 	%{Ni}-ref-x11,
 	%{Ni}-ref-x11-qtmac,
 	%{Ni}-ref-x11-qtx11,
-	%{Ni}3.0.2 ( << 3.0.2-5), 
-	%{Ni}3.0.2-atlas ( << 3.0.2-5) 
+	%{Ni}3.0.2 ( << 3.0.2-5),
+	%{Ni}3.0.2-atlas ( << 3.0.2-5)
 <<
 Replaces: <<
-	%{Ni}, 
-	%{Ni}-qtmac, 
-	%{Ni}-qtx11, 
-	%{Ni}-x11, 
-	%{Ni}-x11-qtmac, 
-	%{Ni}-x11-qtx11, 
+	%{Ni},
+	%{Ni}-qtmac,
+	%{Ni}-qtx11,
+	%{Ni}-x11,
+	%{Ni}-x11-qtmac,
+	%{Ni}-x11-qtx11,
 	%{Ni}-atlas,
 	%{Ni}-atlas-qtmac,
 	%{Ni}-atlas-qtx11,
 	%{Ni}-atlas-x11,
 	%{Ni}-atlas-x11-qtmac,
 	%{Ni}-atlas-x11-qtx11,
-	%{Ni}-ref, 
-	%{Ni}-ref-qtmac, 
-	%{Ni}-ref-qtx11, 
+	%{Ni}-openblas,
+	%{Ni}-openblas-qtmac,
+	%{Ni}-openblas-qtx11,
+	%{Ni}-openblas-x11,
+	%{Ni}-openblas-x11-qtmac,
+	%{Ni}-openblas-x11-qtx11,
+	%{Ni}-ref,
+	%{Ni}-ref-qtmac,
+	%{Ni}-ref-qtx11,
 	%{Ni}-ref-x11,
 	%{Ni}-ref-x11-qtmac,
 	%{Ni}-ref-x11-qtx11,
-	%{Ni}3.0.2 ( << 3.0.2-5), 
-	%{Ni}3.0.2-atlas ( << 3.0.2-5) 
+	%{Ni}3.0.2 ( << 3.0.2-5),
+	%{Ni}3.0.2-atlas ( << 3.0.2-5)
 <<
 
 # source
@@ -129,7 +145,7 @@ PatchScript: <<
 	#!/bin/sh -ev
 
 	#Fink-specific structural changes
-	sed -e 's/@OCTVERSION@/%v/g' -e 's|@FINKPREFIX@|%p|g' %{PatchFile} | patch -p1 
+	sed -e 's/@OCTVERSION@/%v/g' -e 's|@FINKPREFIX@|%p|g' %{PatchFile} | patch -p1
 	# Put in the Fink tree.
 	sed -i -e 's|@FINKPREFIX@|%p|g' doc/interpreter/*.1 src/mkoctfile*in.cc
 
@@ -145,7 +161,7 @@ PatchScript: <<
 
 	# Patch configure not to link like Puma on Yosemite
 	perl -pi -e 's/(10\.\[012\])\*/\1\,.\*/' configure
-	
+
 	# add /opt/X11/include to the legal header directories
 	perl -pi -e "s|(/usr/X11R4/include)|\1\n/opt/X11/include|" configure
 
@@ -156,8 +172,8 @@ PatchScript: <<
 	cp doc/interpreter/mkoctfile.1 doc/interpreter/mkoctfile-%v.1
 
 	# fix executable names in versioned manpages
-	sed -e 's/@OCTVERSION@/%v/g' %{PatchFile2} | patch -p1 
-	
+	sed -e 's/@OCTVERSION@/%v/g' %{PatchFile2} | patch -p1
+
 	# instead of using flag-sort, ensure that the right sysdep.h is used
 	grep -lr '#include "sysdep.h"' * | xargs perl -pi.orig -e 's,sysdep.h,%b/libinterp/corefcn/sysdep.h,'
 
@@ -177,13 +193,17 @@ ConfigureParams: <<
 	--disable-java \
 	(%type_raw[-blas] = .)		--with-lapack=-Wl,-framework,Accelerate \
 	(%type_raw[-blas] = .)		--with-blas=-Wl,-framework,Accelerate \
- 	(%type_raw[-blas] = -atlas)	--with-lapack="-ltatlas" \
- 	(%type_raw[-blas] = -atlas)	--with-blas="-ltatlas" \
- 	(%type_raw[-blas] = -ref)	--with-lapack="-L%p/lib/lapack/%type_raw[lapack] -lreflapack" \
- 	(%type_raw[-blas] = -ref)	--with-blas="-L%p/lib/lapack/%type_raw[lapack] -lrefblas" \
+	(%type_raw[-blas] = -atlas)	--with-lapack="-ltatlas" \
+	(%type_raw[-blas] = -atlas)	--with-blas="-ltatlas" \
+	(%type_raw[-blas] = -openblas)	--with-lapack="-lopenblas" \
+	(%type_raw[-blas] = -openblas)	--with-blas="-lopenblas" \
+	(%type_raw[-blas] = -ref)	--with-lapack="-L%p/lib/lapack3 -lreflapack" \
+	(%type_raw[-blas] = -ref)	--with-blas="-L%p/lib/lapack3 -lrefblas" \
 	--with-framework-carbon \
 	--with-magick=GraphicsMagick \
 	--with-qhull-includedir=%p/include/libqhull \
+	--with-hdf5-includedir=%p/opt/hdf5.v1.12/include \
+	--with-hdf5-libdir=%p/opt/hdf5.v1.12/lib \
 	--host=%m-apple-darwin \
 	--build=%m-apple-darwin \
 	--infodir='${prefix}/share/info' \
@@ -214,50 +234,51 @@ if [ ! -x %p/bin/oct-cc -o ! -x %p/bin/oct-cxx ] ; then
 
  # allow configure to find OpenGL libraries in X11
  export LDFLAGS="-L%p/lib -Wl,-dead_strip_dylibs"
- export CPPFLAGS="-I%p/include -I%p/include/freetype2"
+ # make include paths available in subdirectory builds
+ export CPPFLAGS="-I%p/include -I%p/include/freetype2 -I%p/opt/hdf5.v1.12/include"
  export CPP="clang -E"
  export CXXCPP="clang++ -E"
  export F77=%p/bin/gfortran-fsf-%type_raw[gcc]
  # -ff2c is required when using gfortran and Accelerate.framework
  if [ "%type_raw[-blas]" = "." ]
- 	then export FFLAGS='-O3 -ff2c'
- 	else export FFLAGS='-O3'
+	then export FFLAGS='-O3 -ff2c'
+	else export FFLAGS='-O3'
  fi
  FLIBDIR="%p/lib/gcc%type_raw[gcc]/lib"
  export FLIBS="-L${FLIBDIR} -lgfortran"
  export PKG_CONFIG=%p/bin/pykg-config
  qt_type=`echo %type_pkg[-qtui] | cut -dt -f2`
- if [ "%type_raw[-qtui]" != "."  ] ; then	
- 	export PKG_CONFIG_PATH="%p/lib/qt4-$qt_type/lib/pkgconfig:$PKG_CONFIG_PATH"
+ if [ "%type_raw[-qtui]" != "." ] ; then
+	export PKG_CONFIG_PATH="%p/lib/qt4-$qt_type/lib/pkgconfig:$PKG_CONFIG_PATH"
 	export PATH="%p/lib/qt4-$qt_type/bin:$PATH"
 	# QtCore is inherited
 	export LDFLAGS=`pkg-config QtNetwork --libs`" "`pkg-config QtGui --libs`" -L%p/lib/qt4-$qt_type/lib $LDFLAGS"
  fi
- 
+
  autoreconf -fi
- 
+
  ./configure %c "ac_cv_func_mkostemp=no"
  # don't just use top-level Makefile so that we can do a multi-core build.
- pushd libgnu 
+ pushd libgnu
  /usr/bin/make -j1
  popd
  for dirs in liboctave libinterp ; do
- 	pushd $dirs
- 	/usr/bin/make
- 	popd
+	pushd $dirs
+	/usr/bin/make
+	popd
  done
- if [ "%type_raw[-qtui]" != "."  ] ; then
+ if [ "%type_raw[-qtui]" != "." ] ; then
 	pushd libgui
 	/usr/bin/make
 	popd
  fi
  # src/ and scripts/ need to be built with -j1 since docs get built there.
  for dirs in src scripts ; do
- 	pushd $dirs
- 	/usr/bin/make -j1
- 	popd
+	pushd $dirs
+	/usr/bin/make -j1
+	popd
  done
- /usr/bin/make 
+ /usr/bin/make
  fink-package-precedence .
 <<
 
@@ -293,14 +314,14 @@ InstallScript: <<
  rm mkoctfile mkoctfile-%type_raw[oct]
  /bin/cp %b/src/mkoctfile mkoctfile-%v
  ln -s mkoctfile-%v mkoctfile
-  
+
  # sanitize .la files
  cd %i/lib/%{Ni}/%v/
- perl -pi -e 's/(\-framework)\s(\w+)/-Wl,$1,$2/g' *.la 
+ perl -pi -e 's/(\-framework)\s(\w+)/-Wl,$1,$2/g' *.la
 
  # manually install libcxx-fix.h
  if [ -e %b/liboctave/operators/libcxx-fix.h ] ; then
- 	cp %b/liboctave/operators/libcxx-fix.h %i/include/%{Ni}-%v/%{Ni}/
+	cp %b/liboctave/operators/libcxx-fix.h %i/include/%{Ni}-%v/%{Ni}/
  fi
 <<
 
@@ -309,76 +330,76 @@ DocFiles: AUTHORS BUGS COPYING ChangeLog NEWS README
 ConfFiles: %p/share/%{Ni}/site/m/startup/%{Ni}rc
 
 DescDetail: <<
-Octave provides a convenient command line interface for solving linear and 
-nonlinear problems numerically, and for performing other numerical 
+Octave provides a convenient command line interface for solving linear and
+nonlinear problems numerically, and for performing other numerical
 experiments using a language that is mostly compatible with Matlab.
 It may also be used as a batch-oriented language.
 
 Octave has extensive tools for solving common numerical linear algebra
 problems, finding the roots of nonlinear equations, integrating ordinary
 functions, manipulating polynomials, and integrating ordinary differential
-and differential-algebraic equations. It is easily extensible and 
-customizable via user-defined functions written in Octave's own language, 
-or using dynamically loaded modules written in C++, C, Fortran, 
+and differential-algebraic equations. It is easily extensible and
+customizable via user-defined functions written in Octave's own language,
+or using dynamically loaded modules written in C++, C, Fortran,
 or other languages.
 <<
 
-DescUsage: << 
-The %{Ni}%type_pkg[-blas]%type_pkg[-qtui] package contains 
+DescUsage: <<
+The %{Ni}%type_pkg[-blas]%type_pkg[-qtui] package contains
 unversioned executables, in particular the "octave" executable, along with the
-GNU info documentation.  
+GNU info documentation.
 
 The "-qtmac" variant builds a GUI which uses Qt on Aqua, while
 the "-qtx11" variant builds an X11 Qt gui.
 
 You can select another version of Octave to be the default, i.e. the "octave"
-executable and "info octave" point to it, via 
-"fink install %{Ni}%type_pkg[-blas]-<version>", 
+executable and "info octave" point to it, via
+"fink install %{Ni}%type_pkg[-blas]-<version>",
 where the available <version> options are:
 	3.0.5
 	3.2.4
 	3.4.3
 	3.6.0
 	3.6.1
-	3.6.2 
-	3.6.3 
+	3.6.2
+	3.6.3
 	3.6.4
-	
-By default the plotting output (via gnuplot) is directed to AquaTerm. 
+
+By default the plotting output (via gnuplot) is directed to AquaTerm.
 This can be overidden in your startup scripts, e.g.
- 
+
 	export GNUTERM=x11
- 
+
 in bash
- 
+
 or
- 
+
 	setenv GNUTERM x11
- 
+
 in tcsh.
 
-To build and install packages from Octave Forge manually, or to 
-build anything else against Octave, you will need to install the 
-%{Ni}%type_pkg[-blas]-dev package.  
+To build and install packages from Octave Forge manually, or to
+build anything else against Octave, you will need to install the
+%{Ni}%type_pkg[-blas]-dev package.
 Fink's *-oct%type_pkg[oct] packages do this automatically, as well as
 applying patches, so unless you want to test a pre-release version,
 you are probably better off installing OF packages via Fink.
- 
+
 Note:  Fink's Octave implementation modifies one of the startup files,
 %p/share/%{Ni}/%v/m/startup/octaverc,
-to initialize octave sessions to know about Fink's octave-versioned 
+to initialize octave sessions to know about Fink's octave-versioned
 install location for octave-forge packages.  If you use the '--norc' or '-f'
 flags in your Octave script, these packages won't be visible.  You'll need to
 run the following command in your script:
- 
- 	pkg global_list %p/var/octave/%v/octave_packages
+
+	pkg global_list %p/var/octave/%v/octave_packages
 <<
 
 
 DescPort: <<
 Thanks to Per Persson for most (if not all) of the work on the macos X port.
 
-The Accelerate variant is built with -ff2c in the FFLAGS, 
+The Accelerate variant is built with -ff2c in the FFLAGS,
 because this appears to be necessary when using the Accelerate framework.
 
 Revision 7 -- update X11 detection
@@ -387,11 +408,11 @@ Revision 7 -- update X11 detection
 DescPackaging:  <<
 Revision 101: disable Java for the time being.
 
-Patchfile6 from J. Howarth covers build failure on High Sierra from  
+Patchfile6 from J. Howarth covers build failure on High Sierra from
 
 "error: call to 'pow' is ambiguous"
 
-in liboctave/numeric/lo-specfun.cc and libinterp/corefcn/graphics.cc by using 
+in liboctave/numeric/lo-specfun.cc and libinterp/corefcn/graphics.cc by using
 std::pow() instead of pow().
 
 set ac_cv_func_mkostemp=no explicitly to allow building on OS X Sierra and later.
@@ -411,7 +432,7 @@ Update X11 linkage.
 Revision 6 -- Test suite crashes when built against fltk13-aqua and run as fink-bld.
 Fix some sketchy flag ordering to ensure that Fink's freetype2 headers get brought
 in before those from X11.  Also put a versioned dependency on freetype2.
-Switch to hdf5.9.
+Switch to hdf5.200.v1.12.
 
 Revision 5 --  image-oct382 needs the cxx fix for _all_ OSX versions, so we
 remove the conditional patching and add a virtual package to note that this has been
@@ -419,16 +440,16 @@ applied.
 
 Use pykg-config instead of pkgconfig to lighten the build tree.
 
-Remove a desktop file that gets generated only for users with GNOME/KDE 
+Remove a desktop file that gets generated only for users with GNOME/KDE
 installed.
 
 SetLIBS: -lgl2ps because of missing symbols from that library on 10.7/Xcode
-4.2.6	
+4.2.6
 
 Non-X11 FLTK stuff still uses X headers.
-	
+
 Set the GNUTERM environment variable to AquaTerm because autodetection of
-DISPLAY seems to cause options to be fed to our gnuplot that it doesn't 
+DISPLAY seems to cause options to be fed to our gnuplot that it doesn't
 understand.  AquaTerm seems to be a sensible default.
 
 Create manpages for the versioned executables.
@@ -436,31 +457,32 @@ Create manpages for the versioned executables.
 We have split the package up into versioned runtime+library, development, and
 unversioned runtime packages,  to make upgrades easier for us and for users.  Prior
 packaging had separate libraries, but this led to deadlocks when attempting to swap
-variants.  Also, it's unlikely that anybody is going to want just the libraries, 
+variants.  Also, it's unlikely that anybody is going to want just the libraries,
 anyway.
-	
-The -atlas variant depends on -atlas variants (only) of qrupdate and arpack-ng.  
-The Accelerate variant depends on Accelerate variants (only) of these, and 
+
+The -atlas variant depends on -atlas variants (only) of qrupdate and arpack-ng.
+The Accelerate variant depends on Accelerate variants (only) of these,
+the OpenBLAS variant depends on OpenBLAS variants (only) of the same, and
 the reference LAPACK variant depends on variants of qrupdate and arpack-ng
-which use the reference LAPACK (i.e. lapack350).
- 
+which use the reference LAPACK (i.e. lapack3).
+
 Patch oct-conf.h and mkoctfile to use octave-specific compiler executables
-which are part of the fink-octave-scripts package to avoid issues which 
-would propagate as dependencies, e.g. encoding 'flag-sort' or a 
-ccache-default compiler. This also makes sure that anything that builds 
-against Octave has the proper information when installed manually as well 
+which are part of the fink-octave-scripts package to avoid issues which
+would propagate as dependencies, e.g. encoding 'flag-sort' or a
+ccache-default compiler. This also makes sure that anything that builds
+against Octave has the proper information when installed manually as well
 as via Fink.
 
-We use the platform-independent oct-cc and oct-cxx wrappers from 
+We use the platform-independent oct-cc and oct-cxx wrappers from
 fink-octave-scripts to ensure that user builds:
-1) using the Fink compiler wrapper for the OS X version 
+1) using the Fink compiler wrapper for the OS X version
 2) using a stably named compiler, in case of OS X updates.
 
 We use Provides in a new namespace and new projections to avoid
 unwieldy | lists in the octave-forge packages.
 
-Since octave-forge packages for octave < 3.6.0 link to whatever gcc4N 
-Octave is using, and also since some other packages actually use gcc-4.N, 
+Since octave-forge packages for octave < 3.6.0 link to whatever gcc4N
+Octave is using, and also since some other packages actually use gcc-4.N,
 add "liboctave-gcc4N-dev" and "liboctave-gcc4N" Provides, to make sure that
 things stay in sync; the latter isn't used yet.
 
@@ -476,36 +498,36 @@ SplitOff: <<
 		%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui] (=%v-%r),
 		fink-%{Ni}-scripts (>= 0.3.0-1),
 		fink (>=0.32),
-		gcc%type_pkg[gcc]-compiler 
+		gcc%type_pkg[gcc]-compiler
 	<<
-	Conflicts: << 
-		%{Ni}305-dev, 
+	Conflicts: <<
+		%{Ni}305-dev,
 		%{Ni}305-atlas-dev,
-		%{Ni}305-ref-dev,  
-		%{Ni}324-dev, 
+		%{Ni}305-ref-dev,
+		%{Ni}324-dev,
 		%{Ni}324-atlas-dev,
 		%{Ni}324-ref-dev,
 		%{Ni}324-x11-dev,
 		%{Ni}324-atlas-x11-dev,
 		%{Ni}324-ref-x11-dev,
-		%{Ni}343-dev, 
+		%{Ni}343-dev,
 		%{Ni}343-atlas-dev,
 		%{Ni}343-ref-dev,
 		%{Ni}343-x11-dev,
 		%{Ni}343-atlas-x11-dev,
 		%{Ni}343-ref-x11-dev,
-		%{Ni}360-dev, 
+		%{Ni}360-dev,
 		%{Ni}360-atlas-dev,
 		%{Ni}360-ref-dev,
 		%{Ni}360-x11-dev,
 		%{Ni}360-atlas-x11-dev,
 		%{Ni}360-ref-x11-dev,
-		%{Ni}361-dev, 
+		%{Ni}361-dev,
 		%{Ni}361-atlas-dev,
 		%{Ni}361-ref-dev,
 		%{Ni}361-x11-dev,
 		%{Ni}361-atlas-x11-dev,
-		%{Ni}361-ref-x11-dev,		
+		%{Ni}361-ref-x11-dev,
 		%{Ni}362-dev,
 		%{Ni}362-x11-dev,
 		%{Ni}362-atlas-dev,
@@ -523,61 +545,68 @@ SplitOff: <<
 		%{Ni}364-atlas-dev,
 		%{Ni}364-atlas-x11-dev,
 		%{Ni}382-atlas-dev,
-	   	%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-atlas-x11-qtmac-dev,
-   		%{Ni}382-atlas-x11-qtx11-dev,
-   		%{Ni}382-atlas-qtmac-dev,
-   		%{Ni}382-atlas-qtx11-dev,
-   		%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-dev,
-   		%{Ni}382-x11-dev,
-   		%{Ni}382-x11-qtmac-dev,
-   		%{Ni}382-x11-qtx11-dev,
-   		%{Ni}382-x11-x11-dev,
-   		%{Ni}382-mac-dev,
-   		%{Ni}382-qtmac-dev,
-   		%{Ni}382-qtx11-dev,
-   		%{Ni}382-ref-dev,
-   		%{Ni}382-ref-x11-dev,
-   		%{Ni}382-ref-x11-qtmac-dev,
-   		%{Ni}382-ref-x11-qtx11-dev,
-	   	%{Ni}382-ref-mac-dev,
-   		%{Ni}382-ref-qtmac-dev,
-   		%{Ni}382-ref-qtx11-dev,
-   		%{Ni}382-x11-dev,
-		%{Ni} (<< 3.0.5-5), 
-		%{Ni}-atlas (<< 3.0.5-5), 
-		%{Ni}3.0.2 ( << 3.0.2-5), 
+		%{Ni}382-atlas-x11-dev,
+		%{Ni}382-atlas-x11-qtmac-dev,
+		%{Ni}382-atlas-x11-qtx11-dev,
+		%{Ni}382-atlas-qtmac-dev,
+		%{Ni}382-atlas-qtx11-dev,
+		%{Ni}382-atlas-x11-dev,
+		%{Ni}382-dev,
+		%{Ni}382-x11-dev,
+		%{Ni}382-x11-qtmac-dev,
+		%{Ni}382-x11-qtx11-dev,
+		%{Ni}382-x11-x11-dev,
+		%{Ni}382-mac-dev,
+		%{Ni}382-qtmac-dev,
+		%{Ni}382-qtx11-dev,
+		%{Ni}382-ref-dev,
+		%{Ni}382-ref-x11-dev,
+		%{Ni}382-ref-x11-qtmac-dev,
+		%{Ni}382-ref-x11-qtx11-dev,
+		%{Ni}382-ref-mac-dev,
+		%{Ni}382-ref-qtmac-dev,
+		%{Ni}382-ref-qtx11-dev,
+		%{Ni}382-openblas-dev,
+		%{Ni}382-openblas-x11-dev,
+		%{Ni}382-openblas-x11-qtmac-dev,
+		%{Ni}382-openblas-x11-qtx11-dev,
+		%{Ni}382-openblas-mac-dev,
+		%{Ni}382-openblas-qtmac-dev,
+		%{Ni}382-openblas-qtx11-dev,
+		%{Ni}382-x11-dev,
+		%{Ni} (<< 3.0.5-5),
+		%{Ni}-atlas (<< 3.0.5-5),
+		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
 	Replaces: <<
-		%{Ni}305-dev, 
+		%{Ni}305-dev,
 		%{Ni}305-atlas-dev,
-		%{Ni}305-ref-dev,  
-		%{Ni}324-dev, 
+		%{Ni}305-ref-dev,
+		%{Ni}324-dev,
 		%{Ni}324-atlas-dev,
 		%{Ni}324-ref-dev,
 		%{Ni}324-x11-dev,
 		%{Ni}324-atlas-x11-dev,
 		%{Ni}324-ref-x11-dev,
-		%{Ni}343-dev, 
+		%{Ni}343-dev,
 		%{Ni}343-atlas-dev,
 		%{Ni}343-ref-dev,
 		%{Ni}343-x11-dev,
 		%{Ni}343-atlas-x11-dev,
 		%{Ni}343-ref-x11-dev,
-		%{Ni}360-dev, 
+		%{Ni}360-dev,
 		%{Ni}360-atlas-dev,
 		%{Ni}360-ref-dev,
 		%{Ni}360-x11-dev,
 		%{Ni}360-atlas-x11-dev,
 		%{Ni}360-ref-x11-dev,
-		%{Ni}361-dev, 
+		%{Ni}361-dev,
 		%{Ni}361-atlas-dev,
 		%{Ni}361-ref-dev,
 		%{Ni}361-x11-dev,
 		%{Ni}361-atlas-x11-dev,
-		%{Ni}361-ref-x11-dev,		
+		%{Ni}361-ref-x11-dev,
 		%{Ni}362-dev,
 		%{Ni}362-x11-dev,
 		%{Ni}362-atlas-dev,
@@ -597,50 +626,58 @@ SplitOff: <<
 		%{Ni}364-ref-dev,
 		%{Ni}364-ref-x11-dev,
 		%{Ni}382-atlas-dev,
-	   	%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-atlas-x11-qtmac-dev,
-   		%{Ni}382-atlas-x11-qtx11-dev,
-   		%{Ni}382-atlas-qtmac-dev,
-   		%{Ni}382-atlas-qtx11-dev,
-   		%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-dev,
-   		%{Ni}382-x11-dev,
-   		%{Ni}382-x11-qtmac-dev,
-   		%{Ni}382-x11-qtx11-dev,
-   		%{Ni}382-x11-x11-dev,
-   		%{Ni}382-mac-dev,
-   		%{Ni}382-qtmac-dev,
-   		%{Ni}382-qtx11-dev,
-   		%{Ni}382-ref-dev,
-   		%{Ni}382-ref-x11-dev,
-   		%{Ni}382-ref-x11-qtmac-dev,
-   		%{Ni}382-ref-x11-qtx11-dev,
-	   	%{Ni}382-ref-mac-dev,
-   		%{Ni}382-ref-qtmac-dev,
-   		%{Ni}382-ref-qtx11-dev,
-   		%{Ni}382-x11-dev,
-		%{Ni} (<< 3.0.5-5), 
-		%{Ni}-atlas (<< 3.0.5-5), 
-		%{Ni}3.0.2 ( << 3.0.2-5), 
+		%{Ni}382-atlas-x11-dev,
+		%{Ni}382-atlas-x11-qtmac-dev,
+		%{Ni}382-atlas-x11-qtx11-dev,
+		%{Ni}382-atlas-qtmac-dev,
+		%{Ni}382-atlas-qtx11-dev,
+		%{Ni}382-atlas-x11-dev,
+		%{Ni}382-dev,
+		%{Ni}382-x11-dev,
+		%{Ni}382-x11-qtmac-dev,
+		%{Ni}382-x11-qtx11-dev,
+		%{Ni}382-x11-x11-dev,
+		%{Ni}382-mac-dev,
+		%{Ni}382-qtmac-dev,
+		%{Ni}382-qtx11-dev,
+		%{Ni}382-ref-dev,
+		%{Ni}382-ref-x11-dev,
+		%{Ni}382-ref-x11-qtmac-dev,
+		%{Ni}382-ref-x11-qtx11-dev,
+		%{Ni}382-ref-mac-dev,
+		%{Ni}382-ref-qtmac-dev,
+		%{Ni}382-ref-qtx11-dev,
+		%{Ni}382-openblas-dev,
+		%{Ni}382-openblas-x11-dev,
+		%{Ni}382-openblas-x11-qtmac-dev,
+		%{Ni}382-openblas-x11-qtx11-dev,
+		%{Ni}382-openblas-mac-dev,
+		%{Ni}382-openblas-qtmac-dev,
+		%{Ni}382-openblas-qtx11-dev,
+		%{Ni}382-x11-dev,
+		%{Ni} (<< 3.0.5-5),
+		%{Ni}-atlas (<< 3.0.5-5),
+		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
 	Provides: <<
 		lib%{Ni}%type_pkg[oct]-gcc%type_pkg[gcc]-dev,
 		lib%{Ni}%type_pkg[oct]-cxxfix-dev,
 		lib%{Ni}%type_pkg[oct]-dev,
-		(%type_raw[-blas] = -atlas) 		lib%{Ni}%type_pkg[oct]-newatlas-dev,
-		(%type_raw[-blas] = .) 				lib%{Ni}%type_pkg[oct]-accelerate-dev,
-		(%type_raw[-blas] = -ref) 			lib%{Ni}%type_pkg[oct]-ref-dev,
+		(%type_raw[-blas] = -atlas)		lib%{Ni}%type_pkg[oct]-newatlas-dev,
+		(%type_raw[-blas] = .)				lib%{Ni}%type_pkg[oct]-accelerate-dev,
+		(%type_raw[-blas] = -openblas)			lib%{Ni}%type_pkg[oct]-openblas-dev,
+		(%type_raw[-blas] = -ref)			lib%{Ni}%type_pkg[oct]-ref-dev,
 		lib%{Ni}%type_pkg[oct]-aqua-dev,
 		(%type_raw[-qtui] = -qtx11)			lib%{Ni}%type_pkg[oct]-qtx11-dev,
 		(%type_raw[-qtui] = -qtmac)			lib%{Ni}%type_pkg[oct]-qtmac-dev
 	<<
-	
+
 	BuildDependsOnly: true
-	
+
 	Files: <<
 		include/%{Ni}-%v
-		lib/%{Ni}/%v/*.la 
+		lib/%{Ni}/%v/*.la
 		lib/%{Ni}/%v/lib{%{Ni},octinterp}.dylib
 		(%type_raw[-qtui] != .) lib/%{Ni}/%v/liboctgui.dylib
 		bin/mkoctfile*
@@ -653,9 +690,9 @@ SplitOff: <<
 	headers and the mkoctfile executable.  It also contains symlinks to Fink's
 	compiler wrappers, which are set up at install time to be appropriate to
 	the current machine setup.
-	To use mkoctfile to build dynamically loadable modules, you will need 	
+	To use mkoctfile to build dynamically loadable modules, you will need
 	to install the hdf5.8 and fftw3 packages.
- 	%n cannot Depend on them since they are BuildDependsOnly.
+	%n cannot Depend on them since they are BuildDependsOnly.
 	<<
 	DescPackaging:  <<
 	We make up an extra mkoctfile which uses a Fink gcc for packages that need
@@ -667,7 +704,7 @@ SplitOff: <<
 # versioned executables and shlibs
 SplitOff2: <<
 	Package: octave%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui]
-	Conflicts: << 
+	Conflicts: <<
 		%{Ni}%type_pkg[oct],
 		%{Ni}%type_pkg[oct]-qtmac,
 		%{Ni}%type_pkg[oct]-qtx11,
@@ -680,14 +717,20 @@ SplitOff2: <<
 		%{Ni}%type_pkg[oct]-atlas-x11,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtmac,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtx11,
+		%{Ni}%type_pkg[oct]-openblas,
+		%{Ni}%type_pkg[oct]-openblas-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-qtx11,
+		%{Ni}%type_pkg[oct]-openblas-x11,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtx11,
 		%{Ni}%type_pkg[oct]-ref,
 		%{Ni}%type_pkg[oct]-ref-qtmac,
 		%{Ni}%type_pkg[oct]-ref-qtx11,
 		%{Ni}%type_pkg[oct]-ref-x11,
 		%{Ni}%type_pkg[oct]-ref-x11-qtmac,
 		%{Ni}%type_pkg[oct]-ref-x11-qtx11,
-		%{Ni} (<< 3.0.5-5), 
-		%{Ni}-atlas (<< 3.0.5-5), 
+		%{Ni} (<< 3.0.5-5),
+		%{Ni}-atlas (<< 3.0.5-5),
 		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
@@ -704,6 +747,12 @@ SplitOff2: <<
 		%{Ni}%type_pkg[oct]-atlas-x11,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtmac,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtx11,
+		%{Ni}%type_pkg[oct]-openblas,
+		%{Ni}%type_pkg[oct]-openblas-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-qtx11,
+		%{Ni}%type_pkg[oct]-openblas-x11,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtx11,
 		%{Ni}%type_pkg[oct]-ref,
 		%{Ni}%type_pkg[oct]-ref-qtmac,
 		%{Ni}%type_pkg[oct]-ref-qtx11,
@@ -711,17 +760,19 @@ SplitOff2: <<
 		%{Ni}%type_pkg[oct]-ref-x11-qtmac,
 		%{Ni}%type_pkg[oct]-ref-x11-qtx11,
 		%{Ni}%type_pkg[oct]-ref-x11,
-		%{Ni} (<< 3.0.5-5), 
+		%{Ni} (<< 3.0.5-5),
 		%{Ni}-atlas (<< 3.0.5-5),
-		%{Ni}3.0.2 ( << 3.0.2-5), 
+		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
-	Depends: << 
+	Depends: <<
 		(%type_raw[-blas] = .)		arpack-ng-shlibs (>= 3.1.3-3) | (%type_raw[-blas] = .) arpack-ng-mpi-shlibs (>= 3.1.2-4),
 		(%type_raw[-blas] = -ref)	arpack-ng-ref-shlibs (>= 3.1.3-3) | (%type_raw[-blas] = -ref) arpack-ng-mpi-ref-shlibs (>= 3.1.3-3),
 		(%type_raw[-blas] = -atlas)	arpack-ng-atlas-shlibs (>= 3.1.3-3) | (%type_raw[-blas] = -atlas) arpack-ng-mpi-atlas-shlibs (>= 3.1.3-3),
 		(%type_raw[-blas] = -atlas)	atlas-shlibs (>= 3.10.1-1),
-		fftw3-shlibs (>= 3.1.1-7), 
+		(%type_raw[-blas] = -openblas)	arpack-ng-openblas-shlibs (>= 3.7.0-1) | (%type_raw[-blas] = -openblas) arpack-ng-mpi-openblas-shlibs (>= 3.7.0-1),
+		(%type_raw[-blas] = -openblas)	openblas-shlibs,
+		fftw3-shlibs (>= 3.1.1-7),
 		fltk13-aqua-shlibs,
 		fontconfig2-shlibs,
 		freetype219-shlibs (>= 2.5.5-1),
@@ -730,24 +781,26 @@ SplitOff2: <<
 		glpk36-shlibs,
 		gnuplot-bin,
 		graphicsmagick1322-shlibs,
-		hdf5.9-shlibs,
-		(%type_raw[-blas] = -ref) 	lapack%type_pkg[lapack]-shlibs,
+		hdf5.200.v1.12-shlibs,
+		(%type_raw[-blas] = -ref)	lapack3-shlibs,
 		libcurl4-shlibs,
-		libpcre1-shlibs, 
-		ncurses, 
+		libpcre1-shlibs,
+		ncurses,
 		qhull6.3.1-shlibs,
-	 	(%type_raw[-qtui] = -qtmac) qscintilla2.11-qt4-mac-shlibs, 
-	 	(%type_raw[-qtui] = -qtx11) qscintilla2.11-qt4-x11-shlibs, 
-	 	(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtcore-shlibs, 
-	 	(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtcore-shlibs, 
-	 	(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtgui-shlibs, 
-	 	(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtgui-shlibs, 	 	
-	 	(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtnetwork-shlibs,
+		(%type_raw[-qtui] = -qtmac) qscintilla2.11-qt4-mac-shlibs,
+		(%type_raw[-qtui] = -qtx11) qscintilla2.11-qt4-x11-shlibs,
+		(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtcore-shlibs,
+		(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtcore-shlibs,
+		(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtgui-shlibs,
+		(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtgui-shlibs,
+		(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtnetwork-shlibs,
 		(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtnetwork-shlibs,
 		(%type_raw[-blas] = -atlas)	atlas-shlibs (>= 3.10.1-1),
-		(%type_raw[-blas] = -atlas) qrupdate-atlas-shlibs (>= 1.1.2-7), 
-		(%type_raw[-blas] = .) 		qrupdate-shlibs (>= 1.1.2-7),
-		(%type_raw[-blas] = -ref) 	qrupdate-ref-shlibs (>= 1.1.2-7),
+		(%type_raw[-blas] = -atlas)	qrupdate-atlas-shlibs (>= 1.1.2-7),
+		(%type_raw[-blas] = -openblas)	openblas-shlibs,
+		(%type_raw[-blas] = -openblas)	qrupdate-openblas-shlibs (>= 1.1.2-11),
+		(%type_raw[-blas] = .)		qrupdate-shlibs (>= 1.1.2-7),
+		(%type_raw[-blas] = -ref)	qrupdate-ref-shlibs (>= 1.1.2-7),
 		readline8-shlibs,
 		suitesparse-shlibs (>= 4.0.2-2)
 	 <<
@@ -760,9 +813,10 @@ SplitOff2: <<
 	Provides: <<
 		lib%{Ni}%type_pkg[oct]-gcc%type_pkg[gcc],
 		lib%{Ni}%type_pkg[oct],
-		(%type_raw[-blas] = -atlas) 		lib%{Ni}%type_pkg[oct]-newatlas,
-		(%type_raw[-blas] = .) 				lib%{Ni}%type_pkg[oct]-accelerate,
-		(%type_raw[-blas] = -ref) 			lib%{Ni}%type_pkg[oct]-ref,
+		(%type_raw[-blas] = -atlas)			lib%{Ni}%type_pkg[oct]-newatlas,
+		(%type_raw[-blas] = -openblas)			lib%{Ni}%type_pkg[oct]-openblas,
+		(%type_raw[-blas] = .)				lib%{Ni}%type_pkg[oct]-accelerate,
+		(%type_raw[-blas] = -ref)			lib%{Ni}%type_pkg[oct]-ref,
 		lib%{Ni}%type_pkg[oct]-aqua,
 		(%type_raw[-qtui] = -qtx11)			lib%{Ni}%type_pkg[oct]-qtx11,
 		(%type_raw[-qtui] = -qtmac)			lib%{Ni}%type_pkg[oct]-qtmac,
@@ -770,12 +824,13 @@ SplitOff2: <<
 		%{Ni}%type_pkg[oct]-interpreter-aqua,
 		(%type_raw[-qtui] = -qtx11)			%{Ni}%type_pkg[oct]-interpreter-qtx11,
 		(%type_raw[-qtui] = -qtmac)			%{Ni}%type_pkg[oct]-interpreter-qtmac,
-		(%type_raw[-blas] = -atlas) 		%{Ni}%type_pkg[oct]-interpreter-newatlas,
+		(%type_raw[-blas] = -atlas)			%{Ni}%type_pkg[oct]-interpreter-newatlas,
 		(%type_raw[-blas] = .)				%{Ni}%type_pkg[oct]-interpreter-accelerate,
-		(%type_raw[-blas] = -ref) 			%{Ni}%type_pkg[oct]-interpreter-ref,
-											%{Ni}%type_pkg[oct]-cxxfix-interpreter
+		(%type_raw[-blas] = -ref)			%{Ni}%type_pkg[oct]-interpreter-ref,
+		(%type_raw[-blas] = -openblas)			%{Ni}%type_pkg[oct]-interpreter-openblas,
+								%{Ni}%type_pkg[oct]-cxxfix-interpreter
 	<<
-	
+
 	Files: <<
 		share/%{Ni}/%v
 		lib/%{Ni}/%v
@@ -790,52 +845,52 @@ SplitOff2: <<
 		(%type_raw[-qtui] !=.) %p/lib/%{Ni}/%v/liboctgui.0.dylib 1.0.0 %n (>=3.8.2-1)
 	<<
 	DescUsage: <<
-	The %{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui] 
-	package contains versioned executables, in particular the 
-	"%{Ni}-%type_raw[oct]" executable, as well as all of the core 
-	functionality of the Octave interpreter, and the shared libraries which 
-	are used by the Octave interpreter as well as for packages that build 
+	The %{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui]
+	package contains versioned executables, in particular the
+	"%{Ni}-%type_raw[oct]" executable, as well as all of the core
+	functionality of the Octave interpreter, and the shared libraries which
+	are used by the Octave interpreter as well as for packages that build
 	against Octave, such as the various Octave Forge packages.
-	Any package that either links to the libraries in 
+	Any package that either links to the libraries in
 	%{Ni}%type_pkg[-blas]-shlibs or installs an extension
-	should Depend on 
-	%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui]-shlibs 
-	and BuildDepend on %{Ni}%type_pkg[oct]%type_pkg[-blas]-dev.  
-	In addition, it will need to BuildDepend on hdf5.8 and fftw3.  
+	should Depend on
+	%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui]-shlibs
+	and BuildDepend on %{Ni}%type_pkg[oct]%type_pkg[-blas]-dev.
+	In addition, it will need to BuildDepend on hdf5.200.v1.12 and fftw3.
 
-	The "-qtmac" variant builds a GUI which uses Qt on Aqua, 
-    while the "-qtx11" variant builds an X11 Qt GUI.   
-	
-	Note that the GNU info file, which provides the core documentation, 
-	is installed as part of the 
+	The "-qtmac" variant builds a GUI which uses Qt on Aqua,
+	while the "-qtx11" variant builds an X11 Qt GUI.
+
+	Note that the GNU info file, which provides the core documentation,
+	is installed as part of the
 	"%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui]"
 	package.
-	
-	By default the plotting output (via gnuplot) is directed to AquaTerm. 
+
+	By default the plotting output (via gnuplot) is directed to AquaTerm.
 	This can be overidden in your startup scripts, e.g.
- 
- 		export GNUTERM=x11
- 
+
+		export GNUTERM=x11
+
 	in bash
- 
+
 	or
- 
+
 		setenv GNUTERM x11
- 
+
 	in tcsh.
-	 
+
 	Note:  Fink's Octave implementation modifies one of the startup files,
 	%p/share/%{Ni}/%v/m/startup/octaverc,
-	to initialize octave sessions to know about Fink's octave-versioned 
-	install location for octave-forge packages.  If you use the '--norc' 
-	or '-f' flags in your Octave script, these packages won't be visible.  
+	to initialize octave sessions to know about Fink's octave-versioned
+	install location for octave-forge packages.  If you use the '--norc'
+	or '-f' flags in your Octave script, these packages won't be visible.
 	You'll need to run the following command in your script:
- 
+
 		pkg global_list %p/var/octave/%v/octave_packages
 	<<
 	DocFiles: AUTHORS BUGS COPYING ChangeLog NEWS README doc/interpreter doc/refcard doc/liboctave
 	RuntimeVars: <<
- 		GNUTERM: aqua
+		GNUTERM: aqua
 	<<
 <<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/octave-10.14-3.8.2.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/octave-10.14-3.8.2.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: octave%type_pkg[-blas]%type_pkg[-qtui]
-Type: -blas (. -atlas -ref), oct (3.8.2), gcc (5), lapack (3.5.0), -qtui (. -qtmac -qtx11)
+Type: -blas (. -atlas -openblas -ref), oct (3.8.2), gcc (11), -qtui (. -qtmac -qtx11)
 Version: 3.8.2
-Revision: 204
+Revision: 205
 Distribution: 10.14
 
 Description: MATLAB-like language for computations
@@ -14,19 +14,19 @@ Homepage: https://www.gnu.org/software/octave/
 BuildDepends: <<
 	autoconf2.6,
 	automake1.15,
-	fftw3 (>= 3.1.1-7), 
+	fftw3 (>= 3.1.1-7),
 	fontconfig2-dev,
-	freetype219 (>= 2.5.5-1), 
-	gcc%type_pkg[gcc]-compiler, 
+	freetype219 (>= 2.6-1),
+	gcc%type_pkg[gcc]-compiler,
 	gl2ps-dev,
 	glpk36-dev,
-	graphicsmagick1322-dev, 
-	hdf5.9, 
+	graphicsmagick1322-dev,
+	hdf5.200.v1.12,
 	libcurl4,
 	libpcre1,
 	libtool2,
 	pykg-config,
-	qhull6.3.1-dev, 
+	qhull6.3.1-dev,
 	readline8,
 	sed,
 	suitesparse (>= 4.0.2-2),
@@ -35,20 +35,23 @@ BuildDepends: <<
 	fink-buildenv-modules (>= 0.1.3-1),
 	fink-package-precedence,
 	fltk13-aqua,
-	(%type_raw[-blas] = .) 		arpack-ng (>=3.1.3-3) | (%type_raw[-blas] = .) arpack-ng-mpi (>= 3.1.2-4), 
-	(%type_raw[-blas] = .) 		qrupdate (>= 1.1.2-7),
-	(%type_raw[-blas] = -atlas) atlas (>= 3.10.1-1),
-	(%type_raw[-blas] = -atlas) arpack-ng-atlas (>= 3.1.3-3) | (%type_raw[-blas] = -atlas) arpack-ng-mpi-atlas (>= 3.1.3-3), 
-	(%type_raw[-blas] = -atlas) qrupdate-atlas (>= 1.1.2-7),
-	(%type_raw[-blas] = -ref) 	lapack%type_pkg[lapack], 
-	(%type_raw[-blas] = -ref) 	arpack-ng-ref (>= 3.1.3-3) | (%type_raw[-blas] = -ref) arpack-ng-mpi-ref (>= 3.1.3-3),
-	(%type_raw[-blas] = -ref) 	qrupdate-ref (>= 1.1.2-7),
-	(%type_raw[-qtui] = -qtmac) qt4-base-mac,
-	(%type_raw[-qtui] = -qtmac) qt4-base-mac-linguist,
-	(%type_raw[-qtui] = -qtmac) qscintilla2.11-qt4-mac,
-	(%type_raw[-qtui] = -qtx11) qt4-base-x11,
-	(%type_raw[-qtui] = -qtx11) qt4-base-x11-linguist,
-	(%type_raw[-qtui] = -qtx11) qscintilla2.11-qt4-x11,
+	(%type_raw[-blas] = .)		arpack-ng (>=3.1.3-3) | (%type_raw[-blas] = .) arpack-ng-mpi (>= 3.1.2-4),
+	(%type_raw[-blas] = .)		qrupdate (>= 1.1.2-7),
+	(%type_raw[-blas] = -atlas)	atlas (>= 3.10.1-1),
+	(%type_raw[-blas] = -atlas)	arpack-ng-atlas (>= 3.1.3-3) | (%type_raw[-blas] = -atlas) arpack-ng-mpi-atlas (>= 3.1.3-3),
+	(%type_raw[-blas] = -atlas)	qrupdate-atlas (>= 1.1.2-7),
+	(%type_raw[-blas] = -openblas)	openblas,
+	(%type_raw[-blas] = -openblas)	arpack-ng-openblas (>= 3.7.0-1) | (%type_raw[-blas] = -openblas) arpack-ng-mpi-openblas (>= 3.7.0-1),
+	(%type_raw[-blas] = -openblas)	qrupdate-openblas (>= 1.1.2-11),
+	(%type_raw[-blas] = -ref)	lapack3,
+	(%type_raw[-blas] = -ref)	arpack-ng-ref (>= 3.1.3-3) | (%type_raw[-blas] = -ref) arpack-ng-mpi-ref (>= 3.1.3-3),
+	(%type_raw[-blas] = -ref)	qrupdate-ref (>= 1.1.2-7),
+	(%type_raw[-qtui] = -qtmac)	qt4-base-mac,
+	(%type_raw[-qtui] = -qtmac)	qt4-base-mac-linguist,
+	(%type_raw[-qtui] = -qtmac)	qscintilla2.11-qt4-mac,
+	(%type_raw[-qtui] = -qtx11)	qt4-base-x11,
+	(%type_raw[-qtui] = -qtx11)	qt4-base-x11-linguist,
+	(%type_raw[-qtui] = -qtx11)	qscintilla2.11-qt4-x11,
 	texlive-base | texlive-nox-base
 <<
 Depends: %{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui] (=%v-%r)
@@ -61,51 +64,64 @@ Provides: <<
 (%type_raw[-qtui] = -qtmac)			%{Ni}-interpreter-qtmac,
 (%type_raw[-blas] = -atlas)			%{Ni}-interpreter-newatlas,
 (%type_raw[-blas] = .)				%{Ni}-interpreter-accelerate,
+(%type_raw[-blas] = -openblas)			%{Ni}-interpreter-openblas,
 (%type_raw[-blas] = -ref)			%{Ni}-interpreter-ref
 <<
 Conflicts: <<
-	%{Ni}, 
+	%{Ni},
 	%{Ni}-qtmac,
-	%{Ni}-qtx11, 
-	%{Ni}-x11, 
-	%{Ni}-x11-qtmac, 
-	%{Ni}-x11-qtx11, 
+	%{Ni}-qtx11,
+	%{Ni}-x11,
+	%{Ni}-x11-qtmac,
+	%{Ni}-x11-qtx11,
 	%{Ni}-atlas,
 	%{Ni}-atlas-qtmac,
 	%{Ni}-atlas-qtx11,
 	%{Ni}-atlas-x11,
 	%{Ni}-atlas-x11-qtmac,
 	%{Ni}-atlas-x11-qtx11,
-	%{Ni}-ref, 
-	%{Ni}-ref-qtmac, 
-	%{Ni}-ref-qtx11, 
+	%{Ni}-openblas,
+	%{Ni}-openblas-qtmac,
+	%{Ni}-openblas-qtx11,
+	%{Ni}-openblas-x11,
+	%{Ni}-openblas-x11-qtmac,
+	%{Ni}-openblas-x11-qtx11,
+	%{Ni}-ref,
+	%{Ni}-ref-qtmac,
+	%{Ni}-ref-qtx11,
 	%{Ni}-ref-x11,
 	%{Ni}-ref-x11-qtmac,
 	%{Ni}-ref-x11-qtx11,
-	%{Ni}3.0.2 ( << 3.0.2-5), 
-	%{Ni}3.0.2-atlas ( << 3.0.2-5) 
+	%{Ni}3.0.2 ( << 3.0.2-5),
+	%{Ni}3.0.2-atlas ( << 3.0.2-5)
 <<
 Replaces: <<
-	%{Ni}, 
-	%{Ni}-qtmac, 
-	%{Ni}-qtx11, 
-	%{Ni}-x11, 
-	%{Ni}-x11-qtmac, 
-	%{Ni}-x11-qtx11, 
+	%{Ni},
+	%{Ni}-qtmac,
+	%{Ni}-qtx11,
+	%{Ni}-x11,
+	%{Ni}-x11-qtmac,
+	%{Ni}-x11-qtx11,
 	%{Ni}-atlas,
 	%{Ni}-atlas-qtmac,
 	%{Ni}-atlas-qtx11,
 	%{Ni}-atlas-x11,
 	%{Ni}-atlas-x11-qtmac,
 	%{Ni}-atlas-x11-qtx11,
-	%{Ni}-ref, 
-	%{Ni}-ref-qtmac, 
-	%{Ni}-ref-qtx11, 
+	%{Ni}-openblas,
+	%{Ni}-openblas-qtmac,
+	%{Ni}-openblas-qtx11,
+	%{Ni}-openblas-x11,
+	%{Ni}-openblas-x11-qtmac,
+	%{Ni}-openblas-x11-qtx11,
+	%{Ni}-ref,
+	%{Ni}-ref-qtmac,
+	%{Ni}-ref-qtx11,
 	%{Ni}-ref-x11,
 	%{Ni}-ref-x11-qtmac,
 	%{Ni}-ref-x11-qtx11,
-	%{Ni}3.0.2 ( << 3.0.2-5), 
-	%{Ni}3.0.2-atlas ( << 3.0.2-5) 
+	%{Ni}3.0.2 ( << 3.0.2-5),
+	%{Ni}3.0.2-atlas ( << 3.0.2-5)
 <<
 
 # source
@@ -129,7 +145,7 @@ PatchScript: <<
 	#!/bin/sh -ev
 
 	#Fink-specific structural changes
-	sed -e 's/@OCTVERSION@/%v/g' -e 's|@FINKPREFIX@|%p|g' %{PatchFile} | patch -p1 
+	sed -e 's/@OCTVERSION@/%v/g' -e 's|@FINKPREFIX@|%p|g' %{PatchFile} | patch -p1
 	# Put in the Fink tree.
 	sed -i -e 's|@FINKPREFIX@|%p|g' doc/interpreter/*.1 src/mkoctfile*in.cc
 
@@ -145,7 +161,7 @@ PatchScript: <<
 
 	# Patch configure not to link like Puma on Yosemite
 	perl -pi -e 's/(10\.\[012\])\*/\1\,.\*/' configure
-	
+
 	# add /opt/X11/include to the legal header directories
 	perl -pi -e "s|(/usr/X11R4/include)|\1\n/opt/X11/include|" configure
 
@@ -156,8 +172,8 @@ PatchScript: <<
 	cp doc/interpreter/mkoctfile.1 doc/interpreter/mkoctfile-%v.1
 
 	# fix executable names in versioned manpages
-	sed -e 's/@OCTVERSION@/%v/g' %{PatchFile2} | patch -p1 
-	
+	sed -e 's/@OCTVERSION@/%v/g' %{PatchFile2} | patch -p1
+
 	# instead of using flag-sort, ensure that the right sysdep.h is used
 	grep -lr '#include "sysdep.h"' * | xargs perl -pi.orig -e 's,sysdep.h,%b/libinterp/corefcn/sysdep.h,'
 
@@ -177,13 +193,17 @@ ConfigureParams: <<
 	--disable-java \
 	(%type_raw[-blas] = .)		--with-lapack=-Wl,-framework,Accelerate \
 	(%type_raw[-blas] = .)		--with-blas=-Wl,-framework,Accelerate \
- 	(%type_raw[-blas] = -atlas)	--with-lapack="-ltatlas" \
- 	(%type_raw[-blas] = -atlas)	--with-blas="-ltatlas" \
- 	(%type_raw[-blas] = -ref)	--with-lapack="-L%p/lib/lapack/%type_raw[lapack] -lreflapack" \
- 	(%type_raw[-blas] = -ref)	--with-blas="-L%p/lib/lapack/%type_raw[lapack] -lrefblas" \
+	(%type_raw[-blas] = -atlas)	--with-lapack="-ltatlas" \
+	(%type_raw[-blas] = -atlas)	--with-blas="-ltatlas" \
+	(%type_raw[-blas] = -openblas)	--with-lapack="-lopenblas" \
+	(%type_raw[-blas] = -openblas)	--with-blas="-lopenblas" \
+	(%type_raw[-blas] = -ref)	--with-lapack="-L%p/lib/lapack3 -lreflapack" \
+	(%type_raw[-blas] = -ref)	--with-blas="-L%p/lib/lapack3 -lrefblas" \
 	--with-framework-carbon \
 	--with-magick=GraphicsMagick \
 	--with-qhull-includedir=%p/include/libqhull \
+	--with-hdf5-includedir=%p/opt/hdf5.v1.12/include \
+	--with-hdf5-libdir=%p/opt/hdf5.v1.12/lib \
 	--host=%m-apple-darwin \
 	--build=%m-apple-darwin \
 	--infodir='${prefix}/share/info' \
@@ -214,50 +234,51 @@ if [ ! -x %p/bin/oct-cc -o ! -x %p/bin/oct-cxx ] ; then
 
  # allow configure to find OpenGL libraries in X11
  export LDFLAGS="-L%p/lib -Wl,-dead_strip_dylibs"
- export CPPFLAGS="-I%p/include -I%p/include/freetype2"
+ # make include paths available in subdirectory builds
+ export CPPFLAGS="-I%p/include -I%p/include/freetype2 -I%p/opt/hdf5.v1.12/include"
  export CPP="clang -E"
  export CXXCPP="clang++ -E"
  export F77=%p/bin/gfortran-fsf-%type_raw[gcc]
  # -ff2c is required when using gfortran and Accelerate.framework
  if [ "%type_raw[-blas]" = "." ]
- 	then export FFLAGS='-O3 -ff2c'
- 	else export FFLAGS='-O3'
+	then export FFLAGS='-O3 -ff2c'
+	else export FFLAGS='-O3'
  fi
  FLIBDIR="%p/lib/gcc%type_raw[gcc]/lib"
  export FLIBS="-L${FLIBDIR} -lgfortran"
  export PKG_CONFIG=%p/bin/pykg-config
  qt_type=`echo %type_pkg[-qtui] | cut -dt -f2`
- if [ "%type_raw[-qtui]" != "."  ] ; then	
- 	export PKG_CONFIG_PATH="%p/lib/qt4-$qt_type/lib/pkgconfig:$PKG_CONFIG_PATH"
+ if [ "%type_raw[-qtui]" != "." ] ; then
+	export PKG_CONFIG_PATH="%p/lib/qt4-$qt_type/lib/pkgconfig:$PKG_CONFIG_PATH"
 	export PATH="%p/lib/qt4-$qt_type/bin:$PATH"
 	# QtCore is inherited
 	export LDFLAGS=`pkg-config QtNetwork --libs`" "`pkg-config QtGui --libs`" -L%p/lib/qt4-$qt_type/lib $LDFLAGS"
  fi
- 
+
  autoreconf -fi
- 
+
  ./configure %c "ac_cv_func_mkostemp=no"
  # don't just use top-level Makefile so that we can do a multi-core build.
- pushd libgnu 
+ pushd libgnu
  /usr/bin/make -j1
  popd
  for dirs in liboctave libinterp ; do
- 	pushd $dirs
- 	/usr/bin/make
- 	popd
+	pushd $dirs
+	/usr/bin/make
+	popd
  done
- if [ "%type_raw[-qtui]" != "."  ] ; then
+ if [ "%type_raw[-qtui]" != "." ] ; then
 	pushd libgui
 	/usr/bin/make
 	popd
  fi
  # src/ and scripts/ need to be built with -j1 since docs get built there.
  for dirs in src scripts ; do
- 	pushd $dirs
- 	/usr/bin/make -j1
- 	popd
+	pushd $dirs
+	/usr/bin/make -j1
+	popd
  done
- /usr/bin/make 
+ /usr/bin/make
  fink-package-precedence .
 <<
 
@@ -293,14 +314,14 @@ InstallScript: <<
  rm mkoctfile mkoctfile-%type_raw[oct]
  /bin/cp %b/src/mkoctfile mkoctfile-%v
  ln -s mkoctfile-%v mkoctfile
-  
+
  # sanitize .la files
  cd %i/lib/%{Ni}/%v/
- perl -pi -e 's/(\-framework)\s(\w+)/-Wl,$1,$2/g' *.la 
+ perl -pi -e 's/(\-framework)\s(\w+)/-Wl,$1,$2/g' *.la
 
  # manually install libcxx-fix.h
  if [ -e %b/liboctave/operators/libcxx-fix.h ] ; then
- 	cp %b/liboctave/operators/libcxx-fix.h %i/include/%{Ni}-%v/%{Ni}/
+	cp %b/liboctave/operators/libcxx-fix.h %i/include/%{Ni}-%v/%{Ni}/
  fi
 <<
 
@@ -309,76 +330,76 @@ DocFiles: AUTHORS BUGS COPYING ChangeLog NEWS README
 ConfFiles: %p/share/%{Ni}/site/m/startup/%{Ni}rc
 
 DescDetail: <<
-Octave provides a convenient command line interface for solving linear and 
-nonlinear problems numerically, and for performing other numerical 
+Octave provides a convenient command line interface for solving linear and
+nonlinear problems numerically, and for performing other numerical
 experiments using a language that is mostly compatible with Matlab.
 It may also be used as a batch-oriented language.
 
 Octave has extensive tools for solving common numerical linear algebra
 problems, finding the roots of nonlinear equations, integrating ordinary
 functions, manipulating polynomials, and integrating ordinary differential
-and differential-algebraic equations. It is easily extensible and 
-customizable via user-defined functions written in Octave's own language, 
-or using dynamically loaded modules written in C++, C, Fortran, 
+and differential-algebraic equations. It is easily extensible and
+customizable via user-defined functions written in Octave's own language,
+or using dynamically loaded modules written in C++, C, Fortran,
 or other languages.
 <<
 
-DescUsage: << 
-The %{Ni}%type_pkg[-blas]%type_pkg[-qtui] package contains 
+DescUsage: <<
+The %{Ni}%type_pkg[-blas]%type_pkg[-qtui] package contains
 unversioned executables, in particular the "octave" executable, along with the
-GNU info documentation.  
+GNU info documentation.
 
 The "-qtmac" variant builds a GUI which uses Qt on Aqua, while
 the "-qtx11" variant builds an X11 Qt gui.
 
 You can select another version of Octave to be the default, i.e. the "octave"
-executable and "info octave" point to it, via 
-"fink install %{Ni}%type_pkg[-blas]-<version>", 
+executable and "info octave" point to it, via
+"fink install %{Ni}%type_pkg[-blas]-<version>",
 where the available <version> options are:
 	3.0.5
 	3.2.4
 	3.4.3
 	3.6.0
 	3.6.1
-	3.6.2 
-	3.6.3 
+	3.6.2
+	3.6.3
 	3.6.4
-	
-By default the plotting output (via gnuplot) is directed to AquaTerm. 
+
+By default the plotting output (via gnuplot) is directed to AquaTerm.
 This can be overidden in your startup scripts, e.g.
- 
+
 	export GNUTERM=x11
- 
+
 in bash
- 
+
 or
- 
+
 	setenv GNUTERM x11
- 
+
 in tcsh.
 
-To build and install packages from Octave Forge manually, or to 
-build anything else against Octave, you will need to install the 
-%{Ni}%type_pkg[-blas]-dev package.  
+To build and install packages from Octave Forge manually, or to
+build anything else against Octave, you will need to install the
+%{Ni}%type_pkg[-blas]-dev package.
 Fink's *-oct%type_pkg[oct] packages do this automatically, as well as
 applying patches, so unless you want to test a pre-release version,
 you are probably better off installing OF packages via Fink.
- 
+
 Note:  Fink's Octave implementation modifies one of the startup files,
 %p/share/%{Ni}/%v/m/startup/octaverc,
-to initialize octave sessions to know about Fink's octave-versioned 
+to initialize octave sessions to know about Fink's octave-versioned
 install location for octave-forge packages.  If you use the '--norc' or '-f'
 flags in your Octave script, these packages won't be visible.  You'll need to
 run the following command in your script:
- 
- 	pkg global_list %p/var/octave/%v/octave_packages
+
+	pkg global_list %p/var/octave/%v/octave_packages
 <<
 
 
 DescPort: <<
 Thanks to Per Persson for most (if not all) of the work on the macos X port.
 
-The Accelerate variant is built with -ff2c in the FFLAGS, 
+The Accelerate variant is built with -ff2c in the FFLAGS,
 because this appears to be necessary when using the Accelerate framework.
 
 Revision 7 -- update X11 detection
@@ -387,11 +408,11 @@ Revision 7 -- update X11 detection
 DescPackaging:  <<
 Revision 101: disable Java for the time being.
 
-Patchfile6 from J. Howarth covers build failure on High Sierra from  
+Patchfile6 from J. Howarth covers build failure on High Sierra from
 
 "error: call to 'pow' is ambiguous"
 
-in liboctave/numeric/lo-specfun.cc and libinterp/corefcn/graphics.cc by using 
+in liboctave/numeric/lo-specfun.cc and libinterp/corefcn/graphics.cc by using
 std::pow() instead of pow().
 
 set ac_cv_func_mkostemp=no explicitly to allow building on OS X Sierra and later.
@@ -411,7 +432,7 @@ Update X11 linkage.
 Revision 6 -- Test suite crashes when built against fltk13-aqua and run as fink-bld.
 Fix some sketchy flag ordering to ensure that Fink's freetype2 headers get brought
 in before those from X11.  Also put a versioned dependency on freetype2.
-Switch to hdf5.9.
+Switch to hdf5.200.v1.12.
 
 Revision 5 --  image-oct382 needs the cxx fix for _all_ OSX versions, so we
 remove the conditional patching and add a virtual package to note that this has been
@@ -419,16 +440,16 @@ applied.
 
 Use pykg-config instead of pkgconfig to lighten the build tree.
 
-Remove a desktop file that gets generated only for users with GNOME/KDE 
+Remove a desktop file that gets generated only for users with GNOME/KDE
 installed.
 
 SetLIBS: -lgl2ps because of missing symbols from that library on 10.7/Xcode
-4.2.6	
+4.2.6
 
 Non-X11 FLTK stuff still uses X headers.
-	
+
 Set the GNUTERM environment variable to AquaTerm because autodetection of
-DISPLAY seems to cause options to be fed to our gnuplot that it doesn't 
+DISPLAY seems to cause options to be fed to our gnuplot that it doesn't
 understand.  AquaTerm seems to be a sensible default.
 
 Create manpages for the versioned executables.
@@ -436,31 +457,32 @@ Create manpages for the versioned executables.
 We have split the package up into versioned runtime+library, development, and
 unversioned runtime packages,  to make upgrades easier for us and for users.  Prior
 packaging had separate libraries, but this led to deadlocks when attempting to swap
-variants.  Also, it's unlikely that anybody is going to want just the libraries, 
+variants.  Also, it's unlikely that anybody is going to want just the libraries,
 anyway.
-	
-The -atlas variant depends on -atlas variants (only) of qrupdate and arpack-ng.  
-The Accelerate variant depends on Accelerate variants (only) of these, and 
+
+The -atlas variant depends on -atlas variants (only) of qrupdate and arpack-ng.
+The Accelerate variant depends on Accelerate variants (only) of these,
+the OpenBLAS variant depends on OpenBLAS variants (only) of the same, and
 the reference LAPACK variant depends on variants of qrupdate and arpack-ng
-which use the reference LAPACK (i.e. lapack350).
- 
+which use the reference LAPACK (i.e. lapack3).
+
 Patch oct-conf.h and mkoctfile to use octave-specific compiler executables
-which are part of the fink-octave-scripts package to avoid issues which 
-would propagate as dependencies, e.g. encoding 'flag-sort' or a 
-ccache-default compiler. This also makes sure that anything that builds 
-against Octave has the proper information when installed manually as well 
+which are part of the fink-octave-scripts package to avoid issues which
+would propagate as dependencies, e.g. encoding 'flag-sort' or a
+ccache-default compiler. This also makes sure that anything that builds
+against Octave has the proper information when installed manually as well
 as via Fink.
 
-We use the platform-independent oct-cc and oct-cxx wrappers from 
+We use the platform-independent oct-cc and oct-cxx wrappers from
 fink-octave-scripts to ensure that user builds:
-1) using the Fink compiler wrapper for the OS X version 
+1) using the Fink compiler wrapper for the OS X version
 2) using a stably named compiler, in case of OS X updates.
 
 We use Provides in a new namespace and new projections to avoid
 unwieldy | lists in the octave-forge packages.
 
-Since octave-forge packages for octave < 3.6.0 link to whatever gcc4N 
-Octave is using, and also since some other packages actually use gcc-4.N, 
+Since octave-forge packages for octave < 3.6.0 link to whatever gcc4N
+Octave is using, and also since some other packages actually use gcc-4.N,
 add "liboctave-gcc4N-dev" and "liboctave-gcc4N" Provides, to make sure that
 things stay in sync; the latter isn't used yet.
 
@@ -476,36 +498,36 @@ SplitOff: <<
 		%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui] (=%v-%r),
 		fink-%{Ni}-scripts (>= 0.3.0-1),
 		fink (>=0.32),
-		gcc%type_pkg[gcc]-compiler 
+		gcc%type_pkg[gcc]-compiler
 	<<
-	Conflicts: << 
-		%{Ni}305-dev, 
+	Conflicts: <<
+		%{Ni}305-dev,
 		%{Ni}305-atlas-dev,
-		%{Ni}305-ref-dev,  
-		%{Ni}324-dev, 
+		%{Ni}305-ref-dev,
+		%{Ni}324-dev,
 		%{Ni}324-atlas-dev,
 		%{Ni}324-ref-dev,
 		%{Ni}324-x11-dev,
 		%{Ni}324-atlas-x11-dev,
 		%{Ni}324-ref-x11-dev,
-		%{Ni}343-dev, 
+		%{Ni}343-dev,
 		%{Ni}343-atlas-dev,
 		%{Ni}343-ref-dev,
 		%{Ni}343-x11-dev,
 		%{Ni}343-atlas-x11-dev,
 		%{Ni}343-ref-x11-dev,
-		%{Ni}360-dev, 
+		%{Ni}360-dev,
 		%{Ni}360-atlas-dev,
 		%{Ni}360-ref-dev,
 		%{Ni}360-x11-dev,
 		%{Ni}360-atlas-x11-dev,
 		%{Ni}360-ref-x11-dev,
-		%{Ni}361-dev, 
+		%{Ni}361-dev,
 		%{Ni}361-atlas-dev,
 		%{Ni}361-ref-dev,
 		%{Ni}361-x11-dev,
 		%{Ni}361-atlas-x11-dev,
-		%{Ni}361-ref-x11-dev,		
+		%{Ni}361-ref-x11-dev,
 		%{Ni}362-dev,
 		%{Ni}362-x11-dev,
 		%{Ni}362-atlas-dev,
@@ -523,61 +545,68 @@ SplitOff: <<
 		%{Ni}364-atlas-dev,
 		%{Ni}364-atlas-x11-dev,
 		%{Ni}382-atlas-dev,
-	   	%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-atlas-x11-qtmac-dev,
-   		%{Ni}382-atlas-x11-qtx11-dev,
-   		%{Ni}382-atlas-qtmac-dev,
-   		%{Ni}382-atlas-qtx11-dev,
-   		%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-dev,
-   		%{Ni}382-x11-dev,
-   		%{Ni}382-x11-qtmac-dev,
-   		%{Ni}382-x11-qtx11-dev,
-   		%{Ni}382-x11-x11-dev,
-   		%{Ni}382-mac-dev,
-   		%{Ni}382-qtmac-dev,
-   		%{Ni}382-qtx11-dev,
-   		%{Ni}382-ref-dev,
-   		%{Ni}382-ref-x11-dev,
-   		%{Ni}382-ref-x11-qtmac-dev,
-   		%{Ni}382-ref-x11-qtx11-dev,
-	   	%{Ni}382-ref-mac-dev,
-   		%{Ni}382-ref-qtmac-dev,
-   		%{Ni}382-ref-qtx11-dev,
-   		%{Ni}382-x11-dev,
-		%{Ni} (<< 3.0.5-5), 
-		%{Ni}-atlas (<< 3.0.5-5), 
-		%{Ni}3.0.2 ( << 3.0.2-5), 
+		%{Ni}382-atlas-x11-dev,
+		%{Ni}382-atlas-x11-qtmac-dev,
+		%{Ni}382-atlas-x11-qtx11-dev,
+		%{Ni}382-atlas-qtmac-dev,
+		%{Ni}382-atlas-qtx11-dev,
+		%{Ni}382-atlas-x11-dev,
+		%{Ni}382-dev,
+		%{Ni}382-x11-dev,
+		%{Ni}382-x11-qtmac-dev,
+		%{Ni}382-x11-qtx11-dev,
+		%{Ni}382-x11-x11-dev,
+		%{Ni}382-mac-dev,
+		%{Ni}382-qtmac-dev,
+		%{Ni}382-qtx11-dev,
+		%{Ni}382-ref-dev,
+		%{Ni}382-ref-x11-dev,
+		%{Ni}382-ref-x11-qtmac-dev,
+		%{Ni}382-ref-x11-qtx11-dev,
+		%{Ni}382-ref-mac-dev,
+		%{Ni}382-ref-qtmac-dev,
+		%{Ni}382-ref-qtx11-dev,
+		%{Ni}382-openblas-dev,
+		%{Ni}382-openblas-x11-dev,
+		%{Ni}382-openblas-x11-qtmac-dev,
+		%{Ni}382-openblas-x11-qtx11-dev,
+		%{Ni}382-openblas-mac-dev,
+		%{Ni}382-openblas-qtmac-dev,
+		%{Ni}382-openblas-qtx11-dev,
+		%{Ni}382-x11-dev,
+		%{Ni} (<< 3.0.5-5),
+		%{Ni}-atlas (<< 3.0.5-5),
+		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
 	Replaces: <<
-		%{Ni}305-dev, 
+		%{Ni}305-dev,
 		%{Ni}305-atlas-dev,
-		%{Ni}305-ref-dev,  
-		%{Ni}324-dev, 
+		%{Ni}305-ref-dev,
+		%{Ni}324-dev,
 		%{Ni}324-atlas-dev,
 		%{Ni}324-ref-dev,
 		%{Ni}324-x11-dev,
 		%{Ni}324-atlas-x11-dev,
 		%{Ni}324-ref-x11-dev,
-		%{Ni}343-dev, 
+		%{Ni}343-dev,
 		%{Ni}343-atlas-dev,
 		%{Ni}343-ref-dev,
 		%{Ni}343-x11-dev,
 		%{Ni}343-atlas-x11-dev,
 		%{Ni}343-ref-x11-dev,
-		%{Ni}360-dev, 
+		%{Ni}360-dev,
 		%{Ni}360-atlas-dev,
 		%{Ni}360-ref-dev,
 		%{Ni}360-x11-dev,
 		%{Ni}360-atlas-x11-dev,
 		%{Ni}360-ref-x11-dev,
-		%{Ni}361-dev, 
+		%{Ni}361-dev,
 		%{Ni}361-atlas-dev,
 		%{Ni}361-ref-dev,
 		%{Ni}361-x11-dev,
 		%{Ni}361-atlas-x11-dev,
-		%{Ni}361-ref-x11-dev,		
+		%{Ni}361-ref-x11-dev,
 		%{Ni}362-dev,
 		%{Ni}362-x11-dev,
 		%{Ni}362-atlas-dev,
@@ -597,50 +626,58 @@ SplitOff: <<
 		%{Ni}364-ref-dev,
 		%{Ni}364-ref-x11-dev,
 		%{Ni}382-atlas-dev,
-	   	%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-atlas-x11-qtmac-dev,
-   		%{Ni}382-atlas-x11-qtx11-dev,
-   		%{Ni}382-atlas-qtmac-dev,
-   		%{Ni}382-atlas-qtx11-dev,
-   		%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-dev,
-   		%{Ni}382-x11-dev,
-   		%{Ni}382-x11-qtmac-dev,
-   		%{Ni}382-x11-qtx11-dev,
-   		%{Ni}382-x11-x11-dev,
-   		%{Ni}382-mac-dev,
-   		%{Ni}382-qtmac-dev,
-   		%{Ni}382-qtx11-dev,
-   		%{Ni}382-ref-dev,
-   		%{Ni}382-ref-x11-dev,
-   		%{Ni}382-ref-x11-qtmac-dev,
-   		%{Ni}382-ref-x11-qtx11-dev,
-	   	%{Ni}382-ref-mac-dev,
-   		%{Ni}382-ref-qtmac-dev,
-   		%{Ni}382-ref-qtx11-dev,
-   		%{Ni}382-x11-dev,
-		%{Ni} (<< 3.0.5-5), 
-		%{Ni}-atlas (<< 3.0.5-5), 
-		%{Ni}3.0.2 ( << 3.0.2-5), 
+		%{Ni}382-atlas-x11-dev,
+		%{Ni}382-atlas-x11-qtmac-dev,
+		%{Ni}382-atlas-x11-qtx11-dev,
+		%{Ni}382-atlas-qtmac-dev,
+		%{Ni}382-atlas-qtx11-dev,
+		%{Ni}382-atlas-x11-dev,
+		%{Ni}382-dev,
+		%{Ni}382-x11-dev,
+		%{Ni}382-x11-qtmac-dev,
+		%{Ni}382-x11-qtx11-dev,
+		%{Ni}382-x11-x11-dev,
+		%{Ni}382-mac-dev,
+		%{Ni}382-qtmac-dev,
+		%{Ni}382-qtx11-dev,
+		%{Ni}382-ref-dev,
+		%{Ni}382-ref-x11-dev,
+		%{Ni}382-ref-x11-qtmac-dev,
+		%{Ni}382-ref-x11-qtx11-dev,
+		%{Ni}382-ref-mac-dev,
+		%{Ni}382-ref-qtmac-dev,
+		%{Ni}382-ref-qtx11-dev,
+		%{Ni}382-openblas-dev,
+		%{Ni}382-openblas-x11-dev,
+		%{Ni}382-openblas-x11-qtmac-dev,
+		%{Ni}382-openblas-x11-qtx11-dev,
+		%{Ni}382-openblas-mac-dev,
+		%{Ni}382-openblas-qtmac-dev,
+		%{Ni}382-openblas-qtx11-dev,
+		%{Ni}382-x11-dev,
+		%{Ni} (<< 3.0.5-5),
+		%{Ni}-atlas (<< 3.0.5-5),
+		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
 	Provides: <<
 		lib%{Ni}%type_pkg[oct]-gcc%type_pkg[gcc]-dev,
 		lib%{Ni}%type_pkg[oct]-cxxfix-dev,
 		lib%{Ni}%type_pkg[oct]-dev,
-		(%type_raw[-blas] = -atlas) 		lib%{Ni}%type_pkg[oct]-newatlas-dev,
-		(%type_raw[-blas] = .) 				lib%{Ni}%type_pkg[oct]-accelerate-dev,
-		(%type_raw[-blas] = -ref) 			lib%{Ni}%type_pkg[oct]-ref-dev,
+		(%type_raw[-blas] = -atlas)		lib%{Ni}%type_pkg[oct]-newatlas-dev,
+		(%type_raw[-blas] = .)				lib%{Ni}%type_pkg[oct]-accelerate-dev,
+		(%type_raw[-blas] = -openblas)			lib%{Ni}%type_pkg[oct]-openblas-dev,
+		(%type_raw[-blas] = -ref)			lib%{Ni}%type_pkg[oct]-ref-dev,
 		lib%{Ni}%type_pkg[oct]-aqua-dev,
 		(%type_raw[-qtui] = -qtx11)			lib%{Ni}%type_pkg[oct]-qtx11-dev,
 		(%type_raw[-qtui] = -qtmac)			lib%{Ni}%type_pkg[oct]-qtmac-dev
 	<<
-	
+
 	BuildDependsOnly: true
-	
+
 	Files: <<
 		include/%{Ni}-%v
-		lib/%{Ni}/%v/*.la 
+		lib/%{Ni}/%v/*.la
 		lib/%{Ni}/%v/lib{%{Ni},octinterp}.dylib
 		(%type_raw[-qtui] != .) lib/%{Ni}/%v/liboctgui.dylib
 		bin/mkoctfile*
@@ -653,9 +690,9 @@ SplitOff: <<
 	headers and the mkoctfile executable.  It also contains symlinks to Fink's
 	compiler wrappers, which are set up at install time to be appropriate to
 	the current machine setup.
-	To use mkoctfile to build dynamically loadable modules, you will need 	
+	To use mkoctfile to build dynamically loadable modules, you will need
 	to install the hdf5.8 and fftw3 packages.
- 	%n cannot Depend on them since they are BuildDependsOnly.
+	%n cannot Depend on them since they are BuildDependsOnly.
 	<<
 	DescPackaging:  <<
 	We make up an extra mkoctfile which uses a Fink gcc for packages that need
@@ -667,7 +704,7 @@ SplitOff: <<
 # versioned executables and shlibs
 SplitOff2: <<
 	Package: octave%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui]
-	Conflicts: << 
+	Conflicts: <<
 		%{Ni}%type_pkg[oct],
 		%{Ni}%type_pkg[oct]-qtmac,
 		%{Ni}%type_pkg[oct]-qtx11,
@@ -680,14 +717,20 @@ SplitOff2: <<
 		%{Ni}%type_pkg[oct]-atlas-x11,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtmac,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtx11,
+		%{Ni}%type_pkg[oct]-openblas,
+		%{Ni}%type_pkg[oct]-openblas-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-qtx11,
+		%{Ni}%type_pkg[oct]-openblas-x11,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtx11,
 		%{Ni}%type_pkg[oct]-ref,
 		%{Ni}%type_pkg[oct]-ref-qtmac,
 		%{Ni}%type_pkg[oct]-ref-qtx11,
 		%{Ni}%type_pkg[oct]-ref-x11,
 		%{Ni}%type_pkg[oct]-ref-x11-qtmac,
 		%{Ni}%type_pkg[oct]-ref-x11-qtx11,
-		%{Ni} (<< 3.0.5-5), 
-		%{Ni}-atlas (<< 3.0.5-5), 
+		%{Ni} (<< 3.0.5-5),
+		%{Ni}-atlas (<< 3.0.5-5),
 		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
@@ -704,6 +747,12 @@ SplitOff2: <<
 		%{Ni}%type_pkg[oct]-atlas-x11,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtmac,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtx11,
+		%{Ni}%type_pkg[oct]-openblas,
+		%{Ni}%type_pkg[oct]-openblas-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-qtx11,
+		%{Ni}%type_pkg[oct]-openblas-x11,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtx11,
 		%{Ni}%type_pkg[oct]-ref,
 		%{Ni}%type_pkg[oct]-ref-qtmac,
 		%{Ni}%type_pkg[oct]-ref-qtx11,
@@ -711,17 +760,19 @@ SplitOff2: <<
 		%{Ni}%type_pkg[oct]-ref-x11-qtmac,
 		%{Ni}%type_pkg[oct]-ref-x11-qtx11,
 		%{Ni}%type_pkg[oct]-ref-x11,
-		%{Ni} (<< 3.0.5-5), 
+		%{Ni} (<< 3.0.5-5),
 		%{Ni}-atlas (<< 3.0.5-5),
-		%{Ni}3.0.2 ( << 3.0.2-5), 
+		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
-	Depends: << 
+	Depends: <<
 		(%type_raw[-blas] = .)		arpack-ng-shlibs (>= 3.1.3-3) | (%type_raw[-blas] = .) arpack-ng-mpi-shlibs (>= 3.1.2-4),
 		(%type_raw[-blas] = -ref)	arpack-ng-ref-shlibs (>= 3.1.3-3) | (%type_raw[-blas] = -ref) arpack-ng-mpi-ref-shlibs (>= 3.1.3-3),
 		(%type_raw[-blas] = -atlas)	arpack-ng-atlas-shlibs (>= 3.1.3-3) | (%type_raw[-blas] = -atlas) arpack-ng-mpi-atlas-shlibs (>= 3.1.3-3),
 		(%type_raw[-blas] = -atlas)	atlas-shlibs (>= 3.10.1-1),
-		fftw3-shlibs (>= 3.1.1-7), 
+		(%type_raw[-blas] = -openblas)	arpack-ng-openblas-shlibs (>= 3.7.0-1) | (%type_raw[-blas] = -openblas) arpack-ng-mpi-openblas-shlibs (>= 3.7.0-1),
+		(%type_raw[-blas] = -openblas)	openblas-shlibs,
+		fftw3-shlibs (>= 3.1.1-7),
 		fltk13-aqua-shlibs,
 		fontconfig2-shlibs,
 		freetype219-shlibs (>= 2.5.5-1),
@@ -730,24 +781,26 @@ SplitOff2: <<
 		glpk36-shlibs,
 		gnuplot-bin,
 		graphicsmagick1322-shlibs,
-		hdf5.9-shlibs,
-		(%type_raw[-blas] = -ref) 	lapack%type_pkg[lapack]-shlibs,
+		hdf5.200.v1.12-shlibs,
+		(%type_raw[-blas] = -ref)	lapack3-shlibs,
 		libcurl4-shlibs,
-		libpcre1-shlibs, 
-		ncurses, 
+		libpcre1-shlibs,
+		ncurses,
 		qhull6.3.1-shlibs,
-	 	(%type_raw[-qtui] = -qtmac) qscintilla2.11-qt4-mac-shlibs, 
-	 	(%type_raw[-qtui] = -qtx11) qscintilla2.11-qt4-x11-shlibs, 
-	 	(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtcore-shlibs, 
-	 	(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtcore-shlibs, 
-	 	(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtgui-shlibs, 
-	 	(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtgui-shlibs, 	 	
-	 	(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtnetwork-shlibs,
+		(%type_raw[-qtui] = -qtmac) qscintilla2.11-qt4-mac-shlibs,
+		(%type_raw[-qtui] = -qtx11) qscintilla2.11-qt4-x11-shlibs,
+		(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtcore-shlibs,
+		(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtcore-shlibs,
+		(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtgui-shlibs,
+		(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtgui-shlibs,
+		(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtnetwork-shlibs,
 		(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtnetwork-shlibs,
 		(%type_raw[-blas] = -atlas)	atlas-shlibs (>= 3.10.1-1),
-		(%type_raw[-blas] = -atlas) qrupdate-atlas-shlibs (>= 1.1.2-7), 
-		(%type_raw[-blas] = .) 		qrupdate-shlibs (>= 1.1.2-7),
-		(%type_raw[-blas] = -ref) 	qrupdate-ref-shlibs (>= 1.1.2-7),
+		(%type_raw[-blas] = -atlas)	qrupdate-atlas-shlibs (>= 1.1.2-7),
+		(%type_raw[-blas] = -openblas)	openblas-shlibs,
+		(%type_raw[-blas] = -openblas)	qrupdate-openblas-shlibs (>= 1.1.2-11),
+		(%type_raw[-blas] = .)		qrupdate-shlibs (>= 1.1.2-7),
+		(%type_raw[-blas] = -ref)	qrupdate-ref-shlibs (>= 1.1.2-7),
 		readline8-shlibs,
 		suitesparse-shlibs (>= 4.0.2-2)
 	 <<
@@ -760,9 +813,10 @@ SplitOff2: <<
 	Provides: <<
 		lib%{Ni}%type_pkg[oct]-gcc%type_pkg[gcc],
 		lib%{Ni}%type_pkg[oct],
-		(%type_raw[-blas] = -atlas) 		lib%{Ni}%type_pkg[oct]-newatlas,
-		(%type_raw[-blas] = .) 				lib%{Ni}%type_pkg[oct]-accelerate,
-		(%type_raw[-blas] = -ref) 			lib%{Ni}%type_pkg[oct]-ref,
+		(%type_raw[-blas] = -atlas)			lib%{Ni}%type_pkg[oct]-newatlas,
+		(%type_raw[-blas] = -openblas)			lib%{Ni}%type_pkg[oct]-openblas,
+		(%type_raw[-blas] = .)				lib%{Ni}%type_pkg[oct]-accelerate,
+		(%type_raw[-blas] = -ref)			lib%{Ni}%type_pkg[oct]-ref,
 		lib%{Ni}%type_pkg[oct]-aqua,
 		(%type_raw[-qtui] = -qtx11)			lib%{Ni}%type_pkg[oct]-qtx11,
 		(%type_raw[-qtui] = -qtmac)			lib%{Ni}%type_pkg[oct]-qtmac,
@@ -770,12 +824,13 @@ SplitOff2: <<
 		%{Ni}%type_pkg[oct]-interpreter-aqua,
 		(%type_raw[-qtui] = -qtx11)			%{Ni}%type_pkg[oct]-interpreter-qtx11,
 		(%type_raw[-qtui] = -qtmac)			%{Ni}%type_pkg[oct]-interpreter-qtmac,
-		(%type_raw[-blas] = -atlas) 		%{Ni}%type_pkg[oct]-interpreter-newatlas,
+		(%type_raw[-blas] = -atlas)			%{Ni}%type_pkg[oct]-interpreter-newatlas,
 		(%type_raw[-blas] = .)				%{Ni}%type_pkg[oct]-interpreter-accelerate,
-		(%type_raw[-blas] = -ref) 			%{Ni}%type_pkg[oct]-interpreter-ref,
-											%{Ni}%type_pkg[oct]-cxxfix-interpreter
+		(%type_raw[-blas] = -ref)			%{Ni}%type_pkg[oct]-interpreter-ref,
+		(%type_raw[-blas] = -openblas)			%{Ni}%type_pkg[oct]-interpreter-openblas,
+								%{Ni}%type_pkg[oct]-cxxfix-interpreter
 	<<
-	
+
 	Files: <<
 		share/%{Ni}/%v
 		lib/%{Ni}/%v
@@ -790,52 +845,52 @@ SplitOff2: <<
 		(%type_raw[-qtui] !=.) %p/lib/%{Ni}/%v/liboctgui.0.dylib 1.0.0 %n (>=3.8.2-1)
 	<<
 	DescUsage: <<
-	The %{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui] 
-	package contains versioned executables, in particular the 
-	"%{Ni}-%type_raw[oct]" executable, as well as all of the core 
-	functionality of the Octave interpreter, and the shared libraries which 
-	are used by the Octave interpreter as well as for packages that build 
+	The %{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui]
+	package contains versioned executables, in particular the
+	"%{Ni}-%type_raw[oct]" executable, as well as all of the core
+	functionality of the Octave interpreter, and the shared libraries which
+	are used by the Octave interpreter as well as for packages that build
 	against Octave, such as the various Octave Forge packages.
-	Any package that either links to the libraries in 
+	Any package that either links to the libraries in
 	%{Ni}%type_pkg[-blas]-shlibs or installs an extension
-	should Depend on 
-	%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui]-shlibs 
-	and BuildDepend on %{Ni}%type_pkg[oct]%type_pkg[-blas]-dev.  
-	In addition, it will need to BuildDepend on hdf5.8 and fftw3.  
+	should Depend on
+	%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui]-shlibs
+	and BuildDepend on %{Ni}%type_pkg[oct]%type_pkg[-blas]-dev.
+	In addition, it will need to BuildDepend on hdf5.200.v1.12 and fftw3.
 
-	The "-qtmac" variant builds a GUI which uses Qt on Aqua, 
-    while the "-qtx11" variant builds an X11 Qt GUI.   
-	
-	Note that the GNU info file, which provides the core documentation, 
-	is installed as part of the 
+	The "-qtmac" variant builds a GUI which uses Qt on Aqua,
+	while the "-qtx11" variant builds an X11 Qt GUI.
+
+	Note that the GNU info file, which provides the core documentation,
+	is installed as part of the
 	"%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui]"
 	package.
-	
-	By default the plotting output (via gnuplot) is directed to AquaTerm. 
+
+	By default the plotting output (via gnuplot) is directed to AquaTerm.
 	This can be overidden in your startup scripts, e.g.
- 
- 		export GNUTERM=x11
- 
+
+		export GNUTERM=x11
+
 	in bash
- 
+
 	or
- 
+
 		setenv GNUTERM x11
- 
+
 	in tcsh.
-	 
+
 	Note:  Fink's Octave implementation modifies one of the startup files,
 	%p/share/%{Ni}/%v/m/startup/octaverc,
-	to initialize octave sessions to know about Fink's octave-versioned 
-	install location for octave-forge packages.  If you use the '--norc' 
-	or '-f' flags in your Octave script, these packages won't be visible.  
+	to initialize octave sessions to know about Fink's octave-versioned
+	install location for octave-forge packages.  If you use the '--norc'
+	or '-f' flags in your Octave script, these packages won't be visible.
 	You'll need to run the following command in your script:
- 
+
 		pkg global_list %p/var/octave/%v/octave_packages
 	<<
 	DocFiles: AUTHORS BUGS COPYING ChangeLog NEWS README doc/interpreter doc/refcard doc/liboctave
 	RuntimeVars: <<
- 		GNUTERM: aqua
+		GNUTERM: aqua
 	<<
 <<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/octave-10.14.5-3.8.2.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/octave-10.14.5-3.8.2.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: octave%type_pkg[-blas]%type_pkg[-qtui]
-Type: -blas (. -atlas -ref), oct (3.8.2), gcc (5), lapack (3.5.0), -qtui (. -qtmac -qtx11)
+Type: -blas (. -atlas -openblas -ref), oct (3.8.2), gcc (11), -qtui (. -qtmac -qtx11)
 Version: 3.8.2
-Revision: 304
+Revision: 305
 Distribution: 10.14.5
 
 Description: MATLAB-like language for computations
@@ -14,19 +14,19 @@ Homepage: https://www.gnu.org/software/octave/
 BuildDepends: <<
 	autoconf2.6,
 	automake1.15,
-	fftw3 (>= 3.1.1-7), 
+	fftw3 (>= 3.1.1-7),
 	fontconfig2-dev,
-	freetype219 (>= 2.5.5-1), 
-	gcc%type_pkg[gcc]-compiler, 
+	freetype219 (>= 2.6-1),
+	gcc%type_pkg[gcc]-compiler,
 	gl2ps-dev,
 	glpk36-dev,
-	graphicsmagick1322-dev, 
-	hdf5.9, 
+	graphicsmagick1322-dev,
+	hdf5.200.v1.12,
 	libcurl4,
 	libpcre1,
 	libtool2,
 	pykg-config,
-	qhull6.3.1-dev, 
+	qhull6.3.1-dev,
 	readline8,
 	sed,
 	suitesparse (>= 4.0.2-2),
@@ -35,20 +35,23 @@ BuildDepends: <<
 	fink-buildenv-modules (>= 0.1.3-1),
 	fink-package-precedence,
 	fltk13-aqua,
-	(%type_raw[-blas] = .) 		arpack-ng (>=3.1.3-3) | (%type_raw[-blas] = .) arpack-ng-mpi (>= 3.1.2-4), 
-	(%type_raw[-blas] = .) 		qrupdate (>= 1.1.2-7),
-	(%type_raw[-blas] = -atlas) atlas (>= 3.10.1-1),
-	(%type_raw[-blas] = -atlas) arpack-ng-atlas (>= 3.1.3-3) | (%type_raw[-blas] = -atlas) arpack-ng-mpi-atlas (>= 3.1.3-3), 
-	(%type_raw[-blas] = -atlas) qrupdate-atlas (>= 1.1.2-7),
-	(%type_raw[-blas] = -ref) 	lapack%type_pkg[lapack], 
-	(%type_raw[-blas] = -ref) 	arpack-ng-ref (>= 3.1.3-3) | (%type_raw[-blas] = -ref) arpack-ng-mpi-ref (>= 3.1.3-3),
-	(%type_raw[-blas] = -ref) 	qrupdate-ref (>= 1.1.2-7),
-	(%type_raw[-qtui] = -qtmac) qt4-base-mac,
-	(%type_raw[-qtui] = -qtmac) qt4-base-mac-linguist,
-	(%type_raw[-qtui] = -qtmac) qscintilla2.11-qt4-mac,
-	(%type_raw[-qtui] = -qtx11) qt4-base-x11,
-	(%type_raw[-qtui] = -qtx11) qt4-base-x11-linguist,
-	(%type_raw[-qtui] = -qtx11) qscintilla2.11-qt4-x11,
+	(%type_raw[-blas] = .)		arpack-ng (>=3.1.3-3) | (%type_raw[-blas] = .) arpack-ng-mpi (>= 3.1.2-4),
+	(%type_raw[-blas] = .)		qrupdate (>= 1.1.2-7),
+	(%type_raw[-blas] = -atlas)	atlas (>= 3.10.1-1),
+	(%type_raw[-blas] = -atlas)	arpack-ng-atlas (>= 3.1.3-3) | (%type_raw[-blas] = -atlas) arpack-ng-mpi-atlas (>= 3.1.3-3),
+	(%type_raw[-blas] = -atlas)	qrupdate-atlas (>= 1.1.2-7),
+	(%type_raw[-blas] = -openblas)	openblas,
+	(%type_raw[-blas] = -openblas)	arpack-ng-openblas (>= 3.7.0-1) | (%type_raw[-blas] = -openblas) arpack-ng-mpi-openblas (>= 3.7.0-1),
+	(%type_raw[-blas] = -openblas)	qrupdate-openblas (>= 1.1.2-11),
+	(%type_raw[-blas] = -ref)	lapack3,
+	(%type_raw[-blas] = -ref)	arpack-ng-ref (>= 3.1.3-3) | (%type_raw[-blas] = -ref) arpack-ng-mpi-ref (>= 3.1.3-3),
+	(%type_raw[-blas] = -ref)	qrupdate-ref (>= 1.1.2-7),
+	(%type_raw[-qtui] = -qtmac)	qt4-base-mac,
+	(%type_raw[-qtui] = -qtmac)	qt4-base-mac-linguist,
+	(%type_raw[-qtui] = -qtmac)	qscintilla2.11-qt4-mac,
+	(%type_raw[-qtui] = -qtx11)	qt4-base-x11,
+	(%type_raw[-qtui] = -qtx11)	qt4-base-x11-linguist,
+	(%type_raw[-qtui] = -qtx11)	qscintilla2.11-qt4-x11,
 	texlive-base | texlive-nox-base
 <<
 Depends: %{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui] (=%v-%r)
@@ -61,51 +64,64 @@ Provides: <<
 (%type_raw[-qtui] = -qtmac)			%{Ni}-interpreter-qtmac,
 (%type_raw[-blas] = -atlas)			%{Ni}-interpreter-newatlas,
 (%type_raw[-blas] = .)				%{Ni}-interpreter-accelerate,
+(%type_raw[-blas] = -openblas)			%{Ni}-interpreter-openblas,
 (%type_raw[-blas] = -ref)			%{Ni}-interpreter-ref
 <<
 Conflicts: <<
-	%{Ni}, 
+	%{Ni},
 	%{Ni}-qtmac,
-	%{Ni}-qtx11, 
-	%{Ni}-x11, 
-	%{Ni}-x11-qtmac, 
-	%{Ni}-x11-qtx11, 
+	%{Ni}-qtx11,
+	%{Ni}-x11,
+	%{Ni}-x11-qtmac,
+	%{Ni}-x11-qtx11,
 	%{Ni}-atlas,
 	%{Ni}-atlas-qtmac,
 	%{Ni}-atlas-qtx11,
 	%{Ni}-atlas-x11,
 	%{Ni}-atlas-x11-qtmac,
 	%{Ni}-atlas-x11-qtx11,
-	%{Ni}-ref, 
-	%{Ni}-ref-qtmac, 
-	%{Ni}-ref-qtx11, 
+	%{Ni}-openblas,
+	%{Ni}-openblas-qtmac,
+	%{Ni}-openblas-qtx11,
+	%{Ni}-openblas-x11,
+	%{Ni}-openblas-x11-qtmac,
+	%{Ni}-openblas-x11-qtx11,
+	%{Ni}-ref,
+	%{Ni}-ref-qtmac,
+	%{Ni}-ref-qtx11,
 	%{Ni}-ref-x11,
 	%{Ni}-ref-x11-qtmac,
 	%{Ni}-ref-x11-qtx11,
-	%{Ni}3.0.2 ( << 3.0.2-5), 
-	%{Ni}3.0.2-atlas ( << 3.0.2-5) 
+	%{Ni}3.0.2 ( << 3.0.2-5),
+	%{Ni}3.0.2-atlas ( << 3.0.2-5)
 <<
 Replaces: <<
-	%{Ni}, 
-	%{Ni}-qtmac, 
-	%{Ni}-qtx11, 
-	%{Ni}-x11, 
-	%{Ni}-x11-qtmac, 
-	%{Ni}-x11-qtx11, 
+	%{Ni},
+	%{Ni}-qtmac,
+	%{Ni}-qtx11,
+	%{Ni}-x11,
+	%{Ni}-x11-qtmac,
+	%{Ni}-x11-qtx11,
 	%{Ni}-atlas,
 	%{Ni}-atlas-qtmac,
 	%{Ni}-atlas-qtx11,
 	%{Ni}-atlas-x11,
 	%{Ni}-atlas-x11-qtmac,
 	%{Ni}-atlas-x11-qtx11,
-	%{Ni}-ref, 
-	%{Ni}-ref-qtmac, 
-	%{Ni}-ref-qtx11, 
+	%{Ni}-openblas,
+	%{Ni}-openblas-qtmac,
+	%{Ni}-openblas-qtx11,
+	%{Ni}-openblas-x11,
+	%{Ni}-openblas-x11-qtmac,
+	%{Ni}-openblas-x11-qtx11,
+	%{Ni}-ref,
+	%{Ni}-ref-qtmac,
+	%{Ni}-ref-qtx11,
 	%{Ni}-ref-x11,
 	%{Ni}-ref-x11-qtmac,
 	%{Ni}-ref-x11-qtx11,
-	%{Ni}3.0.2 ( << 3.0.2-5), 
-	%{Ni}3.0.2-atlas ( << 3.0.2-5) 
+	%{Ni}3.0.2 ( << 3.0.2-5),
+	%{Ni}3.0.2-atlas ( << 3.0.2-5)
 <<
 
 # source
@@ -129,7 +145,7 @@ PatchScript: <<
 	#!/bin/sh -ev
 
 	#Fink-specific structural changes
-	sed -e 's/@OCTVERSION@/%v/g' -e 's|@FINKPREFIX@|%p|g' %{PatchFile} | patch -p1 
+	sed -e 's/@OCTVERSION@/%v/g' -e 's|@FINKPREFIX@|%p|g' %{PatchFile} | patch -p1
 	# Put in the Fink tree.
 	sed -i -e 's|@FINKPREFIX@|%p|g' doc/interpreter/*.1 src/mkoctfile*in.cc
 
@@ -145,7 +161,7 @@ PatchScript: <<
 
 	# Patch configure not to link like Puma on Yosemite
 	perl -pi -e 's/(10\.\[012\])\*/\1\,.\*/' configure
-	
+
 	# add /opt/X11/include to the legal header directories
 	perl -pi -e "s|(/usr/X11R4/include)|\1\n/opt/X11/include|" configure
 
@@ -156,8 +172,8 @@ PatchScript: <<
 	cp doc/interpreter/mkoctfile.1 doc/interpreter/mkoctfile-%v.1
 
 	# fix executable names in versioned manpages
-	sed -e 's/@OCTVERSION@/%v/g' %{PatchFile2} | patch -p1 
-	
+	sed -e 's/@OCTVERSION@/%v/g' %{PatchFile2} | patch -p1
+
 	# instead of using flag-sort, ensure that the right sysdep.h is used
 	grep -lr '#include "sysdep.h"' * | xargs perl -pi.orig -e 's,sysdep.h,%b/libinterp/corefcn/sysdep.h,'
 
@@ -177,13 +193,17 @@ ConfigureParams: <<
 	--disable-java \
 	(%type_raw[-blas] = .)		--with-lapack=-Wl,-framework,Accelerate \
 	(%type_raw[-blas] = .)		--with-blas=-Wl,-framework,Accelerate \
- 	(%type_raw[-blas] = -atlas)	--with-lapack="-ltatlas" \
- 	(%type_raw[-blas] = -atlas)	--with-blas="-ltatlas" \
- 	(%type_raw[-blas] = -ref)	--with-lapack="-L%p/lib/lapack/%type_raw[lapack] -lreflapack" \
- 	(%type_raw[-blas] = -ref)	--with-blas="-L%p/lib/lapack/%type_raw[lapack] -lrefblas" \
+	(%type_raw[-blas] = -atlas)	--with-lapack="-ltatlas" \
+	(%type_raw[-blas] = -atlas)	--with-blas="-ltatlas" \
+	(%type_raw[-blas] = -openblas)	--with-lapack="-lopenblas" \
+	(%type_raw[-blas] = -openblas)	--with-blas="-lopenblas" \
+	(%type_raw[-blas] = -ref)	--with-lapack="-L%p/lib/lapack3 -lreflapack" \
+	(%type_raw[-blas] = -ref)	--with-blas="-L%p/lib/lapack3 -lrefblas" \
 	--with-framework-carbon \
 	--with-magick=GraphicsMagick \
 	--with-qhull-includedir=%p/include/libqhull \
+	--with-hdf5-includedir=%p/opt/hdf5.v1.12/include \
+	--with-hdf5-libdir=%p/opt/hdf5.v1.12/lib \
 	--host=%m-apple-darwin \
 	--build=%m-apple-darwin \
 	--infodir='${prefix}/share/info' \
@@ -214,50 +234,51 @@ if [ ! -x %p/bin/oct-cc -o ! -x %p/bin/oct-cxx ] ; then
 
  # allow configure to find OpenGL libraries in X11
  export LDFLAGS="-L%p/lib -Wl,-dead_strip_dylibs"
- export CPPFLAGS="-I%p/include -I%p/include/freetype2"
+ # make include paths available in subdirectory builds
+ export CPPFLAGS="-I%p/include -I%p/include/freetype2 -I%p/opt/hdf5.v1.12/include"
  export CPP="clang -E"
  export CXXCPP="clang++ -E"
  export F77=%p/bin/gfortran-fsf-%type_raw[gcc]
  # -ff2c is required when using gfortran and Accelerate.framework
  if [ "%type_raw[-blas]" = "." ]
- 	then export FFLAGS='-O3 -ff2c'
- 	else export FFLAGS='-O3'
+	then export FFLAGS='-O3 -ff2c'
+	else export FFLAGS='-O3'
  fi
  FLIBDIR="%p/lib/gcc%type_raw[gcc]/lib"
  export FLIBS="-L${FLIBDIR} -lgfortran"
  export PKG_CONFIG=%p/bin/pykg-config
  qt_type=`echo %type_pkg[-qtui] | cut -dt -f2`
- if [ "%type_raw[-qtui]" != "."  ] ; then	
- 	export PKG_CONFIG_PATH="%p/lib/qt4-$qt_type/lib/pkgconfig:$PKG_CONFIG_PATH"
+ if [ "%type_raw[-qtui]" != "." ] ; then
+	export PKG_CONFIG_PATH="%p/lib/qt4-$qt_type/lib/pkgconfig:$PKG_CONFIG_PATH"
 	export PATH="%p/lib/qt4-$qt_type/bin:$PATH"
 	# QtCore is inherited
 	export LDFLAGS=`pkg-config QtNetwork --libs`" "`pkg-config QtGui --libs`" -L%p/lib/qt4-$qt_type/lib $LDFLAGS"
  fi
- 
+
  autoreconf -fi
- 
+
  ./configure %c "ac_cv_func_mkostemp=no"
  # don't just use top-level Makefile so that we can do a multi-core build.
- pushd libgnu 
+ pushd libgnu
  /usr/bin/make -j1
  popd
  for dirs in liboctave libinterp ; do
- 	pushd $dirs
- 	/usr/bin/make
- 	popd
+	pushd $dirs
+	/usr/bin/make
+	popd
  done
- if [ "%type_raw[-qtui]" != "."  ] ; then
+ if [ "%type_raw[-qtui]" != "." ] ; then
 	pushd libgui
 	/usr/bin/make
 	popd
  fi
  # src/ and scripts/ need to be built with -j1 since docs get built there.
  for dirs in src scripts ; do
- 	pushd $dirs
- 	/usr/bin/make -j1
- 	popd
+	pushd $dirs
+	/usr/bin/make -j1
+	popd
  done
- /usr/bin/make 
+ /usr/bin/make
  fink-package-precedence .
 <<
 
@@ -293,14 +314,14 @@ InstallScript: <<
  rm mkoctfile mkoctfile-%type_raw[oct]
  /bin/cp %b/src/mkoctfile mkoctfile-%v
  ln -s mkoctfile-%v mkoctfile
-  
+
  # sanitize .la files
  cd %i/lib/%{Ni}/%v/
- perl -pi -e 's/(\-framework)\s(\w+)/-Wl,$1,$2/g' *.la 
+ perl -pi -e 's/(\-framework)\s(\w+)/-Wl,$1,$2/g' *.la
 
  # manually install libcxx-fix.h
  if [ -e %b/liboctave/operators/libcxx-fix.h ] ; then
- 	cp %b/liboctave/operators/libcxx-fix.h %i/include/%{Ni}-%v/%{Ni}/
+	cp %b/liboctave/operators/libcxx-fix.h %i/include/%{Ni}-%v/%{Ni}/
  fi
 <<
 
@@ -309,76 +330,76 @@ DocFiles: AUTHORS BUGS COPYING ChangeLog NEWS README
 ConfFiles: %p/share/%{Ni}/site/m/startup/%{Ni}rc
 
 DescDetail: <<
-Octave provides a convenient command line interface for solving linear and 
-nonlinear problems numerically, and for performing other numerical 
+Octave provides a convenient command line interface for solving linear and
+nonlinear problems numerically, and for performing other numerical
 experiments using a language that is mostly compatible with Matlab.
 It may also be used as a batch-oriented language.
 
 Octave has extensive tools for solving common numerical linear algebra
 problems, finding the roots of nonlinear equations, integrating ordinary
 functions, manipulating polynomials, and integrating ordinary differential
-and differential-algebraic equations. It is easily extensible and 
-customizable via user-defined functions written in Octave's own language, 
-or using dynamically loaded modules written in C++, C, Fortran, 
+and differential-algebraic equations. It is easily extensible and
+customizable via user-defined functions written in Octave's own language,
+or using dynamically loaded modules written in C++, C, Fortran,
 or other languages.
 <<
 
-DescUsage: << 
-The %{Ni}%type_pkg[-blas]%type_pkg[-qtui] package contains 
+DescUsage: <<
+The %{Ni}%type_pkg[-blas]%type_pkg[-qtui] package contains
 unversioned executables, in particular the "octave" executable, along with the
-GNU info documentation.  
+GNU info documentation.
 
 The "-qtmac" variant builds a GUI which uses Qt on Aqua, while
 the "-qtx11" variant builds an X11 Qt gui.
 
 You can select another version of Octave to be the default, i.e. the "octave"
-executable and "info octave" point to it, via 
-"fink install %{Ni}%type_pkg[-blas]-<version>", 
+executable and "info octave" point to it, via
+"fink install %{Ni}%type_pkg[-blas]-<version>",
 where the available <version> options are:
 	3.0.5
 	3.2.4
 	3.4.3
 	3.6.0
 	3.6.1
-	3.6.2 
-	3.6.3 
+	3.6.2
+	3.6.3
 	3.6.4
-	
-By default the plotting output (via gnuplot) is directed to AquaTerm. 
+
+By default the plotting output (via gnuplot) is directed to AquaTerm.
 This can be overidden in your startup scripts, e.g.
- 
+
 	export GNUTERM=x11
- 
+
 in bash
- 
+
 or
- 
+
 	setenv GNUTERM x11
- 
+
 in tcsh.
 
-To build and install packages from Octave Forge manually, or to 
-build anything else against Octave, you will need to install the 
-%{Ni}%type_pkg[-blas]-dev package.  
+To build and install packages from Octave Forge manually, or to
+build anything else against Octave, you will need to install the
+%{Ni}%type_pkg[-blas]-dev package.
 Fink's *-oct%type_pkg[oct] packages do this automatically, as well as
 applying patches, so unless you want to test a pre-release version,
 you are probably better off installing OF packages via Fink.
- 
+
 Note:  Fink's Octave implementation modifies one of the startup files,
 %p/share/%{Ni}/%v/m/startup/octaverc,
-to initialize octave sessions to know about Fink's octave-versioned 
+to initialize octave sessions to know about Fink's octave-versioned
 install location for octave-forge packages.  If you use the '--norc' or '-f'
 flags in your Octave script, these packages won't be visible.  You'll need to
 run the following command in your script:
- 
- 	pkg global_list %p/var/octave/%v/octave_packages
+
+	pkg global_list %p/var/octave/%v/octave_packages
 <<
 
 
 DescPort: <<
 Thanks to Per Persson for most (if not all) of the work on the macos X port.
 
-The Accelerate variant is built with -ff2c in the FFLAGS, 
+The Accelerate variant is built with -ff2c in the FFLAGS,
 because this appears to be necessary when using the Accelerate framework.
 
 Revision 7 -- update X11 detection
@@ -387,11 +408,11 @@ Revision 7 -- update X11 detection
 DescPackaging:  <<
 Revision 101: disable Java for the time being.
 
-Patchfile6 from J. Howarth covers build failure on High Sierra from  
+Patchfile6 from J. Howarth covers build failure on High Sierra from
 
 "error: call to 'pow' is ambiguous"
 
-in liboctave/numeric/lo-specfun.cc and libinterp/corefcn/graphics.cc by using 
+in liboctave/numeric/lo-specfun.cc and libinterp/corefcn/graphics.cc by using
 std::pow() instead of pow().
 
 set ac_cv_func_mkostemp=no explicitly to allow building on OS X Sierra and later.
@@ -411,7 +432,7 @@ Update X11 linkage.
 Revision 6 -- Test suite crashes when built against fltk13-aqua and run as fink-bld.
 Fix some sketchy flag ordering to ensure that Fink's freetype2 headers get brought
 in before those from X11.  Also put a versioned dependency on freetype2.
-Switch to hdf5.9.
+Switch to hdf5.200.v1.12.
 
 Revision 5 --  image-oct382 needs the cxx fix for _all_ OSX versions, so we
 remove the conditional patching and add a virtual package to note that this has been
@@ -419,16 +440,16 @@ applied.
 
 Use pykg-config instead of pkgconfig to lighten the build tree.
 
-Remove a desktop file that gets generated only for users with GNOME/KDE 
+Remove a desktop file that gets generated only for users with GNOME/KDE
 installed.
 
 SetLIBS: -lgl2ps because of missing symbols from that library on 10.7/Xcode
-4.2.6	
+4.2.6
 
 Non-X11 FLTK stuff still uses X headers.
-	
+
 Set the GNUTERM environment variable to AquaTerm because autodetection of
-DISPLAY seems to cause options to be fed to our gnuplot that it doesn't 
+DISPLAY seems to cause options to be fed to our gnuplot that it doesn't
 understand.  AquaTerm seems to be a sensible default.
 
 Create manpages for the versioned executables.
@@ -436,31 +457,32 @@ Create manpages for the versioned executables.
 We have split the package up into versioned runtime+library, development, and
 unversioned runtime packages,  to make upgrades easier for us and for users.  Prior
 packaging had separate libraries, but this led to deadlocks when attempting to swap
-variants.  Also, it's unlikely that anybody is going to want just the libraries, 
+variants.  Also, it's unlikely that anybody is going to want just the libraries,
 anyway.
-	
-The -atlas variant depends on -atlas variants (only) of qrupdate and arpack-ng.  
-The Accelerate variant depends on Accelerate variants (only) of these, and 
+
+The -atlas variant depends on -atlas variants (only) of qrupdate and arpack-ng.
+The Accelerate variant depends on Accelerate variants (only) of these,
+the OpenBLAS variant depends on OpenBLAS variants (only) of the same, and
 the reference LAPACK variant depends on variants of qrupdate and arpack-ng
-which use the reference LAPACK (i.e. lapack350).
- 
+which use the reference LAPACK (i.e. lapack3).
+
 Patch oct-conf.h and mkoctfile to use octave-specific compiler executables
-which are part of the fink-octave-scripts package to avoid issues which 
-would propagate as dependencies, e.g. encoding 'flag-sort' or a 
-ccache-default compiler. This also makes sure that anything that builds 
-against Octave has the proper information when installed manually as well 
+which are part of the fink-octave-scripts package to avoid issues which
+would propagate as dependencies, e.g. encoding 'flag-sort' or a
+ccache-default compiler. This also makes sure that anything that builds
+against Octave has the proper information when installed manually as well
 as via Fink.
 
-We use the platform-independent oct-cc and oct-cxx wrappers from 
+We use the platform-independent oct-cc and oct-cxx wrappers from
 fink-octave-scripts to ensure that user builds:
-1) using the Fink compiler wrapper for the OS X version 
+1) using the Fink compiler wrapper for the OS X version
 2) using a stably named compiler, in case of OS X updates.
 
 We use Provides in a new namespace and new projections to avoid
 unwieldy | lists in the octave-forge packages.
 
-Since octave-forge packages for octave < 3.6.0 link to whatever gcc4N 
-Octave is using, and also since some other packages actually use gcc-4.N, 
+Since octave-forge packages for octave < 3.6.0 link to whatever gcc4N
+Octave is using, and also since some other packages actually use gcc-4.N,
 add "liboctave-gcc4N-dev" and "liboctave-gcc4N" Provides, to make sure that
 things stay in sync; the latter isn't used yet.
 
@@ -476,36 +498,36 @@ SplitOff: <<
 		%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui] (=%v-%r),
 		fink-%{Ni}-scripts (>= 0.3.0-1),
 		fink (>=0.32),
-		gcc%type_pkg[gcc]-compiler 
+		gcc%type_pkg[gcc]-compiler
 	<<
-	Conflicts: << 
-		%{Ni}305-dev, 
+	Conflicts: <<
+		%{Ni}305-dev,
 		%{Ni}305-atlas-dev,
-		%{Ni}305-ref-dev,  
-		%{Ni}324-dev, 
+		%{Ni}305-ref-dev,
+		%{Ni}324-dev,
 		%{Ni}324-atlas-dev,
 		%{Ni}324-ref-dev,
 		%{Ni}324-x11-dev,
 		%{Ni}324-atlas-x11-dev,
 		%{Ni}324-ref-x11-dev,
-		%{Ni}343-dev, 
+		%{Ni}343-dev,
 		%{Ni}343-atlas-dev,
 		%{Ni}343-ref-dev,
 		%{Ni}343-x11-dev,
 		%{Ni}343-atlas-x11-dev,
 		%{Ni}343-ref-x11-dev,
-		%{Ni}360-dev, 
+		%{Ni}360-dev,
 		%{Ni}360-atlas-dev,
 		%{Ni}360-ref-dev,
 		%{Ni}360-x11-dev,
 		%{Ni}360-atlas-x11-dev,
 		%{Ni}360-ref-x11-dev,
-		%{Ni}361-dev, 
+		%{Ni}361-dev,
 		%{Ni}361-atlas-dev,
 		%{Ni}361-ref-dev,
 		%{Ni}361-x11-dev,
 		%{Ni}361-atlas-x11-dev,
-		%{Ni}361-ref-x11-dev,		
+		%{Ni}361-ref-x11-dev,
 		%{Ni}362-dev,
 		%{Ni}362-x11-dev,
 		%{Ni}362-atlas-dev,
@@ -523,61 +545,68 @@ SplitOff: <<
 		%{Ni}364-atlas-dev,
 		%{Ni}364-atlas-x11-dev,
 		%{Ni}382-atlas-dev,
-	   	%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-atlas-x11-qtmac-dev,
-   		%{Ni}382-atlas-x11-qtx11-dev,
-   		%{Ni}382-atlas-qtmac-dev,
-   		%{Ni}382-atlas-qtx11-dev,
-   		%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-dev,
-   		%{Ni}382-x11-dev,
-   		%{Ni}382-x11-qtmac-dev,
-   		%{Ni}382-x11-qtx11-dev,
-   		%{Ni}382-x11-x11-dev,
-   		%{Ni}382-mac-dev,
-   		%{Ni}382-qtmac-dev,
-   		%{Ni}382-qtx11-dev,
-   		%{Ni}382-ref-dev,
-   		%{Ni}382-ref-x11-dev,
-   		%{Ni}382-ref-x11-qtmac-dev,
-   		%{Ni}382-ref-x11-qtx11-dev,
-	   	%{Ni}382-ref-mac-dev,
-   		%{Ni}382-ref-qtmac-dev,
-   		%{Ni}382-ref-qtx11-dev,
-   		%{Ni}382-x11-dev,
-		%{Ni} (<< 3.0.5-5), 
-		%{Ni}-atlas (<< 3.0.5-5), 
-		%{Ni}3.0.2 ( << 3.0.2-5), 
+		%{Ni}382-atlas-x11-dev,
+		%{Ni}382-atlas-x11-qtmac-dev,
+		%{Ni}382-atlas-x11-qtx11-dev,
+		%{Ni}382-atlas-qtmac-dev,
+		%{Ni}382-atlas-qtx11-dev,
+		%{Ni}382-atlas-x11-dev,
+		%{Ni}382-dev,
+		%{Ni}382-x11-dev,
+		%{Ni}382-x11-qtmac-dev,
+		%{Ni}382-x11-qtx11-dev,
+		%{Ni}382-x11-x11-dev,
+		%{Ni}382-mac-dev,
+		%{Ni}382-qtmac-dev,
+		%{Ni}382-qtx11-dev,
+		%{Ni}382-ref-dev,
+		%{Ni}382-ref-x11-dev,
+		%{Ni}382-ref-x11-qtmac-dev,
+		%{Ni}382-ref-x11-qtx11-dev,
+		%{Ni}382-ref-mac-dev,
+		%{Ni}382-ref-qtmac-dev,
+		%{Ni}382-ref-qtx11-dev,
+		%{Ni}382-openblas-dev,
+		%{Ni}382-openblas-x11-dev,
+		%{Ni}382-openblas-x11-qtmac-dev,
+		%{Ni}382-openblas-x11-qtx11-dev,
+		%{Ni}382-openblas-mac-dev,
+		%{Ni}382-openblas-qtmac-dev,
+		%{Ni}382-openblas-qtx11-dev,
+		%{Ni}382-x11-dev,
+		%{Ni} (<< 3.0.5-5),
+		%{Ni}-atlas (<< 3.0.5-5),
+		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
 	Replaces: <<
-		%{Ni}305-dev, 
+		%{Ni}305-dev,
 		%{Ni}305-atlas-dev,
-		%{Ni}305-ref-dev,  
-		%{Ni}324-dev, 
+		%{Ni}305-ref-dev,
+		%{Ni}324-dev,
 		%{Ni}324-atlas-dev,
 		%{Ni}324-ref-dev,
 		%{Ni}324-x11-dev,
 		%{Ni}324-atlas-x11-dev,
 		%{Ni}324-ref-x11-dev,
-		%{Ni}343-dev, 
+		%{Ni}343-dev,
 		%{Ni}343-atlas-dev,
 		%{Ni}343-ref-dev,
 		%{Ni}343-x11-dev,
 		%{Ni}343-atlas-x11-dev,
 		%{Ni}343-ref-x11-dev,
-		%{Ni}360-dev, 
+		%{Ni}360-dev,
 		%{Ni}360-atlas-dev,
 		%{Ni}360-ref-dev,
 		%{Ni}360-x11-dev,
 		%{Ni}360-atlas-x11-dev,
 		%{Ni}360-ref-x11-dev,
-		%{Ni}361-dev, 
+		%{Ni}361-dev,
 		%{Ni}361-atlas-dev,
 		%{Ni}361-ref-dev,
 		%{Ni}361-x11-dev,
 		%{Ni}361-atlas-x11-dev,
-		%{Ni}361-ref-x11-dev,		
+		%{Ni}361-ref-x11-dev,
 		%{Ni}362-dev,
 		%{Ni}362-x11-dev,
 		%{Ni}362-atlas-dev,
@@ -597,50 +626,58 @@ SplitOff: <<
 		%{Ni}364-ref-dev,
 		%{Ni}364-ref-x11-dev,
 		%{Ni}382-atlas-dev,
-	   	%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-atlas-x11-qtmac-dev,
-   		%{Ni}382-atlas-x11-qtx11-dev,
-   		%{Ni}382-atlas-qtmac-dev,
-   		%{Ni}382-atlas-qtx11-dev,
-   		%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-dev,
-   		%{Ni}382-x11-dev,
-   		%{Ni}382-x11-qtmac-dev,
-   		%{Ni}382-x11-qtx11-dev,
-   		%{Ni}382-x11-x11-dev,
-   		%{Ni}382-mac-dev,
-   		%{Ni}382-qtmac-dev,
-   		%{Ni}382-qtx11-dev,
-   		%{Ni}382-ref-dev,
-   		%{Ni}382-ref-x11-dev,
-   		%{Ni}382-ref-x11-qtmac-dev,
-   		%{Ni}382-ref-x11-qtx11-dev,
-	   	%{Ni}382-ref-mac-dev,
-   		%{Ni}382-ref-qtmac-dev,
-   		%{Ni}382-ref-qtx11-dev,
-   		%{Ni}382-x11-dev,
-		%{Ni} (<< 3.0.5-5), 
-		%{Ni}-atlas (<< 3.0.5-5), 
-		%{Ni}3.0.2 ( << 3.0.2-5), 
+		%{Ni}382-atlas-x11-dev,
+		%{Ni}382-atlas-x11-qtmac-dev,
+		%{Ni}382-atlas-x11-qtx11-dev,
+		%{Ni}382-atlas-qtmac-dev,
+		%{Ni}382-atlas-qtx11-dev,
+		%{Ni}382-atlas-x11-dev,
+		%{Ni}382-dev,
+		%{Ni}382-x11-dev,
+		%{Ni}382-x11-qtmac-dev,
+		%{Ni}382-x11-qtx11-dev,
+		%{Ni}382-x11-x11-dev,
+		%{Ni}382-mac-dev,
+		%{Ni}382-qtmac-dev,
+		%{Ni}382-qtx11-dev,
+		%{Ni}382-ref-dev,
+		%{Ni}382-ref-x11-dev,
+		%{Ni}382-ref-x11-qtmac-dev,
+		%{Ni}382-ref-x11-qtx11-dev,
+		%{Ni}382-ref-mac-dev,
+		%{Ni}382-ref-qtmac-dev,
+		%{Ni}382-ref-qtx11-dev,
+		%{Ni}382-openblas-dev,
+		%{Ni}382-openblas-x11-dev,
+		%{Ni}382-openblas-x11-qtmac-dev,
+		%{Ni}382-openblas-x11-qtx11-dev,
+		%{Ni}382-openblas-mac-dev,
+		%{Ni}382-openblas-qtmac-dev,
+		%{Ni}382-openblas-qtx11-dev,
+		%{Ni}382-x11-dev,
+		%{Ni} (<< 3.0.5-5),
+		%{Ni}-atlas (<< 3.0.5-5),
+		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
 	Provides: <<
 		lib%{Ni}%type_pkg[oct]-gcc%type_pkg[gcc]-dev,
 		lib%{Ni}%type_pkg[oct]-cxxfix-dev,
 		lib%{Ni}%type_pkg[oct]-dev,
-		(%type_raw[-blas] = -atlas) 		lib%{Ni}%type_pkg[oct]-newatlas-dev,
-		(%type_raw[-blas] = .) 				lib%{Ni}%type_pkg[oct]-accelerate-dev,
-		(%type_raw[-blas] = -ref) 			lib%{Ni}%type_pkg[oct]-ref-dev,
+		(%type_raw[-blas] = -atlas)		lib%{Ni}%type_pkg[oct]-newatlas-dev,
+		(%type_raw[-blas] = .)				lib%{Ni}%type_pkg[oct]-accelerate-dev,
+		(%type_raw[-blas] = -openblas)			lib%{Ni}%type_pkg[oct]-openblas-dev,
+		(%type_raw[-blas] = -ref)			lib%{Ni}%type_pkg[oct]-ref-dev,
 		lib%{Ni}%type_pkg[oct]-aqua-dev,
 		(%type_raw[-qtui] = -qtx11)			lib%{Ni}%type_pkg[oct]-qtx11-dev,
 		(%type_raw[-qtui] = -qtmac)			lib%{Ni}%type_pkg[oct]-qtmac-dev
 	<<
-	
+
 	BuildDependsOnly: true
-	
+
 	Files: <<
 		include/%{Ni}-%v
-		lib/%{Ni}/%v/*.la 
+		lib/%{Ni}/%v/*.la
 		lib/%{Ni}/%v/lib{%{Ni},octinterp}.dylib
 		(%type_raw[-qtui] != .) lib/%{Ni}/%v/liboctgui.dylib
 		bin/mkoctfile*
@@ -653,9 +690,9 @@ SplitOff: <<
 	headers and the mkoctfile executable.  It also contains symlinks to Fink's
 	compiler wrappers, which are set up at install time to be appropriate to
 	the current machine setup.
-	To use mkoctfile to build dynamically loadable modules, you will need 	
+	To use mkoctfile to build dynamically loadable modules, you will need
 	to install the hdf5.8 and fftw3 packages.
- 	%n cannot Depend on them since they are BuildDependsOnly.
+	%n cannot Depend on them since they are BuildDependsOnly.
 	<<
 	DescPackaging:  <<
 	We make up an extra mkoctfile which uses a Fink gcc for packages that need
@@ -667,7 +704,7 @@ SplitOff: <<
 # versioned executables and shlibs
 SplitOff2: <<
 	Package: octave%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui]
-	Conflicts: << 
+	Conflicts: <<
 		%{Ni}%type_pkg[oct],
 		%{Ni}%type_pkg[oct]-qtmac,
 		%{Ni}%type_pkg[oct]-qtx11,
@@ -680,14 +717,20 @@ SplitOff2: <<
 		%{Ni}%type_pkg[oct]-atlas-x11,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtmac,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtx11,
+		%{Ni}%type_pkg[oct]-openblas,
+		%{Ni}%type_pkg[oct]-openblas-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-qtx11,
+		%{Ni}%type_pkg[oct]-openblas-x11,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtx11,
 		%{Ni}%type_pkg[oct]-ref,
 		%{Ni}%type_pkg[oct]-ref-qtmac,
 		%{Ni}%type_pkg[oct]-ref-qtx11,
 		%{Ni}%type_pkg[oct]-ref-x11,
 		%{Ni}%type_pkg[oct]-ref-x11-qtmac,
 		%{Ni}%type_pkg[oct]-ref-x11-qtx11,
-		%{Ni} (<< 3.0.5-5), 
-		%{Ni}-atlas (<< 3.0.5-5), 
+		%{Ni} (<< 3.0.5-5),
+		%{Ni}-atlas (<< 3.0.5-5),
 		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
@@ -704,6 +747,12 @@ SplitOff2: <<
 		%{Ni}%type_pkg[oct]-atlas-x11,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtmac,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtx11,
+		%{Ni}%type_pkg[oct]-openblas,
+		%{Ni}%type_pkg[oct]-openblas-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-qtx11,
+		%{Ni}%type_pkg[oct]-openblas-x11,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtx11,
 		%{Ni}%type_pkg[oct]-ref,
 		%{Ni}%type_pkg[oct]-ref-qtmac,
 		%{Ni}%type_pkg[oct]-ref-qtx11,
@@ -711,17 +760,19 @@ SplitOff2: <<
 		%{Ni}%type_pkg[oct]-ref-x11-qtmac,
 		%{Ni}%type_pkg[oct]-ref-x11-qtx11,
 		%{Ni}%type_pkg[oct]-ref-x11,
-		%{Ni} (<< 3.0.5-5), 
+		%{Ni} (<< 3.0.5-5),
 		%{Ni}-atlas (<< 3.0.5-5),
-		%{Ni}3.0.2 ( << 3.0.2-5), 
+		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
-	Depends: << 
+	Depends: <<
 		(%type_raw[-blas] = .)		arpack-ng-shlibs (>= 3.1.3-3) | (%type_raw[-blas] = .) arpack-ng-mpi-shlibs (>= 3.1.2-4),
 		(%type_raw[-blas] = -ref)	arpack-ng-ref-shlibs (>= 3.1.3-3) | (%type_raw[-blas] = -ref) arpack-ng-mpi-ref-shlibs (>= 3.1.3-3),
 		(%type_raw[-blas] = -atlas)	arpack-ng-atlas-shlibs (>= 3.1.3-3) | (%type_raw[-blas] = -atlas) arpack-ng-mpi-atlas-shlibs (>= 3.1.3-3),
 		(%type_raw[-blas] = -atlas)	atlas-shlibs (>= 3.10.1-1),
-		fftw3-shlibs (>= 3.1.1-7), 
+		(%type_raw[-blas] = -openblas)	arpack-ng-openblas-shlibs (>= 3.7.0-1) | (%type_raw[-blas] = -openblas) arpack-ng-mpi-openblas-shlibs (>= 3.7.0-1),
+		(%type_raw[-blas] = -openblas)	openblas-shlibs,
+		fftw3-shlibs (>= 3.1.1-7),
 		fltk13-aqua-shlibs,
 		fontconfig2-shlibs,
 		freetype219-shlibs (>= 2.5.5-1),
@@ -730,24 +781,26 @@ SplitOff2: <<
 		glpk36-shlibs,
 		gnuplot-bin,
 		graphicsmagick1322-shlibs,
-		hdf5.9-shlibs,
-		(%type_raw[-blas] = -ref) 	lapack%type_pkg[lapack]-shlibs,
+		hdf5.200.v1.12-shlibs,
+		(%type_raw[-blas] = -ref)	lapack3-shlibs,
 		libcurl4-shlibs,
-		libpcre1-shlibs, 
-		ncurses, 
+		libpcre1-shlibs,
+		ncurses,
 		qhull6.3.1-shlibs,
-	 	(%type_raw[-qtui] = -qtmac) qscintilla2.11-qt4-mac-shlibs, 
-	 	(%type_raw[-qtui] = -qtx11) qscintilla2.11-qt4-x11-shlibs, 
-	 	(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtcore-shlibs, 
-	 	(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtcore-shlibs, 
-	 	(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtgui-shlibs, 
-	 	(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtgui-shlibs, 	 	
-	 	(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtnetwork-shlibs,
+		(%type_raw[-qtui] = -qtmac) qscintilla2.11-qt4-mac-shlibs,
+		(%type_raw[-qtui] = -qtx11) qscintilla2.11-qt4-x11-shlibs,
+		(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtcore-shlibs,
+		(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtcore-shlibs,
+		(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtgui-shlibs,
+		(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtgui-shlibs,
+		(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtnetwork-shlibs,
 		(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtnetwork-shlibs,
 		(%type_raw[-blas] = -atlas)	atlas-shlibs (>= 3.10.1-1),
-		(%type_raw[-blas] = -atlas) qrupdate-atlas-shlibs (>= 1.1.2-7), 
-		(%type_raw[-blas] = .) 		qrupdate-shlibs (>= 1.1.2-7),
-		(%type_raw[-blas] = -ref) 	qrupdate-ref-shlibs (>= 1.1.2-7),
+		(%type_raw[-blas] = -atlas)	qrupdate-atlas-shlibs (>= 1.1.2-7),
+		(%type_raw[-blas] = -openblas)	openblas-shlibs,
+		(%type_raw[-blas] = -openblas)	qrupdate-openblas-shlibs (>= 1.1.2-11),
+		(%type_raw[-blas] = .)		qrupdate-shlibs (>= 1.1.2-7),
+		(%type_raw[-blas] = -ref)	qrupdate-ref-shlibs (>= 1.1.2-7),
 		readline8-shlibs,
 		suitesparse-shlibs (>= 4.0.2-2)
 	 <<
@@ -760,9 +813,10 @@ SplitOff2: <<
 	Provides: <<
 		lib%{Ni}%type_pkg[oct]-gcc%type_pkg[gcc],
 		lib%{Ni}%type_pkg[oct],
-		(%type_raw[-blas] = -atlas) 		lib%{Ni}%type_pkg[oct]-newatlas,
-		(%type_raw[-blas] = .) 				lib%{Ni}%type_pkg[oct]-accelerate,
-		(%type_raw[-blas] = -ref) 			lib%{Ni}%type_pkg[oct]-ref,
+		(%type_raw[-blas] = -atlas)			lib%{Ni}%type_pkg[oct]-newatlas,
+		(%type_raw[-blas] = -openblas)			lib%{Ni}%type_pkg[oct]-openblas,
+		(%type_raw[-blas] = .)				lib%{Ni}%type_pkg[oct]-accelerate,
+		(%type_raw[-blas] = -ref)			lib%{Ni}%type_pkg[oct]-ref,
 		lib%{Ni}%type_pkg[oct]-aqua,
 		(%type_raw[-qtui] = -qtx11)			lib%{Ni}%type_pkg[oct]-qtx11,
 		(%type_raw[-qtui] = -qtmac)			lib%{Ni}%type_pkg[oct]-qtmac,
@@ -770,12 +824,13 @@ SplitOff2: <<
 		%{Ni}%type_pkg[oct]-interpreter-aqua,
 		(%type_raw[-qtui] = -qtx11)			%{Ni}%type_pkg[oct]-interpreter-qtx11,
 		(%type_raw[-qtui] = -qtmac)			%{Ni}%type_pkg[oct]-interpreter-qtmac,
-		(%type_raw[-blas] = -atlas) 		%{Ni}%type_pkg[oct]-interpreter-newatlas,
+		(%type_raw[-blas] = -atlas)			%{Ni}%type_pkg[oct]-interpreter-newatlas,
 		(%type_raw[-blas] = .)				%{Ni}%type_pkg[oct]-interpreter-accelerate,
-		(%type_raw[-blas] = -ref) 			%{Ni}%type_pkg[oct]-interpreter-ref,
-											%{Ni}%type_pkg[oct]-cxxfix-interpreter
+		(%type_raw[-blas] = -ref)			%{Ni}%type_pkg[oct]-interpreter-ref,
+		(%type_raw[-blas] = -openblas)			%{Ni}%type_pkg[oct]-interpreter-openblas,
+								%{Ni}%type_pkg[oct]-cxxfix-interpreter
 	<<
-	
+
 	Files: <<
 		share/%{Ni}/%v
 		lib/%{Ni}/%v
@@ -790,52 +845,52 @@ SplitOff2: <<
 		(%type_raw[-qtui] !=.) %p/lib/%{Ni}/%v/liboctgui.0.dylib 1.0.0 %n (>=3.8.2-1)
 	<<
 	DescUsage: <<
-	The %{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui] 
-	package contains versioned executables, in particular the 
-	"%{Ni}-%type_raw[oct]" executable, as well as all of the core 
-	functionality of the Octave interpreter, and the shared libraries which 
-	are used by the Octave interpreter as well as for packages that build 
+	The %{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui]
+	package contains versioned executables, in particular the
+	"%{Ni}-%type_raw[oct]" executable, as well as all of the core
+	functionality of the Octave interpreter, and the shared libraries which
+	are used by the Octave interpreter as well as for packages that build
 	against Octave, such as the various Octave Forge packages.
-	Any package that either links to the libraries in 
+	Any package that either links to the libraries in
 	%{Ni}%type_pkg[-blas]-shlibs or installs an extension
-	should Depend on 
-	%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui]-shlibs 
-	and BuildDepend on %{Ni}%type_pkg[oct]%type_pkg[-blas]-dev.  
-	In addition, it will need to BuildDepend on hdf5.8 and fftw3.  
+	should Depend on
+	%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui]-shlibs
+	and BuildDepend on %{Ni}%type_pkg[oct]%type_pkg[-blas]-dev.
+	In addition, it will need to BuildDepend on hdf5.200.v1.12 and fftw3.
 
-	The "-qtmac" variant builds a GUI which uses Qt on Aqua, 
-    while the "-qtx11" variant builds an X11 Qt GUI.   
-	
-	Note that the GNU info file, which provides the core documentation, 
-	is installed as part of the 
+	The "-qtmac" variant builds a GUI which uses Qt on Aqua,
+	while the "-qtx11" variant builds an X11 Qt GUI.
+
+	Note that the GNU info file, which provides the core documentation,
+	is installed as part of the
 	"%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-qtui]"
 	package.
-	
-	By default the plotting output (via gnuplot) is directed to AquaTerm. 
+
+	By default the plotting output (via gnuplot) is directed to AquaTerm.
 	This can be overidden in your startup scripts, e.g.
- 
- 		export GNUTERM=x11
- 
+
+		export GNUTERM=x11
+
 	in bash
- 
+
 	or
- 
+
 		setenv GNUTERM x11
- 
+
 	in tcsh.
-	 
+
 	Note:  Fink's Octave implementation modifies one of the startup files,
 	%p/share/%{Ni}/%v/m/startup/octaverc,
-	to initialize octave sessions to know about Fink's octave-versioned 
-	install location for octave-forge packages.  If you use the '--norc' 
-	or '-f' flags in your Octave script, these packages won't be visible.  
+	to initialize octave sessions to know about Fink's octave-versioned
+	install location for octave-forge packages.  If you use the '--norc'
+	or '-f' flags in your Octave script, these packages won't be visible.
 	You'll need to run the following command in your script:
- 
+
 		pkg global_list %p/var/octave/%v/octave_packages
 	<<
 	DocFiles: AUTHORS BUGS COPYING ChangeLog NEWS README doc/interpreter doc/refcard doc/liboctave
 	RuntimeVars: <<
- 		GNUTERM: aqua
+		GNUTERM: aqua
 	<<
 <<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/octave-3.8.2.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/octave-3.8.2.info
@@ -1,32 +1,31 @@
 Info2: <<
 Package: octave%type_pkg[-blas]%type_pkg[-x11]%type_pkg[-qtui]
-Type: -blas (. -atlas -ref), oct (3.8.2), gcc (5), -x11 (boolean), lapack (3.5.0), java (1.6), -qtui (. -qtmac -qtx11)
+Type: -blas (. -atlas -openblas -ref), oct (3.8.2), gcc (11), -x11 (boolean), java (1.6), -qtui (. -qtmac -qtx11)
 Version: 3.8.2
-Revision: 15
+Revision: 16
 Distribution: ( %type_raw[-x11] = -x11 ) 10.9, ( %type_raw[-x11] = -x11 )  10.10, 10.9, 10.10, 10.11, 10.12
 
 Description: MATLAB-like language for computations
 Maintainer: None <fink-devel@lists.sourceforge.net>
 License: GPL3+
-Homepage: https://www.gnu.org/software/octave/
 
 # package metadata
 BuildDepends: <<
 	autoconf2.6,
 	automake1.15,
-	fftw3 (>= 3.1.1-7), 
+	fftw3 (>= 3.1.1-7),
 	fontconfig2-dev,
-	freetype219 (>= 2.5.5-1), 
-	gcc%type_pkg[gcc]-compiler, 
+	freetype219 (>= 2.6-1),
+	gcc%type_pkg[gcc]-compiler,
 	gl2ps-dev,
 	glpk36-dev,
-	graphicsmagick1322-dev, 
-	hdf5.9, 
+	graphicsmagick1322-dev,
+	hdf5.9,
 	libcurl4,
 	libpcre1,
 	libtool2,
 	pykg-config,
-	qhull6.3.1-dev, 
+	qhull6.3.1-dev,
 	readline8,
 	sed,
 	suitesparse (>= 4.0.2-2),
@@ -38,13 +37,16 @@ BuildDepends: <<
 	(%type_raw[-x11] = -x11)	x11-dev,
 	(%type_raw[-x11] != -x11)	fltk13-aqua,
 	(%type_raw[-x11] = -x11)	fltk-x11,
-	(%type_raw[-blas] = .) 		arpack-ng (>=3.1.3-3) | (%type_raw[-blas] = .) arpack-ng-mpi (>= 3.1.2-4), 
+	(%type_raw[-blas] = .) 		arpack-ng (>=3.1.3-3) | (%type_raw[-blas] = .) arpack-ng-mpi (>= 3.1.2-4),
 	(%type_raw[-blas] = .) 		qrupdate (>= 1.1.2-7),
-	(%type_raw[-blas] = -atlas) atlas (>= 3.10.1-1),
-	(%type_raw[-blas] = -atlas) arpack-ng-atlas (>= 3.1.3-3) | (%type_raw[-blas] = -atlas) arpack-ng-mpi-atlas (>= 3.1.3-3), 
-	(%type_raw[-blas] = -atlas) qrupdate-atlas (>= 1.1.2-7),
-	(%type_raw[-blas] = -ref) 	lapack%type_pkg[lapack], 
-	(%type_raw[-blas] = -ref) 	arpack-ng-ref (>= 3.1.3-3) | (%type_raw[-blas] = -ref) arpack-ng-mpi-ref (>= 3.1.3-3),
+	(%type_raw[-blas] = -atlas)     atlas (>= 3.10.1-1),
+	(%type_raw[-blas] = -atlas)     arpack-ng-atlas (>= 3.1.3-3) | (%type_raw[-blas] = -atlas) arpack-ng-mpi-atlas (>= 3.1.3-3),
+	(%type_raw[-blas] = -atlas)     qrupdate-atlas (>= 1.1.2-7),
+	(%type_raw[-blas] = -openblas)  openblas,
+	(%type_raw[-blas] = -openblas)  arpack-ng-openblas (>= 3.7.0-1) | (%type_raw[-blas] = -openblas) arpack-ng-mpi-openblas (>= 3.7.0-1),
+	(%type_raw[-blas] = -openblas)  qrupdate-openblas (>= 1.1.2-11),
+	(%type_raw[-blas] = -ref) 	lapack3,
+	(%type_raw[-blas] = -ref) 	arpack-ng-ref (>= 3.7.0-2) | (%type_raw[-blas] = -ref) arpack-ng-mpi-ref (>= 3.7.0-2),
 	(%type_raw[-blas] = -ref) 	qrupdate-ref (>= 1.1.2-7),
 	(%type_raw[-qtui] = -qtmac) qt4-base-mac,
 	(%type_raw[-qtui] = -qtmac) qt4-base-mac-linguist,
@@ -58,58 +60,71 @@ Depends: %{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-x11]%type_pkg[-qtui] (=%v
 BuildConflicts: coot-dev, broken-gcc, lammpi-dev, fort77, 4ti2-dev
 Suggests: %{Ni}%type_pkg[oct]-docs
 Provides: <<
-									%{Ni}-interpreter,
+						%{Ni}-interpreter,
 (%type_raw[-x11] = -x11) 			%{Ni}-interpreter-x11,
 (%type_raw[-x11] != -x11)			%{Ni}-interpreter-aqua,
 (%type_raw[-qtui] = -qtx11)			%{Ni}-interpreter-qtx11,
 (%type_raw[-qtui] = -qtmac)			%{Ni}-interpreter-qtmac,
 (%type_raw[-blas] = -atlas)			%{Ni}-interpreter-newatlas,
 (%type_raw[-blas] = .)				%{Ni}-interpreter-accelerate,
+(%type_raw[-blas] = -openblas)			%{Ni}-interpreter-openblas,
 (%type_raw[-blas] = -ref)			%{Ni}-interpreter-ref
 <<
 Conflicts: <<
-	%{Ni}, 
+	%{Ni},
 	%{Ni}-qtmac,
-	%{Ni}-qtx11, 
-	%{Ni}-x11, 
-	%{Ni}-x11-qtmac, 
-	%{Ni}-x11-qtx11, 
+	%{Ni}-qtx11,
+	%{Ni}-x11,
+	%{Ni}-x11-qtmac,
+	%{Ni}-x11-qtx11,
 	%{Ni}-atlas,
 	%{Ni}-atlas-qtmac,
 	%{Ni}-atlas-qtx11,
 	%{Ni}-atlas-x11,
 	%{Ni}-atlas-x11-qtmac,
 	%{Ni}-atlas-x11-qtx11,
-	%{Ni}-ref, 
-	%{Ni}-ref-qtmac, 
-	%{Ni}-ref-qtx11, 
+	%{Ni}-openblas,
+	%{Ni}-openblas-qtmac,
+	%{Ni}-openblas-qtx11,
+	%{Ni}-openblas-x11,
+	%{Ni}-openblas-x11-qtmac,
+	%{Ni}-openblas-x11-qtx11,
+	%{Ni}-ref,
+	%{Ni}-ref-qtmac,
+	%{Ni}-ref-qtx11,
 	%{Ni}-ref-x11,
 	%{Ni}-ref-x11-qtmac,
 	%{Ni}-ref-x11-qtx11,
-	%{Ni}3.0.2 ( << 3.0.2-5), 
-	%{Ni}3.0.2-atlas ( << 3.0.2-5) 
+	%{Ni}3.0.2 ( << 3.0.2-5),
+	%{Ni}3.0.2-atlas ( << 3.0.2-5)
 <<
 Replaces: <<
-	%{Ni}, 
-	%{Ni}-qtmac, 
-	%{Ni}-qtx11, 
-	%{Ni}-x11, 
-	%{Ni}-x11-qtmac, 
-	%{Ni}-x11-qtx11, 
+	%{Ni},
+	%{Ni}-qtmac,
+	%{Ni}-qtx11,
+	%{Ni}-x11,
+	%{Ni}-x11-qtmac,
+	%{Ni}-x11-qtx11,
 	%{Ni}-atlas,
 	%{Ni}-atlas-qtmac,
 	%{Ni}-atlas-qtx11,
 	%{Ni}-atlas-x11,
 	%{Ni}-atlas-x11-qtmac,
 	%{Ni}-atlas-x11-qtx11,
-	%{Ni}-ref, 
-	%{Ni}-ref-qtmac, 
-	%{Ni}-ref-qtx11, 
+	%{Ni}-openblas,
+	%{Ni}-openblas-qtmac,
+	%{Ni}-openblas-qtx11,
+	%{Ni}-openblas-x11,
+	%{Ni}-openblas-x11-qtmac,
+	%{Ni}-openblas-x11-qtx11,
+	%{Ni}-ref,
+	%{Ni}-ref-qtmac,
+	%{Ni}-ref-qtx11,
 	%{Ni}-ref-x11,
 	%{Ni}-ref-x11-qtmac,
 	%{Ni}-ref-x11-qtx11,
-	%{Ni}3.0.2 ( << 3.0.2-5), 
-	%{Ni}3.0.2-atlas ( << 3.0.2-5) 
+	%{Ni}3.0.2 ( << 3.0.2-5),
+	%{Ni}3.0.2-atlas ( << 3.0.2-5)
 <<
 
 # source
@@ -129,11 +144,13 @@ PatchFile5: %{ni}-%v-dont-use-included-texinfo-texmfcnf.patch
 PatchFile5-MD5: a72fed2655902d004b52fd93a8fe3987
 PatchFile6: %{ni}-%v-xcode9.patch
 PatchFile6-MD5: 4ae29343cec4dde59e19246d25c27633
+PatchFile7: %{ni}-%v-fortran2018.patch
+PatchFile7-MD5: edd6555b4c4ea826989fa27a85dc3766
 PatchScript: <<
 	#!/bin/sh -ev
 
 	#Fink-specific structural changes
-	sed -e 's/@OCTVERSION@/%v/g' -e 's|@FINKPREFIX@|%p|g' %{PatchFile} | patch -p1 
+	sed -e 's/@OCTVERSION@/%v/g' -e 's|@FINKPREFIX@|%p|g' %{PatchFile} | patch -p1
 	# Put in the Fink tree.
 	sed -i -e 's|@FINKPREFIX@|%p|g' doc/interpreter/*.1 src/mkoctfile*in.cc
 
@@ -160,7 +177,7 @@ PatchScript: <<
 	cp doc/interpreter/mkoctfile.1 doc/interpreter/mkoctfile-%v.1
 
 	# fix executable names in versioned manpages
-	sed -e 's/@OCTVERSION@/%v/g' %{PatchFile2} | patch -p1 
+	sed -e 's/@OCTVERSION@/%v/g' %{PatchFile2} | patch -p1
 	
 	# instead of using flag-sort, ensure that the right sysdep.h is used
 	grep -lr '#include "sysdep.h"' * | xargs perl -pi.orig -e 's,sysdep.h,%b/libinterp/corefcn/sysdep.h,'
@@ -171,6 +188,9 @@ PatchScript: <<
 		perl -pi -e 's/HAVE_X_WINDOWS/HAVE_X_BINDOWS/g' libinterp/dldfcn/__init_fltk__.cc
 	fi
 
+	# Supress warnings about use of features that are removed from
+	# Fortran 2018. See https://savannah.gnu.org/bugs/?54390
+	patch -p1 < %{PatchFile7}
 <<
 
 GCC: 4.0
@@ -183,10 +203,12 @@ SetLIBS: -lgl2ps
 ConfigureParams: <<
 	(%type_raw[-blas] = .)		--with-lapack=-Wl,-framework,Accelerate \
 	(%type_raw[-blas] = .)		--with-blas=-Wl,-framework,Accelerate \
- 	(%type_raw[-blas] = -atlas)	--with-lapack="-ltatlas" \
- 	(%type_raw[-blas] = -atlas)	--with-blas="-ltatlas" \
- 	(%type_raw[-blas] = -ref)	--with-lapack="-L%p/lib/lapack/%type_raw[lapack] -lreflapack" \
- 	(%type_raw[-blas] = -ref)	--with-blas="-L%p/lib/lapack/%type_raw[lapack] -lrefblas" \
+	(%type_raw[-blas] = -atlas)	--with-lapack="-ltatlas" \
+	(%type_raw[-blas] = -atlas)	--with-blas="-ltatlas" \
+	(%type_raw[-blas] = -openblas)	--with-lapack="-lopenblas" \
+	(%type_raw[-blas] = -openblas)	--with-blas="-lopenblas" \
+	(%type_raw[-blas] = -ref)	--with-lapack="-L%p/lib/lapack/%type_raw[lapack] -lreflapack" \
+	(%type_raw[-blas] = -ref)	--with-blas="-L%p/lib/lapack/%type_raw[lapack] -lrefblas" \
 	(%type_raw[-x11] != -x11)	--with-framework-carbon \
 	(%type_raw[-x11] = -x11)	--without-framework-carbon \
 	(%type_raw[-x11] = -x11)	--without-framework-opengl \
@@ -224,7 +246,7 @@ if [ ! -x %p/bin/oct-cc -o ! -x %p/bin/oct-cxx ] ; then
  # allow configure to find OpenGL libraries in X11
  if [ "%type_raw[-x11]" = "-x11" ] ; then
 	export LDFLAGS="-L%p/lib -L$X11_BASE_DIR/lib -Wl,-dead_strip_dylibs"
- 	export CPPFLAGS="-I%p/include -I%p/include/freetype2 -I$X11_BASE_DIR/include"
+	export CPPFLAGS="-I%p/include -I%p/include/freetype2 -I$X11_BASE_DIR/include"
  else
 	export LDFLAGS="-L%p/lib -Wl,-dead_strip_dylibs"
 	export CPPFLAGS="-I%p/include -I%p/include/freetype2"
@@ -234,31 +256,31 @@ if [ ! -x %p/bin/oct-cc -o ! -x %p/bin/oct-cxx ] ; then
  export F77=%p/bin/gfortran-fsf-%type_raw[gcc]
  # -ff2c is required when using gfortran and Accelerate.framework
  if [ "%type_raw[-blas]" = "." ]
- 	then export FFLAGS='-O3 -ff2c'
- 	else export FFLAGS='-O3'
+	then export FFLAGS='-O3 -ff2c'
+	else export FFLAGS='-O3'
  fi
  FLIBDIR="%p/lib/gcc%type_raw[gcc]/lib"
  export FLIBS="-L${FLIBDIR} -lgfortran"
  export PKG_CONFIG=%p/bin/pykg-config
  qt_type=`echo %type_pkg[-qtui] | cut -dt -f2`
  if [ "%type_raw[-qtui]" != "."  ] ; then	
- 	export PKG_CONFIG_PATH="%p/lib/qt4-$qt_type/lib/pkgconfig:$PKG_CONFIG_PATH"
+	export PKG_CONFIG_PATH="%p/lib/qt4-$qt_type/lib/pkgconfig:$PKG_CONFIG_PATH"
 	export PATH="%p/lib/qt4-$qt_type/bin:$PATH"
 	# QtCore is inherited
 	export LDFLAGS=`pkg-config QtNetwork --libs`" "`pkg-config QtGui --libs`" -L%p/lib/qt4-$qt_type/lib $LDFLAGS"
  fi
- 
+
  autoreconf -fi
- 
+
  ./configure %c "ac_cv_func_mkostemp=no"
  # don't just use top-level Makefile so that we can do a multi-core build.
- pushd libgnu 
+ pushd libgnu
  /usr/bin/make -j1
  popd
  for dirs in liboctave libinterp ; do
- 	pushd $dirs
- 	/usr/bin/make
- 	popd
+	pushd $dirs
+	/usr/bin/make
+	popd
  done
  if [ "%type_raw[-qtui]" != "."  ] ; then
 	pushd libgui
@@ -267,11 +289,11 @@ if [ ! -x %p/bin/oct-cc -o ! -x %p/bin/oct-cxx ] ; then
  fi
  # src/ and scripts/ need to be built with -j1 since docs get built there.
  for dirs in src scripts ; do
- 	pushd $dirs
- 	/usr/bin/make -j1
- 	popd
+	pushd $dirs
+	/usr/bin/make -j1
+	popd
  done
- /usr/bin/make 
+ /usr/bin/make
  fink-package-precedence .
 <<
 
@@ -279,13 +301,13 @@ InfoTest: <<
 	TestDepends: ( %type_raw[-x11] = -x11 ) xvfb-run
 	TestScript: <<
 		#!/bin/sh -ev
-		if [ "%type_pkg[-x11]" = "-x11" ] 
+		if [ "%type_pkg[-x11]" = "-x11" ]
 			then xvfb-run /usr/bin/make check || exit 2
 		else
 			if [ $UID = 0 ]
 				then /usr/bin/make check || exit 2
 				else echo "Test suite under Aqua FLTK is incompatible with building as fink-bld."
-			fi 
+			fi
 		fi
 	<<
 <<
@@ -322,14 +344,14 @@ InstallScript: <<
  rm mkoctfile mkoctfile-%type_raw[oct]
  /bin/cp %b/src/mkoctfile mkoctfile-%v
  ln -s mkoctfile-%v mkoctfile
-  
+
  # sanitize .la files
  cd %i/lib/%{Ni}/%v/
- perl -pi -e 's/(\-framework)\s(\w+)/-Wl,$1,$2/g' *.la 
+ perl -pi -e 's/(\-framework)\s(\w+)/-Wl,$1,$2/g' *.la
 
  # manually install libcxx-fix.h
  if [ -e %b/liboctave/operators/libcxx-fix.h ] ; then
- 	cp %b/liboctave/operators/libcxx-fix.h %i/include/%{Ni}-%v/%{Ni}/
+	cp %b/liboctave/operators/libcxx-fix.h %i/include/%{Ni}-%v/%{Ni}/
  fi
 <<
 
@@ -338,88 +360,88 @@ DocFiles: AUTHORS BUGS COPYING ChangeLog NEWS README
 ConfFiles: %p/share/%{Ni}/site/m/startup/%{Ni}rc
 
 DescDetail: <<
-Octave provides a convenient command line interface for solving linear and 
-nonlinear problems numerically, and for performing other numerical 
+Octave provides a convenient command line interface for solving linear and
+nonlinear problems numerically, and for performing other numerical
 experiments using a language that is mostly compatible with Matlab.
 It may also be used as a batch-oriented language.
 
 Octave has extensive tools for solving common numerical linear algebra
 problems, finding the roots of nonlinear equations, integrating ordinary
 functions, manipulating polynomials, and integrating ordinary differential
-and differential-algebraic equations. It is easily extensible and 
-customizable via user-defined functions written in Octave's own language, 
-or using dynamically loaded modules written in C++, C, Fortran, 
+and differential-algebraic equations. It is easily extensible and
+customizable via user-defined functions written in Octave's own language,
+or using dynamically loaded modules written in C++, C, Fortran,
 or other languages.
 <<
 
-DescUsage: << 
-The %{Ni}%type_pkg[-blas]%type_pkg[-x11]%type_pkg[-qtui] package contains 
+DescUsage: <<
+The %{Ni}%type_pkg[-blas]%type_pkg[-x11]%type_pkg[-qtui] package contains
 unversioned executables, in particular the "octave" executable, along with the
-GNU info documentation.  
+GNU info documentation.
 
-The "-x11" variant has built-in FLTK graphics which use X11 rather than the 
+The "-x11" variant has built-in FLTK graphics which use X11 rather than the
 default Aqua.  The "-qtmac" variant builds a GUI which uses Qt on Aqua, while
 the "-qtx11" variant builds an X11 Qt gui.
 
 You can select another version of Octave to be the default, i.e. the "octave"
-executable and "info octave" point to it, via 
-"fink install %{Ni}%type_pkg[-blas]%type_pkg[-x11]-<version>", 
+executable and "info octave" point to it, via
+"fink install %{Ni}%type_pkg[-blas]%type_pkg[-x11]-<version>",
 where the available <version> options are:
 	3.0.5
 	3.2.4
 	3.4.3
 	3.6.0
 	3.6.1
-	3.6.2 
-	3.6.3 
+	3.6.2
+	3.6.3
 	3.6.4
 	
-By default the plotting output (via gnuplot) is directed to AquaTerm. 
+By default the plotting output (via gnuplot) is directed to AquaTerm.
 This can be overidden in your startup scripts, e.g.
- 
+
 	export GNUTERM=x11
- 
+
 in bash
- 
+
 or
- 
+
 	setenv GNUTERM x11
- 
+
 in tcsh.
 
-To build and install packages from Octave Forge manually, or to 
-build anything else against Octave, you will need to install the 
-%{Ni}%type_pkg[-blas]%type_pkg[-x11]-dev package.  
+To build and install packages from Octave Forge manually, or to
+build anything else against Octave, you will need to install the
+%{Ni}%type_pkg[-blas]%type_pkg[-x11]-dev package.
 Fink's *-oct%type_pkg[oct] packages do this automatically, as well as
 applying patches, so unless you want to test a pre-release version,
 you are probably better off installing OF packages via Fink.
- 
+
 Note:  Fink's Octave implementation modifies one of the startup files,
 %p/share/%{Ni}/%v/m/startup/octaverc,
-to initialize octave sessions to know about Fink's octave-versioned 
+to initialize octave sessions to know about Fink's octave-versioned
 install location for octave-forge packages.  If you use the '--norc' or '-f'
 flags in your Octave script, these packages won't be visible.  You'll need to
 run the following command in your script:
- 
- 	pkg global_list %p/var/octave/%v/octave_packages
+
+	pkg global_list %p/var/octave/%v/octave_packages
 <<
 
 
 DescPort: <<
 Thanks to Per Persson for most (if not all) of the work on the macos X port.
 
-The Accelerate variant is built with -ff2c in the FFLAGS, 
+The Accelerate variant is built with -ff2c in the FFLAGS,
 because this appears to be necessary when using the Accelerate framework.
 
 Revision 7 -- update X11 detection
 <<
 
 DescPackaging:  <<
-Patchfile6 from J. Howarth covers build failure on High Sierra from  
+Patchfile6 from J. Howarth covers build failure on High Sierra from
 
 "error: call to 'pow' is ambiguous"
 
-in liboctave/numeric/lo-specfun.cc and libinterp/corefcn/graphics.cc by using 
+in liboctave/numeric/lo-specfun.cc and libinterp/corefcn/graphics.cc by using
 std::pow() instead of pow().
 
 set ac_cv_func_mkostemp=no explicitly to allow building on OS X Sierra and later.
@@ -446,11 +468,11 @@ remove the conditional patching and add a virtual package to note that this has 
 applied.
 
 Use Java-1.6 because the build actually _links_ to libjvm--contrary to best
-practices.  
+practices.
 
 Use pykg-config instead of pkgconfig to lighten the build tree.
 
-Remove a desktop file that gets generated only for users with GNOME/KDE 
+Remove a desktop file that gets generated only for users with GNOME/KDE
 installed.
 
 SetLIBS: -lgl2ps because of missing symbols from that library on 10.7/Xcode
@@ -459,7 +481,7 @@ SetLIBS: -lgl2ps because of missing symbols from that library on 10.7/Xcode
 Non-X11 FLTK stuff still uses X headers.
 	
 Set the GNUTERM environment variable to AquaTerm because autodetection of
-DISPLAY seems to cause options to be fed to our gnuplot that it doesn't 
+DISPLAY seems to cause options to be fed to our gnuplot that it doesn't
 understand.  AquaTerm seems to be a sensible default.
 
 Create manpages for the versioned executables.
@@ -467,31 +489,32 @@ Create manpages for the versioned executables.
 We have split the package up into versioned runtime+library, development, and
 unversioned runtime packages,  to make upgrades easier for us and for users.  Prior
 packaging had separate libraries, but this led to deadlocks when attempting to swap
-variants.  Also, it's unlikely that anybody is going to want just the libraries, 
+variants.  Also, it's unlikely that anybody is going to want just the libraries,
 anyway.
 	
-The -atlas variant depends on -atlas variants (only) of qrupdate and arpack-ng.  
-The Accelerate variant depends on Accelerate variants (only) of these, and 
+The -atlas variant depends on -atlas variants (only) of qrupdate and arpack-ng.
+The Accelerate variant depends on Accelerate variants (only) of these,
+the OpenBLAS variant depends on OpenBLAS variants (only) of the same, and
 the reference LAPACK variant depends on variants of qrupdate and arpack-ng
-which use the reference LAPACK (i.e. lapack350).
- 
+which use the reference LAPACK (i.e. lapack3).
+
 Patch oct-conf.h and mkoctfile to use octave-specific compiler executables
-which are part of the fink-octave-scripts package to avoid issues which 
-would propagate as dependencies, e.g. encoding 'flag-sort' or a 
-ccache-default compiler. This also makes sure that anything that builds 
-against Octave has the proper information when installed manually as well 
+which are part of the fink-octave-scripts package to avoid issues which
+would propagate as dependencies, e.g. encoding 'flag-sort' or a
+ccache-default compiler. This also makes sure that anything that builds
+against Octave has the proper information when installed manually as well
 as via Fink.
 
-We use the platform-independent oct-cc and oct-cxx wrappers from 
+We use the platform-independent oct-cc and oct-cxx wrappers from
 fink-octave-scripts to ensure that user builds:
-1) using the Fink compiler wrapper for the OS X version 
+1) using the Fink compiler wrapper for the OS X version
 2) using a stably named compiler, in case of OS X updates.
 
 We use Provides in a new namespace and new projections to avoid
 unwieldy | lists in the octave-forge packages.
 
-Since octave-forge packages for octave < 3.6.0 link to whatever gcc4N 
-Octave is using, and also since some other packages actually use gcc-4.N, 
+Since octave-forge packages for octave < 3.6.0 link to whatever gcc4N
+Octave is using, and also since some other packages actually use gcc-4.N,
 add "liboctave-gcc4N-dev" and "liboctave-gcc4N" Provides, to make sure that
 things stay in sync; the latter isn't used yet.
 
@@ -507,31 +530,31 @@ SplitOff: <<
 		%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-x11]%type_pkg[-qtui] (=%v-%r),
 		fink-%{Ni}-scripts (>= 0.3.0-1),
 		fink (>=0.32),
-		gcc%type_pkg[gcc]-compiler 
+		gcc%type_pkg[gcc]-compiler
 	<<
-	Conflicts: << 
-		%{Ni}305-dev, 
+	Conflicts: <<
+		%{Ni}305-dev,
 		%{Ni}305-atlas-dev,
-		%{Ni}305-ref-dev,  
-		%{Ni}324-dev, 
+		%{Ni}305-ref-dev,
+		%{Ni}324-dev,
 		%{Ni}324-atlas-dev,
 		%{Ni}324-ref-dev,
 		%{Ni}324-x11-dev,
 		%{Ni}324-atlas-x11-dev,
 		%{Ni}324-ref-x11-dev,
-		%{Ni}343-dev, 
+		%{Ni}343-dev,
 		%{Ni}343-atlas-dev,
 		%{Ni}343-ref-dev,
 		%{Ni}343-x11-dev,
 		%{Ni}343-atlas-x11-dev,
 		%{Ni}343-ref-x11-dev,
-		%{Ni}360-dev, 
+		%{Ni}360-dev,
 		%{Ni}360-atlas-dev,
 		%{Ni}360-ref-dev,
 		%{Ni}360-x11-dev,
 		%{Ni}360-atlas-x11-dev,
 		%{Ni}360-ref-x11-dev,
-		%{Ni}361-dev, 
+		%{Ni}361-dev,
 		%{Ni}361-atlas-dev,
 		%{Ni}361-ref-dev,
 		%{Ni}361-x11-dev,
@@ -555,55 +578,62 @@ SplitOff: <<
 		%{Ni}364-atlas-x11-dev,
 		%{Ni}382-atlas-dev,
 	   	%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-atlas-x11-qtmac-dev,
-   		%{Ni}382-atlas-x11-qtx11-dev,
-   		%{Ni}382-atlas-qtmac-dev,
-   		%{Ni}382-atlas-qtx11-dev,
-   		%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-dev,
-   		%{Ni}382-x11-dev,
-   		%{Ni}382-x11-qtmac-dev,
-   		%{Ni}382-x11-qtx11-dev,
-   		%{Ni}382-x11-x11-dev,
-   		%{Ni}382-mac-dev,
-   		%{Ni}382-qtmac-dev,
-   		%{Ni}382-qtx11-dev,
-   		%{Ni}382-ref-dev,
-   		%{Ni}382-ref-x11-dev,
-   		%{Ni}382-ref-x11-qtmac-dev,
-   		%{Ni}382-ref-x11-qtx11-dev,
+		%{Ni}382-atlas-x11-qtmac-dev,
+		%{Ni}382-atlas-x11-qtx11-dev,
+		%{Ni}382-atlas-qtmac-dev,
+		%{Ni}382-atlas-qtx11-dev,
+		%{Ni}382-atlas-x11-dev,
+		%{Ni}382-dev,
+		%{Ni}382-x11-dev,
+		%{Ni}382-x11-qtmac-dev,
+		%{Ni}382-x11-qtx11-dev,
+		%{Ni}382-x11-x11-dev,
+		%{Ni}382-mac-dev,
+		%{Ni}382-qtmac-dev,
+		%{Ni}382-qtx11-dev,
+		%{Ni}382-ref-dev,
+		%{Ni}382-ref-x11-dev,
+		%{Ni}382-ref-x11-qtmac-dev,
+		%{Ni}382-ref-x11-qtx11-dev,
 	   	%{Ni}382-ref-mac-dev,
-   		%{Ni}382-ref-qtmac-dev,
-   		%{Ni}382-ref-qtx11-dev,
-   		%{Ni}382-x11-dev,
-		%{Ni} (<< 3.0.5-5), 
-		%{Ni}-atlas (<< 3.0.5-5), 
-		%{Ni}3.0.2 ( << 3.0.2-5), 
+		%{Ni}382-ref-qtmac-dev,
+		%{Ni}382-ref-qtx11-dev,
+		%{Ni}382-openblas-dev,
+		%{Ni}382-openblas-x11-dev,
+		%{Ni}382-openblas-x11-qtmac-dev,
+		%{Ni}382-openblas-x11-qtx11-dev,
+		%{Ni}382-openblas-mac-dev,
+		%{Ni}382-openblas-qtmac-dev,
+		%{Ni}382-openblas-qtx11-dev,
+		%{Ni}382-x11-dev,
+		%{Ni} (<< 3.0.5-5),
+		%{Ni}-atlas (<< 3.0.5-5),
+		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
 	Replaces: <<
-		%{Ni}305-dev, 
+		%{Ni}305-dev,
 		%{Ni}305-atlas-dev,
-		%{Ni}305-ref-dev,  
-		%{Ni}324-dev, 
+		%{Ni}305-ref-dev,
+		%{Ni}324-dev,
 		%{Ni}324-atlas-dev,
 		%{Ni}324-ref-dev,
 		%{Ni}324-x11-dev,
 		%{Ni}324-atlas-x11-dev,
 		%{Ni}324-ref-x11-dev,
-		%{Ni}343-dev, 
+		%{Ni}343-dev,
 		%{Ni}343-atlas-dev,
 		%{Ni}343-ref-dev,
 		%{Ni}343-x11-dev,
 		%{Ni}343-atlas-x11-dev,
 		%{Ni}343-ref-x11-dev,
-		%{Ni}360-dev, 
+		%{Ni}360-dev,
 		%{Ni}360-atlas-dev,
 		%{Ni}360-ref-dev,
 		%{Ni}360-x11-dev,
 		%{Ni}360-atlas-x11-dev,
 		%{Ni}360-ref-x11-dev,
-		%{Ni}361-dev, 
+		%{Ni}361-dev,
 		%{Ni}361-atlas-dev,
 		%{Ni}361-ref-dev,
 		%{Ni}361-x11-dev,
@@ -629,30 +659,37 @@ SplitOff: <<
 		%{Ni}364-ref-x11-dev,
 		%{Ni}382-atlas-dev,
 	   	%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-atlas-x11-qtmac-dev,
-   		%{Ni}382-atlas-x11-qtx11-dev,
-   		%{Ni}382-atlas-qtmac-dev,
-   		%{Ni}382-atlas-qtx11-dev,
-   		%{Ni}382-atlas-x11-dev,
-   		%{Ni}382-dev,
-   		%{Ni}382-x11-dev,
-   		%{Ni}382-x11-qtmac-dev,
-   		%{Ni}382-x11-qtx11-dev,
-   		%{Ni}382-x11-x11-dev,
-   		%{Ni}382-mac-dev,
-   		%{Ni}382-qtmac-dev,
-   		%{Ni}382-qtx11-dev,
-   		%{Ni}382-ref-dev,
-   		%{Ni}382-ref-x11-dev,
-   		%{Ni}382-ref-x11-qtmac-dev,
-   		%{Ni}382-ref-x11-qtx11-dev,
+		%{Ni}382-atlas-x11-qtmac-dev,
+		%{Ni}382-atlas-x11-qtx11-dev,
+		%{Ni}382-atlas-qtmac-dev,
+		%{Ni}382-atlas-qtx11-dev,
+		%{Ni}382-atlas-x11-dev,
+		%{Ni}382-dev,
+		%{Ni}382-x11-dev,
+		%{Ni}382-x11-qtmac-dev,
+		%{Ni}382-x11-qtx11-dev,
+		%{Ni}382-x11-x11-dev,
+		%{Ni}382-mac-dev,
+		%{Ni}382-qtmac-dev,
+		%{Ni}382-qtx11-dev,
+		%{Ni}382-ref-dev,
+		%{Ni}382-ref-x11-dev,
+		%{Ni}382-ref-x11-qtmac-dev,
+		%{Ni}382-ref-x11-qtx11-dev,
 	   	%{Ni}382-ref-mac-dev,
-   		%{Ni}382-ref-qtmac-dev,
-   		%{Ni}382-ref-qtx11-dev,
-   		%{Ni}382-x11-dev,
-		%{Ni} (<< 3.0.5-5), 
-		%{Ni}-atlas (<< 3.0.5-5), 
-		%{Ni}3.0.2 ( << 3.0.2-5), 
+		%{Ni}382-ref-qtmac-dev,
+		%{Ni}382-ref-qtx11-dev,
+		%{Ni}382-openblas-dev,
+		%{Ni}382-openblas-x11-dev,
+		%{Ni}382-openblas-x11-qtmac-dev,
+		%{Ni}382-openblas-x11-qtx11-dev,
+		%{Ni}382-openblas-mac-dev,
+		%{Ni}382-openblas-qtmac-dev,
+		%{Ni}382-openblas-qtx11-dev,
+		%{Ni}382-x11-dev,
+		%{Ni} (<< 3.0.5-5),
+		%{Ni}-atlas (<< 3.0.5-5),
+		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
 	Provides: <<
@@ -661,18 +698,19 @@ SplitOff: <<
 		lib%{Ni}%type_pkg[oct]-dev,
 		(%type_raw[-blas] = -atlas) 		lib%{Ni}%type_pkg[oct]-newatlas-dev,
 		(%type_raw[-blas] = .) 				lib%{Ni}%type_pkg[oct]-accelerate-dev,
+		(%type_raw[-blas] = -openblas) 			lib%{Ni}%type_pkg[oct]-openblas-dev,
 		(%type_raw[-blas] = -ref) 			lib%{Ni}%type_pkg[oct]-ref-dev,
 		(%type_raw[-x11] = -x11) 			lib%{Ni}%type_pkg[oct]-x11-dev,
 		(%type_raw[-x11] != -x11) 			lib%{Ni}%type_pkg[oct]-aqua-dev,
 		(%type_raw[-qtui] = -qtx11)			lib%{Ni}%type_pkg[oct]-qtx11-dev,
 		(%type_raw[-qtui] = -qtmac)			lib%{Ni}%type_pkg[oct]-qtmac-dev
 	<<
-	
+
 	BuildDependsOnly: true
-	
+
 	Files: <<
 		include/%{Ni}-%v
-		lib/%{Ni}/%v/*.la 
+		lib/%{Ni}/%v/*.la
 		lib/%{Ni}/%v/lib{%{Ni},octinterp}.dylib
 		(%type_raw[-qtui] != .) lib/%{Ni}/%v/liboctgui.dylib
 		bin/mkoctfile*
@@ -699,7 +737,7 @@ SplitOff: <<
 # versioned executables and shlibs
 SplitOff2: <<
 	Package: octave%type_pkg[oct]%type_pkg[-blas]%type_pkg[-x11]%type_pkg[-qtui]
-	Conflicts: << 
+	Conflicts: <<
 		%{Ni}%type_pkg[oct],
 		%{Ni}%type_pkg[oct]-qtmac,
 		%{Ni}%type_pkg[oct]-qtx11,
@@ -712,14 +750,20 @@ SplitOff2: <<
 		%{Ni}%type_pkg[oct]-atlas-x11,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtmac,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtx11,
+		%{Ni}%type_pkg[oct]-openblas,
+		%{Ni}%type_pkg[oct]-openblas-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-qtx11,
+		%{Ni}%type_pkg[oct]-openblas-x11,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtx11,
 		%{Ni}%type_pkg[oct]-ref,
 		%{Ni}%type_pkg[oct]-ref-qtmac,
 		%{Ni}%type_pkg[oct]-ref-qtx11,
 		%{Ni}%type_pkg[oct]-ref-x11,
 		%{Ni}%type_pkg[oct]-ref-x11-qtmac,
 		%{Ni}%type_pkg[oct]-ref-x11-qtx11,
-		%{Ni} (<< 3.0.5-5), 
-		%{Ni}-atlas (<< 3.0.5-5), 
+		%{Ni} (<< 3.0.5-5),
+		%{Ni}-atlas (<< 3.0.5-5),
 		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
@@ -736,6 +780,12 @@ SplitOff2: <<
 		%{Ni}%type_pkg[oct]-atlas-x11,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtmac,
 		%{Ni}%type_pkg[oct]-atlas-x11-qtx11,
+		%{Ni}%type_pkg[oct]-openblas,
+		%{Ni}%type_pkg[oct]-openblas-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-qtx11,
+		%{Ni}%type_pkg[oct]-openblas-x11,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtmac,
+		%{Ni}%type_pkg[oct]-openblas-x11-qtx11,
 		%{Ni}%type_pkg[oct]-ref,
 		%{Ni}%type_pkg[oct]-ref-qtmac,
 		%{Ni}%type_pkg[oct]-ref-qtx11,
@@ -743,17 +793,19 @@ SplitOff2: <<
 		%{Ni}%type_pkg[oct]-ref-x11-qtmac,
 		%{Ni}%type_pkg[oct]-ref-x11-qtx11,
 		%{Ni}%type_pkg[oct]-ref-x11,
-		%{Ni} (<< 3.0.5-5), 
+		%{Ni} (<< 3.0.5-5),
 		%{Ni}-atlas (<< 3.0.5-5),
-		%{Ni}3.0.2 ( << 3.0.2-5), 
+		%{Ni}3.0.2 ( << 3.0.2-5),
 		%{Ni}3.0.2-atlas ( << 3.0.2-5)
 	<<
-	Depends: << 
+	Depends: <<
 		(%type_raw[-blas] = .)		arpack-ng-shlibs (>= 3.1.3-3) | (%type_raw[-blas] = .) arpack-ng-mpi-shlibs (>= 3.1.2-4),
 		(%type_raw[-blas] = -ref)	arpack-ng-ref-shlibs (>= 3.1.3-3) | (%type_raw[-blas] = -ref) arpack-ng-mpi-ref-shlibs (>= 3.1.3-3),
 		(%type_raw[-blas] = -atlas)	arpack-ng-atlas-shlibs (>= 3.1.3-3) | (%type_raw[-blas] = -atlas) arpack-ng-mpi-atlas-shlibs (>= 3.1.3-3),
 		(%type_raw[-blas] = -atlas)	atlas-shlibs (>= 3.10.1-1),
-		fftw3-shlibs (>= 3.1.1-7), 
+		(%type_raw[-blas] = -openblas)	arpack-ng-openblas-shlibs (>= 3.7.0-1) | (%type_raw[-blas] = -openblas) arpack-ng-mpi-openblas-shlibs (>= 3.7.0-1),
+		(%type_raw[-blas] = -openblas)	openblas-shlibs,
+		fftw3-shlibs (>= 3.1.1-7),
 		(%type_raw[-x11] != -x11) 	fltk13-aqua-shlibs,
 		(%type_raw[-x11] = -x11) 	fltk-x11-shlibs,
 		fontconfig2-shlibs,
@@ -764,21 +816,23 @@ SplitOff2: <<
 		gnuplot-bin,
 		graphicsmagick1322-shlibs,
 		hdf5.9-shlibs,
-		(%type_raw[-blas] = -ref) 	lapack%type_pkg[lapack]-shlibs,
+		(%type_raw[-blas] = -ref) 	lapack3-shlibs,
 		libcurl4-shlibs,
-		libpcre1-shlibs, 
-		ncurses, 
+		libpcre1-shlibs,
+		ncurses,
 		qhull6.3.1-shlibs,
-	 	(%type_raw[-qtui] = -qtmac) qscintilla2.11-qt4-mac-shlibs, 
-	 	(%type_raw[-qtui] = -qtx11) qscintilla2.11-qt4-x11-shlibs, 
-	 	(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtcore-shlibs, 
-	 	(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtcore-shlibs, 
-	 	(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtgui-shlibs, 
-	 	(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtgui-shlibs, 	 	
-	 	(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtnetwork-shlibs,
+		(%type_raw[-qtui] = -qtmac) qscintilla2.11-qt4-mac-shlibs,
+		(%type_raw[-qtui] = -qtx11) qscintilla2.11-qt4-x11-shlibs,
+		(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtcore-shlibs,
+		(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtcore-shlibs,
+		(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtgui-shlibs,
+		(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtgui-shlibs, 	 	
+		(%type_raw[-qtui] = -qtmac) qt4-base-mac-qtnetwork-shlibs,
 		(%type_raw[-qtui] = -qtx11) qt4-base-x11-qtnetwork-shlibs,
 		(%type_raw[-blas] = -atlas)	atlas-shlibs (>= 3.10.1-1),
-		(%type_raw[-blas] = -atlas) qrupdate-atlas-shlibs (>= 1.1.2-7), 
+		(%type_raw[-blas] = -atlas) qrupdate-atlas-shlibs (>= 1.1.2-7),
+		(%type_raw[-blas] = -openblas)	openblas-shlibs,
+		(%type_raw[-blas] = -openblas) qrupdate-openblas-shlibs (>= 1.1.2-11),
 		(%type_raw[-blas] = .) 		qrupdate-shlibs (>= 1.1.2-7),
 		(%type_raw[-blas] = -ref) 	qrupdate-ref-shlibs (>= 1.1.2-7),
 		readline8-shlibs,
@@ -794,9 +848,10 @@ SplitOff2: <<
 	Provides: <<
 		lib%{Ni}%type_pkg[oct]-gcc%type_pkg[gcc],
 		lib%{Ni}%type_pkg[oct],
-		(%type_raw[-blas] = -atlas) 		lib%{Ni}%type_pkg[oct]-newatlas,
+		(%type_raw[-blas] = -atlas) 			lib%{Ni}%type_pkg[oct]-newatlas,
 		(%type_raw[-blas] = .) 				lib%{Ni}%type_pkg[oct]-accelerate,
 		(%type_raw[-blas] = -ref) 			lib%{Ni}%type_pkg[oct]-ref,
+		(%type_raw[-blas] = -openblas) 			lib%{Ni}%type_pkg[oct]-openblas,
 		(%type_raw[-x11] = -x11) 			lib%{Ni}%type_pkg[oct]-x11,
 		(%type_raw[-x11] != -x11) 			lib%{Ni}%type_pkg[oct]-aqua,
 		(%type_raw[-qtui] = -qtx11)			lib%{Ni}%type_pkg[oct]-qtx11,
@@ -806,10 +861,11 @@ SplitOff2: <<
 		(%type_raw[-x11] != -x11) 			%{Ni}%type_pkg[oct]-interpreter-aqua,
 		(%type_raw[-qtui] = -qtx11)			%{Ni}%type_pkg[oct]-interpreter-qtx11,
 		(%type_raw[-qtui] = -qtmac)			%{Ni}%type_pkg[oct]-interpreter-qtmac,
-		(%type_raw[-blas] = -atlas) 		%{Ni}%type_pkg[oct]-interpreter-newatlas,
+		(%type_raw[-blas] = -atlas) 			%{Ni}%type_pkg[oct]-interpreter-newatlas,
 		(%type_raw[-blas] = .)				%{Ni}%type_pkg[oct]-interpreter-accelerate,
 		(%type_raw[-blas] = -ref) 			%{Ni}%type_pkg[oct]-interpreter-ref,
-											%{Ni}%type_pkg[oct]-cxxfix-interpreter
+		(%type_raw[-blas] = -openblas) 			%{Ni}%type_pkg[oct]-interpreter-openblas,
+								%{Ni}%type_pkg[oct]-cxxfix-interpreter
 	<<
 	
 	Files: <<
@@ -826,48 +882,48 @@ SplitOff2: <<
 		(%type_raw[-qtui] !=.) %p/lib/%{Ni}/%v/liboctgui.0.dylib 1.0.0 %n (>=3.8.2-1)
 	<<
 	DescUsage: <<
-	The %{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-x11]%type_pkg[-qtui] 
-	package contains versioned executables, in particular the 
-	"%{Ni}-%type_raw[oct]" executable, as well as all of the core 
-	functionality of the Octave interpreter, and the shared libraries which 
-	are used by the Octave interpreter as well as for packages that build 
+	The %{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-x11]%type_pkg[-qtui]
+	package contains versioned executables, in particular the
+	"%{Ni}-%type_raw[oct]" executable, as well as all of the core
+	functionality of the Octave interpreter, and the shared libraries which
+	are used by the Octave interpreter as well as for packages that build
 	against Octave, such as the various Octave Forge packages.
-	Any package that either links to the libraries in 
+	Any package that either links to the libraries in
 	%{Ni}%type_pkg[-blas]%type_pkg[-x11]-shlibs or installs an extension
-	should Depend on 
-	%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-x11]%type_pkg[-qtui]-shlibs 
-	and BuildDepend on %{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-x11]-dev.  
-	In addition, it will need to BuildDepend on hdf5.8 and fftw3.  
+	should Depend on
+	%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-x11]%type_pkg[-qtui]-shlibs
+	and BuildDepend on %{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-x11]-dev.
+	In addition, it will need to BuildDepend on hdf5.8 and fftw3.
 
-    The "-x11" variant has built-in FLTK graphics which use X11 rather than  
-    the default Aqua.  The "-qtmac" variant builds a GUI which uses Qt on Aqua, 
-    while the "-qtx11" variant builds an X11 Qt GUI.   
+    The "-x11" variant has built-in FLTK graphics which use X11 rather than
+    the default Aqua.  The "-qtmac" variant builds a GUI which uses Qt on Aqua,
+    while the "-qtx11" variant builds an X11 Qt GUI.
 	
-	Note that the GNU info file, which provides the core documentation, 
-	is installed as part of the 
+	Note that the GNU info file, which provides the core documentation,
+	is installed as part of the
 	"%{Ni}%type_pkg[oct]%type_pkg[-blas]%type_pkg[-x11]%type_pkg[-qtui]"
 	package.
 	
-	By default the plotting output (via gnuplot) is directed to AquaTerm. 
+	By default the plotting output (via gnuplot) is directed to AquaTerm.
 	This can be overidden in your startup scripts, e.g.
- 
+
  		export GNUTERM=x11
- 
+
 	in bash
- 
+
 	or
- 
+
 		setenv GNUTERM x11
- 
+
 	in tcsh.
-	 
+
 	Note:  Fink's Octave implementation modifies one of the startup files,
 	%p/share/%{Ni}/%v/m/startup/octaverc,
-	to initialize octave sessions to know about Fink's octave-versioned 
-	install location for octave-forge packages.  If you use the '--norc' 
-	or '-f' flags in your Octave script, these packages won't be visible.  
+	to initialize octave sessions to know about Fink's octave-versioned
+	install location for octave-forge packages.  If you use the '--norc'
+	or '-f' flags in your Octave script, these packages won't be visible.
 	You'll need to run the following command in your script:
- 
+
 		pkg global_list %p/var/octave/%v/octave_packages
 	<<
 	DocFiles: AUTHORS BUGS COPYING ChangeLog NEWS README doc/interpreter doc/refcard doc/liboctave

--- a/10.9-libcxx/stable/main/finkinfo/sci/qrupdate.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/qrupdate.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: qrupdate%type_pkg[-blas]
 Version: 1.1.2
-Revision: 12
+Revision: 13
 Type: -blas (. -atlas -openblas -ref), gcc (11)
 
 Source: mirror:sourceforge:%{Ni}/1.1/%{Ni}-%v.tar.gz
@@ -19,7 +19,9 @@ Patch out hardcoded /usr/local.
 Revision 7: Change library install location to allow coexistence between
 the variants and thereby avoid dependency deadlocks.
 
-Revision 12: Update to lapack3 and gcc11 build, add -openblas type.
+Revision 12: Update to lapack3 and gcc11 build.
+
+Revision 13: Add -openblas type.
 <<
 DescPort: <<
 Uses GNU 'install -D', so we patch that out and use 'mkdir -p' first to avoid

--- a/10.9-libcxx/stable/main/finkinfo/sci/qrupdate.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/qrupdate.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: qrupdate%type_pkg[-blas]
 Version: 1.1.2
 Revision: 12
-Type: -blas (. -atlas -ref), gcc (11)
+Type: -blas (. -atlas -openblas -ref), gcc (11)
 
 Source: mirror:sourceforge:%{Ni}/1.1/%{Ni}-%v.tar.gz
 Source-MD5: 6d073887c6e858c24aeda5b54c57a8c4
@@ -18,6 +18,8 @@ Patch out hardcoded /usr/local.
 
 Revision 7: Change library install location to allow coexistence between
 the variants and thereby avoid dependency deadlocks.
+
+Revision 12: Update to lapack3 and gcc11 build, add -openblas type.
 <<
 DescPort: <<
 Uses GNU 'install -D', so we patch that out and use 'mkdir -p' first to avoid
@@ -31,14 +33,15 @@ Homepage: http://qrupdate.sourceforge.net/
 
 BuildDepends: <<
 (%type_raw[-blas] = -atlas) atlas (>= 3.10.1-1),
+(%type_raw[-blas] = -openblas) openblas,
 (%type_raw[-blas] = -ref) lapack3,
 (%type_raw[-blas] = -ref) pykg-config,
 gcc%type_pkg[gcc]-compiler
 <<
 Depends: %N-shlibs (=%v-%r)
 BuildDependsOnly: true
-Conflicts: %{Ni}, %{Ni}-atlas, %{Ni}-ref
-Replaces: %{Ni}, %{Ni}-atlas, %{Ni}-ref
+Conflicts: %{Ni}, %{Ni}-atlas, %{Ni}-openblas, %{Ni}-ref
+Replaces: %{Ni}, %{Ni}-atlas, %{Ni}-openblas, %{Ni}-ref
 
 PatchFile: %{ni}.patch
 PatchFile-MD5: 7931184403d475403f20e1c5c6ceaebd
@@ -58,6 +61,10 @@ PatchScript: <<
 	then
 		perl -pi -e "s|^(BLAS=)-lblas|LDFLAGS=$LDFLAGS\n\1-ltatlas|" Makeconf
 		perl -pi -e "s|^(LAPACK=)-llapack|\1-ltatlas|" Makeconf
+	elif [ "%type_pkg[-blas]" = "-openblas" ]
+	then
+		perl -pi -e "s|^(BLAS=)-lblas|LDFLAGS=$LDFLAGS $MYLDFLAGS\n\1-lopenblas|" Makeconf
+		perl -pi -e "s|^(LAPACK=)-llapack|\1-lopenblas|" Makeconf
 	elif [ "%type_pkg[-blas]" = "-ref" ]
 	then
 		export PKG_CONFIG_PATH="%p/lib/lapack/pkgconfig:$PKG_CONFIG_PATH"
@@ -107,6 +114,7 @@ SplitOff: <<
 	
 	Depends: <<
 		(%type_raw[-blas] = -atlas) atlas-shlibs (>= 3.10.1-1),
+		(%type_raw[-blas] = -openblas) openblas-shlibs,
 		(%type_raw[-blas] = -ref) lapack3-shlibs,
 		gcc%type_pkg[gcc]-shlibs
 	<<


### PR DESCRIPTION
Incl. matching arpack-ng and qrupdate flavours.
Built and tested for the 10.14.5 distribution; gcc11+openblas also with 10.13.
I had an earlier version of this working with gcc9 on 10.12, but cannot test that right now.
I have also built the base (`[-blas] = .`) variant, but _not_ the atlas version in  a while!