### PR TITLE
Openldap 2.6 update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/openldap24.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/openldap24.info
@@ -2,7 +2,7 @@
 Info4: <<
 Package: openldap24
 Version: 2.4.59
-Revision: 1
+Revision: 2
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Source: mirror:custom:openldap-release/openldap-%v.tgz
 CustomMirror: <<
@@ -24,8 +24,8 @@ BuildDepends: <<
 	fink (>= 0.30.0-1),
 	openssl110-dev (>= 1.1.0h-1)
 <<
-Conflicts: openldap-ssl, openldap23, openldap24, openldap24
-Replaces: openldap-ssl, openldap23, openldap24, openldap24
+Conflicts: openldap-ssl, openldap23, openldap24, openldap24, openldap26
+Replaces: openldap-ssl, openldap23, openldap24, openldap24, openldap26
 Provides: openldap
 PatchFile: %{ni}.patch
 PatchFile-MD5: 0492da596271831c1eae985c611f1199
@@ -79,8 +79,8 @@ SplitOff: <<
 SplitOff2: <<
  Package: %N-dev
  Depends: %N-shlibs (= %v-%r)
- Conflicts: openldap-ssl-dev, openldap23-dev, openldap24-dev, openldap26-dev
- Replaces: openldap-ssl-dev, openldap23-dev, openldap24-dev, openldap26-dev
+ Conflicts: openldap-ssl-dev, openldap23-dev, openldap24-dev, openldap2-dev
+ Replaces: openldap-ssl-dev, openldap23-dev, openldap24-dev, openldap2-dev
  Description: Libraries and headers for LDAP development
  Files: include %lib/*.la %lib/*.dylib share/man/man3
  BuildDependsOnly: True

--- a/10.9-libcxx/stable/main/finkinfo/libs/openldap26-xcode12.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/openldap26-xcode12.patch
@@ -1,0 +1,35 @@
+diff -ruN openldap-2.4.56.orig/libraries/libldap/tls2.c openldap-2.4.56/libraries/libldap/tls2.c
+--- openldap-2.4.56.orig/libraries/libldap/tls2.c	2020-11-10 12:22:13.000000000 -0600
++++ openldap-2.4.56/libraries/libldap/tls2.c	2020-11-13 19:39:54.000000000 -0600
+@@ -74,6 +74,9 @@
+ 	{ BER_BVNULL, BER_BVNULL }
+ };
+ 
++static int
++ldap_pvt_tls_check_hostname( LDAP *ld, void *s, const char *name_in );
++
+ #ifdef HAVE_TLS
+ 
+ void
+@@ -503,7 +506,7 @@
+ 	return rc;
+ }
+ 
+-int
++static int
+ ldap_pvt_tls_check_hostname( LDAP *ld, void *s, const char *name_in )
+ {
+ 	tls_session *session = s;
+diff -ruN openldap-2.4.56.orig/servers/slapd/back-ldap/bind.c openldap-2.4.56/servers/slapd/back-ldap/bind.c
+--- openldap-2.4.56.orig/servers/slapd/back-ldap/bind.c	2020-11-10 12:22:13.000000000 -0600
++++ openldap-2.4.56/servers/slapd/back-ldap/bind.c	2020-11-14 04:09:02.000000000 -0600
+@@ -145,6 +145,9 @@
+ }
+ #endif /* LDAP_BACK_PRINT_CONNTREE */
+ 
++void
++slap_client_keepalive(LDAP *ld, slap_keepalive *sk);
++
+ static int
+ ldap_back_freeconn( ldapinfo_t *li, ldapconn_t *lc, int dolock );
+ 

