### PR TITLE
Distribution: 13.0 versions of various packages

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/help2man-perl.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/help2man-perl.info
@@ -13,7 +13,8 @@ Distribution: <<
   (%type_pkg[systemperl] = 5184) 10.15,
   (%type_pkg[systemperl] = 5282) 11.0,
   (%type_pkg[systemperl] = 5302) 11.3,
-  (%type_pkg[systemperl] = 5303) 12.0
+  (%type_pkg[systemperl] = 5303) 12.0,
+  (%type_pkg[systemperl] = 5303) 13.0
 <<
 Source: mirror:gnu:help2man/help2man-%v.tar.xz
 Source-Checksum: SHA256(9e2e0e213a7e0a36244eed6204d902b6504602a578b6ecd15268b1454deadd36)
@@ -28,6 +29,10 @@ CompileScript: <<
 #!/bin/sh -ex
  perl -pi.bak -e 's,-shared,-bundle,g' Makefile.in
 #Need to build w/same perl as %type_raw[systemperl]
+  m=%m
+  if [ "$m" = "arm" ] ; then
+    m=arm64
+  fi
   if [ "%type_pkg[systemperl]" = "5100" ] && [ "%m" != "powerpc" ] ; then
     PERL="/usr/bin/arch -%m perl%type_raw[systemperl]"
   elif [ "%type_pkg[systemperl]" = "5123" ] && [ -e "/usr/bin/perl5.12" ] ; then
@@ -43,9 +48,9 @@ CompileScript: <<
   elif [ "%type_pkg[systemperl]" = "5282" ] && [ -e "/usr/bin/perl5.28" ] ; then
     PERL="/usr/bin/arch -%m perl5.28"
   elif [ "%type_pkg[systemperl]" = "5302" ] && [ -e "/usr/bin/perl5.30" ] ; then
-    PERL="/usr/bin/arch -%m perl5.30"
+    PERL="/usr/bin/arch -$m perl5.30"
   elif [ "%type_pkg[systemperl]" = "5303" ] && [ -e "/usr/bin/perl5.30" ] ; then
-    PERL="/usr/bin/arch -%m perl5.30"
+    PERL="/usr/bin/arch -$m perl5.30"
   else
     PERL="/usr/bin/env perl%type_raw[systemperl]"
   fi

--- a/10.9-libcxx/stable/main/finkinfo/devel/help2man-perl.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/help2man-perl.info
@@ -29,10 +29,6 @@ CompileScript: <<
 #!/bin/sh -ex
  perl -pi.bak -e 's,-shared,-bundle,g' Makefile.in
 #Need to build w/same perl as %type_raw[systemperl]
-  m=%m
-  if [ "$m" = "arm" ] ; then
-    m=arm64
-  fi
   if [ "%type_pkg[systemperl]" = "5100" ] && [ "%m" != "powerpc" ] ; then
     PERL="/usr/bin/arch -%m perl%type_raw[systemperl]"
   elif [ "%type_pkg[systemperl]" = "5123" ] && [ -e "/usr/bin/perl5.12" ] ; then
@@ -48,9 +44,9 @@ CompileScript: <<
   elif [ "%type_pkg[systemperl]" = "5282" ] && [ -e "/usr/bin/perl5.28" ] ; then
     PERL="/usr/bin/arch -%m perl5.28"
   elif [ "%type_pkg[systemperl]" = "5302" ] && [ -e "/usr/bin/perl5.30" ] ; then
-    PERL="/usr/bin/arch -$m perl5.30"
+    PERL="/usr/bin/arch -%m perl5.30"
   elif [ "%type_pkg[systemperl]" = "5303" ] && [ -e "/usr/bin/perl5.30" ] ; then
-    PERL="/usr/bin/arch -$m perl5.30"
+    PERL="/usr/bin/arch -%m perl5.30"
   else
     PERL="/usr/bin/env perl%type_raw[systemperl]"
   fi

