### PR TITLE
Patch all Python calls in ninja build to use system /usr/bin/python[3]

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/ninja.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/ninja.info
@@ -8,14 +8,11 @@ Source-Checksum: SHA256(3c6ba2e66400fe3f1ae83deb4b235faf3137ec20bd5b08c29bfc368d
 SourceRename: %n-%v.tar.gz
 # re2c >= 0.15.3 for its --no-version flag
 BuildDepends: re2c (>= 0.15.3)
-CompileScript: <<
-  #!/bin/sh -ex
-  if [ -x /usr/bin/python ]; then
-    ./configure.py --bootstrap
-  else
-    /usr/bin/python3 configure.py --bootstrap
-  fi
-<<
+
+PatchScript: [ -x /usr/bin/python ] || perl -pi -e 's|(/bin/env python)$|${1}3|' configure.py src/browse.py misc/*.py
+
+CompileScript: ./configure.py --bootstrap
+
 InstallScript: <<
   #!/bin/sh -ex
   mkdir -p %i/bin


### PR DESCRIPTION
Follow-up to #936, addressing https://github.com/fink/fink-distributions/issues/932#issuecomment-1428157720.
I have not found any evidence that the compiled-in `browse.py` script is used anywhere, but as this does change the binary for 12.0, 13.0 now, may need a new revision.