### PR TITLE
OpenBLAS update to 0.3.20 and test/benchmark fix for pre-10.12

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
@@ -1,9 +1,9 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: openblas
-Version: 0.3.21
+Version: 0.3.26
 Revision: 1
-Type: gcc (12)
+Type: gcc (11)
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
 
 BuildDependsOnly: true
@@ -11,11 +11,10 @@ BuildDepends: fink (>= 0.30.0), gcc%type_raw[gcc]-compiler
 Depends: %N-shlibs (= %v-%r)
 
 Source: https://github.com/xianyi/OpenBLAS/archive/v%v.tar.gz
-Source-Checksum: SHA256(f36ba3d7a60e7c8bcc54cd9aaa9b1223dd42eaf02c811791c37e8ca707c241ca)
+Source-Checksum: SHA256(4e6e4f5cb14c209262e33e6816d70221a2fe49eb69eaf0a06f065598ac602c68)
 SourceRename: OpenBLAS-%v.tar.gz
 PatchFile: %n.patch
-PatchFile-MD5: c2249f0373477783e310f83c97c2d565
-SetCC: gcc-fsf-%type_raw[gcc]
+PatchFile-MD5: a82d2d28369faa468b2c3b3be0933f8b
 
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 
@@ -28,15 +27,15 @@ CompileScript: <<
 	darwin_vers=$(uname -r | cut -d. -f1)
 	if [ "%m" = "arm64" ]; then
 		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=native -march=armv8.5-a|g;" Makefile.system
-		export CC=clang DYNAMIC_ARCH=0 TARGET=VORTEX DYNAMIC_LIST="ARMV8 NEOVERSEN1"  # "ARMV8SVE NEOVERSEN2" require sve instruction support
+		export DYNAMIC_ARCH=0 TARGET=VORTEX DYNAMIC_LIST="ARMV8 NEOVERSEN1"  # "ARMV8SVE NEOVERSEN2" require sve instruction support
 	elif [ "$darwin_vers" -ge 18 ]; then
-		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=intel|g;" Makefile.system
+		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=cascadelake  -march=ivybridge|g;" Makefile.system
 		export DYNAMIC_LIST="SANDYBRIDGE HASWELL SKYLAKEX COOPERLAKE"
 	else
-		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=intel -march=core2|g;" Makefile.system
+		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=skylake-avx512 -march=core2|g;" Makefile.system
 		export DYNAMIC_LIST="CORE2 PENRYN NEHALEM SANDYBRIDGE HASWELL"
 	fi
-	make CC=$CC FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 libs netlib shared
+	make CC=clang FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 libs netlib shared
 	cd benchmark
 	mkdir -m 755 bin
 	mv Makefile Makefile.orig
@@ -156,6 +155,8 @@ identical assembler and object code.)
   and failing on 10.11; disabled since substitute function from smallscaling.c does
   not seem to produce accurate enough timings
   Build dynamically linked benchmarks (static versions grew to > 1.5 GB).
+0.3.26: revert to gcc11; use clang as the c compiler on arm64 and macOS 10.13 and
+  before for performance and stability reasons.
 <<
 # Info2
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
@@ -1,9 +1,9 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: openblas
-Version: 0.3.20
+Version: 0.3.21
 Revision: 1
-Type: gcc (11)
+Type: gcc (12)
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
 
 BuildDependsOnly: true
@@ -11,10 +11,11 @@ BuildDepends: fink (>= 0.30.0), gcc%type_raw[gcc]-compiler
 Depends: %N-shlibs (= %v-%r)
 
 Source: https://github.com/xianyi/OpenBLAS/archive/v%v.tar.gz
-Source-Checksum: SHA256(8495c9affc536253648e942908e88e097f2ec7753ede55aca52e5dead3029e3c)
+Source-Checksum: SHA256(f36ba3d7a60e7c8bcc54cd9aaa9b1223dd42eaf02c811791c37e8ca707c241ca)
 SourceRename: OpenBLAS-%v.tar.gz
 PatchFile: %n.patch
 PatchFile-MD5: c2249f0373477783e310f83c97c2d565
+SetCC: gcc-fsf-%type_raw[gcc]
 
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
 
@@ -24,19 +25,18 @@ CompileScript: <<
 	# remove excessive truncating of $hostarch https://github.com/xianyi/OpenBLAS/commit/00ce353
 	perl -pi -e 's|;chop..hostarch.;|;|' c_check
 	# set arch to minimum model supported in OS version
-	CC=gcc-fsf-%type_raw[gcc]
 	darwin_vers=$(uname -r | cut -d. -f1)