--- a/10.9-libcxx/stable/main/finkinfo/libs/openldap26.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/openldap26.info
@@ -1,0 +1,200 @@
+# -*- coding: ascii; tab-width: 4; x-counterpart: openldap24.patch -*-
+Info4: <<
+Package: openldap26
+Version: 2.6.3
+Revision: 1
+Description: LDAP directory services implementation
+License: Restrictive/Distributable
+Maintainer: None <fink-devel@lists.sourceforge.net>
+Source: mirror:custom:openldap-release/openldap-%v.tgz
+CustomMirror: <<
+	asi-JP: ftp://ftp.dti.ad.jp/pub/net/OpenLDAP/
+	eur-AT: ftp://gd.tuwien.ac.at/infosys/network/OpenLDAP/
+	eur-CH: ftp://mirror.switch.ch/mirror/OpenLDAP/
+	eur-DE: http://mirror.eu.oneandone.net/software/openldap/
+	eur-FR: http://repository.linagora.org/OpenLDAP/
+	eur-GR: ftp://ftp.ntua.gr/mirror/OpenLDAP/
+	nam-US: ftp://ftp.OpenLDAP.org/pub/OpenLDAP/
+	nam-CA: http://gpl.savoirfairelinux.net/pub/mirrors/openldap/
+<<
+Source-Checksum: SHA256(d2a2a1d71df3d77396b1c16ad7502e674df446e06072b0e5a4e941c3d06c0d46)
+# NOTE: configure looks for libicu but doesn't actually use it.
+Depends: openldap2-shlibs (= %v-%r), daemonic
+BuildDepends: <<
+	cyrus-sasl2.3-dev (>= 2.1.27-1),
+	db60-aes,
+	fink (>= 0.30.0-1),
+	openssl300-dev
+<<
+Conflicts: openldap-ssl, openldap23, openldap24, openldap26
+Replaces: openldap-ssl, openldap23, openldap24, openldap26
+Provides: openldap
+PatchFile: %{ni}.patch
+PatchFile-MD5: d94ddb2fb5bc43d4026580060e4d12e5
+PatchFile2: %{ni}-xcode12.patch
+PatchFile2-MD5: 4fe35d038a6e6b3a9409d7e31880817c
+PatchScript: <<
+	%{default_script}
+<<
+#NoSetLDFLAGS: True
+#SetLDFLAGS: -Wl,-dead_strip_dylibs
+#SetLibs: -lkrb5 -L%p/%lib -ldb-6.0
+#SetCPPFLAGS: -I%p/include/db5 -DBIND_8_COMPAT
+ConfigureParams: <<
+	--libexecdir=%p/sbin \
+	--mandir=%p/share/man \
+	--with-cyrus-sasl \
+	--enable-ldap \
+	--enable-dynamic \
+	--enable-shared \
+	--disable-static \
+	--libdir='${prefix}/%lib'
+<<
+
+InfoTest: <<
+	TestSuiteSize: large
+	# Tdep for gdate
+	TestDepends: coreutils
+	TestScript: <<
+	#!/bin/sh -ev
+	# play with install_name so that progs can find uninstalled libraries when running
+	install_name_tool -id %b/libraries/liblber/.libs/liblber.2.dylib libraries/liblber/.libs/liblber.2.dylib
+	install_name_tool -id %b/libraries/libldap/.libs/libldap.2.dylib libraries/libldap/.libs/libldap.2.dylib
+	install_name_tool -change %p/lib/liblber.2.dylib %b/libraries/liblber/.libs/liblber.2.dylib \
+		%b/libraries/libldap/.libs/libldap.2.dylib
+	pushd clients/tools
+		for i in ldapcompare ldapdelete ldapexop ldapmodify ldapmodrdn ldappasswd ldapsearch ldapurl ldapvc ldapwhoami; do 
+			install_name_tool -change %p/lib/libldap.2.dylib %b/libraries/libldap/.libs/libldap.2.dylib \
+			-change %p/lib/liblber.2.dylib %b/libraries/liblber/.libs/liblber.2.dylib $i
+		done
+	popd
+	pushd servers/slapd
+		for i in slapd; do
+			install_name_tool -change %p/lib/libldap.2.dylib %b/libraries/libldap/.libs/libldap.2.dylib \
+			-change %p/lib/liblber.2.dylib %b/libraries/liblber/.libs/liblber.2.dylib $i
+		done
+	popd
+	pushd tests/progs
+		for i in ldif-filter slapd-addel slapd-bind slapd-modify slapd-modrdn slapd-mtread slapd-read slapd-search slapd-tester slapd-watcher; do
+			install_name_tool -change %p/lib/libldap.2.dylib %b/libraries/libldap/.libs/libldap.2.dylib \
+			-change %p/lib/liblber.2.dylib %b/libraries/liblber/.libs/liblber.2.dylib $i
+		done
+	popd
+
+	/usr/bin/make -k -j1 check || exit 2
+
+	# restore install_names
+	pushd tests/progs
+		for i in ldif-filter slapd-addel slapd-bind slapd-modify slapd-modrdn slapd-mtread slapd-read slapd-search slapd-tester slapd-watcher; do
+			install_name_tool -change %b/libraries/libldap/.libs/libldap.2.dylib %p/lib/libldap.2.dylib \
+			-change %b/libraries/liblber/.libs/liblber.2.dylib %p/lib/liblber.2.dylib $i
+		done
+	popd
+	pushd servers/slapd
+		for i in slapd; do
+			install_name_tool -change %b/libraries/libldap/.libs/libldap.2.dylib %p/lib/libldap.2.dylib \
+			-change %b/libraries/liblber/.libs/liblber.2.dylib %p/lib/liblber.2.dylib $i
+		done
+	popd
+	pushd clients/tools
+		for i in ldapcompare ldapdelete ldapexop ldapmodify ldapmodrdn ldappasswd ldapsearch ldapurl ldapvc ldapwhoami; do 
+			install_name_tool -change %b/libraries/libldap/.libs/libldap.2.dylib %p/lib/libldap.2.dylib \
+			-change %b/libraries/liblber/.libs/liblber.2.dylib %p/lib/liblber.2.dylib $i
+		done
+	popd
+	install_name_tool -id %p/lib/libldap.2.dylib libraries/libldap/.libs/libldap.2.dylib
+	install_name_tool -id %p/lib/liblber.2.dylib libraries/liblber/.libs/liblber.2.dylib
+	<<
+<<
+
+InstallScript: <<
+	/usr/bin/make install DESTDIR=%d
+<<
+DocFiles: ANNOUNCEMENT CHANGES COPYRIGHT LICENSE README build/LICENSE-2.0.1 doc/drafts/draft*
+ConfFiles: <<
+	%p/etc/openldap/ldap.conf
+	%p/etc/openldap/slapd.conf
+<<
+SplitOff: <<
+	Package: openldap2-shlibs
+	Depends: <<
+		cyrus-sasl2.3-shlibs (>= 2.1.27-1),
+		db60-aes-shlibs,
+		openssl300-shlibs
+	 <<
+	Description: Shared libraries for LDAP
+	Files: %lib/lib{lber,ldap}.2.dylib
+	Shlibs: <<
+		%p/%lib/liblber.2.dylib 3.0.0 %n (>= 2.6.3-1)
+		%p/%lib/libldap.2.dylib 3.0.0 %n (>= 2.6.3-1)
+	<<
+	DocFiles: ANNOUNCEMENT CHANGES COPYRIGHT LICENSE README build/LICENSE-2.0.1 
+<<
+SplitOff2: <<
+	Package: openldap2-dev
+	Depends: openldap2-shlibs (= %v-%r)
+	Conflicts: <<
+		openldap-ssl-dev,
+		openldap23-dev,
+		openldap24-dev,
+		openldap2-dev
+	<<
+	Replaces: <<
+		openldap-ssl-dev,
+		openldap23-dev,
+		openldap24-dev,
+		openldap2-dev
+	<<
+	Description: Libraries and headers for LDAP development
+	Files: <<
+		include
+		lib/pkgconfig
+		%lib/*.la
+		%lib/*.dylib
+		share/man/man3
+	<<
+	BuildDependsOnly: True
+	DocFiles: COPYRIGHT LICENSE README build/LICENSE-2.0.1
+<<
+DaemonicName: slapd
+DaemonicFile: <<
+<service>
+<description>LDAP Server</description>
+<message>LDAP Server</message>
+
+<daemon name="slapd">
+<executable background="yes">%p/sbin/slapd</executable>
+<configfile>%p/etc/openldap/slapd.conf</configfile>
+</daemon>
+
+</service>
+<<
+PreRmScript: <<
+if [ $1 != "upgrade" ]; then
+  daemonic remove slapd
+fi
+<<
+Homepage: https://www.openldap.org
+DescDetail: <<
+OpenLDAP is an open source implementation of the Lightweight Directory
+Access Protocol. The suite includes:
+*  slapd - stand-alone LDAP server
+*  slurpd - stand-alone LDAP replication server
+*  libraries implementing the LDAP protocol, and
+*  utilities, tools, and sample clients.
+<<
+DescUsage: <<
+ To create a startup item that starts slapd after reboot just run as root
+'daemonic enable slapd'. To remove the slapd startup item just run as root
+'daemonic remove slapd'.
+<<
+DescPackaging: <<
+	Disabled static libs and cleaned dependency_libs in *.la files.
+	Dependent packages no longer need to depend on our dependencies.
+<<
+DescPort: <<
+* Properly detect and link on macOS11+.
+* Force gdate for tests rather than clumsily patching to BSD date.
+<<
+# Info4
+<< 

--- a/10.9-libcxx/stable/main/finkinfo/libs/openldap26.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/openldap26.info
@@ -24,6 +24,7 @@ BuildDepends: <<
 	cyrus-sasl2.3-dev (>= 2.1.27-1),
 	db60-aes,
 	fink (>= 0.30.0-1),
+	groff,
 	openssl300-dev
 <<
 Conflicts: openldap-ssl, openldap23, openldap24, openldap26
@@ -37,7 +38,7 @@ PatchScript: <<
 	%{default_script}
 <<
 #NoSetLDFLAGS: True
-#SetLDFLAGS: -Wl,-dead_strip_dylibs
+SetLDFLAGS: -Wl,-headerpad,64
 #SetLibs: -lkrb5 -L%p/%lib -ldb-6.0
 #SetCPPFLAGS: -I%p/include/db5 -DBIND_8_COMPAT
 ConfigureParams: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/openldap26.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/openldap26.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: openldap24.patch -*-
 Info4: <<
 Package: openldap26
-Version: 2.6.3
+Version: 2.6.4
 Revision: 1
 Description: LDAP directory services implementation
 License: Restrictive/Distributable
@@ -17,11 +17,11 @@ CustomMirror: <<
 	nam-US: ftp://ftp.OpenLDAP.org/pub/OpenLDAP/
 	nam-CA: http://gpl.savoirfairelinux.net/pub/mirrors/openldap/
 <<
-Source-Checksum: SHA256(d2a2a1d71df3d77396b1c16ad7502e674df446e06072b0e5a4e941c3d06c0d46)
+Source-Checksum: SHA256(d51704e50178430c06cf3d8aa174da66badf559747a47d920bb54b2d4aa40991)
 # NOTE: configure looks for libicu but doesn't actually use it.
 Depends: openldap2-shlibs (= %v-%r), daemonic
 BuildDepends: <<
-	cyrus-sasl2.3-dev (>= 2.1.27-1),
+	cyrus-sasl2.3-dev (>= 2.1.28-4),
 	db60-aes,
 	fink (>= 0.30.0-1),
 	groff,
@@ -31,14 +31,14 @@ Conflicts: openldap-ssl, openldap23, openldap24, openldap26
 Replaces: openldap-ssl, openldap23, openldap24, openldap26
 Provides: openldap
 PatchFile: %{ni}.patch
-PatchFile-MD5: d94ddb2fb5bc43d4026580060e4d12e5
+PatchFile-MD5: b1348708cc351d7ff5809658c6d0d6f4
 PatchFile2: %{ni}-xcode12.patch
 PatchFile2-MD5: 4fe35d038a6e6b3a9409d7e31880817c
 PatchScript: <<
 	%{default_script}
 <<
 #NoSetLDFLAGS: True
-SetLDFLAGS: -Wl,-headerpad,64
+SetLDFLAGS: -Wl,-headerpad_max_install_names
 #SetLibs: -lkrb5 -L%p/%lib -ldb-6.0
 #SetCPPFLAGS: -I%p/include/db5 -DBIND_8_COMPAT
 ConfigureParams: <<
@@ -55,7 +55,7 @@ ConfigureParams: <<
 InfoTest: <<
 	TestSuiteSize: large
 	# Tdep for gdate
-	TestDepends: coreutils
+	#TestDepends: coreutils
 	TestScript: <<
 	#!/bin/sh -ev
 	# play with install_name so that progs can find uninstalled libraries when running
@@ -119,7 +119,7 @@ ConfFiles: <<
 SplitOff: <<
 	Package: openldap2-shlibs
 	Depends: <<
-		cyrus-sasl2.3-shlibs (>= 2.1.27-1),
+		cyrus-sasl2.3-shlibs (>= 2.1.28-4),
 		db60-aes-shlibs,
 		openssl300-shlibs
 	 <<
@@ -190,12 +190,12 @@ DescUsage: <<
 'daemonic remove slapd'.
 <<
 DescPackaging: <<
-	Disabled static libs and cleaned dependency_libs in *.la files.
-	Dependent packages no longer need to depend on our dependencies.
+Disabled static libs and cleaned dependency_libs in *.la files.
+Dependent packages no longer need to depend on our dependencies.
+cyrus-sasl2.3 %r>=-4 needed for full compat with openssl3.
 <<
 DescPort: <<
 * Properly detect and link on macOS11+.
-* Force gdate for tests rather than clumsily patching to BSD date.
 <<
 # Info4
 << 

--- a/10.9-libcxx/stable/main/finkinfo/libs/openldap26.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/openldap26.patch
@@ -1,0 +1,60 @@
+Handle macOS 11 and later properly. Based on patch in libtool port.
+--- a/configure.orig	2021-10-27 12:30:23.000000000 -0400
++++ b/configure	2021-10-27 12:37:51.000000000 -0400
+@@ -9211,9 +9211,9 @@
+       case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
+ 	10.0,*86*-darwin8*|10.0,*-darwin[91]*)
+ 	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+-	10.[012][,.]*)
++	10.[012][,.]*|,*powerpc*)
+ 	  _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+-	10.*)
++	*)
+ 	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+       esac
+     ;;
+@@ -14978,6 +14978,7 @@
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <stdlib.h>
+ #include <ctype.h>
+ #ifndef HAVE_EBCDIC
+ #	define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
+@@ -20854,6 +20855,7 @@
+ 
+ #include <sys/types.h>
+ #include <sys/time.h>
++#include <stdlib.h>
+ #include <unistd.h>
+ #include <pthread.h>
+ #ifndef NULL
+@@ -23241,6 +23243,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <ctype.h>
+ main()
+ {
+--- a/build/ltmain.sh.orig	2021-10-25 13:06:00.000000000 -0400
++++ b/build/ltmain.sh	2021-10-27 12:17:55.000000000 -0400
+@@ -8140,7 +8140,7 @@
+ 	  *)
+ 	    if test no = "$installed"; then
+ 	      func_append notinst_deplibs " $lib"
+-	      need_relink=yes
++	      need_relink=no
+ 	    fi
+ 	    ;;
+ 	  esac
+--- a/tests/scripts/functions.sh.orig	2022-08-03 10:11:26.000000000 -0400
++++ b/tests/scripts/functions.sh	2022-08-03 10:11:37.000000000 -0400
+@@ -15,6 +15,6 @@
+ 
+ timer() {
+ 	if [ -n "$STARTTIME" ]; then
+-		date -u -d "now - $STARTTIME sec" +%T
++		gdate -u -d "now - $STARTTIME sec" +%T
+ 	fi
+ }

--- a/10.9-libcxx/stable/main/finkinfo/libs/openldap26.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/openldap26.patch
@@ -1,7 +1,19 @@
-Handle macOS 11 and later properly. Based on patch in libtool port.
---- a/configure.orig	2021-10-27 12:30:23.000000000 -0400
-+++ b/configure	2021-10-27 12:37:51.000000000 -0400
-@@ -9211,9 +9211,9 @@
+diff -ruN openldap-2.6.4-orig/build/ltmain.sh openldap-2.6.4/build/ltmain.sh
+--- openldap-2.6.4-orig/build/ltmain.sh	2023-02-08 12:53:35.000000000 -0600
++++ openldap-2.6.4/build/ltmain.sh	2023-03-09 06:34:53.000000000 -0600
+@@ -8140,7 +8140,7 @@
+ 	  *)
+ 	    if test no = "$installed"; then
+ 	      func_append notinst_deplibs " $lib"
+-	      need_relink=yes
++	      need_relink=no
+ 	    fi
+ 	    ;;
+ 	  esac
+diff -ruN openldap-2.6.4-orig/configure openldap-2.6.4/configure
+--- openldap-2.6.4-orig/configure	2023-02-08 12:53:35.000000000 -0600
++++ openldap-2.6.4/configure	2023-03-09 06:34:53.000000000 -0600
+@@ -9210,9 +9210,9 @@
        case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
  	10.0,*86*-darwin8*|10.0,*-darwin[91]*)
  	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
@@ -13,7 +25,7 @@ Handle macOS 11 and later properly. Based on patch in libtool port.
  	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
        esac
      ;;
-@@ -14978,6 +14978,7 @@
+@@ -14977,6 +14977,7 @@
  else
    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
@@ -21,7 +33,7 @@ Handle macOS 11 and later properly. Based on patch in libtool port.
  #include <ctype.h>
  #ifndef HAVE_EBCDIC
  #	define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
-@@ -20854,6 +20855,7 @@
+@@ -20853,6 +20854,7 @@
  
  #include <sys/types.h>
  #include <sys/time.h>
@@ -29,7 +41,7 @@ Handle macOS 11 and later properly. Based on patch in libtool port.
  #include <unistd.h>
  #include <pthread.h>
  #ifndef NULL
-@@ -23241,6 +23243,7 @@
+@@ -23240,6 +23242,7 @@
    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
  
@@ -37,24 +49,3 @@ Handle macOS 11 and later properly. Based on patch in libtool port.
  #include <ctype.h>
  main()
  {
---- a/build/ltmain.sh.orig	2021-10-25 13:06:00.000000000 -0400
-+++ b/build/ltmain.sh	2021-10-27 12:17:55.000000000 -0400
-@@ -8140,7 +8140,7 @@
- 	  *)
- 	    if test no = "$installed"; then
- 	      func_append notinst_deplibs " $lib"
--	      need_relink=yes
-+	      need_relink=no
- 	    fi
- 	    ;;
- 	  esac
---- a/tests/scripts/functions.sh.orig	2022-08-03 10:11:26.000000000 -0400
-+++ b/tests/scripts/functions.sh	2022-08-03 10:11:37.000000000 -0400
-@@ -15,6 +15,6 @@
- 
- timer() {
- 	if [ -n "$STARTTIME" ]; then
--		date -u -d "now - $STARTTIME sec" +%T
-+		gdate -u -d "now - $STARTTIME sec" +%T
- 	fi
- }


### PR DESCRIPTION
Creates a new package for openldap-2.6
* The server and executables are in openldap26, which C/R older openldap24. I have no idea if we can just normalize to an openldap2 package.
* The library now uses a normal versioning scheme, and the new library package is openldap2-shlibs/-dev, which C/R the older openldap24-dev.
