### PR TITLE
bison: new version, disable java for self-test/examples

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/bison.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/bison.info
@@ -1,8 +1,8 @@
 Package: bison
-Version: 3.4.2
+Version: 3.8.2
 Revision: 1
 Source: gnu
-Source-Checksum: SHA1(e54a89ff5b74ed76ae1e83b368e9e3001917265c)
+Source-Checksum: SHA1(8e4b861eb765a7797ea0a6257ec600b3ff5ee37d)
 Maintainer: Darian Lanx <dmalloc@users.sourceforge.net>
 BuildDepends: <<
 	fink-package-precedence,
@@ -19,11 +19,12 @@ Depends: <<
 	libiconv,
 	m4
 <<
+# disable java so we don't need to haul it into a mainline package
+PatchFile: %n.patch
+PatchFile-MD5: 019fd43681b6fd260fc6dbaedb101132
 ConfigureParams: <<
 	--with-libiconv-prefix=%p \
 	--with-libintl-prefix=%p \
-	--mandir=%p/share/man \
-	--infodir=%p/share/info \
 	ac_cv_prog_AWK=/usr/bin/awk \
 	ac_cv_prog_LEX=/usr/bin/flex \
 	ac_cv_path_GREP=/usr/bin/grep \
@@ -40,7 +41,10 @@ CompileScript: <<
 InfoTest: <<
   TestDepends: ghostscript (>= 9.25)
   # rely on java/javac instead of gij for java testsuite
-  TestScript: make check || exit 2
+  TestScript: <<
+    make check || exit 2
+    fink-package-precedence . || exit 2
+  <<
 <<
 InstallScript: <<
  cp INSTALL INSTALL.txt
@@ -48,7 +52,7 @@ InstallScript: <<
  rm -f %i/share/locale/locale.alias
  rm -f %i/lib/charset.alias
 <<
-DocFiles: INSTALL.txt README COPYING AUTHORS NEWS THANKS TODO PACKAGING
+DocFiles: AUTHORS COPYING NEWS PACKAGING README THANKS TODO
 InfoDocs: bison.info
 #
 Description: Parser generator

--- a/10.9-libcxx/stable/main/finkinfo/devel/bison.patch
+++ b/10.9-libcxx/stable/main/finkinfo/devel/bison.patch
@@ -1,0 +1,13 @@
+--- bison-3.8.2.orig/configure	2021-09-25 04:44:09.000000000 -0400
++++ bison-3.8.2/configure	2022-04-03 17:55:36.000000000 -0400
+@@ -13278,8 +13278,8 @@
+ 
+ 
+ 
+-
+- if test x"$CONF_JAVAC" != x && test x"$CONF_JAVA" != x; then
++ printf %s "disabling java by packager fiat\n" >&6
++ if test x"$CONF_JAVAC" != x && test x"$CONF_JAVA" != x && false; then
+   ENABLE_JAVA_TRUE=
+   ENABLE_JAVA_FALSE='#'
+ else


### PR DESCRIPTION
Some long-deprecated YY* macros are no longer supported, but I spot-checked some oooold packages that have BDep:bison and they still seem to build.