### PR TITLE
Uncertainties 3.1.6

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/future-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/future-py.info
@@ -30,7 +30,7 @@ Distribution: <<
 	(%type_pkg[python] = 36 ) 10.15
 <<
 
-Type: python (2.7 3.4 3.5 3.6 3.7 3.8)
+Type: python (2.7 3.4 3.5 3.6 3.7 3.8 3.9 3.10)
 
 Description: Single-source support for Python 3 and 2
 DescDetail: <<
@@ -45,7 +45,8 @@ DescUsage: <<
 	and pasteurize, which downconverts py3 code.
 <<
 DescPackaging: <<
-	Tests require net access. Also, files needed are missing from tarball.
+	Tests requiring net access de-selected.
+	Also, files needed are missing from tarball.
 <<
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 License: BSD
@@ -62,13 +63,16 @@ CompileScript: <<
 	%p/bin/python%type_raw[python] setup.py build
 <<
 
-# Tests need network access.
-#InfoTest: <<
-#	TestDepends: <<
-#		pytest-py%type_pkg[python]
-#	<<
-#	TestScript: PYTHONPATH=%b/build/lib %p/bin/py.test-%type_raw[python] || exit 2
-#<<
+# Some tests need network access.
+InfoTest: <<
+	TestDepends: <<
+		pytest-py%type_pkg[python]
+	<<
+	TestScript: <<
+		PYTHONPATH=%b/build/lib %p/bin/python%type_raw[python] -Bm pytest -k 'not (test_pow or test_httplib or test_requests or test_standard_library or test_urllib)' || exit 2
+		find build/lib -name '*.pyc' -delete
+	<<
+<<
 InstallScript: <<
 	%p/bin/python%type_raw[python] setup.py install --root=%d
 	mv %i/bin/futurize %i/bin/futurize-py%type_pkg[python]

--- a/10.9-libcxx/stable/main/finkinfo/sci/uncertainties-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/uncertainties-py.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: uncertainties-py%type_pkg[python]
-Version: 2.4.8.1
+Version: 3.1.6
 Revision: 1
 Distribution: <<
 	(%type_pkg[python] = 34 ) 10.9,
@@ -29,12 +29,17 @@ Distribution: <<
 	(%type_pkg[python] = 36 ) 10.15
 <<
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
-Type: python (2.7 3.4 3.5 3.6)
+Type: python (2.7 3.4 3.5 3.6 3.7 3.8 3.9 3.10)
 Description: Transparent calculations with uncertainties
-Depends: python%type_pkg[python], numpy-py%type_pkg[python] (>= 1.9.0), setuptools-tng-py%type_pkg[python]
+Depends: <<
+	python%type_pkg[python],
+	future-py%type_pkg[python],
+	numpy-py%type_pkg[python] (>= 1.9.0),
+	setuptools-tng-py%type_pkg[python]
+<<
 BuildDepends: fink (>= 0.24.12)
 Source: https://pypi.io/packages/source/u/uncertainties/uncertainties-%v.tar.gz
-Source-MD5: 1faf2f9f54e077d81b1de649984bc3a1
+Source-Checksum: SHA256(7c4db5aaafd227e95485b61fba5d235dc8133aeecd98f8fc1224c038ce063e2d)
 
 CompileScript: <<
  %p/bin/python%type_raw[python] setup.py build
@@ -45,16 +50,20 @@ InstallScript: <<
 <<
 
 InfoTest: <<
- TestDepends: nose-py%type_pkg[python], coverage-py%type_pkg[python]
+ TestDepends: <<
+  nose-py%type_pkg[python],
+  (%type_pkg[python] >> 27) nose-py%type_pkg[python] (>= 1.3.7-4),
+  coverage-py%type_pkg[python]
+ <<
  TestScript: <<
-  %p/bin/nosetests-%type_raw[python] --no-byte-compile --with-coverage build
+  %p/bin/nosetests%type_raw[python] --no-byte-compile --with-coverage build || exit 2
  <<
  TestSuiteSize: small
 <<
 
 DocFiles: README.rst LICENSE.txt doc/[i-u]*.rst
 DescDetail: <<
-Uncertainties allows calculations such as (2 +/- 0.1)*2 = 4 +/- 0.2 to be
+Uncertainties allows calculations such as (2 +/- 0.1) * 2 = 4 +/- 0.2 to be
 performed transparently while handling error propagation and correlation
 between variable. Much more complex mathematical expressions involving
 numbers with uncertainties can also be evaluated directly.


### PR DESCRIPTION
Update to current upstream, fixing the `nosetests` call for #917.
This version requires `future-py`, which comes in with the missing pyversions as well; also trying to get its tests to run again. As far as I could check, the enabled tests are running without network access now.
Tested all variants on 10.14.5, py39/310 on 12.4 and 10.13.6 as well.