### PR TITLE
TclTk update to 8.6.13 fixing large integer bug

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/tcltk.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/tcltk.info
@@ -2,15 +2,15 @@ Package: tcltk
 Epoch: 1
 
 # update itcl path-flags in "itk" and versions in "iwidgets" when updating
-Version: 8.6.10
+Version: 8.6.13
 
-Revision: 2
+Revision: 1
 BuildDepends: <<
 	fink (>= 0.28),
 	fink-package-precedence,
 	fontconfig2-dev (>= 2.10.0-1),
 	freetype219 (>= 2.6-1),
-	ppkg-config,
+	pkgconf,
 	x11-dev,
 	xft2-dev (>= 2.2.0-1)
 <<
@@ -22,24 +22,19 @@ Depends: <<
 	xft2-shlibs (>= 2.2.0-1)
 <<
 Source: mirror:sourceforge:tcl/tcl%v-src.tar.gz
-Source-Checksum: SHA256(5196dbf6638e3df8d5c87b5815c8c2b758496eb6f0e41446596c9a4e638d87ed)
+Source-Checksum: SHA256(43a1fae7412f61ff11de2cfd05d28cfc3a73762f354a417c62370a54e2caf066)
 SourceDirectory: tcl%v
 Source2: mirror:sourceforge:tcl/tk%v-src.tar.gz
-Source2-Checksum: SHA256(63df418a859d0a463347f95ded5cd88a3dd3aaa1ceecaeee362194bc30f3e386)
+Source2-Checksum: SHA256(2e65fa069a23365440a3c56c556b8673b5e32a283800d8d9b257e3f584ce0675)
 PatchFile: %n.patch
-PatchFile-MD5: fa90f0d1f5d62da177c8a5b8c2c97938
+PatchFile-MD5: a17e26252d5567cb3a93c8a2d99bb7a4
 PatchScript: <<
 	%{default_script}
 	# patch *ancient* darwin-ignorant autoconf
 	perl -pi -e 's/(a so sl)/dylib \1/' tk%v/unix/configure
 	# autoconf2.6ish patch for modern XQuartz paths
-	perl -pi -e "s|/usr/lpp/Xamples|/opt/X11|" tk%v/unix/configure
+	perl -pi -e 's|/usr/lpp/Xamples|/opt/X11|' tk%v/unix/configure
 	perl -ni -e 'print unless /Requires.private:/' tcl%v/unix/tcl.pc.in
-
-	# ppkg-config is the BuildDepend but it's not used since configure
-	# hardcodes pkg-config calls.  This moves it to using ppkg-config
-	# which also fixed it for Apple Silicon
-	perl -pi -e "s|pkg-config|ppkg-config|g" tk%v/unix/configure
 <<
 NoSourceDirectory: true
 SetCPPFLAGS: -MD -g
@@ -122,16 +117,16 @@ InstallScript: <<
 
 	# manually fix install names (fink wants full path even though
 	# private and dlopen'ed). Why are these .dylib not .so ?
-	chmod u+w %i/lib/thread2.8.5/libthread2.8.5.dylib
-	chmod u+w %i/lib/tdbcpostgres1.1.1/libtdbcpostgres1.1.1.dylib
+	chmod u+w %i/lib/thread2.8.8/libthread2.8.8.dylib
+	chmod u+w %i/lib/tdbcpostgres1.1.5/libtdbcpostgres1.1.5.dylib
 	for modulepath in \
-		itcl4.2.0/libitcl4.2.0.dylib \
-		sqlite3.30.1.2/libsqlite3.30.1.2.dylib \
-		tdbc1.1.1/libtdbc1.1.1.dylib \
-		tdbcmysql1.1.1/libtdbcmysql1.1.1.dylib \
-		tdbcodbc1.1.1/libtdbcodbc1.1.1.dylib \
-		tdbcpostgres1.1.1/libtdbcpostgres1.1.1.dylib \
-		thread2.8.5/libthread2.8.5.dylib \
+		itcl4.2.3/libitcl4.2.3.dylib \
+		sqlite3.40.0/libsqlite3.40.0.dylib \
+		tdbc1.1.5/libtdbc1.1.5.dylib \
+		tdbcmysql1.1.5/libtdbcmysql1.1.5.dylib \
+		tdbcodbc1.1.5/libtdbcodbc1.1.5.dylib \
+		tdbcpostgres1.1.5/libtdbcpostgres1.1.5.dylib \
+		thread2.8.8/libthread2.8.8.dylib \
 	; do
 		install_name_tool -id %p/lib/$modulepath %i/lib/$modulepath
 	done
