### PR TITLE
mbsystem 5.7.8

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/mbsystem.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/mbsystem.info
@@ -1,11 +1,11 @@
 Package: mbsystem
-Version: 5.7.6
-Revision: 3
+Version: 5.7.8
+Revision: 1
 
 Source: https://github.com/dwcaress/MB-System/archive/%v.tar.gz
 SourceRename: %n-%v.tar.gz
 SourceDirectory: MB-System-%v
-Source-Checksum: SHA256(472dfa863905e27c0484f49ba90650bd1c743798d001e0a2a275d0d8c05ffab9)
+Source-Checksum: SHA256(aa3f7c7f79a933d22ff7410284c3c7de9ba9416c14f271bec231b2307101abad)
 
 BuildDepends: <<
   gmt6-dev (>= 6.1.0),
@@ -25,7 +25,7 @@ Depends: <<
   proj-bin (>= 7.2.0),
   libproj19-shlibs,
   gdal3-shlibs,
-  parallel-forkmanager-pm5182 | parallel-forkmanager-pm5184
+  parallel-forkmanager-pm5182 | parallel-forkmanager-pm5184 | parallel-forkmanager-pm5282 | parallel-forkmanager-pm5302 | parallel-forkmanager-pm5303
 <<
 ConfigureParams: <<
 	--disable-static \
@@ -46,7 +46,7 @@ SetLDFLAGS:-L/opt/X11/lib
 GCC: 4.0
 
 InfoTest: <<
-   TestDepends: python36 | python37 | python38
+   TestDepends: python3 | python37 | python38 | python39 | python310
    TestConfigureParams: --enable-test
    TestScript: <<
      make check || exit 2


### PR DESCRIPTION
A trivial update to mbsystem:

- update to latest release version (5.7.8)
- update the perl and python versions in the info file

Tested on Mac OS 12.6.1 (using @TheSin-'s dpkg1.16 branch), where it appears to work, including with "-m" (using Python 3.10 for the tests).