### PR TITLE
New package 'meson-py'

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/meson-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/meson-py.info
@@ -1,0 +1,103 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+Package: meson-py%type_pkg[python]
+Version: 0.62.2
+Revision: 1
+Type: python (3.7 3.8 3.9 3.10)
+Depends: python%type_pkg[python], ninja (>= 1.7-1)
+BuildDepends: fink (>= 0.24.12), setuptools-tng-py%type_pkg[python]
+
+Source: https://files.pythonhosted.org/packages/source/m/meson/meson-%v.tar.gz
+Source-Checksum: SHA256(a7669e4c4110b06b743d57cc5d6432591a6677ef2402139fe4f3d42ac13380b0)
+
+PatchScript: <<
+    #!/bin/sh -ev
+    HDF5INC="$(ls -d %p/opt/hdf5.v1.12/include 2> /dev/null || echo '')"
+    perl -pi -e 's|(/bin/env python)(3)|${1}%type_raw[python]|;' *.py mesonbuild/*.py tools/*.py test*/*/*/*.py
+    perl -pi -e "s|(python)(3)(')|\${1}%type_raw[python]\${3}|;" test\ cases/python/[1345]*/meson.build
+    perl -pi -e "s|(python)(3)(')|\${1}-%type_raw[python]\${3}|;" test\ cases/python/2*/meson.build
+    if [ -n "$HDF5INC" ]; then
+        HDF5LIB=${HDF5INC%%/include}/lib
+        perl -pi -e "s|(h5c =)|add_project_arguments('-I${HDF5INC}', language: ['c', 'cpp'])\n\$1|;" "test cases/frameworks/25 hdf5/meson.build"
+        perl -pi -e "s|(h5c =)|add_project_link_arguments('-L${HDF5LIB}', language: ['c', 'cpp'])\n\$1|;" "test cases/frameworks/25 hdf5/meson.build"
+    fi
+<<
+
+CompileScript: <<
+    %p/bin/python%type_raw[python] setup.py build
+<<
+
+InstallScript: <<
+    %p/bin/python%type_raw[python] setup.py install --root %d
+    mv %i/bin/meson %i/bin/meson-py%type_pkg[python] 
+    mv %i/share/man/man1/meson.1 %i/share/man/man1/meson-py%type_pkg[python].1 
+    perl -pi -e 's|(/usr)(/bin/python)(3)|%p${2}%type_raw[python]|;' %i/share/polkit-1/actions/com.mesonbuild.install.policy
+    perl -pi -e 's|(/usr)(/bin/meson)|%p${2}-py%type_pkg[python]|;' %i/share/polkit-1/actions/com.mesonbuild.install.policy
+    mv %i/share/polkit-1/actions/com.mesonbuild.install.policy %i/share/polkit-1/actions/com.mesonbuild.install.policy-py%type_pkg[python]
+<<
+
+PostInstScript: <<
+    update-alternatives --install %p/bin/meson meson %p/bin/meson-py%type_pkg[python] %type_pkg[python] \
+          --slave %p/share/man/man1/meson.1 meson_man %p/share/man/man1/meson-py%type_pkg[python].1 \
+          --slave %p/share/polkit-1/actions/com.mesonbuild.install.policy mesonbuild %p/share/polkit-1/actions/com.mesonbuild.install.policy-py%type_pkg[python]
+<<
+
+PreRmScript: <<
+    if [ $1 != "upgrade" ]; then
+        update-alternatives --verbose --remove meson %p/bin/meson-py%type_pkg[python]
+    fi
+<<
+
+UseMaxBuildJobs: true
+InfoTest: <<
+    TestDepends: <<
+        cmake,
+        hdf5.200.v1.12,
+        hdf5-cpp.200.v1.12,
+        hdf5.200-gfortran.v1.12,
+        ninja (>= 1.10.0)
+    <<
+    TestScript: PATH=/usr/bin:$PATH %p/bin/python%type_raw[python] -B run_tests.py || exit 1
+    TestSuiteSize: medium
+<<
+
+DocFiles: COPYING PKG-INFO README.md contributing.md
+Description: Fast and user friendly build system
+DescDetail: <<
+Meson is an open source build system meant to be both extremely fast, and,
+even more importantly, as user friendly as possible.
+
+The main design point of Meson is that every moment a developer spends writing
+or debugging build definitions is a second wasted. So is every second spent
+waiting for the build system to actually start compiling code.
+
+Features
+
+ * multiplatform support for Linux, macOS, Windows, GCC, Clang, Visual Studio
+   and others
+ * supported languages include C, C++, D, Fortran, Java, Rust
+ * build definitions in a very readable and user friendly non-Turing complete
+   DSL
+ * cross compilation for many operating systems as well as bare metal
+ * optimized for extremely fast full and incremental builds without sacrificing
+   correctness
+ * built-in multiplatform dependency provider that works together with distro
+   packages
+ * fun!
+<<
+
+DescPackaging: <<
+Straightforward copy from Homebrew recipe; ninja only needed for Ninja backend.
+Skipping hotdoc build of markdown docs for now.
+hdf5 tests are only run when installed, but need to be pointed to install loc;
+for consistency made hdf5.200.v1.12 TestDepends.
+Fixed some tests by setting python3 to the versioned executable, but 2-3
+failures remaining (e.g. tests trying to use Framework Python version etc.).
+Initially packaged by Leigh Smith <leigh@leighsmith.com>
+<<
+License: BSD
+Homepage: https://mesonbuild.com/
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+
+# Info2
+<<


### PR DESCRIPTION
Packaging the `meson` build system building on the earlier (closed) attempt from #582 and homebrew recipes.
Built, tested (with a few failures) and used to build scipy 1.9.0rc1 on 12.4/arm64 and 10.14.6.