@@ -156,24 +151,24 @@ SplitOff: <<
 	Files: <<
 		lib/libtcl8.6.dylib
 		lib/libtk8.6.dylib
-		lib/itcl4.2.0/libitcl4.2.0.dylib
-		lib/sqlite3.30.1.2/libsqlite3.30.1.2.dylib
-		lib/tdbc1.1.1/libtdbc1.1.1.dylib
-		lib/tdbcmysql1.1.1/libtdbcmysql1.1.1.dylib
-		lib/tdbcodbc1.1.1/libtdbcodbc1.1.1.dylib
-		lib/tdbcpostgres1.1.1/libtdbcpostgres1.1.1.dylib
-		lib/thread2.8.5/libthread2.8.5.dylib
+		lib/itcl4.2.3/libitcl4.2.3.dylib
+		lib/sqlite3.40.0/libsqlite3.40.0.dylib
+		lib/tdbc1.1.5/libtdbc1.1.5.dylib
+		lib/tdbcmysql1.1.5/libtdbcmysql1.1.5.dylib
+		lib/tdbcodbc1.1.5/libtdbcodbc1.1.5.dylib
+		lib/tdbcpostgres1.1.5/libtdbcpostgres1.1.5.dylib
+		lib/thread2.8.8/libthread2.8.8.dylib
 	<<
 	Shlibs: <<
 		%p/lib/libtcl8.6.dylib 8.6.0 %n (>= 8.6.0-1)
 		%p/lib/libtk8.6.dylib 8.6.0 %n (>= 8.6.0-1)
-		!%p/lib/itcl4.2.0/libitcl4.2.0.dylib
-		!%p/lib/sqlite3.30.1.2/libsqlite3.30.1.2.dylib
-		!%p/lib/tdbc1.1.1/libtdbc1.1.1.dylib
-		!%p/lib/tdbcmysql1.1.1/libtdbcmysql1.1.1.dylib
-		!%p/lib/tdbcodbc1.1.1/libtdbcodbc1.1.1.dylib
-		!%p/lib/tdbcpostgres1.1.1/libtdbcpostgres1.1.1.dylib
-		!%p/lib/thread2.8.5/libthread2.8.5.dylib
+		!%p/lib/itcl4.2.3/libitcl4.2.3.dylib
+		!%p/lib/sqlite3.40.0/libsqlite3.40.0.dylib
+		!%p/lib/tdbc1.1.5/libtdbc1.1.5.dylib
+		!%p/lib/tdbcmysql1.1.5/libtdbcmysql1.1.5.dylib
+		!%p/lib/tdbcodbc1.1.5/libtdbcodbc1.1.5.dylib
+		!%p/lib/tdbcpostgres1.1.5/libtdbcpostgres1.1.5.dylib
+		!%p/lib/thread2.8.8/libthread2.8.8.dylib
 	<<
 	DocFiles: <<
 		tcl%v/license.terms:LICENSE.tcl

