### PR TITLE
AquaTerm build update to Xcode 14

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/aquaterm-1.1.1-5.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/aquaterm-1.1.1-5.info
@@ -1,8 +1,8 @@
 Package: aquaterm
 Version: 1.1.1
-Revision: 6
-# Updated MACOSX_DEPLOYMENT_TARGET
-Distribution: 10.13, 10.14, 10.14.5, 10.15, 11.0, 11.3, 12.0, 13.0
+Revision: 5
+# Pinned to old MACOSX_DEPLOYMENT_TARGET
+Distribution: 10.9, 10.10, 10.11, 10.12
 # original source
 #Source: http://www.kilohotel.com/fink/AquaTerm-%v.tar.gz
 # renamed root dir. files match. Real source?
@@ -15,8 +15,8 @@ BuildDepends: xcode.app
 Depends: %N-shlibs (= %v-%r)
 GCC: 4.0
 SourceDirectory: AquaTerm-AquaTerm-5c223a5
-PatchFile: %n.patch
-PatchFile-MD5: 5adc980817df7ba9bf4425351eb9265c
+PatchFile: %n-%v-%r.patch
+PatchFile-MD5: 94fb89d7b6eab5dc76da57fd4f7d5194
 TarFilesRename: README:README.txt Readme:Readme.txt
 CompileScript: echo nothing to do here, everything is done in the installscript
 InstallScript: <<
@@ -38,10 +38,10 @@ InstallScript: <<
  set -v
  # Don't use new Xcode build system with Xcode10+
  if [ `xcodebuild -version 2>/dev/null | head -n 1 | cut -f 2 -d ' ' | cut -f 1 -d.` -ge 10 ]; then
-   XCODE_BUILD_FLAG="-scheme AquaTerm -derivedDataPath `dirname %b` -UseNewBuildSystem=NO"
+   XCODE_BUILD_FLAG="-UseNewBuildSystem=NO"
  fi  
  cd aquaterm
- xcodebuild install $XCODE_BUILD_FLAG -arch $archname -target AquaTerm DSTROOT=%d INSTALL_PATH=%p/Applications DYLIB_INSTALL_NAME_BASE=%p/Library/Frameworks GCC_PREPROCESSOR_DEFINITIONS="AQT_APP" SDKROOT=`xcrun --sdk macosx --show-sdk-path` MACOSX_DEPLOYMENT_TARGET=10.13
+ xcodebuild install $XCODE_BUILD_FLAG -target AquaTerm DSTROOT=%d INSTALL_PATH=%p/Applications DYLIB_INSTALL_NAME_BASE=%p/Library/Frameworks GCC_PREPROCESSOR_DEFINITIONS="AQT_APP" ARCHS=$archname MACOSX_DEPLOYMENT_TARGET=10.7
  mkdir -p %i/include/aquaterm
  cp AQTAdapter.h aquaterm.h %i/include
  cp AQTAdapter.h %i/include/aquaterm
@@ -95,9 +95,6 @@ DescPackaging: <<
   On at least Xcode9 and above, Xcode.app needs to be run at least once before building 
   aquaterm to install things into /Library/Developer/PrivateFrameworks/
   https://github.com/fink/fink-distributions/pull/334#issuecomment-457997796
-
-  Pointed to correct sdk-path, incremented MACOSX_DEPLOYMENT_TARGET to 10.13
-  (minimum accepted by Xcode 14); set DerivedData path to builddir rather than ~/Library/Xcode.
 <<
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Homepage: http://aquaterm.github.com

