### PR TITLE
swi-prolog: new version

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/swi-prolog-7.2.3.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/swi-prolog-7.2.3.info
@@ -1,0 +1,152 @@
+Info3: <<
+Package: swi-prolog
+# OPENSSL110 FTBFS (does not detect); new upstream might support, but
+# also has /local/ pathname entanglement
+Version: 7.2.3
+Revision: 6
+Source: http://www.swi-prolog.org/download/stable/src/swipl-%v.tar.gz
+Source-Checksum: SHA256(43657d51b7c5887bc2d2bced50a9822b86a08a6841399b8e76ee877f51d646b5)
+BuildDepends: <<
+	fink-package-precedence,
+	fontconfig2-dev (>= 2.10.0-1),
+	freetype219 (>= 2.10.2-1),
+	gmp5,
+	libarchive31,
+	libjpeg9,
+	libncursesw5,
+	libodbc3-dev,
+	openssl100-dev,
+	pkgconfig,
+	readline8,
+	uuid,
+	x11-dev,
+	xft2-dev,
+	libxt
+<<
+# bad -I ordering picks up installed version instead of source-dist
+BuildConflicts: swi-prolog-dev
+# should remove junit dep in 64bit mode (hence also comment out "export JUNIT=..." below..), since I can't build junit there..
+# assume junit only TestDepends (w/o that export I run into many java errors in make check)
+Depends: %N-shlibs (= %v-%r)
+PatchFile: %n-%v.patch
+PatchFile-MD5: f7b5a3ab1c2f5c750cbae8011017510d
+PatchScript: <<
+	%{default_script}
+	sed -i.bak -e 's/ARCH=.*/ARCH=%m-darwin/' -e 's,-no-cpp-precomp,-Wall,' \
+		-e 's;-flat_namespace -undefined suppress;-bundle_loader %b/src/swipl -undefined dynamic_lookup -Wl,-x -dead-strip;' \
+		src/configure{,.in}
+	# autoconf2.6ish patch for modern XQuartz paths
+	perl -pi -e "s|/usr/lpp/Xamples|/opt/X11|" packages/xpce/src/configure
+<<
+SetCPPFLAGS: -MD
+ConfigureParams: --mandir=%p/share/man --with-world JAVAC=javac
+# set javac, otherwise it would detect fink's gcj and that does not work
+CompileScript: <<
+#!/bin/sh -ev
+	# export JUNIT=%p/share/java/junit/junit.jar
+	export CIFLAGS="-I%p/include";
+	%{default_script}
+	fink-package-precedence --depfile-ext='\.d' --prohibit-bdep=swi-prolog-dev,swi-prolog9-dev .
+<<
+#InfoTest: <<
+# # To run tests, run the tests under x11, and not from fink (since fink destroys your environment, a.o. DISPLAY)
+#	TestScript: <<
+#		make -ik check || :
+#	<<
+#<<
+InstallScript: <<
+	make install DESTDIR=%d
+	mkdir -p %i/share/doc/%N
+	mv %i/lib/swipl-%v/doc/Manual %i/share/doc/%N
+	rm -fR %i/lib/swipl-%v/doc
+	ln -s ../%N-shlibs/COPYING %i/share/doc/%N
+<<
+DocFiles: README README.doc VERSION
+Splitoff: <<
+	Package: %N-dev
+	BuildDependsOnly: true
+	Depends: %N-shlibs (= %v-%r)
+	Conflicts: <<
+		swi-prolog-dev,
+		swi-prolog9-dev
+	<<
+	Replaces: <<
+		swi-prolog-dev,
+		swi-prolog9-dev
+	<<
+	Files: lib/pkgconfig
+	InstallScript: <<
+		#!/bin/sh -ev
+		mkdir -p %i/lib %i/include %i/share/doc
+		ln -s swipl-%v/lib/%m-darwin %i/lib/%N
+		ln -s %N %i/lib/swipl
+		ln -s %N/libpl.dylib %i/lib
+		mv %I/lib/swipl-%v/include/* %i/include
+		ln -s %p/lib/swipl-%v/xpce/include/pce %i/include
+		ln -s %N-shlibs %i/share/doc/%n
+	<<
+<<
+Splitoff2: <<
+	Package: %N-shlibs
+	Depends: <<
+		fontconfig2-shlibs (>= 2.10.0-1),
+		gmp5-shlibs,
+		libarchive31-shlibs,
+		libjpeg9-shlibs,
+		libncursesw5-shlibs,
+		libodbc3-shlibs,
+		libxt-shlibs,
+		openssl100-shlibs,
+		readline8-shlibs,
+		uuid-shlibs,
+		xft2-shlibs,
+		x11
+	<<
+	Files: lib
+	Shlibs: %p/lib/swipl-%v/lib/%m-darwin/libswipl.dylib 0.0.0 %n (>= 5.6.64-1)
+	DocFiles: COPYING
+<<
+License: LGPL/OpenSSL
+Description: SWI Prolog interpreter
+DescDetail: <<
+SWI-Prolog offers a comprehensive Free Software Prolog environment,
+licensed under the Lesser GNU Public License. Together with its graphics
+toolkit XPCE, its development started in 1987 and has been driven by the
+needs for real-world applications. These days SWI-Prolog is widely used
+in research and education as well as for commercial applications.
+<<
+DescPackaging: <<
+Packaging is an ersatz for FsHS compliance, and for Shlibs policy
+compliance, but hopefully functionally equivalent.
+Upstream should be pressed to facilatate FHS compliance,
+and if possible before we have to number %n...
+(There are already pkgs linking to the dylib, even with the old version _ eg, ppl)
+
+And, once things are correct, probably a %N-lite variant (resurrecting
+the former fink pkg with that name IIRC).
+
+X and the tests seem nettlesome.  See:
+
+http://sourceforge.net/p/fink/package-submissions/4344/?limit=10&page=1#ee05
+
+"For the xvfb-run failure, danielj on #fink just discovered that you
+have to first run X11 at least once after a reboot for xvfb-run to
+work. Both he and I were seeing a similar Xvfb failed to start error,
+and just starting X11 once made it work (X11.app doesn't have to be
+actually running when the tests run; it just has to have run at least
+once)."
+
+<<
+DescPort: <<
+Without the patch to the link commands, 'essentially' no linking was done:
+no undefined symbol had a "from"; with it, all have.
+This still has to be communicated upstream.
+
+There do remain errors when running make check; please contribute
+fixes _ to the info-file and upstream.
+
+Formerly maintained by Rob Braun and Adrian Prantl.
+<<
+Maintainer: Jesse Alama <jesse.alama@gmail.com>
+Homepage: http://www.swi-prolog.org/
+<<

--- a/10.9-libcxx/stable/main/finkinfo/languages/swi-prolog-7.2.3.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/swi-prolog-7.2.3.patch
@@ -1,0 +1,22 @@
+diff -Nurd -x'*~' swipl-7.2.3.orig/packages/xpce/src/configure swipl-7.2.3/packages/xpce/src/configure
+--- swipl-7.2.3.orig/packages/xpce/src/configure	2015-06-18 08:15:09.000000000 -0400
++++ swipl-7.2.3/packages/xpce/src/configure	2016-03-14 23:54:42.000000000 -0400
+@@ -7919,6 +7919,8 @@
+   XLIBS="-lXext $XLIBS"
+ fi
+ 
++CPPFLAGS="$XINCLUDES ${CPPFLAGS}"
++CIFLAGS="$XINCLUDES ${CIFLAGS}"
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lXinerama" >&5
+ $as_echo_n "checking for main in -lXinerama... " >&6; }
+@@ -7972,9 +7974,6 @@
+ 
+ echo "	XLIBS=$XLIBS"
+ 
+-CPPFLAGS="$XINCLUDES ${CPPFLAGS}"
+-CIFLAGS="$XINCLUDES ${CIFLAGS}"
+-
+ fi
+ 
+ XLIBDIRS=""

--- a/10.9-libcxx/stable/main/finkinfo/languages/swi-prolog.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/swi-prolog.info
@@ -1,86 +1,130 @@
 Info3: <<
 Package: swi-prolog
-# OPENSSL110 FTBFS (does not detect); new upstream might support, but
-# also has /local/ pathname entanglement
-Version: 7.2.3
-Revision: 5
+Version: 9.0.4
+Revision: 1
 Source: http://www.swi-prolog.org/download/stable/src/swipl-%v.tar.gz
-Source-Checksum: SHA256(43657d51b7c5887bc2d2bced50a9822b86a08a6841399b8e76ee877f51d646b5)
+Source-Checksum: SHA256(feb2815a51d34fa81cb34e8149830405935a7e1d1c1950461239750baa8b49f0)
 BuildDepends: <<
-  fink-package-precedence,
-  fontconfig2-dev,
-  freetype219,
-  gmp5,
-  libarchive31,
-  libjpeg9,
-  libncursesw5,
-  libodbc3-dev,
-  openssl100-dev,
-  pkgconfig,
-  readline8,
-  uuid,
-  x11-dev,
-  xft2-dev,
+	cmake,
+	db60-aes,
+	fink (>= 0.28),
+	fink-package-precedence,
+	fontconfig2-dev (>= 2.10.0-1),
+	freetype219 (>= 2.10.2-1),
+	gmp5,
+	libarchive31,
+	libjpeg9,
+	libncurses5,
+	libodbc3-dev,
+	libpcre2,
+	libxt,
+	libyaml,
+	openssl300-dev,
+	readline8,
+	uuid,
+	x11-dev,
+	xft2-dev
 <<
 # bad -I ordering picks up installed version instead of source-dist
-BuildConflicts: swi-prolog-dev
-# should remove junit dep in 64bit mode (hence also comment out "export JUNIT=..." below..), since I can't build junit there..
-# assume junit only TestDepends (w/o that export I run into many java errors in make check)
-Depends: %N-shlibs (= %v-%r)
+BuildConflicts: swi-prolog-dev, swi-prolog9-dev
+# Should remove junit dep in 64bit mode, since I can't build junit
+# there. Assume junit only TestDepends (w/o that export I run into
+# many java errors in make check) -- Jesse Alama, from on or before
+# 7.2.3-5
+Depends: %N9-shlibs (>= %v-%r)
 PatchFile: %n.patch
-PatchFile-MD5: f7b5a3ab1c2f5c750cbae8011017510d
+PatchFile-MD5: 8ffd839ddbda670657bd043dbf25800f
 PatchScript: <<
-  %{default_script}
-  sed -i.bak -e 's/ARCH=.*/ARCH=%m-darwin/' -e 's,-no-cpp-precomp,-Wall,' \
-	-e 's;-flat_namespace -undefined suppress;-bundle_loader %b/src/swipl -undefined dynamic_lookup -Wl,-x -dead-strip;' \
-	src/configure{,.in}
-	# autoconf2.6ish patch for modern XQuartz paths
-	perl -pi -e "s|/usr/lpp/Xamples|/opt/X11|" packages/xpce/src/configure
+	%{default_script}
+	# Debian swi-prolog-9.0.4+dfsg-1 disable_http_proxy_test.diff
+	perl -pi -e 's/proxy// if /test_libs/' packages/http/CMakeLists.txt
+	# TODO: Debian swi-prolog-9.0.4+dfsg-1 use-local-jquery.diff
+
+	# In 7.x.x, libraries were type BUNDLE but .dylib extension.
+	# In 9.x.x, they are ext .so, which makes more sense. But
+	# jpl/CMakeFiles.txt for APPLE instead explicitly sets type
+	# DYLIB, and a self-consistent ext .dylib. No idea if this ext
+	# is a thing (why isn't is .jnlib?) but it's clearly not
+	# dyld-loaded, so we keep it a BUNDLE just like it is on other
+	# platforms.
+	perl -ni -e 'print unless /JPLTYPE SHARED/' packages/jpl/CMakeLists.txt
 <<