--- a/10.9-libcxx/stable/main/finkinfo/languages/tcltk.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/tcltk.patch
@@ -1,6 +1,6 @@
-diff -uNr tcltk-8.6.10.orig/tcl8.6.10/generic/tclInt.h tcltk-8.6.10/tcl8.6.10/generic/tclInt.h
---- tcltk-8.6.10.orig/tcl8.6.10/generic/tclInt.h	2019-11-13 11:57:08.000000000 -0600
-+++ tcltk-8.6.10/tcl8.6.10/generic/tclInt.h	2020-11-08 06:21:12.000000000 -0600
+diff -uNr tcltk-8.6.13.orig/tcl8.6.13/generic/tclInt.h tcltk-8.6.13/tcl8.6.13/generic/tclInt.h
+--- tcltk-8.6.13.orig/tcl8.6.13/generic/tclInt.h	2019-11-13 11:57:08.000000000 -0600
++++ tcltk-8.6.13/tcl8.6.13/generic/tclInt.h	2020-11-08 06:21:12.000000000 -0600
 @@ -3277,7 +3277,7 @@
  MODULE_SCOPE int	TclClockOldscanObjCmd(
  			    ClientData clientData, Tcl_Interp *interp,
@@ -19,9 +19,9 @@ diff -uNr tcltk-8.6.10.orig/tcl8.6.10/generic/tclInt.h tcltk-8.6.10/tcl8.6.10/ge
  			    Tcl_Interp *interp, int objc,
  			    Tcl_Obj *const objv[]);
  MODULE_SCOPE int	Tcl_ScanObjCmd(ClientData clientData,
-diff -uNr tcltk-8.6.10.orig/tcl8.6.10/generic/tclPort.h tcltk-8.6.10/tcl8.6.10/generic/tclPort.h
---- tcltk-8.6.10.orig/tcl8.6.10/generic/tclPort.h	2019-06-17 13:39:57.000000000 -0500
-+++ tcltk-8.6.10/tcl8.6.10/generic/tclPort.h	2020-11-08 06:21:12.000000000 -0600
+diff -uNr tcltk-8.6.13.orig/tcl8.6.13/generic/tclPort.h tcltk-8.6.13/tcl8.6.13/generic/tclPort.h
+--- tcltk-8.6.13.orig/tcl8.6.13/generic/tclPort.h	2019-06-17 13:39:57.000000000 -0500
++++ tcltk-8.6.13/tcl8.6.13/generic/tclPort.h	2020-11-08 06:21:12.000000000 -0600
 @@ -20,7 +20,7 @@
  #if defined(_WIN32)
  #   include "tclWinPort.h"
@@ -31,9 +31,9 @@ diff -uNr tcltk-8.6.10.orig/tcl8.6.10/generic/tclPort.h tcltk-8.6.10/tcl8.6.10/g
  #endif
  #include "tcl.h"
  
-diff -uNr tcltk-8.6.10.orig/tcl8.6.10/pkgs/itcl4.2.0/configure tcltk-8.6.10/tcl8.6.10/pkgs/itcl4.2.0/configure
---- tcltk-8.6.10.orig/tcl8.6.10/pkgs/itcl4.2.0/configure	2019-11-20 11:38:54.000000000 -0500
-+++ tcltk-8.6.10/tcl8.6.10/pkgs/itcl4.2.0/configure	2020-11-21 14:33:08.000000000 -0500
+diff -uNr tcltk-8.6.13.orig/tcl8.6.13/pkgs/itcl4.2.3/configure tcltk-8.6.13/tcl8.6.13/pkgs/itcl4.2.3/configure
+--- tcltk-8.6.13.orig/tcl8.6.13/pkgs/itcl4.2.3/configure	2019-11-20 11:38:54.000000000 -0500
++++ tcltk-8.6.13/tcl8.6.13/pkgs/itcl4.2.3/configure	2020-11-21 14:33:08.000000000 -0500
 @@ -8459,9 +8459,9 @@
  	eval itcl_LIB_FLAG="-litcl`echo ${PACKAGE_VERSION} | tr -d .`${DBGX}"
  	eval itcl_STUB_LIB_FLAG="-litclstub`echo ${PACKAGE_VERSION} | tr -d .`${DBGX}"
@@ -46,9 +46,9 @@ diff -uNr tcltk-8.6.10.orig/tcl8.6.10/pkgs/itcl4.2.0/configure tcltk-8.6.10/tcl8
      itcl_STUB_LIB_SPEC="-L`$CYGPATH ${pkglibdir}` ${itcl_STUB_LIB_FLAG}"
      itcl_BUILD_STUB_LIB_PATH="`$CYGPATH $(pwd)`/${PKG_STUB_LIB_FILE}"
      itcl_STUB_LIB_PATH="`$CYGPATH ${pkglibdir}`/${PKG_STUB_LIB_FILE}"
-diff -uNr tcltk-8.6.10.orig/tcl8.6.10/pkgs/tdbc1.1.1/configure tcltk-8.6.10/tcl8.6.10/pkgs/tdbc1.1.1/configure
---- tcltk-8.6.10.orig/tcl8.6.10/pkgs/tdbc1.1.1/configure	2019-11-20 11:33:00.000000000 -0500
-+++ tcltk-8.6.10/tcl8.6.10/pkgs/tdbc1.1.1/configure	2020-11-21 14:45:57.000000000 -0500
+diff -uNr tcltk-8.6.13.orig/tcl8.6.13/pkgs/tdbc1.1.5/configure tcltk-8.6.13/tcl8.6.13/pkgs/tdbc1.1.5/configure
+--- tcltk-8.6.13.orig/tcl8.6.13/pkgs/tdbc1.1.5/configure	2019-11-20 11:33:00.000000000 -0500
++++ tcltk-8.6.13/tcl8.6.13/pkgs/tdbc1.1.5/configure	2020-11-21 14:45:57.000000000 -0500
 @@ -8543,9 +8543,9 @@
  	eval tdbc_LIB_FLAG="-ltdbc`echo ${PACKAGE_VERSION} | tr -d .`${DBGX}"
  	eval tdbc_STUB_LIB_FLAG="-ltdbcstub`echo ${PACKAGE_VERSION} | tr -d .`${DBGX}"
@@ -61,9 +61,9 @@ diff -uNr tcltk-8.6.10.orig/tcl8.6.10/pkgs/tdbc1.1.1/configure tcltk-8.6.10/tcl8
      tdbc_STUB_LIB_SPEC="-L`$CYGPATH ${pkglibdir}` ${tdbc_STUB_LIB_FLAG}"
      tdbc_BUILD_STUB_LIB_PATH="`$CYGPATH $(pwd)`/${PKG_STUB_LIB_FILE}"
      tdbc_STUB_LIB_PATH="`$CYGPATH ${pkglibdir}`/${PKG_STUB_LIB_FILE}"
-diff -uNr tcltk-8.6.10.orig/tcl8.6.10/unix/configure tcltk-8.6.10/tcl8.6.10/unix/configure
---- tcltk-8.6.10.orig/tcl8.6.10/unix/configure	2019-11-21 13:10:50.000000000 -0600
-+++ tcltk-8.6.10/tcl8.6.10/unix/configure	2020-11-08 06:21:12.000000000 -0600
+diff -uNr tcltk-8.6.13.orig/tcl8.6.13/unix/configure tcltk-8.6.13/tcl8.6.13/unix/configure
+--- tcltk-8.6.13.orig/tcl8.6.13/unix/configure	2019-11-21 13:10:50.000000000 -0600
++++ tcltk-8.6.13/tcl8.6.13/unix/configure	2020-11-08 06:21:12.000000000 -0600
 @@ -18820,7 +18820,7 @@
      else
          TCL_LIB_FLAG="-ltcl`echo ${TCL_VERSION} | tr -d .`"
@@ -91,10 +91,10 @@ diff -uNr tcltk-8.6.10.orig/tcl8.6.10/unix/configure tcltk-8.6.10/tcl8.6.10/unix
  
  : ${CONFIG_STATUS=./config.status}
  ac_clean_files_save=$ac_clean_files
-diff -uNr tcltk-8.6.10.orig/tk8.6.10/unix/Makefile.in tcltk-8.6.10/tk8.6.10/unix/Makefile.in
---- tcltk-8.6.10.orig/tk8.6.10/unix/Makefile.in	2019-11-20 13:56:52.000000000 -0600
-+++ tcltk-8.6.10/tk8.6.10/unix/Makefile.in	2020-11-08 06:21:12.000000000 -0600
-@@ -149,7 +149,7 @@
+diff -uNr tcltk-8.6.13.orig/tk8.6.13/unix/Makefile.in tcltk-8.6.13/tk8.6.13/unix/Makefile.in
+--- tcltk-8.6.13.orig/tk8.6.13/unix/Makefile.in	2022-11-21 20:56:01.000000000 -0600
++++ tcltk-8.6.13/tk8.6.13/unix/Makefile.in	2023-01-28 16:21:12.000000000 -0600
+@@ -150,7 +150,7 @@
  # X11 include files accessible (the configure script will try to
  # set this value, and will cause it to be an empty string if the
  # include files are accessible via /usr/include).
@@ -113,23 +113,25 @@ diff -uNr tcltk-8.6.10.orig/tk8.6.10/unix/Makefile.in tcltk-8.6.10/tk8.6.10/unix
  # The symbols below provide support for dynamic loading and shared
  # libraries.  See configure.in for a description of what the
  # symbols mean.  The values of the symbols are normally set by the
-@@ -283,9 +286,6 @@
+@@ -284,9 +284,6 @@
  CC_SEARCH_FLAGS	= @CC_SEARCH_FLAGS@
  LD_SEARCH_FLAGS	= @LD_SEARCH_FLAGS@
  
 -# support for embedded libraries on Darwin / Mac OS X
--DYLIB_INSTALL_DIR	= ${LIB_RUNTIME_DIR}
+-DYLIB_INSTALL_DIR	= $(libdir)
 -
  # support for building the Aqua resource file
  TK_RSRC_FILE		= @TK_RSRC_FILE@
  WISH_RSRC_FILE		= @WISH_RSRC_FILE@
-@@ -330,18 +330,18 @@
+@@ -330,19 +327,19 @@
+ CC			= @CC@
  
- CC_SWITCHES_NO_STUBS = ${CFLAGS} ${CFLAGS_WARNING} ${SHLIB_CFLAGS} \
- -I${UNIX_DIR} -I${GENERIC_DIR} -I${BMAP_DIR} -I${TCL_GENERIC_DIR} \
---I${TCL_PLATFORM_DIR} ${@TK_WINDOWINGSYSTEM@_INCLUDES} ${AC_FLAGS} \
+ CC_SWITCHES_NO_STUBS = -I${UNIX_DIR} -I${GENERIC_DIR} -I${BMAP_DIR} \
+-${@TK_WINDOWINGSYSTEM@_INCLUDES} ${CFLAGS} ${CFLAGS_WARNING} \
+-${SHLIB_CFLAGS} -I${TCL_GENERIC_DIR} -I${TCL_PLATFORM_DIR} ${AC_FLAGS} \
 -${PROTO_FLAGS} ${SECURITY_FLAGS} ${MEM_DEBUG_FLAGS} ${KEYSYM_FLAGS} \
 -${NO_DEPRECATED_FLAGS} @EXTRA_CC_SWITCHES@
++${CFLAGS} ${CFLAGS_WARNING} ${SHLIB_CFLAGS} -I${TCL_GENERIC_DIR} \
 +-I${TCL_PLATFORM_DIR} ${AC_FLAGS} ${PROTO_FLAGS} ${SECURITY_FLAGS} \
 +${MEM_DEBUG_FLAGS} ${KEYSYM_FLAGS} ${NO_DEPRECATED_FLAGS} \
 +@EXTRA_CC_SWITCHES@ ${@TK_WINDOWINGSYSTEM@_INCLUDES}
@@ -138,17 +140,17 @@ diff -uNr tcltk-8.6.10.orig/tk8.6.10/unix/Makefile.in tcltk-8.6.10/tk8.6.10/unix
  
  APP_CC_SWITCHES = $(CC_SWITCHES_NO_STUBS) @EXTRA_APP_CC_SWITCHES@
  
- DEPEND_SWITCHES = ${CFLAGS} -I${UNIX_DIR} -I${GENERIC_DIR} -I${BMAP_DIR} \
---I${TCL_GENERIC_DIR} -I${TCL_PLATFORM_DIR} ${@TK_WINDOWINGSYSTEM@_INCLUDES} \
--${AC_FLAGS} ${PROTO_FLAGS} ${SECURITY_FLAGS} ${MEM_DEBUG_FLAGS} \
--${KEYSYM_FLAGS} @EXTRA_CC_SWITCHES@
-+-I${TCL_GENERIC_DIR} -I${TCL_PLATFORM_DIR} ${AC_FLAGS} ${PROTO_FLAGS} \
-+${SECURITY_FLAGS} ${MEM_DEBUG_FLAGS} ${KEYSYM_FLAGS} @EXTRA_CC_SWITCHES@ \
-+${@TK_WINDOWINGSYSTEM@_INCLUDES}
+ DEPEND_SWITCHES = -I${UNIX_DIR} -I${GENERIC_DIR} -I${BMAP_DIR} \
+-${@TK_WINDOWINGSYSTEM@_INCLUDES} ${CFLAGS} -I${TCL_GENERIC_DIR} \
+--I${TCL_PLATFORM_DIR} ${AC_FLAGS} ${PROTO_FLAGS} ${SECURITY_FLAGS} \
+-${MEM_DEBUG_FLAGS} ${KEYSYM_FLAGS} @EXTRA_CC_SWITCHES@
++${CFLAGS} -I${TCL_GENERIC_DIR} -I${TCL_PLATFORM_DIR} ${AC_FLAGS} \
++${PROTO_FLAGS} ${SECURITY_FLAGS} ${MEM_DEBUG_FLAGS} ${KEYSYM_FLAGS} \
++@EXTRA_CC_SWITCHES@ ${@TK_WINDOWINGSYSTEM@_INCLUDES}
  
  WISH_OBJS = tkAppInit.o
- 
-@@ -1202,7 +1202,7 @@
+
+@@ -1205,7 +1202,7 @@
  
  # NB: tkUnixRFont.o uses nondefault CFLAGS
  tkUnixRFont.o: $(UNIX_DIR)/tkUnixRFont.c
@@ -157,9 +159,9 @@ diff -uNr tcltk-8.6.10.orig/tk8.6.10/unix/Makefile.in tcltk-8.6.10/tk8.6.10/unix
  
  tkUnixInit.o: $(UNIX_DIR)/tkUnixInit.c tkConfig.sh
  	$(CC) -c $(CC_SWITCHES) -DTK_LIBRARY=\"${TK_LIBRARY}\" \
-diff -uNr tcltk-8.6.10.orig/tk8.6.10/unix/configure tcltk-8.6.10/tk8.6.10/unix/configure
---- tcltk-8.6.10.orig/tk8.6.10/unix/configure	2019-11-20 13:56:52.000000000 -0600
-+++ tcltk-8.6.10/tk8.6.10/unix/configure	2020-11-08 06:21:12.000000000 -0600
+diff -uNr tcltk-8.6.13.orig/tk8.6.13/unix/configure tcltk-8.6.13/tk8.6.13/unix/configure
+--- tcltk-8.6.13.orig/tk8.6.13/unix/configure	2019-11-20 13:56:52.000000000 -0600
++++ tcltk-8.6.13/tk8.6.13/unix/configure	2020-11-08 06:21:12.000000000 -0600
 @@ -10004,19 +10004,14 @@
  	echo "$as_me:$LINENO: result: $enable_xft" >&5
  echo "${ECHO_T}$enable_xft" >&6
@@ -217,9 +219,9 @@ diff -uNr tcltk-8.6.10.orig/tk8.6.10/unix/configure tcltk-8.6.10/tk8.6.10/unix/c
  
  : ${CONFIG_STATUS=./config.status}
  ac_clean_files_save=$ac_clean_files
-diff -uNr tcltk-8.6.10.orig/tk8.6.10/unix/tkConfig.sh.in tcltk-8.6.10/tk8.6.10/unix/tkConfig.sh.in
---- tcltk-8.6.10.orig/tk8.6.10/unix/tkConfig.sh.in	2019-11-20 13:56:52.000000000 -0600
-+++ tcltk-8.6.10/tk8.6.10/unix/tkConfig.sh.in	2020-11-08 06:21:12.000000000 -0600
+diff -uNr tcltk-8.6.13.orig/tk8.6.13/unix/tkConfig.sh.in tcltk-8.6.13/tk8.6.13/unix/tkConfig.sh.in
+--- tcltk-8.6.13.orig/tk8.6.13/unix/tkConfig.sh.in	2019-11-20 13:56:52.000000000 -0600
++++ tcltk-8.6.13/tk8.6.13/unix/tkConfig.sh.in	2020-11-08 06:21:12.000000000 -0600
 @@ -32,7 +32,7 @@
  TK_LIB_FILE='@TK_LIB_FILE@'
  


### PR DESCRIPTION
Fixes a number of test failures like https://github.com/fink/fink-distributions/issues/956#issuecomment-1407521945 and by way of this also the `test_tcl` failures in our Python builds.

Checking the changes made though the last upstream update, all library versions that have changed are again just the non-public ones like
```
		!%p/lib/itcl4.2.3/libitcl4.2.3.dylib
		!%p/lib/sqlite3.40.0/libsqlite3.40.0.dylib
```
so this should be OK to update without packaging as a new version?