### PR TITLE
Pep517 build system

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bootstrap-modules-py-build_env.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bootstrap-modules-py-build_env.patch
@@ -1,0 +1,29 @@
+https://github.com/pypa/build/pull/401
+
+--- src/build/env.py.orig	2022-05-23 00:59:47.000000000 +1000
++++ src/build/env.py	2022-07-27 11:28:30.000000000 +1000
+@@ -17,12 +17,6 @@
+ 
+ import build
+ 
+-
+-if sys.version_info < (3, 8):
+-    import importlib_metadata as metadata
+-else:
+-    from importlib import metadata
+-
+ try:
+     import virtualenv
+ except ModuleNotFoundError:
+@@ -260,6 +254,11 @@
+ 
+     import packaging.version
+ 
++    if sys.version_info < (3, 8):
++        import importlib_metadata as metadata
++    else:
++        from importlib import metadata
++
+     symlinks = _fs_supports_symlink()
+     try:
+         venv.EnvBuilder(with_pip=True, symlinks=symlinks).create(path)

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bootstrap-modules-py-flit_core-timestamps.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bootstrap-modules-py-flit_core-timestamps.patch
@@ -1,0 +1,24 @@
+Don't error out on file timestamps older than what zip supports.
+https://trac.macports.org/ticket/63926
+--- flit_core/wheel.py.orig	2022-02-22 06:04:37.000000000 +1100
++++ flit_core/wheel.py	2022-07-27 11:35:18.000000000 +1000
+@@ -8,6 +8,7 @@
+ import os
+ import os.path as osp
+ import stat
++import sys
+ import tempfile
+ from pathlib import Path
+ from types import SimpleNamespace
+@@ -108,7 +109,10 @@
+             rel_path = rel_path.replace(os.sep, '/')
+ 
+         if self.source_time_stamp is None:
+-            zinfo = zipfile.ZipInfo.from_file(full_path, rel_path)
++            if sys.version_info[:2] >= (3, 8):
++                zinfo = zipfile.ZipInfo.from_file(full_path, rel_path, strict_timestamps=False)
++            else:
++                zinfo = zipfile.ZipInfo.from_file(full_path, rel_path)
+         else:
+             # Set timestamps in zipfile for reproducible build
+             zinfo = zipfile.ZipInfo(rel_path, self.source_time_stamp)

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bootstrap-modules-py-install-__init__.py.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bootstrap-modules-py-install-__init__.py.patch
@@ -1,0 +1,73 @@
+--- install/__init__.py.orig	2020-11-30 08:53:24.000000000 +1100
++++ install/__init__.py	2022-07-27 06:59:19.000000000 +1000
+@@ -84,6 +84,8 @@
+ else:
+ 
+     def _copy_dir(src, dst, ignore=[]):  # type: (str, str, List[str]) -> None
++        if not os.path.exists(dst):
++            os.makedirs(dst)
+         from distutils.dir_util import copy_tree
+         for node in os.listdir(src):
+             if node in ignore:
+@@ -116,11 +118,7 @@
+ 
+ 
+ def _replace_shebang(dir, interpreter):  # type: (str, str) -> None
+-    scripts = [os.path.join(dir, script) for script in os.listdir(dir)]
+-
+-    for script in scripts:
+-        if not os.path.isfile(script):
+-            raise InstallException('Script is not a file: {}'.format(script))
++    scripts = [script for script in [os.path.join(dir, f) for f in os.listdir(dir)] if os.path.isfile(script)]
+ 
+     # Python 2 does not support fileinput as a contex manager
+     f = fileinput.input(scripts, inplace=True)
+@@ -131,6 +129,17 @@
+     f.close()
+ 
+ 
++def _make_executable(dir):  # type: (str) -> None
++    scripts = [os.path.join(dir, script) for script in os.listdir(dir)]
++    import stat
++
++    for script in scripts:
++        mode = os.stat(script).st_mode
++        mode |= stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP \
++            | stat.S_IROTH | stat.S_IXOTH
++        os.chmod(script, mode)
++
++
+ def _check_requirement(requirement_string):  # type: (str) -> bool
+     import packaging.requirements
+ 
+@@ -238,9 +247,12 @@
+ 
+     if os.path.isfile(entrypoints_file):
+         _generate_entrypoint_scripts(entrypoints_file, scripts_cache_dir)
++        if os.path.isdir(scripts_cache_dir):
++            _make_executable(scripts_cache_dir)
+ 
+     if os.path.isdir(scripts_dir):
+         _replace_shebang(scripts_dir, sys.executable)
++        _make_executable(scripts_dir)
+ 
+     _save_pickle(cache_dir, 'wheel-info', wheel_info)
+     _save_pickle(cache_dir, 'metadata', metadata)
+@@ -258,7 +270,7 @@
+     pkg_cache_dir = os.path.join(cache_dir, 'pkg')
+     scripts_cache_dir = os.path.join(cache_dir, 'scripts')
+     pkg_data_dir_name = '{}-{}.data'.format(wheel_info['distribution'], wheel_info['version'])
+-    pkg_data_dir = os.path.join(cache_dir, pkg_data_dir_name)
++    pkg_data_dir = os.path.join(pkg_cache_dir, pkg_data_dir_name)
+ 
+     pkg_dir = destdir_path('purelib' if metadata['Root-Is-Purelib'] == 'true' else 'platlib')
+ 
+@@ -269,7 +281,7 @@
+             _copy_dir(target, destdir_path(lib))
+     if os.path.isdir(pkg_data_dir):
+         for node in os.listdir(pkg_data_dir):
+-            target = os.path.join(pkg_cache_dir, node)
++            target = os.path.join(pkg_data_dir, node)
+             if node == 'purelib':
+                 _copy_dir(target, destdir_path('purelib'))
+             if node == 'platlib':

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bootstrap-modules-py-installer_scripts.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bootstrap-modules-py-installer_scripts.patch
@@ -1,0 +1,18 @@
+--- install/_vendor/installer/src/installer/scripts.py.orig	2020-11-30 08:40:56.000000000 +1100
++++ install/_vendor/installer/src/installer/scripts.py	2021-11-03 04:29:23.000000000 +1100
+@@ -5,7 +5,6 @@
+ import zipfile
+ 
+ from installer import _scripts
+-from installer._compat import importlib_resources
+ from installer._compat.typing import TYPE_CHECKING, Binary, Text
+ 
+ 
+@@ -116,6 +115,7 @@
+         )
+ 
+     def _get_launcher_data(self, kind):
++        from installer._compat import importlib_resources
+         # type: (LauncherKind) -> Optional[Binary]
+         if kind == "posix":
+             return None

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bootstrap-modules-py-pep517-no-deps-option.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bootstrap-modules-py-pep517-no-deps-option.patch
@@ -1,0 +1,63 @@
+--- pep517/build.py.orig	2020-10-19 07:41:27.000000000 +1100
++++ pep517/build.py	2020-12-01 12:49:53.000000000 +1100
+@@ -55,14 +55,15 @@
+     return system
+ 
+ 
+-def _do_build(hooks, env, dist, dest):
++def _do_build(hooks, env, dist, dest, no_deps=False):
+     get_requires_name = 'get_requires_for_build_{dist}'.format(**locals())
+     get_requires = getattr(hooks, get_requires_name)
+     reqs = get_requires({})
+     log.info('Got build requires: %s', reqs)
+ 
+-    env.pip_install(reqs)
+-    log.info('Installed dynamic build dependencies')
++    if not no_deps:
++        env.pip_install(reqs)
++        log.info('Installed dynamic build dependencies')
+ 
+     with tempdir() as td:
+         log.info('Trying to build %s in %s', dist, td)
+@@ -73,7 +74,7 @@
+         shutil.move(source, os.path.join(dest, os.path.basename(filename)))
+ 
+ 
+-def build(source_dir, dist, dest=None, system=None):
++def build(source_dir, dist, dest=None, system=None, no_deps=False):
+     system = system or load_system(source_dir)
+     dest = os.path.join(source_dir, dest or 'dist')
+     mkdir_p(dest)
+@@ -84,8 +85,9 @@
+     )
+ 
+     with BuildEnvironment() as env:
+-        env.pip_install(system['requires'])
+-        _do_build(hooks, env, dist, dest)
++        if not no_deps:
++            env.pip_install(system['requires'])
++        _do_build(hooks, env, dist, dest, no_deps=no_deps)
+ 
+ 
+ parser = argparse.ArgumentParser()
+@@ -104,6 +106,11 @@
+     default=False,
+ )
+ parser.add_argument(
++    '--no-deps', '-n',
++    action='store_true',
++    default=False,
++)
++parser.add_argument(
+     '--out-dir', '-o',
+     help="Destination in which to save the builds relative to source dir",
+ )
+@@ -117,7 +124,7 @@
+     )))
+ 
+     for dist in dists:
+-        build(args.source_dir, dist, args.out_dir)
++        build(args.source_dir, dist, args.out_dir, no_deps=args.no_deps)
+ 
+ 
+ if __name__ == '__main__':

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bootstrap-modules-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bootstrap-modules-py.info
@@ -1,0 +1,102 @@
+Info2: <<
+Package: bootstrap-modules-py%type_pkg[python]
+Version: 20221003
+Revision: 1
+Distribution: <<
+	(%type_pkg[python] = 36 ) 10.9,
+	(%type_pkg[python] = 36 ) 10.10,
+	(%type_pkg[python] = 36 ) 10.11,
+	(%type_pkg[python] = 36 ) 10.12,
+	(%type_pkg[python] = 36 ) 10.13,
+	(%type_pkg[python] = 36 ) 10.14,
+	(%type_pkg[python] = 36 ) 10.14.5,
+	(%type_pkg[python] = 36 ) 10.15
+<<
+Type: python (3.6 3.7 3.8 3.9 3.10)
+Description: Bootstrap PEP 517 module builds
+License: BSD
+# Free to modify, update, and take over
+Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
+
+NoSourceDirectory: true
+Source: https://files.pythonhosted.org/packages/source/b/build/build-0.8.0.tar.gz
+Source-Checksum: SHA256(887a6d471c901b1a6e6574ebaeeebb45e5269a79d095fe9a8f88d6614ed2e5f0)
+Source2: https://files.pythonhosted.org/packages/source/f/flit_core/flit_core-3.7.1.tar.gz
+Source2-Checksum: SHA256(14955af340c43035dbfa96b5ee47407e377ee337f69e70f73064940d27d0a44f)
+Source3: https://files.pythonhosted.org/packages/source/i/installer/installer-0.5.1.tar.gz
+Source3-Checksum: SHA256(f970995ec2bb815e2fdaf7977b26b2091e1e386f0f42eafd5ac811953dc5d445)
+Source4: https://files.pythonhosted.org/packages/source/p/packaging/packaging-21.3.tar.gz
+Source4-Checksum: SHA256(dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb)
+Source5: https://files.pythonhosted.org/packages/source/p/pep517/pep517-0.12.0.tar.gz
+Source5-Checksum: SHA256(931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0)
+Source6: https://files.pythonhosted.org/packages/source/p/pyparsing/pyparsing-3.0.9.tar.gz
+Source6-Checksum: SHA256(2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb)
+Source7: https://files.pythonhosted.org/packages/source/p/python-install/python-install-0.0.3.tar.gz
+Source7-Checksum: SHA256(926f9e0cb959203629ba6ffdc889f96e1a075c36ca6e7528ba7be96ade189a7d)
+Source8: https://files.pythonhosted.org/packages/source/s/setuptools_scm/setuptools_scm-6.4.2.tar.gz
+Source8-Checksum: SHA256(6833ac65c6ed9711a4d5d2266f8024cfa07c533a0e55f4c12f6eff280a5a9e30)
+Source9: https://files.pythonhosted.org/packages/source/t/tomli/tomli-1.2.3.tar.gz
+Source9-Checksum: SHA256(05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f)
+Source10: https://files.pythonhosted.org/packages/source/w/wheel/wheel-0.37.1.tar.gz
+Source10-Checksum: SHA256(e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4)
+PatchFile: %{Ni}-build_env.patch
+PatchFile-MD5: 14435654b7f08804d8428ef9d78162f0
+PatchFile2: %{Ni}-flit_core-timestamps.patch
+PatchFile2-MD5: 95b415d628bbcde9bd1a9d82619488b0
+PatchFile3: %{Ni}-install-__init__.py.patch
+PatchFile3-MD5: 3a31d987c40700065e8049b148d2fb97
+PatchFile4: %{Ni}-installer_scripts.patch
+PatchFile4-MD5: a1c87041fe5dddec1134ac547e05ecc2
+PatchFile5: %{Ni}-pep517-no-deps-option.patch
+PatchFile5-MD5: 828e3732ef2b33a8d14965824ffa0f06
+PatchScript: <<
+	cd %b/build-0.8.0; patch -p0 < %{PatchFile}
+	cd %b/flit_core-3.7.1; patch -p0 < %{PatchFile2}
+	cd %b/python-install-0.0.3; patch -p0 < %{PatchFile3}
+	cd %b/python-install-0.0.3; patch -p0 < %{PatchFile4}
+	cd %b/pep517-0.12.0; patch -p0 < %{PatchFile5}
+<<
+Depends: <<
+	python%type_pkg[python]
+<<
+BuildDepends: <<
+	fink (>= 0.30.0)
+<<
+CompileScript: echo "Nothing to compile"
+
+InstallScript: <<
+#!/bin/sh -ev
+	mkdir -p %i/share/bootstrap-modules-python%type_pkg[python]
+	/bin/cp -Rp %b/build-0.8.0/src/build \
+		%b/build-0.8.0/src/build.egg-info \
+		%b/flit_core-3.7.1/flit_core \
+		%b/installer-0.5.1/src/installer \
+		%b/packaging-21.3/packaging \
+		%b/packaging-21.3/packaging.egg-info \
+		%b/pep517-0.12.0/pep517 \
+		%b/pyparsing-3.0.9/pyparsing \
+		%b/python-install-0.0.3/install \
+		%b/setuptools_scm-6.4.2/src/setuptools_scm \
+		%b/setuptools_scm-6.4.2/src/setuptools_scm.egg-info \
+		%b/tomli-1.2.3/tomli \
+		%b/wheel-0.37.1/src/wheel \
+		%b/wheel-0.37.1/src/wheel.egg-info \
+		%i/share/bootstrap-modules-python%type_pkg[python]
+<<
+Homepage: https://www.finkproject.org
+DescPackaging: <<
+After PEP517 became the standard, many python modules need each other to
+build themselves. This package installs them all at the same time to
+avoid circular dependencies. You can then use these modules to bootstrap
+other packages that follow PEP517.
+<<
+DescDetail: <<
+This is a set of Python modules that are needed to do PEP 517 building
+and wheel installation. They have to be installed together to enable
+bootstrapping, because of circular dependencies.
+<<
+DescUsage: <<
+Add %p/share/bootstrap-modules-python%type_pkg[python] to PYTHONPATH in
+Compile-, Test-, and Install- scripts as necessary.
+<<
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/build-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/build-py.info
@@ -1,0 +1,68 @@
+Info2: <<
+Package: build-py%type_pkg[python]
+Version: 0.8.0
+Revision: 1
+Distribution: <<
+	(%type_pkg[python] = 36 ) 10.9,
+	(%type_pkg[python] = 36 ) 10.10,
+	(%type_pkg[python] = 36 ) 10.11,
+	(%type_pkg[python] = 36 ) 10.12,
+	(%type_pkg[python] = 36 ) 10.13,
+	(%type_pkg[python] = 36 ) 10.14,
+	(%type_pkg[python] = 36 ) 10.14.5,
+	(%type_pkg[python] = 36 ) 10.15
+<<
+Type: python (3.6 3.7 3.8 3.9 3.10)
+Description: Simple, correct PEP517 package builder
+License: BSD
+# Free to modify, update, and take over
+Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
+
+Homepage: https://pypi.org/project/build
+Source: https://files.pythonhosted.org/packages/source/b/build/build-%v.tar.gz
+Source-Checksum: SHA256(887a6d471c901b1a6e6574ebaeeebb45e5269a79d095fe9a8f88d6614ed2e5f0)
+Depends: <<
+	python%type_pkg[python],
+	(%type_pkg[python] << 38) importlib-metadata-py%type_pkg[python] (>= 0.22),
+	packaging-py%type_pkg[python] (>= 19.0),
+	pep517-py%type_pkg[python] (>= 0.9.1),
+	tomli-py%type_pkg[python]
+<<
+BuildDepends: <<
+	setuptools-tng-py%type_pkg[python] (>= 42.0.0),
+	wheel-py%type_pkg[python]
+<<
+CompileScript: PYTHONPATH=%b/src %p/bin/python%type_raw[python] -m build --wheel --no-isolation
+
+InfoTest: <<
+#	TestDepends: <<
+#		pytest-py%type_pkg[python] (>= 6.2.4),
+#		pytest-cov-py%type_pkg[python] (>= 2.12),
+#		pytest-mock-py%type_pkg[python] (>= 2),
+#		pytest-rerunfailures-py%type_pkg[python] (>= 9.1),
+#		pytest-xdist-py%type_pkg[python] (>= 1.34),
+#		toml-py%type_pkg[python] (>= 0.10.0),
+#		wheel-py%type_pkg[python] (>= 0.36.0),
+#		toml-py%type_pkg[python] (>= 0.10.0)
+#	<<
+	# tests are too complicated, so just check if the command works.
+	TestScript: PYTHONPATH=%b/src %p/bin/python%type_raw[python] -m build --help || exit 2
+<<
+InstallScript: <<
+	%p/bin/python%type_raw[python] setup.py install --root=%d
+	mv %i/bin/pyproject-build %i/bin/pyproject-build-py%type_raw[python]
+<<
+PostInstScript: <<
+	update-alternatives --install %p/bin/pyproject-build pyproject-build %p/bin/pyproject-build-py%type_raw[python] %type_pkg[python] 		
+<<
+PreRmScript: <<
+	if [ $1 != "upgrade" ]; then
+		update-alternatives --remove pyproject-build %p/bin/pyproject-build-py%type_raw[python]
+	fi
+<<
+DocFiles: LICENSE README.md
+DescDetail: <<
+build will invoke the PEP 517 hooks to build a distribution package. It
+is a simple build tool and does not perform any dependency management.
+<<
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pep517-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pep517-py.info
@@ -1,0 +1,56 @@
+Info2: <<
+Package: pep517-py%type_pkg[python]
+Version: 0.13.0
+Revision: 1
+Distribution: <<
+	(%type_pkg[python] = 36 ) 10.9,
+	(%type_pkg[python] = 36 ) 10.10,
+	(%type_pkg[python] = 36 ) 10.11,
+	(%type_pkg[python] = 36 ) 10.12,
+	(%type_pkg[python] = 36 ) 10.13,
+	(%type_pkg[python] = 36 ) 10.14,
+	(%type_pkg[python] = 36 ) 10.14.5,
+	(%type_pkg[python] = 36 ) 10.15
+<<
+Type: python (3.7 3.8 3.9 3.10)
+Description: Wrappers for Python packages using PEP 517
+License: BSD
+# Free to modify, update, and take over
+Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
+
+Homepage: https://pypi.org/project/pep517
+Source: https://files.pythonhosted.org/packages/source/p/pep517/pep517-%v.tar.gz
+Source-Checksum: SHA256(ae69927c5c172be1add9203726d4b84cf3ebad1edcd5f71fcdc746e66e829f59)
+Depends: <<
+	python%type_pkg[python],
+	(%type_pkg[python] << 38) importlib-metadata-py%type_pkg[python] (>= 0.22),
+	tomli-py%type_pkg[python],
+	(%type_pkg[python] << 38) zipp-py%type_pkg[python]
+<<
+BuildDepends: <<
+	bootstrap-modules-py%type_pkg[python],
+	testpath-py%type_pkg[python]
+<<
+PatchScript: <<
+	# remove pytest incompatible parameters
+	perl -ni -e 'print unless /--strict-config/' pytest.ini
+	perl -ni -e 'print unless /--flake8/' pytest.ini
+<<
+CompileScript: <<
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m build --wheel --no-isolation --skip-dependency-check
+<<
+# Don't run tests because they require PIP to download already installed modules
+#InfoTest: <<
+#	TestScript: PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m pytest || exit 2
+#<<
+InstallScript: <<
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m installer --destdir %d dist/*.whl
+<<
+DocFiles: LICENSE README.rst
+DescDetail: <<
+PEP 517 specifies a standard API for systems which build Python packages.
+PEP 660 extends it with a build mode that leads to editable installs.
+This package contains wrappers around the hooks specified by PEP 517 and
+PEP 660.
+<<
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tomli-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tomli-py.info
@@ -1,0 +1,29 @@
+Info2: <<
+Package: tomli-py%type_pkg[python]
+Version: 2.0.1
+Revision: 1
+Type: python (3.7 3.8 3.9 3.10)
+Description: Lil' TOML parser
+License: BSD
+# Free to modify, update, and take over
+Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
+
+Source: https://files.pythonhosted.org/packages/source/t/tomli/tomli-%v.tar.gz
+Source-Checksum: SHA256(de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f)
+Depends: <<
+	python%type_pkg[python]
+<<
+BuildDepends: <<
+	bootstrap-modules-py%type_pkg[python]
+<<
+CompileScript: PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m build --wheel --no-isolation --skip-dependency-check
+
+InstallScript: <<
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m installer --destdir %d dist/*.whl
+<<
+DocFiles: LICENSE README.md
+Homepage: https://github.com/hukkin/tomli
+DescDetail: <<
+A lil' TOML parser.
+<<
+<<


### PR DESCRIPTION
Python is trying to get rid of setuptools with new backends and frontends for building pymods (PEP517). Not exactly sure what all that means. But many packages will start not including setup.py anymore.

This creates a bootstrap module that contains several of the necessary packages for building these new PEP517 packages. Because many depend on each other, they're installed all as one Fink package as pure python (and stashed in %p/share).
Other packages that need them can just add to PYTHONPATH as necessary in order to build.