### PR TITLE
postgresql12 new upstream 12.10

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql12.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql12.info
@@ -1,6 +1,6 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 12.8
+Version: 12.10
 Revision: 1
 Type: postgresql 12
 Description: PostgreSQL open-source database
@@ -11,7 +11,7 @@ Depends: <<
 	daemonic (>= 20010902-1),
 	libxml2-shlibs,
 	libxslt-shlibs,
-	openssl110-shlibs,
+	openssl300-shlibs (>= 3.0.1-2),
 	passwd-postgres,
 	readline8-shlibs,
 	tcltk-shlibs,
@@ -22,7 +22,7 @@ BuildDepends: <<
 	libxml2,
 	libxslt,
 	readline8,
-	openssl110-dev,
+	openssl300-dev (>= 3.0.1-2),
 	system-perl,
 	tcltk,
 	tcltk-dev
@@ -31,8 +31,8 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-MD5: 2f37bc7efbe4ed38768a167148876746
-Source-Checksum: SHA256(e26401e090c34ccb15ffb33a111f340833833535a7b7c5cd11cd88ab57d9c62a)
+Source-MD5: 1f17b5b21a703335a03a153d4dcec6da
+Source-Checksum: SHA256(83dd192e6034951192b9a86dc19cf3717a8b82120e2f11a0a36723c820d2b257)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
@@ -49,7 +49,7 @@ PatchScript: <<
 	fi
 <<
 PatchFile: %n.patch
-PatchFile-MD5: 91a8667740f58cccac0ac0ea4ced0dfe
+PatchFile-MD5: ea668e2e2009b89b361c3f1e0a767b4a
 
 SetCPPFLAGS: -DHAVE_OPTRESET -fno-common
 SetLDFLAGS: -F/System/Library/Frameworks -headerpad_max_install_names
@@ -223,7 +223,7 @@ SplitOff: <<
 		postgresql10-dev,
 		postgresql11-dev,
 		postgresql12-dev,
-		postgresql13-dev
+		postgresql14-dev
 	<<
 	Replaces: <<
 		postgresql12 (<< 12.7-1),
@@ -235,7 +235,7 @@ SplitOff: <<
 		postgresql10-dev,
 		postgresql11-dev,
 		postgresql12-dev,
-		postgresql13-dev
+		postgresql14-dev
 	<<
 	BuildDependsOnly: true
 	Files: <<
@@ -263,7 +263,7 @@ fi
 SplitOff2: <<
 	Package: %N-shlibs
 	Description: PostgreSQL shared libraries
-	Depends: openssl110-shlibs
+	Depends: openssl300-shlibs (>= 3.0.1-2)
 	Files: <<
 		opt/postgresql-%type_raw[postgresql]/lib/lib*.*.dylib
 		var/postgresql-%type_raw[postgresql]/*.sh

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql12.patch
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql12.patch
@@ -100,7 +100,7 @@ diff -x '*~' -urN postgresql-12.1_original/src/Makefile.global.in postgresql-12.
 +#       fink patch:
 +#       macos with SIP enabled, workarround during make test and stripped DYLD_LIBRARY_PATH
 +	for binary in '$(abs_top_builddir)'/tmp_install$(bindir)/* ; do install_name_tool $$binary -change $(libdir)/libpq.5.dylib '$(abs_top_builddir)'/tmp_install$(libdir)/libpq.5.dylib   >>'$(abs_top_builddir)'/tmp_install/log/install.log 2>&1 ; done
-+	for libary in '$(abs_top_builddir)'/tmp_install$(libdir)/* ; do install_name_tool $$libary -change $(libdir)/libpq.5.dylib '$(abs_top_builddir)'/tmp_install$(libdir)/libpq.5.dylib   >>'$(abs_top_builddir)'/tmp_install/log/install.log 2>&1 ; done
++	for libary in '$(abs_top_builddir)'/tmp_install$(libdir)/*.dylib ; do install_name_tool $$libary -change $(libdir)/libpq.5.dylib '$(abs_top_builddir)'/tmp_install$(libdir)/libpq.5.dylib   >>'$(abs_top_builddir)'/tmp_install/log/install.log 2>&1 ; done
 +endif
  endif
  endif


### PR DESCRIPTION
updates the PostgreSQL 12 package to the latest upstream package and change the dependency for OpenSSL to OpenSSL 3.0.

