### PR TITLE
Patch libnss3.0e to build with Fink Python (not /usr/bin/python)

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/libnss3.0e-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/libnss3.0e-shlibs.info
@@ -4,7 +4,7 @@ Revision: 1
 # gyp version to avoid needing BuildDepends:xcode.app (Issue #865)
 BuildDepends: <<
 	fink (>= 0.28),
-	gyp-py27 (>=  0.1+20210831gitd6c5dd5-1),
+	gyp-py310 | gyp-py27 (>=  0.1+20210831gitd6c5dd5-1),
 	ninja,
 	nspr.0f,
 	sqlite3-dev
@@ -20,9 +20,14 @@ SourceDirectory: nss-%v
 PatchFile: %n.patch
 PatchFile-MD5: 47ea72df5a1dc6f6a3a83b7e61341d60
 PatchScript: <<
+#!/bin/sh -ev
 	%{default_script}
 	# fix install_name to have absolute path to libdir
 	perl -pi -e 's,\@executable_path,%p/lib/nss3.0e,g' nss/coreconf/Darwin.mk nss/lib/freebl/config.mk nss/coreconf/config.gypi
+	# patch Python executable to match gyp's (crucial for 12.3+ without system python[2])
+	gyppy=$(awk -F 'python' 'NR==1{print $2}' %p/bin/gyp)
+	perl -pi -e "s,(/bin/env python)(2?)\$,\${1}$gyppy," nss/coreconf/*.py
+	perl -pi -e "s,(python)( |'),\${1}$gyppy\${2}," nss/build.sh nss/coreconf/config.gypi nss/lib/ckfw/builtins/builtins.gyp nss/lib/ckfw/builtins/testlib/builtins-testlib.gyp
 <<
 CompileScript: <<
 #!/bin/sh -ev
@@ -139,6 +144,10 @@ DescPackaging: <<
 	the headers, a pre-installed version's files are not visible.
 
 	nss-config uses pkg-config at runtime
+
+	build script and a bunch of gyp config files hardcoded to use
+	'python' even when running Fink's py-versioned gyp; need to
+	patch all as /usr/bin/python no longer available.
 <<
 License: GPL/LGPL
 Maintainer: Daniel Macks <dmacks@netspace.org>


### PR DESCRIPTION
The gyp build hardcodes `python` or `python2` in various scripts and configuration files that all need to be fixed; probably something to occur more frequently in gyp-based packages. Fixing build on 12.3+
AFAICT only the build process is changed, no installed files, thus not incrementing revision yet.
Tested with gyp-py27 and gyp-py310 (which should be more stable long-term) on 10.14.6, 13.2.