### PR TITLE
arm64/aarch64 build fixes for nettle7 and libid3tag

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/nettle7-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/nettle7-shlibs.info
@@ -37,6 +37,7 @@ PatchScript: <<
 <<
 #
 ConfigureParams: <<
+	("%m" = "arm64") --host=aarch64-apple-darwin`uname -r` \
 	--enable-shared \
 	--disable-openssl
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sound/libid3tag.info
+++ b/10.9-libcxx/stable/main/finkinfo/sound/libid3tag.info
@@ -13,6 +13,7 @@ PatchScript: <<
  %{default_script}
  perl -pi.bak -e 's,-flat_namespace -undefined suppress,-twolevel_namespace -undefined error,g' configure && perl -pi.bak -e 's,FINK_PREFIX,%p,g' id3tag.pc
 <<
+UpdateConfigGuess: true
 InstallScript: <<
  make install DESTDIR=%d && mkdir -p %i/lib/pkgconfig && mv id3tag.pc %i/lib/pkgconfig/
 <<


### PR DESCRIPTION
Separating the packages addressed in #952 out here.
`libid3tag` works as proposed with updated `config.guess` (tested on old 10.14 installation with fink 0.45 and dpkg 1.10.21 as well). Both are building as `aarch64-apple-darwin...` now.
`nettle8` from ab0978d builds without further changes.
