### PR TITLE
gnupg2: 2.2.40 - typo in checksum

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/gnupg2.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/gnupg2.info
@@ -44,7 +44,7 @@ RunTimeDepends: pinentry | pinentry-fltk | pinentry-gtk2 | pinentry-qt | pinentr
 Conflicts: gpg-agent (<= 1.9.20-1), gnupg-unified (<= 1.4.23-1)
 Replaces: gpg-agent (<= 1.9.20-1)
 Source: https://www.gnupg.org/ftp/gcrypt/gnupg//gnupg-%v.tar.bz2
-Source-Checksum: SHA256(1164b29a75e8ab93ea15033300149e1872a7ef6bdda3d7c78229a735f8204c28s)
+Source-Checksum: SHA256(1164b29a75e8ab93ea15033300149e1872a7ef6bdda3d7c78229a735f8204c28)
 Source2: mirror:sourceforge:fink/gnupg-docs-20021001.tar.gz
 Source2-Checksum: SHA256(af6739940e864b8c74c39137916abf4ed0a9841aa4b0acc2ea8341c7c7289217)
 Source2ExtractDir: gnupg-%v


### PR DESCRIPTION
Fixes a typo in the source checksum in @nieder's latest commit!