### PR TITLE
PyTables 3.7.0 update and build against hdf5.200.v1.12

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/pytables-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/pytables-py.info
@@ -1,81 +1,55 @@
 Info2: <<
 
 Package: pytables-py%type_pkg[python]
-Version: 3.5.1
+Version: 3.7.0
 Revision: 1
-Distribution: <<
-	(%type_pkg[python] = 34 ) 10.9,
-	(%type_pkg[python] = 34 ) 10.10,
-	(%type_pkg[python] = 34 ) 10.11,
-	(%type_pkg[python] = 34 ) 10.12,
-	(%type_pkg[python] = 34 ) 10.13,
-	(%type_pkg[python] = 34 ) 10.14,
-	(%type_pkg[python] = 34 ) 10.14.5,
-	(%type_pkg[python] = 34 ) 10.15,
-	(%type_pkg[python] = 35 ) 10.9,
-	(%type_pkg[python] = 35 ) 10.10,
-	(%type_pkg[python] = 35 ) 10.11,
-	(%type_pkg[python] = 35 ) 10.12,
-	(%type_pkg[python] = 35 ) 10.13,
-	(%type_pkg[python] = 35 ) 10.14,
-	(%type_pkg[python] = 35 ) 10.14.5,
-	(%type_pkg[python] = 35 ) 10.15,
-	(%type_pkg[python] = 36 ) 10.9,
-	(%type_pkg[python] = 36 ) 10.10,
-	(%type_pkg[python] = 36 ) 10.11,
-	(%type_pkg[python] = 36 ) 10.12,
-	(%type_pkg[python] = 36 ) 10.13,
-	(%type_pkg[python] = 36 ) 10.14,
-	(%type_pkg[python] = 36 ) 10.14.5,
-	(%type_pkg[python] = 36 ) 10.15
-<<
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
-Type: python (2.7 3.4 3.5 3.6 3.7 3.8 3.9 3.10)
+Type: python (3.7 3.8 3.9 3.10)
 Depends: <<
   python%type_pkg[python],
   mock-py%type_pkg[python],
-  numpy-py%type_pkg[python] (>= 1.7.1-1),
-  numexpr-py%type_pkg[python] (>= 2.2.2-1),
+  numpy-py%type_pkg[python] (>= 1.19.0-1),
+  numexpr-py%type_pkg[python] (>= 2.6.2-1),
+  packaging-py%type_pkg[python],
   six-py%type_pkg[python],
   bzip2-shlibs,
   libblosc1-shlibs,
   lzo2-shlibs,
-  hdf5.10-shlibs,
-  hdf5-cpp11-shlibs
+  hdf5.200.v1.12-shlibs,
+  hdf5-cpp.200.v1.12-shlibs
 <<
 BuildDepends: <<
   bzip2-dev,
   lzo2,
   libblosc1-dev,
   cython-py%type_pkg[python] (>= 0.13-1),
-  hdf5.10,
-  hdf5-cpp11,
-  setuptools-tng-py%type_pkg[python],
-  ( %type_pkg[python] <= 27 ) sphinx-py%type_pkg[python] (>= 1.2.3-1)
+  hdf5.200.v1.12,
+  hdf5-cpp.200.v1.12,
+  setuptools-tng-py%type_pkg[python]
 <<
-CustomMirror: <<
-  Primary: https://github.com/PyTables/PyTables/archive
-<<
-Source: mirror:custom:v%v.tar.gz
-Source-MD5: 5725181cee7f42eaad115aec593cb188
-SourceRename: PyTables-%v.tar.gz
+#CustomMirror: <<
+#  Primary: https://github.com/PyTables/PyTables/archive
+#<<
+#Source: mirror:custom:v%v.tar.gz
+#Source-MD5: 5725181cee7f42eaad115aec593cb188
+#SourceRename: PyTables-%v.tar.gz
+Source: https://files.pythonhosted.org/packages/source/t/tables/tables-%v.tar.gz
+Source-Checksum: SHA256(e92a887ad6f2a983e564a69902de4a7645c30069fc01abd353ec5da255c5e1fe)
 PatchScript: sed -i.bak -e 's|"python"|sys.executable|' setup.py
 
 CompileScript: <<
  #!/bin/sh -ev
