### PR TITLE
Enable python3 for ninja bootstrap on macOS 11+

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/ninja.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/ninja.info
@@ -8,7 +8,14 @@ Source-Checksum: SHA256(3c6ba2e66400fe3f1ae83deb4b235faf3137ec20bd5b08c29bfc368d
 SourceRename: %n-%v.tar.gz
 # re2c >= 0.15.3 for its --no-version flag
 BuildDepends: re2c (>= 0.15.3)
-CompileScript: ./configure.py --bootstrap
+CompileScript: <<
+  #!/bin/sh -ex
+  if [ -x /usr/bin/python ]; then
+    ./configure.py --bootstrap
+  else
+    /usr/bin/python3 configure.py --bootstrap
+  fi
+<<
 InstallScript: <<
   #!/bin/sh -ex
   mkdir -p %i/bin


### PR DESCRIPTION
Fixes #932 (tested on 12.1-13.1 – no further py3 conversion needed).