### PR TITLE
xtide: bump to version 2.15.4 with harmonics 20220109

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide-harmonics-us.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide-harmonics-us.info
@@ -1,5 +1,5 @@
 Package: xtide-harmonics-us
-Version: 20210110
+Version: 20220109
 Revision: 1
 Description: US harmonic data for XTide
 DescDetail: <<
@@ -19,8 +19,8 @@ Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 BuildDepends: fink (>= 0.32)
 
 Source: https://flaterco.com/files/xtide/harmonics-dwf-%v-free.tar.xz
-Source-MD5: b14454b1cb477a93bf8311687ade2c79
-Source-Checksum: SHA1(7b2734c879a8ca1ff0fbbad09443103264fc315b)
+Source-MD5: 095eaf7f8a62fba55b91455182974154
+Source-Checksum: SHA1(5dc561f8e08699e3ae0a699b0520461aa4d4a5ed)
 SourceDirectory: harmonics-dwf-%v
 
 CompileScript: printf "No compiling needed.\n" 

--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: xtide
-Version: 2.15.3
-Revision: 2
-Type: harm (20210110)
+Version: 2.15.4
+Revision: 1
+Type: harm (20220109)
 
 Description: Tide and current prediction software
 License: Public Domain
@@ -39,8 +39,8 @@ Depends: <<
 Recommends: xtide-coastline (>= 20110414-2)
 
 Source: https://flaterco.com/files/xtide/%n-%v.tar.xz
-Source-MD5: 0381904d2d623685c4971efd2f54c7ba
-Source-Checksum: SHA1(333ca9fa42afd62868d722d9f1627e9447f78c19)
+Source-MD5: e878577704e474921e0ad9502f0deb09
+Source-Checksum: SHA1(fc8d65da87d3041e93b4a6d628dafee557546b50)
 
 PatchScript: <<
 	perl -pi -e 's,(/etc/xtide\.conf),%p\1,g' libxtide/Global.cc README tide.1 xtide.1 xttpd.8


### PR DESCRIPTION
A very simple update: a handful of bug fixes in the main code, and updated harmonics files.

Tested on MacOS 10.15.7, where it builds and appears to work correctly. Maintainer is @akhansen 