- %p/bin/python%type_raw[python] setup.py build_ext --cflags='-I%p/include' --lflags='-L%p/lib' --hdf5=%p/ --lzo=%p/ --bzip2=%p/ 
- %p/bin/python%type_raw[python] setup.py build --hdf5=%p/ --lzo=%p/ --bzip2=%p/ 
- cd doc
- mkdir -p build/html
- cat <<EOF > build/html/README
-   The PyTables HTML documentation currently cannot be built under Sphinx
-   v1.8.4 due to Sphinx errors.
-   Please see https://www.pytables.org for the online docs.
-EOF
+ if [ %type_pkg[python] -ge 38 ]; then
+  cython-py%type_pkg[python] -2 tables/[h-t]*extension.pyx
+  perl -pi -e 's|(from time import time,) (clock)|$1 process_time as $2|;' tables/index.py
+  perl -pi -e 's|(from time import) (clock) (as cputime)|$1 process_time $3|;' tables/scripts/ptrepack.py
+ fi
+ %p/bin/python%type_raw[python] setup.py build_ext --cflags='-I%p/include' --lflags='-L%p/lib' --hdf5=%p/opt/hdf5.v1.12 --lzo=%p --bzip2=%p 
+ %p/bin/python%type_raw[python] setup.py build --hdf5=%p/opt/hdf5.v1.12 --lzo=%p --bzip2=%p
 <<
 
 InstallScript: <<
- %p/bin/python%type_raw[python] setup.py install --cflags='-I%p/include' --lflags='-L%p/lib' --hdf5=%p/ --lzo=%p/ --bzip2=%p/ --root=%d 
+ %p/bin/python%type_raw[python] setup.py install --cflags='-I%p/include' --lflags='-L%p/lib' --hdf5=%p/opt/hdf5.v1.12 --lzo=%p --bzip2=%p --root=%d 
 
  mv %i/bin/pt2to3 %i/bin/pt2to3-py%type_pkg[python]
  mv %i/bin/ptdump %i/bin/ptdump-py%type_pkg[python]
@@ -123,7 +97,8 @@ InfoTest: <<
 
 License: BSD
 HomePage: http://www.pytables.org
-DocFiles: *.txt doc/build/html doc/scripts examples LICENSES
+DocFiles: LICENSE.txt PKG-INFO README.rst THANKS doc/html doc/scripts examples LICENSES
+
 Description: Hierarchical datasets in Python
 DescDetail: <<
 PyTables is a Python package for managing hierarchical datasets
@@ -138,15 +113,14 @@ resources so that data occupies much less space than with other
 solutions such as relational or object-oriented databases (especially
 when compression is used).
 
-The offline documentation is installed (for the -py27 variant only) in
- %p/share/doc/pytables-py27/html/index.html
+The offline documentation is installed in
+ %p/share/doc/pytables-py%type_pkg[python]/html/index.html
 <<
 DescPort: <<
-All tests return as 'OK' as of 3.1 and python 2.7-3.5.
+All tests return as 'OK' as of 3.7 and python 3.7-3.10.
 Don't know why 'python -B' is not doing what it's supposed to do!
-HTML documentation only built for the py27 version due to Sphinx errors
-under Python3; setup PYTHONPATH to ensure Sphinx can build it without
-the package yet installed.
+HTML documentation not included with the source distribution;
+fortunately since doc-build depends on ipython.
 <<
 
 <<


### PR DESCRIPTION
Updating to the latest upstream version and moving to the `hdf5.200.v1.12` library set. This version is dropping support for older version; officially 3.6 is still supported, but building against `hdf5.200.v1.12` or `hdf5.200.v1.10` fails on an `UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2` on `H5public.h`.
If the py27-py36 types are still needed, they are probably best moved out to a 3.5.1 version.