-	if [ "%m" = "arm" ]; then
-		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=native|g;" Makefile.system
-		CC=clang
+	if [ "%m" = "arm64" ]; then
+		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=native -march=armv8.5-a|g;" Makefile.system
+		export CC=clang DYNAMIC_ARCH=0 TARGET=VORTEX DYNAMIC_LIST="ARMV8 NEOVERSEN1"  # "ARMV8SVE NEOVERSEN2" require sve instruction support
 	elif [ "$darwin_vers" -ge 18 ]; then
 		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=intel|g;" Makefile.system
-		export DYNAMIC_LIST="SANDYBRIDGE HASWELL SKYLAKEX"
+		export DYNAMIC_LIST="SANDYBRIDGE HASWELL SKYLAKEX COOPERLAKE"
 	else
 		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=intel -march=core2|g;" Makefile.system
 		export DYNAMIC_LIST="CORE2 PENRYN NEHALEM SANDYBRIDGE HASWELL"
 	fi
-	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 libs netlib shared
+	make CC=$CC FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 libs netlib shared
 	cd benchmark
 	mkdir -m 755 bin
 	mv Makefile Makefile.orig

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: openblas
-Version: 0.3.19
+Version: 0.3.20
 Revision: 1
 Type: gcc (11)
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
@@ -11,14 +11,12 @@ BuildDepends: fink (>= 0.30.0), gcc%type_raw[gcc]-compiler
 Depends: %N-shlibs (= %v-%r)
 
 Source: https://github.com/xianyi/OpenBLAS/archive/v%v.tar.gz
-Source-Checksum: SHA256(947f51bfe50c2a0749304fbe373e00e7637600b0a47b78a51382aeb30ca08562)
+Source-Checksum: SHA256(8495c9affc536253648e942908e88e097f2ec7753ede55aca52e5dead3029e3c)
 SourceRename: OpenBLAS-%v.tar.gz
 PatchFile: %n.patch
-PatchFile-MD5: e9d16e8a2772758bbd37e29e3c25c0f8
+PatchFile-MD5: c2249f0373477783e310f83c97c2d565
 
 PatchScript: sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
-
-SetCC: gcc-fsf-%type_raw[gcc]
 
 CompileScript: <<
 	#!/bin/sh -ev
@@ -26,12 +24,16 @@ CompileScript: <<
 	# remove excessive truncating of $hostarch https://github.com/xianyi/OpenBLAS/commit/00ce353
 	perl -pi -e 's|;chop..hostarch.;|;|' c_check
 	# set arch to minimum model supported in OS version
+	CC=gcc-fsf-%type_raw[gcc]
 	darwin_vers=$(uname -r | cut -d. -f1)
-	if [ "$darwin_vers" -ge 18 ]; then
-		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=cascadelake -march=ivybridge|g;" Makefile.system
+	if [ "%m" = "arm" ]; then
+		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=native|g;" Makefile.system
+		CC=clang
+	elif [ "$darwin_vers" -ge 18 ]; then
+		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=intel|g;" Makefile.system
 		export DYNAMIC_LIST="SANDYBRIDGE HASWELL SKYLAKEX"
 	else
-		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=skylake-avx512 -march=core2|g;" Makefile.system
+		perl -pi -e "s|(COMMON_OPT = -O2)|\$1 -mtune=intel -march=core2|g;" Makefile.system
 		export DYNAMIC_LIST="CORE2 PENRYN NEHALEM SANDYBRIDGE HASWELL"
 	fi
 	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 libs netlib shared
@@ -45,8 +47,9 @@ CompileScript: <<
 		egrep -v 'saxpy\.veclib.*daxpy\.veclib.*.caxpy\.veclib' Makefile.orig > Makefile
 	fi
 	# For some reason #define RETURN_BY_STACK 1 is not properly recognised in zdot-intel.c...
-	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp LIBSUFFIX=dylib CFLAGS+=-DRETURN_BY_STACK=1 {c,z}dot-intel.o
-	make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp LIBSUFFIX=dylib veclib goto smallscaling
+	# Always compile executables with gcc for OpenMP support.
+	make CC=gcc-fsf-%type_raw[gcc] FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp LIBSUFFIX=dylib CFLAGS+=-DRETURN_BY_STACK=1 {c,z}dot-intel.o
+	make CC=gcc-fsf-%type_raw[gcc] FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp LIBSUFFIX=dylib veclib goto smallscaling
 	for x in smallscaling *.goto; do
 		install_name_tool -change %b/exports/../libopenblas.0.dylib %p/lib/libopenblas.0.dylib $x
 	done
