### PR TITLE
Add pkgconf package as an alternative to pkgconfig

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/pkgconf.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/pkgconf.info
@@ -1,0 +1,79 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+Package: pkgconf
+Version: 1.8.0
+Revision: 1
+Source: https://distfiles.dereferenced.org/%n/%n-%v.tar.xz
+Source-Checksum: SHA256(ef9c7e61822b7cb8356e6e9e1dca58d9556f3200d78acab35e4347e9d4c2bbaf)
+Depends: %N-shlibs (= %v-%r)
+BuildDepends: fink (>= 0.32), pkgconfig-common
+BuildDependsOnly: true
+
+ConfigureParams: --mandir=%p/share/man
+
+# tests require `kyua`
+#InfoTest: TestScript: make check || exit 2
+
+InstallScript: make install DESTDIR=%d
+
+SplitOff: <<
+  Description: Pkgconf - Shared library
+  Package: %N-shlibs
+  Files: lib/libpkgconf.3.dylib
+  Shlibs: %p/lib/libpkgconf.3.dylib 4.0.0 %n (>= 1.8.0-1)
+  DocFiles: AUTHORS COPYING NEWS README.md
+<<
+
+DocFiles: AUTHORS COPYING NEWS README.md doc
+
+Description: Drop-in pkg-config replacement w/o [B]Deps
+DescDetail: <<
+pkgconf is a program which helps to configure compiler and linker flags for
+development libraries. It is similar to pkg-config from freedesktop.org.
+
+libpkgconf is a library which provides access to most of pkgconf's
+functionality, to allow other tooling such as compilers and IDEs to discover
+and use libraries configured by pkgconf.
+<<
+DescUsage: <<
+You can run 'pkgconf' directly (it's in fink's default PATH), or,
+for most build systems set PKG_CONFIG=%p/bin/pkgconf in the build
+environment to have it use this C implementation instead of the
+Freedesktop pkg-config program.
+
+pkgconf uses a strict "first match" search scheme to find .pc
+files. The default search-path list is hardcoded into the pkgconf
+binary at compile-time using data from the 'pkgconfig-common' package.
+See the pkgconf manpage for env vars that can alter the default.
+A dependency on 'pkgconf' (at the version where things work for you)
+is the only BuildDepends needed in packages that use others' .pc
+files.
+
+As of 0.22-4, lists of -I and -L flags are re-sorted to place all
+fink paths before any system (/usr or X11) paths; other paths come
+first, so PKG_CONFIG_PATH should allow users to over-ride fink, but fink
+always over-rides system-supplied paths). This operation is controlled
+by a wrapper script supplied by the 'pkgconfig-common' package.
+
+## using `pkgconf` with autotools
+
+Implementations of pkg-config, such as pkgconf, are typically used with the
+PKG_CHECK_MODULES autoconf macro.  As far as we know, pkgconf is
+compatible with all known variations of this macro. pkgconf detects at
+runtime whether or not it was started as 'pkg-config', and if so, attempts
+to set program options such that its behaviour is similar.
+
+In terms of the autoconf macro, it is possible to specify the PKG_CONFIG
+environment variable, so that you can test pkgconf without overwriting your
+pkg-config binary.  Some other build systems may also respect the PKG_CONFIG
+environment variable.
+
+To set the environment variable on the bourne shell and clones (i.e. bash), you
+can run:
+
+    $ export PKG_CONFIG=/usr/bin/pkgconf
+<<
+Homepage: https://github.com/%n/%n
+License: OSI-Approved
+Maintainer: None <fink-devel@lists.sourceforge.net>
+<<


### PR DESCRIPTION
As pointed out in https://github.com/fink/fink-distributions/issues/918#issuecomment-1163887385 some of the circular dependency problems caused by Freedesktop's `pkgconfig` are not resolved by switching to `ppkg-config`, since e.g. meson builds do not accept the latter as a pkg-config replacement.
This is an initial attempt to package the suggested alternative https://github.com/pkgconf/pkgconf.
Could not run tests due to a missing dependency, and shlibs layout may need discussion.
`pkgconf` was tested to build and work in building `python310` and the meson build of scipy 1.9.0rc1 on 12.4/arm64 and 10.14.6.