-SetCPPFLAGS: -MD
-ConfigureParams: --mandir=%p/share/man --with-world JAVAC=javac
-# set javac, otherwise it would detect fink's gcj and that does not work
 CompileScript: <<
 #!/bin/sh -ev
-# export JUNIT=%p/share/java/junit/junit.jar
- export CIFLAGS="-I%p/include";
- %{default_script}
- fink-package-precedence --depfile-ext='\.d' --prohibit-bdep=%n-dev .
+	. %p/sbin/fink-buildenv-cmake.sh
+	mkdir finkbuild
+	pushd finkbuild
+	# SWIPL_* are based on Debian's 'rules' file
+	cmake \
+		$FINK_CMAKE_ARGS \
+		\
+		-DSWIPL_INSTALL_DIR=swi-prolog \
+		-DSWIPL_INSTALL_IN_LIB=ON \
+		-DSWIPL_INSTALL_IN_SHARE=ON \
+		-DSWIPL_PACAKGES_QT=OFF \
+		\
+		-DMACOSX_DEPENDENCIES_FROM=%p \
+		-DCURSES_INCLUDE_DIR=%p/include \
+		-DCURSES_LIBRARY=%p/lib/libcurses.dylib \
+		-DLibArchive_INCLUDE_DIR=%p/include \
+		-DLibArchive_LIBRARY=%p/lib/libarchive.dylib \
+		-DODBC_INCLUDE_DIR=%p/include \
+		-DODBC_LIBRARY=%p/lib/libiodbc.dylib \
+		-DReadline_ROOT=%p \
+		-DBDB_INCLUDE_DIR=%p/include/db5 \
+		-DBDB_LIBRARY=%p/lib/libdb.dylib \
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5Widgets=TRUE \
+		..
+	make
+	popd
+	fink-package-precedence --depfile-ext='\.d' --prohibit-bdep=swi-prolog-dev,swi-prolog9-dev .
 <<
 #InfoTest: <<