@@ -60,23 +63,16 @@ InstallScript: <<
 <<
 
 InfoTest: <<
-	TestDepends: atlas
 	TestScript: <<
 		#!/bin/sh -ev
 		make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 tests | tee tests.log
 		grep -il fail tests.log && grep -i fail tests.log
 		grep -c PASSED tests.log
 		cd benchmark
-		make FC=gfortran-fsf-%type_raw[gcc] USE_THREAD=1 FOPENMP=-fopenmp atlas
 		# use hw.physicalcpu to run without hyperthreading
 		ncore=$(sysctl -n hw.logicalcpu)
 		# created a ton of *.veclib, *.goto, *.atlas executables to be compared in performance...
 		# just filter results for a sample of matrix sizes and run a little suite of comparisons of threaded vs. openmp speedup
-		echo ATLAS
-		for x in *.atlas; do
-			echo OPENBLAS_NUM_THREADS=$ncore OMP_NUM_THREADS=1 $x
-			OPENBLAS_NUM_THREADS=$ncore OMP_NUM_THREADS=1 ./$x 2>&1 | awk '(NR < 4)||((NR-2)%%20 == 0)'
-		done
 		cd bin
 		echo VecLib
 		for x in *.veclib; do

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
@@ -1,28 +1,27 @@
 diff -uNr a/Makefile.system b/Makefile.system
---- a/Makefile.system	2020-02-09 23:16:28.000000000 +0100
-+++ b/Makefile.system	2020-02-20 18:06:14.000000000 +0100
-@@ -550,8 +550,10 @@
+--- a/Makefile.system	2023-11-12 22:55:00.000000000 +0100
++++ b/Makefile.system	2023-11-13 21:14:34.000000000 +0100
+@@ -607,7 +607,9 @@
  endif
  
  ifeq ($(C_COMPILER), CLANG)
 +ifneq ($(OSNAME), Darwin)
  CCOMMON_OPT    += -fopenmp
- endif
 +endif
- 
- ifeq ($(C_COMPILER), INTEL)
- CCOMMON_OPT    += -fopenmp
-@@ -1438,8 +1440,8 @@
+ ifeq ($(F_COMPILER), GFORTRAN)
+ FEXTRALIB := $(subst -lgomp,-lomp,$(FEXTRALIB))
  endif
-
-
+@@ -1604,8 +1606,8 @@
+ endif
+ 
+ 
 -REVISION = -r$(VERSION)
  MAJOR_VERSION = $(word 1,$(subst ., ,$(VERSION)))
 +REVISION = .$(MAJOR_VERSION)
-
+ 
  ifeq ($(DEBUG), 1)
  COMMON_OPT += -g
-@@ -1512,19 +1514,19 @@
+@@ -1686,19 +1688,19 @@
  
  ifneq ($(DYNAMIC_ARCH), 1)
  ifndef SMP
@@ -50,9 +49,9 @@ diff -uNr a/Makefile.system b/Makefile.system
  endif
 
 diff -uNr a/benchmark/Makefile b/benchmark/Makefile
---- a/benchmark/Makefile   2020-06-14 22:03:04.000000000 +0200
-+++ b/benchmark/Makefile   2020-07-01 16:47:19.000000000 +0200
-@@ -19,8 +19,13 @@
+--- a/benchmark/Makefile   2023-04-01 22:18:00.000000000 +0200
++++ b/benchmark/Makefile   2023-04-04 01:37:35.000000000 +0200
+@@ -19,9 +19,13 @@
  #LIBATLAS = -fopenmp $(ATLAS)/liblapack_atlas.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
  
  # Atlas RHEL and Fedora
@@ -60,39 +59,15 @@ diff -uNr a/benchmark/Makefile b/benchmark/Makefile
 -LIBATLAS = -fopenmp $(ATLAS)/liblapack.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
 +#ATLAS=/usr/lib64/atlas
 +#LIBATLAS = -fopenmp $(ATLAS)/liblapack.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
-+
-+# Atlas MacOS X Fink (Xcode clang does not support -fopenmp)
-+ATLAS=@PREFIX@/lib
-+LIBATLAS = $(FOPENMP) $(ATLAS)/liblapack.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
-+
  
++# Atlas macOS Fink (Xcode clang does not support -fopenmp)
+++ATLAS=/opt/lib
+++LIBATLAS = $(FOPENMP) $(ATLAS)/liblapack.a  $(ATLAS)/libptcblas.a  $(ATLAS)/libptf77blas.a  $(ATLAS)/libatlas.a -lgfortran -lm
++
  # Intel standard
  # MKL=/opt/intel/mkl/lib/intel64