--- a/10.9-libcxx/stable/main/finkinfo/devel/intltool40-13.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/intltool40-13.0.info
@@ -1,0 +1,58 @@
+Info2: <<
+Package: intltool40
+Version: 0.51.0
+Revision: 1104
+Distribution: 13.0
+Type: systemperl (5.30.3)
+Depends: <<
+	gettext-tools,
+	system-perl%type_pkg[systemperl],
+	xml-parser-pm%type_pkg[systemperl]
+<<
+Conflicts: intltool
+Replaces: intltool
+Source: https://edge.launchpad.net/intltool/trunk/%v/+download/intltool-%v.tar.gz
+Source-Checksum: SHA256(67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd)
+PatchFile: %n.patch
+PatchFile-MD5: dddfe2a2c6a86f57529d8eb97ffd92f3
+UseMaxBuildJobs: false
+RuntimeVars: ac_cv_path_INTLTOOL_PERL: /usr/bin/perl
+ConfigureParams: PERL=/usr/bin/perl
+InfoTest: TestScript: make check || exit 2
+InstallScript: <<
+	make install DESTDIR=%d
+<<
+DocFiles: AUTHORS COPYING README TODO doc/I18N-HOWTO
+Description: Internationalize various kinds of data files
+DescDetail: <<
+Automatically extracts translatable strings from oaf, glade, bonobo
+ui, nautilus theme and other files into the po files.
+
+Automatically merges translations from po files back into .oaf files
+(encoding to be 7-bit clean). Also merges into other kinds of files.
+<<
+DescPort: <<
+	Use Dep:system-perlXXX,xml-parser-pmXXX to correspond to what Apple
+	ships as /usr/bin/perl. Unfortunately ./configure doesn't allow PERL
+	to be versioned (perlX.X.X), so that's the best we can figure to try
+	to force things to be self-consistent and likely-to-be-present with
+	a minimum of additional packages needed.
+<<
+DescPackaging: <<
+	The ac_cv_path_INTLTOOL_PERL shell variable is automatically set to
+	the system perl interpreter, so any package that uses intltool and
+	has ./configure checks for "perl" and "XML::Parser" will get the
+	correct perl interpreter that is used by intltool and thus test for
+	the matched perl version of xml-parser-pmXXX that is needed, even if
+	there are other perl interpreters in PATH.
+
+	Import upstream patch (revision 748) to fix race condition:
+	https://bugs.launchpad.net/intltool/+bug/1687644
+
+	Debian patch to avoid errors from unescaped braces:
+	https://salsa.debian.org/gnome-team/intltool/-/blob/debian/master/debian/patches/perl5.26-regex-fixes.patch
+<<
+License: GPL
+Maintainer: The Gnome Core Team <fink-gnome-core@lists.sourceforge.net>
+Homepage: https://www.freedesktop.org/wiki/Software/intltool
+<<

--- a/10.9-libcxx/stable/main/finkinfo/devel/po4a-13.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/po4a-13.0.info
@@ -1,7 +1,7 @@
 Package: po4a
 Version: 0.47
-Revision: 601
-Distribution: 12.0
+Revision: 701
+Distribution: 13.0
 ###
 ###   *  Unicode::GCString is not installed (Unicode-LineBreak)
 BuildDepends: <<

