### PR TITLE
qhull8.0: revive non-reentrant lib, unified in existing -shlibs/-dev

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/qhull8.0-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/qhull8.0-shlibs.info
@@ -1,6 +1,6 @@
 Package: qhull8.0-shlibs
 Version: 2020.2
-Revision: 1
+Revision: 2
 Description: Calculate convex hulls and related structures
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
@@ -22,19 +22,40 @@ DescPackaging: <<
 * The prior static-only qhull package was maintained by Stefan Langerman 
   <fink@slef.org>.
 * Patch library install_name to be a full and not relative path.
+* Steal some debian patches, especially to retain the legacy libqhull
+  from older versions that upstream says it will continue to support,
+  not just the new libqhull_r. This allows easy migration from older
+  package libversions. Also their patch to convert libqhullcpp to
+  shared (rather than static). If you need either the legacy lib or
+  the cpp lib, be sure you depend on package-version 2020.2-2
+  (2020.2-1 only had the _r library).
 <<
 BuildDepends: <<
 	cmake,
-	fink (>= 0.30.0),
+	fink (>= 0.32),
 	fink-buildenv-modules
 <<
 
 Source: https://github.com/qhull/qhull/archive/%v.tar.gz
 SourceRename: qhull-%v.tar.gz
 Source-MD5: 123bf4764c374a645b34d44af7853799
+Source2: mirror:debian:pool/main/q/qhull/qhull_2020.2-4.debian.tar.xz
+Source2-MD5: 6a51dcc9dd62644563849938f0bdfd58
 
 PatchFile: %n.patch
 PatchFile-MD5: d01385e1d7a5a16ac40551e7962cc0f6
+PatchScript: <<
+	#!/bin/sh -ev
+	for f in \
+		0002-Fix-privacy-breach.patch \
+		0003-Use-local-version-of-function-index.patch \
+		0004-Build-qhullcpp-as-shared-library.patch \
+		0006-Build-deprecated-libqhull-for-now.patch \
+	; do
+		patch -p1 < ../debian/patches/$f
+	done
+	%{default_script}
+<<
 GCC: 4.0
 CompileScript: <<
 	#!/bin/sh -ev
@@ -63,14 +84,11 @@ InstallScript: <<
 	#!/bin/sh -ev
 	cd finkbuild
 	make install DESTDIR=%d
-	#pushd %i/lib
-	# make sure that the unversioned dylibs are actually symlinks
-	#rm libqhull.dylib libqhull_p.dylib
-	#ln -s libqhull.6.3.1.dylib libqhull.dylib
-	#ln -s libqhull_p.6.3.1.dylib libqhull_p.dylib
 <<
 Shlibs: <<
+	%p/lib/libqhull.8.0.dylib 8.0.0 %n (>= 2020.2-2)
 	%p/lib/libqhull_r.8.0.dylib 8.0.0 %n (>= 2020.2-1)
+	%p/lib/libqhullcpp.8.0.dylib 8.0.0 %n (>= 2020.2-2)
 <<
 
 DocFiles: Announce.txt COPYING.txt README.txt REGISTER.txt
@@ -102,7 +120,9 @@ SplitOff2:  <<
 	Files: <<
 		include
 		lib/cmake
+		lib/libqhull.dylib
 		lib/libqhull_r.dylib
+		lib/libqhullcpp.dylib
 		lib/lib*.a
 		lib/pkgconfig
 	<<


### PR DESCRIPTION
Upstream still supports libqhull even though it now also has libqhull_r, and the API changes mean it's not always trivial to migrate existing users of the older interface. Also flip libqhullcpp to shared (both changes per Debian patches).

This allows eventual killing of qhull6.3.1.