-@@ -87,7 +92,7 @@
-        cher.goto zher.goto \
-        cher2.goto zher2.goto \
-        sgemv.goto dgemv.goto cgemv.goto zgemv.goto \
--	   sspmv.goto dspmv.goto \
-+       sspmv.goto dspmv.goto \
-        strmv.goto dtrmv.goto ctrmv.goto ztrmv.goto \
-        stpmv.goto dtpmv.goto ctpmv.goto ztpmv.goto \
-        stpsv.goto dtpsv.goto ctpsv.goto ztpsv.goto \
-@@ -254,13 +259,12 @@
-        cher.goto zher.goto \
-        cher2.goto zher2.goto \
-        sgemv.goto dgemv.goto cgemv.goto zgemv.goto \
--	   sspmv.goto dspmv.goto \
-+       sspmv.goto dspmv.goto \
-        strmv.goto dtrmv.goto ctrmv.goto ztrmv.goto \
-        stpmv.goto dtpmv.goto ctpmv.goto ztpmv.goto \
-        stpsv.goto dtpsv.goto ctpsv.goto ztpsv.goto \
-        strsv.goto dtrsv.goto ctrsv.goto ztrsv.goto \
-        ssymm.goto dsymm.goto csymm.goto zsymm.goto \
--       smallscaling \
-        isamax.goto idamax.goto icamax.goto izamax.goto \
-        ismax.goto idmax.goto \
-        isamin.goto idamin.goto icamin.goto izamin.goto \
-@@ -3431,7 +3436,7 @@
+ # LIBMKL = -L$(MKL) -lmkl_intel_lp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm
+@@ -3431,7 +3435,7 @@
  
  
  smallscaling: smallscaling.c ../$(LIBNAME)
@@ -184,7 +159,7 @@ diff -uNr a/benchmark/bench.h b/benchmark/bench.h
  #include "common.h"
  
  #if defined(__WIN32__) || defined(__WIN64__)