--- a/10.9-libcxx/stable/main/finkinfo/devel/xmkmf-12.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/xmkmf-12.0.info
@@ -1,0 +1,83 @@
+Package: xmkmf
+Version: 1.0.8
+Revision: 101
+Distribution: 12.0
+Description: X11 legacy build tools
+License: BSD
+Maintainer:  Dave Morrison <drm@finkproject.org>
+BuildDepends: <<
+	fink (>= 0.30.0),
+	ppkg-config,
+	xcode (>= 10.1)
+<<
+Depends: tradcpp
+Source:  https://xorg.freedesktop.org/releases/individual/util/imake-%v.tar.bz2
+Source2: https://xorg.freedesktop.org/releases/individual/util/xorg-cf-files-1.0.6.tar.bz2
+Source-Checksum: SHA256(b8d2e416b3f29cd6482bcffaaf19286d32917a164d07102a0e531ccd41a2a702)
+Source2-Checksum: SHA256(4dcf5a9dbe3c6ecb9d2dd05e629b3d373eae9ba12d13942df87107fdc1b3934d)
+PatchFile: %n-compiler.patch
+PatchFile-MD5: 78adf9d2be8bcda21c064e6d3ea127f7
+PatchScript: <<
+#! /bin/sh -ev
+# avoid convenience symlinks
+	X11DIR=/opt/X11
+	sed 's|@FINK_CPP_CMD@|%p/bin/tradcpp|g' < %{PatchFile} | patch -p1
+	perl -pi -e "s|/usr/X11R6|$X11DIR|g" imakemdep.h 
+	perl -pi -e "s|/usr/local|$X11DIR|" ../xorg-cf-files-1.0.6/site.def
+<<
+UseMaxBuildJobs: false
+ConfigureParams: --mandir=%p/share/man
+CompileScript: <<
+#!/bin/sh -ev
+	# avoid convenience symlinks
+	X11DIR=/opt/X11
+	#if [ `uname -r | cut -f 1 -d.` -ge 18 ]; then
+	#	SDK_PATH=`xcrun --show-sdk-path --sdk macosx`
+	#fi
+	export PKG_CONFIG=%p/bin/ppkg-config
+	./configure %c CPP=/usr/bin/cpp RAWCPP=/usr/bin/cpp
+	make 
+	cd ../xorg-cf-files-1.0.6
+	./configure %c RAWCPP=/usr/bin/cpp
+	perl -pi -e "s|%p|$X11DIR|" site.def 
+<<
+InstallScript: <<
+#!/bin/sh -ev
+	make install DESTDIR=%d
+	cd ../xorg-cf-files-1.0.6
+	make install DESTDIR=%d
+	mkdir %i/lib/%n
+	mv %i/bin %i/lib/%n
+<<
+DocFiles: COPYING ChangeLog README.md
+Homepage: http://xorg.freedesktop.org/
+DescDetail: <<
+ Under 10.5+, this package provides the xmkmf script and the imake executable
+ and their supporting config files that are no longer supplied with the
+ X11R7 release from x.org.
+
+ Thanks to Martin Costabel and Benjamin Reed for earlier versions.
+<<
+DescUsage: <<
+ In order to use xmkmf and imake to compile legacy packages,
+ one should have a BuildDepends on the present package, and supply
+    export PATH=%p/lib/xmkmf/bin:$PATH 
+    export IMAKEINCLUDE=-I%p/lib/X11/config
+ in the CompileScript and InstallScript of the packages.
+
+ Failing to do this runs the risk that some users may not have xmkmf and/or
+ imake (or the necessary config files) available at build time.
+<<
+DescPackaging: <<
+ imake has hardcoded information about build tools and will fail if a particular
+ one is unavailable, so as of 1.0.6-1202 we use names without the full paths and
+ allow either an Xcode with llvm-gcc (<5) or the Fink llvm-gcc42 package (>=5)
+ or clang >=6.0 as a dependency.
+
+ tradcpp seems to have a problem with macros pulled in from /usr/include/assert.h
+ during ./configure on Xcode10, so we make configure check with /usr/bin/cpp, 
+ but use tradcpp during runtime.
+
+ Possible whitespace patch if needed:
+ https://github.com/samueljohn/homebrew/blob/398110ff1c5e5138bec1fe10dfab3a878b8fc3d3/Library/Formula/imake.rb 
+<<