-# # To run tests, run the tests under x11, and not from fink (since fink destroys your environment, a.o. DISPLAY)
-# TestScript: make -ik check || :
+# To run tests, run the tests under x11, and not from fink (since fink
+# destroys your environment, a.o. DISPLAY) -- Jesse Alama from on or
+# before 7.2.3-5
+#	TestScript: <<
+#	#!/bin/sh -ev
+#		pushd finkbuild
+#		export USE_PUBLIC_NETWORK_TESTS=false
+#		ctest -V || exit 2
+#	<<
 #<<
 InstallScript: <<
- make install DESTDIR=%d
- mkdir -p %i/share/doc/%N
- mv %i/lib/swipl-%v/doc/Manual %i/share/doc/%N
- rm -fR %i/lib/swipl-%v/doc
- ln -s ../%N-shlibs/COPYING %i/share/doc/%N
+#!/bin/sh -ev
+	pushd finkbuild
+	make install DESTDIR=%d
 <<
-DocFiles: README README.doc VERSION
+DocFiles: Code-of-Conduct.md LICENSE README.md
 Splitoff: <<
- Package: %N-dev
- BuildDependsOnly: true
- Depends: %N-shlibs (= %v-%r)
- Files: lib/pkgconfig
- InstallScript: <<
- #!/bin/sh -ev
-	mkdir -p %i/lib %i/include %i/share/doc
-	ln -s swipl-%v/lib/%m-darwin %i/lib/%N
-	ln -s %N %i/lib/swipl
-	ln -s %N/libpl.dylib %i/lib
-	mv %I/lib/swipl-%v/include/* %i/include
-	ln -s %p/lib/swipl-%v/xpce/include/pce %i/include
-	ln -s %N-shlibs %i/share/doc/%n
- <<
+	Package: %N9-dev
+	BuildDependsOnly: true
+	Depends: %N9-shlibs (= %v-%r)
+	Conflicts: <<
+		swi-prolog-dev,
+		swi-prolog9-dev
+	<<
+	Replaces: <<
+		swi-prolog-dev,
+		swi-prolog9-dev
+	<<
+	Files: <<
+		lib/cmake
+		lib/swi-prolog/include
+		lib/libswipl.dylib
+		share/pkgconfig
+	<<
+	DocFiles: Code-of-Conduct.md LICENSE README.md
 <<
 Splitoff2: <<
- Package: %N-shlibs
- Depends: fontconfig2-shlibs, gmp5-shlibs, libarchive31-shlibs, libjpeg9-shlibs, libncursesw5-shlibs, libodbc3-shlibs, openssl100-shlibs, readline8-shlibs, uuid-shlibs, x11-shlibs, xft2-shlibs
- Files: lib
- Shlibs: %p/lib/swipl-%v/lib/%m-darwin/libswipl.dylib	0.0.0	%n	(>= 5.6.64-1)
- DocFiles: COPYING
+	Package: %N9-shlibs
+	Depends: <<
+		gmp5-shlibs,
+		libncurses5-shlibs
+	<<
+	Files: lib/libswipl.*.dylib
+	Shlibs: %p/lib/libswipl.9.dylib 9.0.0 %n (>= 9.0.4-1)
+	DocFiles: Code-of-Conduct.md LICENSE README.md
 <<
 License: LGPL/OpenSSL
 Description: SWI Prolog interpreter
@@ -114,12 +158,8 @@ once)."
 
 <<
 DescPort: <<
-Without the patch to the link commands, 'essentially' no linking was done:
-no undefined symbol had a "from"; with it, all have.
-This still has to be communicated upstream.
-
 There do remain errors when running make check; please contribute
-fixes _ to the info-file and upstream.
+fixes _ to the info-file and upstream. -- Jesse Alama
 
 Formerly maintained by Rob Braun and Adrian Prantl.
 <<

--- a/10.9-libcxx/stable/main/finkinfo/languages/swi-prolog.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/swi-prolog.info
@@ -31,7 +31,23 @@ BuildConflicts: swi-prolog-dev, swi-prolog9-dev
 # there. Assume junit only TestDepends (w/o that export I run into
 # many java errors in make check) -- Jesse Alama, from on or before
 # 7.2.3-5
-Depends: %N9-shlibs (>= %v-%r)
+Depends: <<
+	%N9-shlibs (>= %v-%r),
+	db60-aes-shlibs,
+	fontconfig2-shlibs (>= 2.10.0-1),
+	freetype219-shlibs (>= 2.10.2-1),
+	libarchive31-shlibs,
+	libodbc3-shlibs,
+	libjpeg9-shlibs,
+	libpcre2-shlibs,
+	libxt-shlibs,
+	libyaml-shlibs,
+	openssl300-shlibs,
+	readline8-shlibs,
+	uuid-shlibs,
+	x11,
+	xft2-shlibs
+<<
 PatchFile: %n.patch
 PatchFile-MD5: 8ffd839ddbda670657bd043dbf25800f
 PatchScript: <<
@@ -69,7 +85,7 @@ CompileScript: <<
 		-DLibArchive_INCLUDE_DIR=%p/include \
 		-DLibArchive_LIBRARY=%p/lib/libarchive.dylib \
 		-DODBC_INCLUDE_DIR=%p/include \
-		-DODBC_LIBRARY=%p/lib/libiodbc.dylib \
+		-DODBC_LIBRARY=%p/lib/libodbc.dylib \
 		-DReadline_ROOT=%p \
 		-DBDB_INCLUDE_DIR=%p/include/db5 \
 		-DBDB_LIBRARY=%p/lib/libdb.dylib \

--- a/10.9-libcxx/stable/main/finkinfo/languages/swi-prolog.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/swi-prolog.patch
@@ -1,22 +1,15 @@
-diff -Nurd -x'*~' swipl-7.2.3.orig/packages/xpce/src/configure swipl-7.2.3/packages/xpce/src/configure
---- swipl-7.2.3.orig/packages/xpce/src/configure	2015-06-18 08:15:09.000000000 -0400
-+++ swipl-7.2.3/packages/xpce/src/configure	2016-03-14 23:54:42.000000000 -0400
-@@ -7919,6 +7919,8 @@
-   XLIBS="-lXext $XLIBS"
- fi
+diff -Nurd swipl-9.0.4.orig/packages/xpce/CMakeLists.txt swipl-9.0.4/packages/xpce/CMakeLists.txt
+--- swipl-9.0.4.orig/packages/xpce/CMakeLists.txt	2023-01-24 07:10:09.000000000 -0500
++++ swipl-9.0.4/packages/xpce/CMakeLists.txt	2023-02-03 23:19:46.000000000 -0500
+@@ -46,9 +46,9 @@
+ 	  ${FONTCONFIG_LIBRARIES})
  
-+CPPFLAGS="$XINCLUDES ${CPPFLAGS}"
-+CIFLAGS="$XINCLUDES ${CIFLAGS}"
- 
- { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lXinerama" >&5
- $as_echo_n "checking for main in -lXinerama... " >&6; }
-@@ -7972,9 +7974,6 @@
- 
- echo "	XLIBS=$XLIBS"
- 
--CPPFLAGS="$XINCLUDES ${CPPFLAGS}"
--CIFLAGS="$XINCLUDES ${CIFLAGS}"
--
- fi
- 
- XLIBDIRS=""
+       set(GUI_INCLUDE_DIRS
+-	  ${X11_INCLUDE_DIR}
+ 	  ${FREETYPE_INCLUDE_DIRS}
+-	  ${FONTCONFIG_INCLUDE_DIR})
++	  ${FONTCONFIG_INCLUDE_DIR}
++	  ${X11_INCLUDE_DIR})
+       set(XPCE_LINK_RC swipl)
+       has_package(swipl-win HAVE_SWIPL_WIN)
+       if(HAVE_SWIPL_WIN)


### PR DESCRIPTION
This is the latest upstream version. Our previous version was pinned on openssl100 (Issue #499), whereas this is openssl300.

There is a shared library, whose install_name has changed, so whereas the previous package has a swi-prolog-{shlibs,dev}, this one has swi-prolog9-{shlibs,dev} instead. By policy, we would keep at least the old -shlibs, so I retainined the old swi-prolog.info at a different .info filename. There's a packaging note about 'ppl' using it, but our ppl package does not (and I can't find that it ever has in our current distro). So I have no objection to nuking the old version altogether to clear an openssl100 dependant altogether. Anyone have any objections?