### PR TITLE
Python 3.9.13 + 3.10.5 updates with build against openssl300

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/python310.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python310.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: python310.patch -*-
 Info2: <<
 Package: python%type_pkg[python]
-Version: 3.10.4
+Version: 3.10.5
 Revision: 1
 Type: python 3.10
 # Free to modify, update, and take over
@@ -17,7 +17,7 @@ Depends: <<
 	libgettext8-shlibs,
 	liblzma5-shlibs,
 	libncursesw5-shlibs,
-	openssl110-shlibs (>= 1.1.1g-1),
+	openssl300-shlibs (>= 3.0.1-1),
 	readline8-shlibs,
 	sqlite3-shlibs  (>= 3.30.1-1),
 	tcltk (>= 8.4.1-1),
@@ -35,7 +35,7 @@ BuildDepends: <<
 	libgettext8-dev,
 	liblzma5,
 	libncursesw5,
-	openssl110-dev (>= 1.1.1g-1),
+	openssl300-dev (>= 3.0.1-1),
 	pkgconfig,
 	readline8,
 	sqlite3-dev (>= 3.30.1-1),
@@ -57,7 +57,7 @@ Provides: <<
 <<
 
 Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
-Source-Checksum: SHA256(80bf925f571da436b35210886cf79f6eb5fa5d6c571316b73568343451f77a19)
+Source-Checksum: SHA256(8437efd5b106ef0a75aabfbf23d880625120a73a86a22ade4d2e2e68d7b74486)
 
 PatchFile: %n.patch
 PatchFile-MD5: accc53203fdb4c50b45aea0d9d6ecf5e
@@ -126,8 +126,8 @@ InfoTest: <<
 		# test_ctypes is currently broken on 12.0 (py3.10.1)
 		# test_tcl and test_idle require an active $DISPLAY
 		# test_select is missing attribute 'poll'
-		# test_pkgutil fails on HFS+ https://bugs.python.org/issue41154
-		EXTRATESTOPTS='-w -unone -x test_socket test_multiprocessing_spawn test_code test_ctypes test_idle test_tcl test_select test_pkgutil'
+		# test_pkgutil fails on HFS+ https://bugs.python.org/issue41154 (marked resolved)
+		EXTRATESTOPTS='-w -unone -x test_idle test_select test_tcl'
 		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
 
 		# Put install_name back.
@@ -154,6 +154,8 @@ InstallScript: <<
 	perl -pi -e 's/-lintl //' `ls -d %b/build/lib*`/_sysconfigdata__darwin_darwin.py
 	# Remove stray .pyc that get made during tests (including preliminary ones in CompileScript) to keep validator happy.
 	find ./Lib ./Parser ./Tools ./build -name '*.pyc' -delete
+	# Change interpreter name in scripts to versioned executable.
+	perl -pi -e 's|(/usr/bin/env python)(3?)$|${1}%type_raw[python]|' ./Tools/scripts/*
 	# install fails with -j greater than 1
 	export MAKEFLAGS=-j1
 	make install DESTDIR=%d
@@ -177,6 +179,8 @@ InstallScript: <<
 	# install some docs and other useful tidbits
 	rm -rf Misc/RPM
 	/bin/cp -R Misc Tools %i/lib/python%type_raw[python]
+	pushd %i/lib/python%type_raw[python]
+	DYLD_LIBRARY_PATH=%i/lib %i/bin/python%type_raw[python] -m compileall -o 0 -o 1 -o 2 Tools || echo 'some files were not byte-compiled'
 
 # Doc tarball missing upstream.
 #	mkdir -p %i/share/doc/%n/html

--- a/10.9-libcxx/stable/main/finkinfo/languages/python39.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python39.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: python39.patch -*-
 Info2: <<
 Package: python%type_pkg[python]
-Version: 3.9.12
+Version: 3.9.13
 Revision: 1
 Type: python 3.9
 # Free to modify, update, and take over
@@ -17,7 +17,7 @@ Depends: <<
 	libgettext8-shlibs,
 	liblzma5-shlibs,
 	libncursesw5-shlibs,
-	openssl110-shlibs (>= 1.1.1g-1),
+	openssl300-shlibs (>= 3.0.1-1),
 	readline8-shlibs,
 	sqlite3-shlibs  (>= 3.30.1-1),
 	tcltk (>= 8.4.1-1),
@@ -35,7 +35,7 @@ BuildDepends: <<
 	libgettext8-dev,
 	liblzma5,
 	libncursesw5,
-	openssl110-dev (>= 1.1.1g-1),
+	openssl300-dev (>= 3.0.1-1),
 	pkgconfig,
 	readline8,
 	sqlite3-dev (>= 3.30.1-1),
@@ -57,7 +57,7 @@ Provides: <<
 <<
 
 Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
-Source-Checksum: SHA256(2cd94b20670e4159c6d9ab57f91dbf255b97d8c1a1451d1c35f4ec1968adf971)
+Source-Checksum: SHA256(125b0c598f1e15d2aa65406e83f792df7d171cdf38c16803b149994316a3080f)
 
 PatchFile: %n.patch
 PatchFile-MD5: f564298ddd9d3866c36e9842fcd240ac
@@ -125,8 +125,8 @@ InfoTest: <<
 		# multiprocessing_spawn fails on "KeyboardInterrupt not raised by wait",
 		# test_ctypes is currently broken on 11.0 (py3.9.9)
 		# test_tcl and test_idle require an active $DISPLAY
-		# test_pkgutil fails on HFS+ https://bugs.python.org/issue41154
-		EXTRATESTOPTS='-w -unone -x test_socket test_multiprocessing_spawn test_code test_ctypes test_idle test_tcl test_pkgutil'
+		# test_pkgutil fails on HFS+ https://bugs.python.org/issue41154 (marked resolved)
+		EXTRATESTOPTS='-w -unone -x test_grp test_idle test_tcl'
 		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
 
 		# Put install_name back.
@@ -153,6 +153,8 @@ InstallScript: <<
 	perl -pi -e 's/-lintl //' `ls -d %b/build/lib*`/_sysconfigdata__darwin_darwin.py
 	# Remove stray .pyc that get made during tests (including preliminary ones in CompileScript) to keep validator happy.
 	find ./Lib ./Parser ./Tools ./build -name '*.pyc' -delete
+	# Change interpreter name in scripts to versioned executable.
+	perl -pi -e 's|(/usr/bin/env python)(3?)$|${1}%type_raw[python]|' ./Tools/scripts/*
 	# install fails with -j greater than 1
 	export MAKEFLAGS=-j1
 	make install DESTDIR=%d
@@ -176,6 +178,8 @@ InstallScript: <<
 	# install some docs and other useful tidbits
 	rm -rf Misc/RPM
 	/bin/cp -R Misc Tools %i/lib/python%type_raw[python]
+	pushd %i/lib/python%type_raw[python]
+	DYLD_LIBRARY_PATH=%i/lib %i/bin/python%type_raw[python] -m compileall -o 0 -o 1 -o 2 Tools || echo 'some files were not byte-compiled'
 
 # Doc tarball missing upstream.
 #	mkdir -p %i/share/doc/%n/html


### PR DESCRIPTION
New upstream versions for the two current Python versions. I gave this a try and bumped the OpenSSL version from 1.1.1 to 3.0.1; built and tested successfully on 10.13, 10.14 and 12.4 (arm64).
Also added a patch to various scripts installed under `Tools` to make them directly executable with the right Python interpreter.