### PR TITLE
Patch pykg-config to allow using system python3

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/pykg-config.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/pykg-config.info
@@ -1,6 +1,6 @@
 Package: pykg-config
 Version: 1.3.0
-Revision: 3
+Revision: 4
 Source: https://files.pythonhosted.org/packages/source/p/%n/%n-%v.tar.gz
 Source-Checksum: SHA256(9c646103c4390bbc5070ab7075a271970333ddad54dc245df5628ed8e3dc3624)
 BuildDepends: pkgconfig-common (= 3-1)
@@ -12,10 +12,13 @@ PatchScript: <<
 CompileScript: <<
 #!/bin/sh -evx
 	pc_path=`cat %p/share/pkgconfig-common/pc-path`
-	/usr/bin/python setup.py build_py --with-pc-path="$pc_path" build_scripts
+	[ -x /usr/bin/python ] || pyversion=3
+	/usr/bin/python$pyversion setup.py build_py --with-pc-path="$pc_path" build_scripts
 <<
 InstallScript: <<
-	/usr/bin/python setup.py install --prefix=%p --install-lib=%p/lib/%n/lib --root=%d --skip-build
+#!/bin/sh -ev
+	[ -x /usr/bin/python ] || pyversion=3
+	/usr/bin/python$pyversion setup.py install --prefix=%p --install-lib=%p/lib/%n/lib --root=%d --skip-build
 	mv %i/bin/pykg-config.py %i/bin/pykg-config.real
 	install -m 755 %p/share/pkgconfig-common/pc-resort %i/bin/pykg-config
 
@@ -25,7 +28,7 @@ InstallScript: <<
 <<
 DocFiles: LICENSE.txt README.txt
 DescPackaging: <<
-	Uses system-python for maximum portability and availability at
+	Uses system-python[3] for maximum portability and availability at
 	lowest levels of dep trees. And therefore install in private
 	libdir to avoid pythonversion dependency.
 


### PR DESCRIPTION
#918 has initiated a replacement process for `pykg-config` for systems (possibly since Catalina) providing no `/usr/bin/python` anymore. However `ppkg-config` as a general substitute raises other problems described in https://github.com/fink/fink-distributions/issues/918#issuecomment-1165042297, so I am putting up modifications to detect a `/usr/bin/python3` installation as an intermediate workaround, at least until the time Apple will no longer provide any Python interpreter with the macOS/Xcode installation.
Possibly still needs some instructions to install xcode[.app] or add it as a Dep in case python3 is not included with the system installation (do not remember if it was for Monterey 12.3, but the python3 executable has the same timestamp as the clang* binaries...).