--- a/10.9-libcxx/stable/main/finkinfo/graphics/aquaterm-1.1.1-5.patch
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/aquaterm-1.1.1-5.patch
@@ -1,0 +1,45 @@
+--- a/aquaterm/AQTController.m	2012-07-30 07:39:50.000000000 -0700
++++ b/aquaterm/AQTController.m	2013-08-09 08:05:56.000000000 -0700
+@@ -11,7 +11,7 @@
+ #import "AQTAdapter.h"
+ 
+ #import "AQTPlot.h"
+-#import <Message/NSMailDelivery.h>
++#import <Foundation/Foundation.h>
+ 
+ extern void aqtDebug(id sender);
+ extern void aqtTestview(id sender);
+--- a/aquaterm/AquaTerm.xcodeproj/project.pbxproj	2012-07-30 07:39:50.000000000 -0700
++++ b/aquaterm/AquaTerm.xcodeproj/project.pbxproj	2013-08-09 08:08:35.000000000 -0700
+@@ -93,7 +93,6 @@
+ 		CBC4B44305E4C784001BE8D7 /* Timing.m in Sources */ = {isa = PBXBuildFile; fileRef = FEBB59D0055CF40600EEC8EA /* Timing.m */; };
+ 		CBC4B44405E4C784001BE8D7 /* AQTFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = CBB06FE905740EB900D208BA /* AQTFunctions.m */; };
+ 		CBC4B44605E4C784001BE8D7 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+-		CBC4B44705E4C784001BE8D7 /* Message.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE82528EC5B321F400CFA73B /* Message.framework */; };
+ /* End PBXBuildFile section */
+ 
+ /* Begin PBXContainerItemProxy section */
+@@ -207,7 +206,6 @@
+ 		F5E3AFAA026D80D2012F88DF /* AQTView.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = AQTView.m; sourceTree = "<group>"; };
+ 		F5E70371026D8645012F88DF /* English */ = {isa = PBXFileReference; lastKnownFileType = wrapper.nib; name = English; path = English.lproj/AQTWindow.nib; sourceTree = "<group>"; };
+ 		F5FEAC2801A7219B0143D50D /* English */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; name = English; path = English.lproj/Credits.rtf; sourceTree = "<group>"; };
+-		FE82528EC5B321F400CFA73B /* Message.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Message.framework; path = /System/Library/Frameworks/Message.framework; sourceTree = "<absolute>"; };
+ 		FE8252ACC5B321F400CFA73B /* Demo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Demo.m; sourceTree = SOURCE_ROOT; };
+ 		FEBB59CE055CF10B00EEC8EA /* Bugs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Bugs.m; sourceTree = "<group>"; };
+ 		FEBB59D0055CF40600EEC8EA /* Timing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Timing.m; sourceTree = "<group>"; };
+@@ -228,7 +226,6 @@
+ 			buildActionMask = 2147483647;
+ 			files = (
+ 				CBC4B44605E4C784001BE8D7 /* Cocoa.framework in Frameworks */,
+-				CBC4B44705E4C784001BE8D7 /* Message.framework in Frameworks */,
+ 				CB91259D07CB4A92001D5EAF /* AquaTerm.framework in Frameworks */,
+ 				CB12640607CB5F5A00EF1763 /* AquaTerm.framework in Frameworks */,
+ 			);
+@@ -250,7 +247,6 @@
+ 		1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */ = {
+ 			isa = PBXGroup;
+ 			children = (
+-				FE82528EC5B321F400CFA73B /* Message.framework */,
+ 				1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */,
+ 			);
+ 			name = "Linked Frameworks";

--- a/10.9-libcxx/stable/main/finkinfo/graphics/aquaterm.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/aquaterm.info
@@ -1,6 +1,6 @@
 Package: aquaterm
 Version: 1.1.1
-Revision: 5
+Revision: 6
 # original source
 #Source: http://www.kilohotel.com/fink/AquaTerm-%v.tar.gz
 # renamed root dir. files match. Real source?
@@ -14,7 +14,7 @@ Depends: %N-shlibs (= %v-%r)
 GCC: 4.0
 SourceDirectory: AquaTerm-AquaTerm-5c223a5
 PatchFile: %n.patch
-PatchFile-MD5: 94fb89d7b6eab5dc76da57fd4f7d5194
+PatchFile-MD5: 5adc980817df7ba9bf4425351eb9265c
 TarFilesRename: README:README.txt Readme:Readme.txt
 CompileScript: echo nothing to do here, everything is done in the installscript
 InstallScript: <<
@@ -36,10 +36,10 @@ InstallScript: <<
  set -v
  # Don't use new Xcode build system with Xcode10+
  if [ `xcodebuild -version 2>/dev/null | head -n 1 | cut -f 2 -d ' ' | cut -f 1 -d.` -ge 10 ]; then
-   XCODE_BUILD_FLAG="-UseNewBuildSystem=NO"
+   XCODE_BUILD_FLAG="-scheme AquaTerm -derivedDataPath `dirname %b` -UseNewBuildSystem=NO"
  fi  
  cd aquaterm
- xcodebuild install $XCODE_BUILD_FLAG -target AquaTerm DSTROOT=%d INSTALL_PATH=%p/Applications DYLIB_INSTALL_NAME_BASE=%p/Library/Frameworks GCC_PREPROCESSOR_DEFINITIONS="AQT_APP" ARCHS=$archname MACOSX_DEPLOYMENT_TARGET=10.7
+ xcodebuild install $XCODE_BUILD_FLAG -arch $archname -target AquaTerm DSTROOT=%d INSTALL_PATH=%p/Applications DYLIB_INSTALL_NAME_BASE=%p/Library/Frameworks GCC_PREPROCESSOR_DEFINITIONS="AQT_APP" SDKROOT=`xcrun --sdk macosx --show-sdk-path` MACOSX_DEPLOYMENT_TARGET=10.13
  mkdir -p %i/include/aquaterm
  cp AQTAdapter.h aquaterm.h %i/include
  cp AQTAdapter.h %i/include/aquaterm
@@ -93,6 +93,9 @@ DescPackaging: <<
   On at least Xcode9 and above, Xcode.app needs to be run at least once before building 
   aquaterm to install things into /Library/Developer/PrivateFrameworks/
   https://github.com/fink/fink-distributions/pull/334#issuecomment-457997796
+
+  Pointed to correct sdk-path, incremented MACOSX_DEPLOYMENT_TARGET to 10.13
+  (minimum accepted by Xcode 14); set DerivedData path to builddir rather than ~/Library/Xcode.
 <<
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Homepage: http://aquaterm.github.com

--- a/10.9-libcxx/stable/main/finkinfo/graphics/aquaterm.patch
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/aquaterm.patch
@@ -11,6 +11,14 @@
  extern void aqtTestview(id sender);
 --- a/aquaterm/AquaTerm.xcodeproj/project.pbxproj	2012-07-30 07:39:50.000000000 -0700
 +++ b/aquaterm/AquaTerm.xcodeproj/project.pbxproj	2013-08-09 08:08:35.000000000 -0700
+@@ -27,7 +27,6 @@
+ 		CB2CC1100677017B0042863D /* AQTModelAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CB2CC10E0677017B0042863D /* AQTModelAdditions.m */; };
+ 		CB3949DA0E8D7A5B00BA7404 /* AquaTerm.bridgesupport in Resources */ = {isa = PBXBuildFile; fileRef = CB3949D90E8D7A5B00BA7404 /* AquaTerm.bridgesupport */; };
+ 		CB58A20006F9A60900AF8A5E /* AQTAdapter.html in Resources */ = {isa = PBXBuildFile; fileRef = CB58A1FE06F9A60900AF8A5E /* AQTAdapter.html */; };
+-		CB58A20106F9A60900AF8A5E /* help.html in Resources */ = {isa = PBXBuildFile; fileRef = CB58A1FF06F9A60900AF8A5E /* help.html */; };
+ 		CB58A20206F9A62300AF8A5E /* help.html in CopyFiles */ = {isa = PBXBuildFile; fileRef = CB58A1FF06F9A60900AF8A5E /* help.html */; };
+ 		CB58A23B06FA0FB600AF8A5E /* ReadMe.rtf in Resources */ = {isa = PBXBuildFile; fileRef = CB58A23A06FA0FB600AF8A5E /* ReadMe.rtf */; };
+ 		CB72184906072CF6008DCEAD /* ReleaseNotes in Resources */ = {isa = PBXBuildFile; fileRef = CB72184806072CF6008DCEAD /* ReleaseNotes */; };
 @@ -93,7 +93,6 @@
  		CBC4B44305E4C784001BE8D7 /* Timing.m in Sources */ = {isa = PBXBuildFile; fileRef = FEBB59D0055CF40600EEC8EA /* Timing.m */; };
  		CBC4B44405E4C784001BE8D7 /* AQTFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = CBB06FE905740EB900D208BA /* AQTFunctions.m */; };
@@ -43,3 +51,11 @@
  				1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */,
  			);
  			name = "Linked Frameworks";
+@@ -609,7 +608,6 @@
+ 				CB72184906072CF6008DCEAD /* ReleaseNotes in Resources */,
+ 				CB9B70CD065A0AD100563010 /* Preferences.nib in Resources */,
+ 				CB58A20006F9A60900AF8A5E /* AQTAdapter.html in Resources */,
+-				CB58A20106F9A60900AF8A5E /* help.html in Resources */,
+ 				CB58A23B06FA0FB600AF8A5E /* ReadMe.rtf in Resources */,
+ 				CB9C491B0BB1C3D700FDF03C /* crossBlack.tiff in Resources */,
+ 				CB9C491C0BB1C3D700FDF03C /* crossBlue.tiff in Resources */,


### PR DESCRIPTION
The old revision had `MACOSX_DEPLOYMENT_TARGET=10.7`, and 10.5 in the xcodeproj. Set here to the minimum accepted by Xcode 14 on 13.2, which still builds as is with Xcode 11.3.1 on 10.14.6, but obviously will need to dist-restrict this for still older versions – or set the target depending on the build host?