-@@ -98,7 +123,7 @@
+@@ -116,7 +141,7 @@
  void begin() {
  #if defined(__WIN32__) || defined(__WIN64__) || !defined(_POSIX_TIMERS)
      gettimeofday( &start, (struct timezone *)0);
@@ -193,7 +168,7 @@ diff -uNr a/benchmark/bench.h b/benchmark/bench.h
      start = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
  #else
      clock_gettime(CLOCK_REALTIME, &start);
-@@ -108,7 +133,7 @@
+@@ -126,7 +151,7 @@
  void end() {
  #if defined(__WIN32__) || defined(__WIN64__) || !defined(_POSIX_TIMERS)
      gettimeofday( &stop, (struct timezone *)0);
@@ -205,7 +180,7 @@ diff -uNr a/benchmark/bench.h b/benchmark/bench.h
 diff -uNr a/Makefile b/Makefile
 --- a/Makefile		2019-08-11 23:23:27.000000000 +0100
 +++ b/Makefile		2019-11-06 19:18:15.000000000 +0100
-@@ -130,8 +130,10 @@
+@@ -144,8 +144,10 @@
  ifeq ($(OSNAME), Darwin)
 	@$(MAKE) -C exports dyn
 	@ln -fs $(LIBDYNNAME) $(LIBPREFIX).dylib
@@ -219,7 +194,7 @@ diff -uNr a/Makefile b/Makefile
 diff -uNr a/Makefile.install b/Makefile.install
 --- a/Makefile.install	2019-08-11 23:23:27.000000000 +0100
 +++ b/Makefile.install	2019-11-06 2019-11-06 20:13:02.000000000 +0100
-@@ -107,8 +107,7 @@
+@@ -120,8 +120,7 @@
 	@-cp $(LIBDYNNAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
 	@-install_name_tool -id "$(OPENBLAS_LIBRARY_DIR)/$(LIBPREFIX).$(MAJOR_VERSION).dylib" "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)/$(LIBDYNNAME)"
 	@cd "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)" ; \

--- a/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/openblas.patch
@@ -68,6 +68,30 @@ diff -uNr a/benchmark/Makefile b/benchmark/Makefile
  
  # Intel standard
  # MKL=/opt/intel/mkl/lib/intel64
+@@ -87,7 +92,7 @@
+        cher.goto zher.goto \
+        cher2.goto zher2.goto \
+        sgemv.goto dgemv.goto cgemv.goto zgemv.goto \
+-	   sspmv.goto dspmv.goto \
++       sspmv.goto dspmv.goto \
+        strmv.goto dtrmv.goto ctrmv.goto ztrmv.goto \
+        stpmv.goto dtpmv.goto ctpmv.goto ztpmv.goto \
+        stpsv.goto dtpsv.goto ctpsv.goto ztpsv.goto \
+@@ -254,13 +259,12 @@
+        cher.goto zher.goto \
+        cher2.goto zher2.goto \
+        sgemv.goto dgemv.goto cgemv.goto zgemv.goto \
+-	   sspmv.goto dspmv.goto \
++       sspmv.goto dspmv.goto \
+        strmv.goto dtrmv.goto ctrmv.goto ztrmv.goto \
+        stpmv.goto dtpmv.goto ctpmv.goto ztpmv.goto \
+        stpsv.goto dtpsv.goto ctpsv.goto ztpsv.goto \
+        strsv.goto dtrsv.goto ctrsv.goto ztrsv.goto \
+        ssymm.goto dsymm.goto csymm.goto zsymm.goto \
+-       smallscaling \
+        isamax.goto idamax.goto icamax.goto izamax.goto \
+        ismax.goto idmax.goto \
+        isamin.goto idamin.goto icamin.goto izamin.goto \
 @@ -3431,7 +3436,7 @@
  
  
@@ -123,6 +147,61 @@ diff -uNr a/benchmark/smallscaling.c b/benchmark/smallscaling.c
      double inc_factor = exp(log((double)MAX_SIZE / MIN_SIZE) / NB_SIZE);
      BenchParam param;
      int test_id;
+diff -uNr a/benchmark/bench.h b/benchmark/bench.h
+--- a/benchmark/bench.h	2021-12-19 20:55:57.000000000 +0100
++++ b/benchmark/bench.h	2022-03-17 02:35:18.000000000 +0100
+@@ -5,7 +5,32 @@
+ #include <sys/time.h>
+ #elif defined(__APPLE__)
+ #include <mach/mach_time.h>
+-#endif
++// Workaround for missing CLOCK_MONOTONIC on OS X El Capitan & earlier
++#ifndef CLOCK_MONOTONIC
++#include <mach/clock_types.h>
++#define CLOCK_MONOTONIC SYSTEM_CLOCK
++#define CLOCK_REALTIME SYSTEM_CLOCK
++#define MACH_CLOCK_NEEDS_INIT 1
++double sec_factor;
++double nsec_factor;
++
++void clock_gett_init() {
++    mach_timebase_info_data_t timebase;
++    mach_timebase_info(&timebase);
++    nsec_factor = ((double)timebase.numer)/((double)timebase.denom);
++    sec_factor = ((double)timebase.numer)/((double)timebase.denom * 1e-9);
++}
++
++int clock_gettime(clock_id_t clk_id, struct timespec *tp) {
++    uint64_t time;
++    time = mach_absolute_time();
++    tp->tv_sec = (double)time * sec_factor;
++    tp->tv_nsec = (double)time * nsec_factor;
++    return 0;
++}
++#endif // CLOCK_MONOTONIC
++#endif // __APPLE__
++
+ #include "common.h"
+ 
+ #if defined(__WIN32__) || defined(__WIN64__)
+@@ -98,7 +123,7 @@
+ void begin() {
+ #if defined(__WIN32__) || defined(__WIN64__) || !defined(_POSIX_TIMERS)
+     gettimeofday( &start, (struct timezone *)0);
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && !defined(MACH_CLOCK_NEEDS_INIT)
+     start = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+ #else
+     clock_gettime(CLOCK_REALTIME, &start);
+@@ -108,7 +133,7 @@
+ void end() {
+ #if defined(__WIN32__) || defined(__WIN64__) || !defined(_POSIX_TIMERS)
+     gettimeofday( &stop, (struct timezone *)0);
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && !defined(MACH_CLOCK_NEEDS_INIT)
+     stop = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+ #else
+     clock_gettime(CLOCK_REALTIME, &stop);
 diff -uNr a/Makefile b/Makefile
 --- a/Makefile		2019-08-11 23:23:27.000000000 +0100
 +++ b/Makefile		2019-11-06 19:18:15.000000000 +0100


### PR DESCRIPTION
Latest upstream version; adding an additional replacement for `CLOCK_*` functions missing from 10.11 or earlier – thanks to David Neuhaus for reporting this.
Optimisation options also add a check for M1 (aarch64), for now as `arm` until an Architecture is officially set.