### PR TITLE
OpenSSL -  disable apple  crypto random api on macOS 10.12 and lower 

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/openssl110-dev.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/openssl110-dev.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Package: openssl110-dev
 Version: 1.1.1m
-Revision: 1
+Revision: 2
 Description: Secure Sockets Layer and Crypto Library
 License: OSI-Approved
 Homepage: https://www.openssl.org/
@@ -32,7 +32,13 @@ BuildDepends: text-template-pm
 Depends: openssl110-shlibs (= %v-%r)
 UseMaxBuildJobs: false
 CompileScript: <<
-	./config --prefix=%p --openssldir=%p/etc/ssl zlib-dynamic enable-ec_nistp_64_gcc_128
+#!/bin/sh -ev
+        # Apple Crypto Random API is not availabe in macOS 10.12 and lower
+        OSX_MAJOR_VERSION=`sw_vers -productVersion | cut -d. -f1-2`
+        if dpkg --compare-versions "$OSX_MAJOR_VERSION" le "10.12"; then
+           params="-DOPENSSL_NO_APPLE_CRYPTO_RANDOM"
+        fi
+	./config --prefix=%p --openssldir=%p/etc/ssl zlib-dynamic enable-ec_nistp_64_gcc_128 $params
 	make
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/crypto/openssl110-dev.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/openssl110-dev.info
@@ -33,7 +33,9 @@ Depends: openssl110-shlibs (= %v-%r)
 UseMaxBuildJobs: false
 CompileScript: <<
 #!/bin/sh -ev
-        # Apple Crypto Random API is not availabe in macOS 10.12 and lower
+        # disable Apple Crypto Random API for macOS 10.12 and lower
+        # because it will be detected but is broken on 10.12
+        # see: https://github.com/fink/fink-distributions/issues/888
         OSX_MAJOR_VERSION=`sw_vers -productVersion | cut -d. -f1-2`
         if dpkg --compare-versions "$OSX_MAJOR_VERSION" le "10.12"; then
            params="-DOPENSSL_NO_APPLE_CRYPTO_RANDOM"

--- a/10.9-libcxx/stable/main/finkinfo/crypto/openssl300-dev.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/openssl300-dev.info
@@ -40,7 +40,9 @@ Depends: openssl300-shlibs (= %v-%r)
 UseMaxBuildJobs: false
 CompileScript: <<
 #!/bin/sh -ev
-        # Apple Crypto Random API is not availabe in macOS 10.12 and lower
+        # disable Apple Crypto Random API for macOS 10.12 and lower
+        # because it will be detected but is broken on 10.12
+        # see: https://github.com/fink/fink-distributions/issues/888
         OSX_MAJOR_VERSION=`sw_vers -productVersion | cut -d. -f1-2`
         if dpkg --compare-versions "$OSX_MAJOR_VERSION" le "10.12"; then
            params="-DOPENSSL_NO_APPLE_CRYPTO_RANDOM"

--- a/10.9-libcxx/stable/main/finkinfo/crypto/openssl300-dev.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/openssl300-dev.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Package: openssl300-dev
 Version: 3.0.1
-Revision: 1
+Revision: 2
 Description: Secure Sockets Layer and Crypto Library
 License: BSD
 Homepage: https://www.openssl.org/
@@ -39,7 +39,13 @@ PatchFile-MD5: 25047e2511f9be63d941820a56d89d38
 Depends: openssl300-shlibs (= %v-%r)
 UseMaxBuildJobs: false
 CompileScript: <<
-	./Configure -w --prefix=%p --openssldir=%p/etc/ssl zlib-dynamic enable-ec_nistp_64_gcc_128
+#!/bin/sh -ev
+        # Apple Crypto Random API is not availabe in macOS 10.12 and lower
+        OSX_MAJOR_VERSION=`sw_vers -productVersion | cut -d. -f1-2`
+        if dpkg --compare-versions "$OSX_MAJOR_VERSION" le "10.12"; then
+           params="-DOPENSSL_NO_APPLE_CRYPTO_RANDOM"
+        fi
+	./Configure -w --prefix=%p --openssldir=%p/etc/ssl zlib-dynamic enable-ec_nistp_64_gcc_128 $params
 	make
 <<
 


### PR DESCRIPTION
a PullRequest to fix issue #888 which causes start issue of PostgreSQL on macOS 10.12 with OpenSSL 1.1.1l/1.1.1m or OpenSSL 3.0.