--- a/10.9-libcxx/stable/main/finkinfo/devel/xmkmf-13.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/xmkmf-13.0.info
@@ -1,0 +1,83 @@
+Package: xmkmf
+Version: 1.0.8
+Revision: 101
+Distribution: 13.0
+Description: X11 legacy build tools
+License: BSD
+Maintainer:  Dave Morrison <drm@finkproject.org>
+BuildDepends: <<
+	fink (>= 0.30.0),
+	ppkg-config,
+	xcode (>= 10.1)
+<<
+Depends: tradcpp
+Source:  https://xorg.freedesktop.org/releases/individual/util/imake-%v.tar.bz2
+Source2: https://xorg.freedesktop.org/releases/individual/util/xorg-cf-files-1.0.6.tar.bz2
+Source-Checksum: SHA256(b8d2e416b3f29cd6482bcffaaf19286d32917a164d07102a0e531ccd41a2a702)
+Source2-Checksum: SHA256(4dcf5a9dbe3c6ecb9d2dd05e629b3d373eae9ba12d13942df87107fdc1b3934d)
+PatchFile: %n-compiler.patch
+PatchFile-MD5: 78adf9d2be8bcda21c064e6d3ea127f7
+PatchScript: <<
+#! /bin/sh -ev
+# avoid convenience symlinks
+	X11DIR=/opt/X11
+	sed 's|@FINK_CPP_CMD@|%p/bin/tradcpp|g' < %{PatchFile} | patch -p1
+	perl -pi -e "s|/usr/X11R6|$X11DIR|g" imakemdep.h 
+	perl -pi -e "s|/usr/local|$X11DIR|" ../xorg-cf-files-1.0.6/site.def
+<<
+UseMaxBuildJobs: false
+ConfigureParams: --mandir=%p/share/man
+CompileScript: <<
+#!/bin/sh -ev
+	# avoid convenience symlinks
+	X11DIR=/opt/X11
+	#if [ `uname -r | cut -f 1 -d.` -ge 18 ]; then
+	#	SDK_PATH=`xcrun --show-sdk-path --sdk macosx`
+	#fi
+	export PKG_CONFIG=%p/bin/ppkg-config
+	./configure %c CPP=/usr/bin/cpp RAWCPP=/usr/bin/cpp
+	make 
+	cd ../xorg-cf-files-1.0.6
+	./configure %c RAWCPP=/usr/bin/cpp
+	perl -pi -e "s|%p|$X11DIR|" site.def 
+<<
+InstallScript: <<
+#!/bin/sh -ev
+	make install DESTDIR=%d
+	cd ../xorg-cf-files-1.0.6
+	make install DESTDIR=%d
+	mkdir %i/lib/%n
+	mv %i/bin %i/lib/%n
+<<
+DocFiles: COPYING ChangeLog README.md
+Homepage: http://xorg.freedesktop.org/
+DescDetail: <<
+ Under 10.5+, this package provides the xmkmf script and the imake executable
+ and their supporting config files that are no longer supplied with the
+ X11R7 release from x.org.
+
+ Thanks to Martin Costabel and Benjamin Reed for earlier versions.
+<<
+DescUsage: <<
+ In order to use xmkmf and imake to compile legacy packages,
+ one should have a BuildDepends on the present package, and supply
+    export PATH=%p/lib/xmkmf/bin:$PATH 
+    export IMAKEINCLUDE=-I%p/lib/X11/config
+ in the CompileScript and InstallScript of the packages.
+
+ Failing to do this runs the risk that some users may not have xmkmf and/or
+ imake (or the necessary config files) available at build time.
+<<
+DescPackaging: <<
+ imake has hardcoded information about build tools and will fail if a particular
+ one is unavailable, so as of 1.0.6-1202 we use names without the full paths and
+ allow either an Xcode with llvm-gcc (<5) or the Fink llvm-gcc42 package (>=5)
+ or clang >=6.0 as a dependency.
+
+ tradcpp seems to have a problem with macros pulled in from /usr/include/assert.h
+ during ./configure on Xcode10, so we make configure check with /usr/bin/cpp, 
+ but use tradcpp during runtime.
+
+ Possible whitespace patch if needed:
+ https://github.com/samueljohn/homebrew/blob/398110ff1c5e5138bec1fe10dfab3a878b8fc3d3/Library/Formula/imake.rb 
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/capture-tiny-pm-13.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/capture-tiny-pm-13.0.info
@@ -1,0 +1,21 @@
+Info2: <<
+Package: capture-tiny-pm
+Version: 0.48
+Revision: 1001
+Source: mirror:cpan:authors/id/D/DA/DAGOLDEN/Capture-Tiny-%v.tar.gz
+Source-MD5: f5d24083ad270f8326dd659dd83eeb54
+Type: perl, systemperl (5.30.3)
+Distribution: 13.0
+InfoTest: <<
+	TestDepends: <<
+		cpan-meta-pm%type_pkg[systemperl] (>= 2.120900),
+		system-perl%type_pkg[systemperl]
+	<<
+<<
+UpdatePOD: True
+DocFiles: CONTRIBUTING.mkdn Changes LICENSE README Todo
+Description: Capture STDOUT and STDERR output streams
+License: BSD
+Homepage: http://search.cpan.org/dist/Capture-Tiny/
+Maintainer: Daniel Macks <dmacks@netspace.org>
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/math-matrixreal-pm-13.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/math-matrixreal-pm-13.0.info
@@ -1,0 +1,26 @@
+Info2: <<
+Package: math-matrixreal-pm
+Version: 2.13
+Revision: 701
+
+Source: mirror:cpan:authors/id/L/LE/LETO/Math-MatrixReal-%v.tar.gz
+Source-Checksum: SHA256(4f9fa1a46dd34d2225de461d9a4ed86932cdd821c121fa501a15a6d4302fb4b2)
+
+Distribution: 13.0
+Type: perl, systemperl (5.30.3)
+
+InfoTest: <<
+	TestDepends: <<
+		system-perl%type_pkg[systemperl],
+		test-most-pm%type_pkg[systemperl]
+	<<
+<<
+
+DocFiles: CHANGES CONTRIBUTING.md CREDITS GOALS README.mkd
+UpdatePOD: true
+
+Description: Real-number matrix operations and overloading
+Homepage: https://metacpan.org/dist/Math-MatrixReal
+License: Artistic/GPL
+Maintainer: Daniel Macks <dmacks@netspace.org>
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/module-build-pm-13.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/module-build-pm-13.0.info
@@ -1,0 +1,21 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Package: module-build-pm
+Version: 0.42.31
+Revision: 1201
+Epoch: 1
+Distribution: 13.0
+Depends: system-perl5303, %n5303 (>= %e:%v-1)
+Type: bundle
+Description: Module::Build for /usr/bin/perl
+DescDetail: <<
+	Use BuildDepends:module-build-pm for packages that do not
+	otherwise need to be perl-version varianted so that they do
+	not need to be perl-version varianted on account of this build
+	dependency.
+
+	For packages that *are* perl-version varianted, use
+	BuildDepends:module-build-pmXXX for the appropriate perlXXX.
+<<
+License: Artistic
+Maintainer: Fink Core Group <fink-core@lists.sourceforge.net>
+Homepage: http://search.cpan.org/dist/Module-Build/

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/package-generator-pm-13.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/package-generator-pm-13.0.info
@@ -1,0 +1,21 @@
+Info2: <<
+Package: package-generator-pm
+Version: 1.106
+Revision: 1001
+Distribution: 13.0
+Source: mirror:cpan:authors/id/R/RJ/RJBS/Package-Generator-%v.tar.gz
+Source-MD5: 92ed633a2d18bbe22d8feda32f761de3
+Type: perl, systemperl (5.30.3)
+InfoTest: <<
+	TestDepends: <<
+		system-perl%type_pkg[systemperl],
+		params-util-pm%type_pkg[systemperl]
+	<<
+<<
+DocFiles: Changes LICENSE README
+UpdatePOD: true
+Description: Create packages on-the-fly
+License: Artistic/GPL
+Maintainer: Daniel Macks <dmacks@netspace.org>
+Homepage: http://search.cpan.org/dist/Package-Generator
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/test-simple-pm-13.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/test-simple-pm-13.0.info
@@ -1,0 +1,20 @@
+# -*- coding: ascii; tab-width: 4; x-counterpart: test-simple-pm.info -*-
+Package: test-simple-pm
+Version: 1.302120
+Revision: 1101
+Distribution: 13.0
+Depends: system-perl5303, %n5303 (>= %v-1)
+Type: bundle
+Description: Test::Simple for /usr/bin/perl
+DescDetail: <<
+	Use BuildDepends:test-simple-pm (or TestDepends as needed)
+	for packages that do not otherwise need to be perl-version
+	varianted so that they do not need to be perl-version varianted
+	on account of this build dependency.
+
+	For packages that *are* perl-version varianted, use
+	BuildDepends:test-simple-pmXXX for the appropriate perlXXX.
+<<
+License: Artistic
+Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
+Homepage: http://search.cpan.org/dist/Test-Simple/


### PR DESCRIPTION
Mostly perlmods for `system-perl5303` without further changes required; tested on arm64 as well.

The `xmkmf`-distversions from 10.14 to 13.0 are really identical, wondering if we really need separate package files for all.