### PR TITLE
Python updates with openssl300

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/python310.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python310.info
@@ -1,8 +1,8 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: python310.patch -*-
 Info2: <<
 Package: python%type_pkg[python]
-Version: 3.10.4
-Revision: 2
+Version: 3.10.10
+Revision: 1
 Type: python 3.10
 # Free to modify, update, and take over
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
@@ -17,7 +17,7 @@ Depends: <<
 	libgettext8-shlibs,
 	liblzma5-shlibs,
 	libncursesw5-shlibs,
-	openssl110-shlibs (>= 1.1.1g-1),
+	openssl300-shlibs (>= 3.0.1-1),
 	readline8-shlibs,
 	sqlite3-shlibs  (>= 3.30.1-1),
 	tcltk (>= 8.4.1-1),
@@ -27,7 +27,7 @@ BuildDepends: <<
 	blt-dev (>= 2.4z-15),
 	bzip2-dev,
 	expat1 (>= 2.2.8-1),
-	fink (>= 0.32), 
+	fink (>= 0.32),
 	gdbm6,
 	gettext-bin,
 	gettext-tools,
@@ -35,8 +35,8 @@ BuildDepends: <<
 	libgettext8-dev,
 	liblzma5,
 	libncursesw5,
-	openssl110-dev (>= 1.1.1g-1),
-	pkgconfig,
+	openssl300-dev (>= 3.0.1-1),
+	pkgconfig (>= 0.9.0-1),
 	readline8,
 	sqlite3-dev (>= 3.30.1-1),
 	tcltk-dev (>= 8.4.1-1),
@@ -57,10 +57,10 @@ Provides: <<
 <<
 
 Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
-Source-Checksum: SHA256(80bf925f571da436b35210886cf79f6eb5fa5d6c571316b73568343451f77a19)
+Source-Checksum: SHA256(0419e9085bf51b7a672009b3f50dbf1859acdf18ba725d0ec19aa5c8503f0ea3)
 
 PatchFile: %n.patch
-PatchFile-MD5: accc53203fdb4c50b45aea0d9d6ecf5e
+PatchFile-MD5: 71f46ebb7efbc99ebcc7d5ae25d8d08d
 
 PatchScript: <<
 	#!/bin/sh -ex
@@ -126,8 +126,8 @@ InfoTest: <<
 		# test_ctypes is currently broken on 12.0 (py3.10.1)
 		# test_tcl and test_idle require an active $DISPLAY
 		# test_select is missing attribute 'poll'
-		# test_pkgutil fails on HFS+ https://bugs.python.org/issue41154
-		EXTRATESTOPTS='-w -unone -x test_socket test_multiprocessing_spawn test_code test_ctypes test_idle test_tcl test_select test_pkgutil'
+		# test_pkgutil fails on HFS+ https://bugs.python.org/issue41154 (marked resolved)
+		EXTRATESTOPTS='-w -unone -x test_idle test_select test_tcl'
 		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
 
 		# Put install_name back.
@@ -154,13 +154,15 @@ InstallScript: <<
 	perl -pi -e 's/-lintl //' `ls -d %b/build/lib*`/_sysconfigdata__darwin_darwin.py
 	# Remove stray .pyc that get made during tests (including preliminary ones in CompileScript) to keep validator happy.
 	find ./Lib ./Parser ./Tools ./build -name '*.pyc' -delete
+	# Change interpreter name in scripts to versioned executable.
+	perl -pi -e 's|(/usr/bin/env python)(3?)$|${1}%type_raw[python]|' ./Tools/scripts/*
 	# install fails with -j greater than 1
 	export MAKEFLAGS=-j1
 	make install DESTDIR=%d
 
 	# we don't want -lintl to appear in LIBS otherwise python-config will propagate it
 	perl -pi -e 's/-lintl //' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile
-	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile	
+	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile
 	# Fix all main things to be python-versioned filenames with unversioned symlinks to them.
 	pushd %i/bin
 		for f in idle3 pydoc3; do
@@ -177,6 +179,8 @@ InstallScript: <<
 	# install some docs and other useful tidbits
 	rm -rf Misc/RPM
 	/bin/cp -R Misc Tools %i/lib/python%type_raw[python]
+	pushd %i/lib/python%type_raw[python]
+	DYLD_LIBRARY_PATH=%i/lib %i/bin/python%type_raw[python] -m compileall -o 0 -o 1 -o 2 Tools || echo 'some files were not byte-compiled'
 
 # Doc tarball missing upstream.
 #	mkdir -p %i/share/doc/%n/html
@@ -190,7 +194,7 @@ SplitOff: <<
 		lib/python%type_raw[python]/config-%type_raw[python]-darwin/libpython%type_raw[python].dylib
 	<<
 	Shlibs: %p/lib/libpython%type_raw[python].dylib 3.10.0 %n (>= 3.10.1-1)
-	DocFiles: README.rst LICENSE 
+	DocFiles: README.rst LICENSE
 <<
 SplitOff2: <<
 	Package: python3
@@ -215,10 +219,10 @@ SplitOff2: <<
 		python 3.x interpreter you need.
 	<<
 <<
-DocFiles: README.rst LICENSE 
+DocFiles: README.rst LICENSE
 Description: Interpreted, object-oriented language
 DescDetail: <<
-	Python is often compared to Tcl, Perl, Scheme or Java. 
+	Python is often compared to Tcl, Perl, Scheme or Java.
 	This package installs unix python - not the OSX Framework version.
 	Builds a two-level namespace dynamic libpython (needed for koffice).
 
@@ -228,7 +232,7 @@ DescDetail: <<
 	the "python3" command there is not guaranteed to be python%type_raw[python]!).
 <<
 DescUsage: <<
-	python%type_raw[python] changes the compiler options used to compile
+	Python 3.10+ changes the compiler options used to compile
 	third-party python modules. Please do not add %type_raw[python] variants
 	to them without actually testing that they build cleanly.
 <<
@@ -250,7 +254,7 @@ DescPackaging: <<
 	for libpython instead of %p/lib. Revert to using default library
 	location but make symlink in config dir.
 
-	Upstream no longer links extensions to libpython and use of 
+	Upstream no longer links extensions to libpython and use of
 	-undefined dynamic_lookup is recommended instead so remove those
 	patches.
 <<

--- a/10.9-libcxx/stable/main/finkinfo/languages/python310.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python310.patch
@@ -12,7 +12,7 @@ diff -ruN Python-3.10.1-orig/Lib/ctypes/macholib/dyld.py Python-3.10.1/Lib/ctype
 diff -ruN Python-3.10.1-orig/Lib/test/test_posix.py Python-3.10.1/Lib/test/test_posix.py
 --- Python-3.10.1-orig/Lib/test/test_posix.py	2021-12-06 13:23:39.000000000 -0500
 +++ Python-3.10.1/Lib/test/test_posix.py	2021-12-24 05:31:43.000000000 -0500
-@@ -1728,7 +1728,8 @@
+@@ -1705,7 +1705,8 @@
          output = os.read(rfd, 100)
          child_sid = int(output)
          parent_sid = os.getsid(os.getpid())
@@ -58,7 +58,7 @@ diff -ruN Python-3.10.1-orig/Modules/_dbmmodule.c Python-3.10.1/Modules/_dbmmodu
 diff -ruN Python-3.10.1-orig/configure Python-3.10.1/configure
 --- Python-3.10.1-orig/configure	2021-12-06 13:23:39.000000000 -0500
 +++ Python-3.10.1/configure	2021-12-24 05:31:43.000000000 -0500
-@@ -16454,7 +16454,7 @@
+@@ -16432,7 +16432,7 @@
  # first curses header check
  ac_save_cppflags="$CPPFLAGS"
  if test "$cross_compiling" = no; then
@@ -67,7 +67,7 @@ diff -ruN Python-3.10.1-orig/configure Python-3.10.1/configure
  fi
  
  for ac_header in curses.h ncurses.h
-@@ -16964,7 +16964,7 @@
+@@ -16942,7 +16942,7 @@
  
  if test $ac_sys_system = Darwin
  then
@@ -76,29 +76,30 @@ diff -ruN Python-3.10.1-orig/configure Python-3.10.1/configure
  fi
  
  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for %zd printf() format support" >&5
-diff -ruN Python-3.10.1-orig/setup.py Python-3.10.1/setup.py
---- Python-3.10.1-orig/setup.py	2021-12-06 13:23:39.000000000 -0500
-+++ Python-3.10.1/setup.py	2021-12-24 05:31:43.000000000 -0500
-@@ -518,6 +518,7 @@
+diff -ruN Python-3.10.8-orig/setup.py Python-3.10.8/setup.py
+--- Python-3.10.8-orig/setup.py	2022-10-11 13:21:44.000000000 +0200
++++ Python-3.10.8/setup.py	2022-10-12 23:25:52.000000000 +0200
+@@ -518,12 +518,16 @@
                                                longest, g))
  
          if self.missing:
-+            num_missing=len(self.missing)
++            num_missing = len(self.missing)
              print()
-             print("Python build finished successfully!")
-             print("The necessary bits to build these optional modules were not "
-@@ -525,7 +526,10 @@
+-            print("The necessary bits to build these optional modules were not "
+-                  "found:")
++            print(f"The necessary bits to build these {num_missing} optional "
++                  "modules were not found:")
              print_three_column(self.missing)
              print("To find the necessary bits, look in setup.py in"
-                   " detect_modules() for the module's name.")
-+            print ("(Fink package build should have 2 missing)")
-             print()
+-                  " detect_modules() for the module's name.")
++                  " detect_modules() for the module's name")
++            print("(Fink package build should have 2 missing).")
 +            if num_missing != 2:
 +                sys.exit(1)
+             print()
  
          if mods_built:
-             print()
-@@ -558,6 +562,7 @@
+@@ -557,6 +561,7 @@
              print("Failed to build these modules:")
              print_three_column(failed)
              print()
@@ -106,7 +107,7 @@ diff -ruN Python-3.10.1-orig/setup.py Python-3.10.1/setup.py
  
          if self.failed_on_import:
              failed = self.failed_on_import[:]
-@@ -824,9 +829,9 @@
+@@ -825,9 +830,9 @@
          # Ensure that /usr/local is always used, but the local build
          # directories (i.e. '.' and 'Include') must be first.  See issue
          # 10520.
@@ -119,7 +120,7 @@ diff -ruN Python-3.10.1-orig/setup.py Python-3.10.1/setup.py
          # only change this for cross builds for 3.3, issues on Mageia
          if CROSS_COMPILING:
              self.add_cross_compiling_paths()
-@@ -1163,7 +1168,7 @@
+@@ -1164,7 +1169,7 @@
          if curses_library == 'ncursesw':
              curses_defines.append(('HAVE_NCURSESW', '1'))
              if not CROSS_COMPILING:
@@ -128,7 +129,7 @@ diff -ruN Python-3.10.1-orig/setup.py Python-3.10.1/setup.py
              # Bug 1464056: If _curses.so links with ncursesw,
              # _curses_panel.so must link with panelw.
              panel_library = 'panelw'
-@@ -1491,7 +1496,7 @@
+@@ -1492,7 +1497,7 @@
                          if self.compiler.find_library_file(self.lib_dirs,
                                                                 'gdbm_compat'):
                              gdbm_libs.append('gdbm_compat')
@@ -137,7 +138,7 @@ diff -ruN Python-3.10.1-orig/setup.py Python-3.10.1/setup.py
                              if dbm_setup_debug: print("building dbm using gdbm")
                              dbmext = Extension(
                                  '_dbm', ['_dbmmodule.c'],
-@@ -1541,13 +1546,8 @@
+@@ -1542,13 +1547,8 @@
  
          # We hunt for #define SQLITE_VERSION "n.n.n"
          sqlite_incdir = sqlite_libdir = None
@@ -153,7 +154,7 @@ diff -ruN Python-3.10.1-orig/setup.py Python-3.10.1/setup.py
          if CROSS_COMPILING:
              sqlite_inc_paths = []
          MIN_SQLITE_VERSION_NUMBER = (3, 7, 15)  # Issue 40810
-@@ -1560,7 +1560,7 @@
+@@ -1561,7 +1561,7 @@
          if MACOS:
              sysroot = macosx_sdk_root()
  
@@ -162,7 +163,7 @@ diff -ruN Python-3.10.1-orig/setup.py Python-3.10.1/setup.py
              d = d_
              if MACOS and is_macosx_sdk_path(d):
                  d = os.path.join(sysroot, d[1:])
-@@ -1593,11 +1593,9 @@
+@@ -1594,11 +1594,9 @@
              sqlite_dirs_to_check = [
                  os.path.join(sqlite_incdir, '..', 'lib64'),
                  os.path.join(sqlite_incdir, '..', 'lib'),

--- a/10.9-libcxx/stable/main/finkinfo/languages/python311.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python311.info
@@ -1,0 +1,283 @@
+# -*- coding: ascii; tab-width: 4; x-counterpart: python310.patch -*-
+Info2: <<
+Package: python%type_pkg[python]
+Version: 3.11.2
+Revision: 1
+Type: python 3.11
+# Free to modify, update, and take over
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+Depends: <<
+	%N-shlibs (= %v-%r),
+	blt-shlibs,
+	bzip2-shlibs,
+	expat1-shlibs (>= 2.2.8-1),
+	fink (>= 0.34.8),
+	gdbm6-shlibs,
+	libffi8-shlibs,
+	libgettext8-shlibs,
+	liblzma5-shlibs,
+	libncursesw5-shlibs,
+	openssl300-shlibs (>= 3.0.1-1),
+	readline8-shlibs,
+	sqlite3-shlibs  (>= 3.30.1-1),
+	tcltk (>= 8.4.1-1),
+	x11
+<<
+BuildDepends: <<
+	blt-dev (>= 2.4z-15),
+	bzip2-dev,
+	expat1 (>= 2.2.8-1),
+	fink (>= 0.32),
+	gdbm6,
+	gettext-bin,
+	gettext-tools,
+	libffi8,
+	libgettext8-dev,
+	liblzma5,
+	libncursesw5,
+	openssl300-dev (>= 3.0.1-1),
+	pkgconfig (>= 0.9.0-1),
+	readline8,
+	sqlite3-dev (>= 3.30.1-1),
+	tcltk-dev (>= 8.4.1-1),
+	x11-dev
+<<
+# See https://github.com/fink/fink-distributions/issues/193
+BuildConflicts: uuid
+# Python 3.4+ wants to install these packages but that conflicts with fink's.
+Recommends: <<
+	pip-py%type_pkg[python],
+	setuptools-tng-py%type_pkg[python]
+<<
+Provides: <<
+	argparse-py%type_pkg[python],
+	enum34-py%type_pkg[python],
+	futures-py%type_pkg[python],
+	pathlib-py%type_pkg[python]
+<<
+
+Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
+Source-Checksum: SHA256(29e4b8f5f1658542a8c13e2dd277358c9c48f2b2f7318652ef1675e402b9d2af)
+
+PatchFile: %n.patch
+PatchFile-MD5: 2c1c108f70f54a8817d5d5b44f41fc1a
+
+PatchScript: <<
+	#!/bin/sh -ex
+	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
+	# /tmp and /var/tmp are symlinks to /private/tmp and /private/var/tmp
+	# on OS X. That's fine except it can cause tests in some packages to
+	# fail since '/tmp' != '/private/tmp'. Default to using /private/tmp.
+	perl -pi -e "s|'/tmp', '/var/tmp'|'/private/tmp', '/private/var/tmp'|" Lib/tempfile.py
+	# reason for removing SystemStubs?
+	perl -pi -e 's/ -lSystemStubs//' ./configure
+<<
+
+ConfigureParams: <<
+	--enable-shared \
+	--enable-loadable-sqlite-extensions \
+	--enable-optimizations \
+	--with-dbmliborder=gdbm \
+	--with-pkgconfig=yes \
+	--with-system-expat \
+	--with-system-ffi \
+	--with-dtrace \
+	--without-ensurepip \
+	--enable-ipv6 \
+	TCLTK_CFLAGS="-I%p/include -I/opt/X11/include" \
+	TCLTK_LIBS="-L%p/lib -ltcl -ltk"
+<<
+
+CompileScript: <<
+#!/bin/sh -ex
+	SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
+	# for OS X 10.14, ensure full SDK is available, but include it after any fink specific versions.
+	#if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
+		export CFLAGS="-Wno-nullability-completeness -Wno-expansion-to-defined"
+		# is this forced ordering needed on <= 10.14?
+		#export CPPFLAGS="-I%p/include -I%p/include/ncursesw -I$SDK_PATH/usr/include"
+		#perl -pi -e "s|/usr/include|$SDK_PATH/usr/include|" setup.py
+	#fi
+
+	# https://bugs.python.org/issue28456 and radar://28372390
+	# https://daniel.haxx.se/blog/2016/10/11/poll-on-mac-10-12-is-broken/
+	./configure %c $DIST_CONFIG_PARAMS
+	perl -pi -e 's|\#define HAVE_POLL 1||' ./pyconfig.h
+	perl -pi -e 's|\#define HAVE_POLL_H 1||g' ./pyconfig.h
+	perl -pi -e 's|\#define HAVE_SYS_POLL_H 1||g' ./pyconfig.h
+	make
+<<
+
+InfoTest: <<
+	TestConflicts: apple-gdb
+	TestScript: <<
+		#!/bin/sh -ex
+		# Change install_name of lib during tests since DYLD_LIBRARY_PATH is not exported to test_subprocess on 10.11+.
+		if [ -x python.exe ]; then
+			python_exe=python.exe
+		else
+			python_exe=python
+		fi
+		install_name_tool -change %p/lib/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib $python_exe
+		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %p/lib/libpython%type_raw[python].dylib %b/libpython%type_raw[python].dylib {} \;
+		install_name_tool -id %b/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
+
+		# test_socket can fail with some DNS settings.
+		# multiprocessing_spawn fails on "KeyboardInterrupt not raised by wait",
+		# test_ctypes is currently broken on 12.0 (py3.10.1)
+		# test_tcl and test_idle require an active $DISPLAY
+		# test_select is missing attribute 'poll'
+		# test_pkgutil fails on HFS+ https://bugs.python.org/issue41154 (marked resolved)
+		# test_grp was failing on 3.10
+		EXTRATESTOPTS='-w -unone -x test_idle test_select test_tcl'
+		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
+
+		# Put install_name back.
+		install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib $python_exe
+		/usr/bin/find `ls -d %b/build/lib*` -name *.so -exec install_name_tool -change %b/libpython%type_raw[python].dylib %p/lib/libpython%type_raw[python].dylib {} \;
+		install_name_tool -id %p/lib/libpython%type_raw[python].dylib libpython%type_raw[python].dylib
+
+		# remove leftovers from testing
+		# these dirs are empty and only created if tests are run
+		find ./Tools -name __pycache__ -type d -depth -exec rm -rf "{}" \;
+		exit $TESTRETURN
+	<<
+<<
+
+InstallScript: <<
+#!/bin/sh -ex
+	# Rebuild _sysconfigdata.py if we ran tests.
+	find ./build -name _sysconfigdata.py -delete
+	make
+	# Remove stray .pyc that get made during tests (including preliminary ones in CompileScript) to keep validator happy.
+	find ./Lib ./Parser ./Tools ./build -name '*.pyc' -delete
+	# Change interpreter name in scripts to versioned executable.
+	perl -pi -e 's|(/usr/bin/env python)(3?)$|${1}%type_raw[python]|' ./Tools/scripts/*
+	# _sysconfigdata.py contains build-time variables that point to %b.
+	# This is harmless but upsets fink's validator.
+	# Change to %p/lib to make fink happy.
+	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' `cat pybuilddir.txt`/_sysconfigdata__darwin_darwin.py
+	# Don't propagate -lintl to other packages.
+	perl -pi -e 's/-lintl //' `cat pybuilddir.txt`/_sysconfigdata__darwin_darwin.py
+	# install fails with -j greater than 1
+	export MAKEFLAGS=-j1
+	make install DESTDIR=%d
+
+	# we don't want -lintl to appear in LIBS otherwise python-config will propagate it
+	perl -pi -e 's/-lintl //' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile
+	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile
+	# Fix all main things to be python-versioned filenames with unversioned symlinks to them.
+	pushd %i/bin
+		for f in idle3 pydoc3; do
+			mv ${f} ${f}-%type_raw[python]
+			ln -s ${f}-%type_raw[python] %i/bin/${f}
+		done
+		#Remove this for now to avoid conflicting with 'python' package.
+		rm 2to3
+	popd
+
+	# Add symlink to %p/lib/python%type_raw[python]/config-%type_raw[python]-darwin.
+	ln -s %p/lib/libpython%type_raw[python].dylib %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/libpython%type_raw[python].dylib
+
+	# install some docs and other useful tidbits
+	rm -rf Misc/RPM
+	/bin/cp -R Misc Tools %i/lib/python%type_raw[python]
+
+	# Some stuff still seems to be rebuilt/byte-compiled after `make`; empty f-string error in c-analyzer/c_parser/parser/_delim.py
+	pushd %i/lib/python%type_raw[python]
+	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,;s/-lintl //' _sysconfigdata__darwin_darwin.py
+	DYLD_LIBRARY_PATH=%i/lib %i/bin/python%type_raw[python] -m compileall -f -o 0 -o 1 -o 2 _sysconfigdata__darwin_darwin.py Tools || echo 'some files were not byte-compiled'
+
+# Doc tarball missing upstream.
+#	mkdir -p %i/share/doc/%n/html
+#	/bin/cp -R ../python-%v-docs-html/ %i/share/doc/%n/html
+<<
+SplitOff: <<
+	Package: %N-shlibs
+	Depends: libgettext8-shlibs
+	Files: <<
+		lib/libpython%type_raw[python].dylib
+		lib/python%type_raw[python]/config-%type_raw[python]-darwin/libpython%type_raw[python].dylib
+	<<
+	Shlibs: %p/lib/libpython%type_raw[python].dylib 3.11.0 %n (>= 3.11.0-1)
+	DocFiles: README.rst LICENSE
+<<
+SplitOff2: <<
+	Package: python3
+	Depends: %N (>= %v-%r)
+	Files: <<
+		bin/idle3
+		bin/pydoc3
+		bin/python3
+		bin/python3-config
+		lib/pkgconfig/python3.pc
+		lib/pkgconfig/python3-embed.pc
+		share/man/man1/python3.1
+	<<
+	DocFiles: README.rst LICENSE
+	Description: Generic commands to invoke python%type_pkg[python]
+	DescDetail: <<
+		This package only contains non-versioned symlinks to the binaries included
+		with python%type_pkg[python].
+	<<
+	DescUsage: <<
+		This package should only be used when you don't care which version of the
+		python 3.x interpreter you need.
+	<<
+<<
+DocFiles: README.rst LICENSE
+Description: Interpreted, object-oriented language
+DescDetail: <<
+	Python is often compared to Tcl, Perl, Scheme or Java.
+	This package installs unix python - not the OSX Framework version.
+	Builds a two-level namespace dynamic libpython (needed for koffice).
+
+	The interpreter is installed as "python%type_raw[python]", and all associated
+	commands are similarly named with the python-version in them. To get
+	the simple "python3" command, install the fink package "python3" (note:
+	the "python3" command there is not guaranteed to be python%type_raw[python]!).
+<<
+DescUsage: <<
+	Python 3.10+ changes the compiler options used to compile
+	third-party python modules. Please do not add %type_raw[python] variants
+	to them without actually testing that they build cleanly.
+<<
+
+DescPackaging: <<
+	Adjust "python3" unversioned link to be a symlink not a hard link.
+
+	New in 3.2, .pyc files are saved in the __pycache__ directory
+	at the same level as the matching .py file. Any packages that
+	expect the .pyc file to be next to the .py file will need adjustment.
+
+	The .pyc and .so files also include the python version in the name.
+
+	Don't run ensurepip since it installs files that conflict with
+	the pip and setuptools packages.
+
+	Previous python packages went to great lengths to patch to use
+	%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin
+	for libpython instead of %p/lib. Revert to using default library
+	location but make symlink in config dir.
+
+	Upstream no longer links extensions to libpython and use of
+	-undefined dynamic_lookup is recommended instead so remove those
+	patches.
+<<
+DescPort: <<
+	libpython needs to link to CF because that lib has the parent
+	thread that load modules that need to have CF available. See:
+	http://bugs.python.org/issue7085
+
+	bsddb is gone so drop db* patch and dep.
+	Patch setup.py to find ncursesw headers and drop libncurses5 dep.
+	Ensure $(LDFLAGS) is used linking libpython or else it can't find libintl.
+
+	Patch ctypes to look in %p/lib for libraries.
+
+	Call build executable by correct filename in test suite
+	(python on case-sensitive, python.exe on -insensitive file systems).
+<<
+License: OSI-Approved
+Homepage: https://www.python.org/
+<<

--- a/10.9-libcxx/stable/main/finkinfo/languages/python311.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python311.patch
@@ -1,0 +1,117 @@
+diff -ruN Python-3.10.1-orig/Lib/ctypes/macholib/dyld.py Python-3.10.1/Lib/ctypes/macholib/dyld.py
+--- Python-3.10.1-orig/Lib/ctypes/macholib/dyld.py	2021-12-06 13:23:39.000000000 -0500
++++ Python-3.10.1/Lib/ctypes/macholib/dyld.py	2021-12-24 05:31:43.000000000 -0500
+@@ -28,6 +28,7 @@
+ 
+ DEFAULT_LIBRARY_FALLBACK = [
+     os.path.expanduser("~/lib"),
++    "@PREFIX@/lib",
+     "/usr/local/lib",
+     "/lib",
+     "/usr/lib",
+diff -ruN Python-3.11.0-orig/Lib/test/test_posix.py Python-3.11.0/Lib/test/test_posix.py
+--- Python-3.11.0-orig/Lib/test/test_posix.py	2022-06-01 13:23:39.000000000 -0500
++++ Python-3.11.0/Lib/test/test_posix.py	2022-06-09 05:31:43.000000000 -0500
+@@ -1729,7 +1729,8 @@
+         output = os.read(rfd, 100)
+         child_sid = int(output)
+         parent_sid = os.getsid(os.getpid())
+-        self.assertNotEqual(parent_sid, child_sid)
++        # This assertion is failing.
++        #self.assertNotEqual(parent_sid, child_sid)
+ 
+     @unittest.skipUnless(hasattr(signal, 'pthread_sigmask'),
+                          'need signal.pthread_sigmask()')
+diff -ruN Python-3.11.0-orig/Makefile.pre.in Python-3.11.0/Makefile.pre.in
+--- Python-3.11.0-orig/Makefile.pre.in	2022-06-01 13:23:39.000000000 -0500
++++ Python-3.11.0/Makefile.pre.in	2022-06-09 05:31:43.000000000 -0500
+@@ -761,7 +761,7 @@
+ 	$(BLDSHARED) $(NO_AS_NEEDED) -o $@ -Wl,-h$@ $^
+ 
+ libpython$(LDVERSION).dylib: $(LIBRARY_OBJS)
+-	 $(CC) -dynamiclib -Wl,-single_module $(PY_CORE_LDFLAGS) -undefined dynamic_lookup -Wl,-install_name,$(prefix)/lib/libpython$(LDVERSION).dylib -Wl,-compatibility_version,$(VERSION) -Wl,-current_version,$(VERSION) -o $@ $(LIBRARY_OBJS) $(DTRACE_OBJS) $(SHLIBS) $(LIBC) $(LIBM); \
++	 $(CC) -dynamiclib -Wl,-single_module $(PY_CORE_LDFLAGS) -Wl,-install_name,$(prefix)/lib/libpython$(LDVERSION).dylib -Wl,-compatibility_version,$(VERSION) -Wl,-current_version,$(VERSION) -o $@ $(LIBRARY_OBJS) $(DTRACE_OBJS) $(SHLIBS) $(LIBC) $(LIBM); \
+ 
+ 
+ libpython$(VERSION).sl: $(LIBRARY_OBJS)
+@@ -1803,7 +1803,7 @@
+ 		if test -f $(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE) -o -h $(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE); \
+ 		then rm -f $(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE); \
+ 		fi; \
+-		(cd $(DESTDIR)$(BINDIR); $(LN) python$(LDVERSION)$(EXE) python$(VERSION)$(EXE)); \
++		(cd $(DESTDIR)$(BINDIR); $(LN) -s python$(LDVERSION)$(EXE) python$(VERSION)$(EXE)); \
+ 	fi
+ 	@if test "$(PY_ENABLE_SHARED)" = 1 -o "$(STATIC_LIBPYTHON)" = 1; then \
+ 		if test -f $(LDLIBRARY) && test "$(PYTHONFRAMEWORKDIR)" = "no-framework" ; then \
+diff -ruN Python-3.11.0-orig/configure Python-3.11.0/configure
+--- Python-3.11.0-orig/configure	2022-06-01 13:23:39.000000000 -0500
++++ Python-3.11.0/configure	2022-06-09 05:31:43.000000000 -0500
+@@ -21327,7 +21327,7 @@
+ # first curses header check
+ ac_save_cppflags="$CPPFLAGS"
+ if test "$cross_compiling" = no; then
+-  CPPFLAGS="$CPPFLAGS -I/usr/include/ncursesw"
++  CPPFLAGS="$CPPFLAGS -I@PREFIX@/include/ncursesw"
+ fi
+ 
+ for ac_header in curses.h ncurses.h
+@@ -21959,7 +21959,7 @@
+ 
+ if test $ac_sys_system = Darwin
+ then
+-	LIBS="$LIBS -framework CoreFoundation"
++	LIBS="$LIBS -Wl,-framework,CoreFoundation"
+ fi
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for %zd printf() format support" >&5
+diff -ruN Python-3.11.0-orig/setup.py Python-3.11.0/setup.py
+--- Python-3.11.0-orig/setup.py	2022-06-01 13:23:39.000000000 -0500
++++ Python-3.11.0/setup.py	2022-06-09 05:31:43.000000000 -0500
+@@ -537,13 +537,17 @@
+                                               longest, g))
+ 
+         if self.missing:
++            num_missing=len(self.missing)
+             print()
+             print("The necessary bits to build these optional modules were not "
+                   "found:")
+             print_three_column(self.missing)
+             print("To find the necessary bits, look in setup.py in"
+                   " detect_modules() for the module's name.")
++            print ("(Fink package build should have '_dbm' missing.)")
+             print()
++            if num_missing > 1:
++                sys.exit(1)
+ 
+         if mods_built:
+             print()
+@@ -576,6 +580,7 @@
+             print("Failed to build these modules:")
+             print_three_column(failed)
+             print()
++            sys.exit(1)
+ 
+         if self.failed_on_import:
+             failed = self.failed_on_import[:]
+@@ -846,9 +851,9 @@
+         # Ensure that /usr/local is always used, but the local build
+         # directories (i.e. '.' and 'Include') must be first.  See issue
+         # 10520.
+-        if not CROSS_COMPILING:
+-            add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+-            add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
++        # if not CROSS_COMPILING:
++        #     add_dir_to_list(self.compiler.library_dirs, '/usr/lib')
++        #     add_dir_to_list(self.compiler.include_dirs, '/usr/include')
+         # only change this for cross builds for 3.3, issues on Mageia
+         if CROSS_COMPILING:
+             self.add_cross_compiling_paths()
+@@ -1122,7 +1127,7 @@
+         if curses_library == 'ncursesw':
+             curses_defines.append(('HAVE_NCURSESW', '1'))
+             if not CROSS_COMPILING:
+-                curses_includes.append('/usr/include/ncursesw')
++                curses_includes.append('@PREFIX@/include/ncursesw')
+             # Bug 1464056: If _curses.so links with ncursesw,
+             # _curses_panel.so must link with panelw.
+             panel_library = 'panelw'

--- a/10.9-libcxx/stable/main/finkinfo/languages/python38.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python38.info
@@ -1,8 +1,8 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: python38.patch -*-
 Info2: <<
 Package: python%type_pkg[python]
-Version: 3.8.13
-Revision: 2
+Version: 3.8.16
+Revision: 1
 Type: python 3.8
 Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
 Depends: <<
@@ -16,7 +16,7 @@ Depends: <<
 	libgettext8-shlibs,
 	liblzma5-shlibs,
 	libncursesw5-shlibs,
-	openssl110-shlibs (>= 1.1.1g-1),
+	openssl300-shlibs (>= 3.0.1-1),
 	readline8-shlibs,
 	sqlite3-shlibs  (>= 3.30.1-1),
 	tcltk (>= 8.4.1-1),
@@ -26,7 +26,7 @@ BuildDepends: <<
 	blt-dev (>= 2.4z-15),
 	bzip2-dev,
 	expat1 (>= 2.2.8-1),
-	fink (>= 0.32), 
+	fink (>= 0.32),
 	gdbm6,
 	gettext-bin,
 	gettext-tools,
@@ -36,8 +36,8 @@ BuildDepends: <<
 	libncursesw5,
 	readline8,
 	sqlite3-dev (>= 3.30.1-1),
-	openssl110-dev (>= 1.1.1g-1),
-	pkgconfig,
+	openssl300-dev (>= 3.0.1-1),
+	pkgconfig (>= 0.9.0-1),
 	tcltk-dev (>= 8.4.1-1),
 	x11-dev
 <<
@@ -49,7 +49,7 @@ Recommends: pip-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
 Provides: argparse-py%type_pkg[python], futures-py%type_pkg[python], enum34-py%type_pkg[python], pathlib-py%type_pkg[python]
 
 Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
-Source-Checksum: SHA256(6f309077012040aa39fe8f0c61db8c0fa1c45136763299d375c9e5756f09cf57)
+Source-Checksum: SHA256(d85dbb3774132473d8081dcb158f34a10ccad7a90b96c7e50ea4bb61f5ce4562)
 
 PatchFile: %n.patch
 PatchFile-MD5: 25181b340fc83818ea6d910b64481f0b
@@ -146,13 +146,15 @@ InstallScript: <<
 	perl -pi -e 's/-lintl //' `ls -d %b/build/lib*`/_sysconfigdata__darwin_darwin.py
 	# Remove stray .pyc that get made during tests (including preliminary ones in CompileScript) to keep validator happy.
 	find ./Lib ./Parser ./Tools ./build -name '*.pyc' -delete
+	# Change interpreter name in scripts to versioned executable.
+	perl -pi -e 's|(/usr/bin/env python)(3?)$|${1}%type_raw[python]|' ./Tools/scripts/*
 	# install fails with -j greater than 1
 	export MAKEFLAGS=-j1
 	make install DESTDIR=%d
 
 	# we don't want -lintl to appear in LIBS otherwise python-config will propagate it
 	perl -pi -e 's/-lintl //' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile
-	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile	
+	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile
 	# Fix all main things to be python-versioned filenames with unversioned symlinks to them.
 	pushd %i/bin
 		for f in idle3 pydoc3; do
@@ -179,7 +181,7 @@ SplitOff: <<
  Depends: libgettext8-shlibs
  Files: lib/libpython%type_raw[python].dylib  lib/python%type_raw[python]/config-%type_raw[python]-darwin/libpython%type_raw[python].dylib
  Shlibs: %p/lib/libpython%type_raw[python].dylib 3.8.0 %n (>= 3.8.0-1)
- DocFiles: README.rst LICENSE 
+ DocFiles: README.rst LICENSE
 <<
 SplitOff2: <<
  Package: python3
@@ -204,10 +206,10 @@ SplitOff2: <<
   python 3.x interpreter you need.
  <<
 <<
-DocFiles: README.rst LICENSE 
+DocFiles: README.rst LICENSE
 Description: Interpreted, object-oriented language
 DescDetail: <<
- Python is often compared to Tcl, Perl, Scheme or Java. 
+ Python is often compared to Tcl, Perl, Scheme or Java.
  This package installs unix python - not the OSX Framework version.
  Builds a two-level namespace dynamic libpython (needed for koffice).
 
@@ -239,7 +241,7 @@ DescPackaging: <<
 	for libpython instead of %p/lib. Revert to using default library
 	location but make symlink in config dir.
 
-	Upstream no longer links extensions to libpython and use of 
+	Upstream no longer links extensions to libpython and use of
 	-undefined dynamic_lookup is recommended instead so remove those
 	patches.
 <<

--- a/10.9-libcxx/stable/main/finkinfo/languages/python39.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/python39.info
@@ -1,8 +1,8 @@
 # -*- coding: ascii; tab-width: 4; x-counterpart: python39.patch -*-
 Info2: <<
 Package: python%type_pkg[python]
-Version: 3.9.12
-Revision: 2
+Version: 3.9.15
+Revision: 1
 Type: python 3.9
 # Free to modify, update, and take over
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
@@ -17,7 +17,7 @@ Depends: <<
 	libgettext8-shlibs,
 	liblzma5-shlibs,
 	libncursesw5-shlibs,
-	openssl110-shlibs (>= 1.1.1g-1),
+	openssl300-shlibs (>= 3.0.1-1),
 	readline8-shlibs,
 	sqlite3-shlibs  (>= 3.30.1-1),
 	tcltk (>= 8.4.1-1),
@@ -27,7 +27,7 @@ BuildDepends: <<
 	blt-dev (>= 2.4z-15),
 	bzip2-dev,
 	expat1 (>= 2.2.8-1),
-	fink (>= 0.32), 
+	fink (>= 0.32),
 	gdbm6,
 	gettext-bin,
 	gettext-tools,
@@ -35,8 +35,8 @@ BuildDepends: <<
 	libgettext8-dev,
 	liblzma5,
 	libncursesw5,
-	openssl110-dev (>= 1.1.1g-1),
-	pkgconfig,
+	openssl300-dev (>= 3.0.1-1),
+	pkgconfig (>= 0.9.0-1),
 	readline8,
 	sqlite3-dev (>= 3.30.1-1),
 	tcltk-dev (>= 8.4.1-1),
@@ -57,7 +57,7 @@ Provides: <<
 <<
 
 Source: https://www.python.org/ftp/python/%v/Python-%v.tar.xz
-Source-Checksum: SHA256(2cd94b20670e4159c6d9ab57f91dbf255b97d8c1a1451d1c35f4ec1968adf971)
+Source-Checksum: SHA256(12daff6809528d9f6154216950423c9e30f0e47336cb57c6aa0b4387dd5eb4b2)
 
 PatchFile: %n.patch
 PatchFile-MD5: f564298ddd9d3866c36e9842fcd240ac
@@ -78,6 +78,7 @@ ConfigureParams: <<
 	--enable-loadable-sqlite-extensions \
 	--enable-optimizations \
 	--with-dbmliborder=gdbm \
+	--with-pkgconfig=yes \
 	--with-system-expat \
 	--with-system-ffi \
 	--with-tcltk-includes="-I%p/include -I/opt/X11/include" \
@@ -125,8 +126,8 @@ InfoTest: <<
 		# multiprocessing_spawn fails on "KeyboardInterrupt not raised by wait",
 		# test_ctypes is currently broken on 11.0 (py3.9.9)
 		# test_tcl and test_idle require an active $DISPLAY
-		# test_pkgutil fails on HFS+ https://bugs.python.org/issue41154
-		EXTRATESTOPTS='-w -unone -x test_socket test_multiprocessing_spawn test_code test_ctypes test_idle test_tcl test_pkgutil'
+		# test_pkgutil fails on HFS+ https://bugs.python.org/issue41154 (marked resolved)
+		EXTRATESTOPTS='-w -unone -x test_idle test_tcl'
 		LANG=en_US.UTF-8 make -k test EXTRATESTOPTS="$EXTRATESTOPTS" || TESTRETURN=$?
 
 		# Put install_name back.
@@ -153,13 +154,15 @@ InstallScript: <<
 	perl -pi -e 's/-lintl //' `ls -d %b/build/lib*`/_sysconfigdata__darwin_darwin.py
 	# Remove stray .pyc that get made during tests (including preliminary ones in CompileScript) to keep validator happy.
 	find ./Lib ./Parser ./Tools ./build -name '*.pyc' -delete
+	# Change interpreter name in scripts to versioned executable.
+	perl -pi -e 's|(/usr/bin/env python)(3?)$|${1}%type_raw[python]|' ./Tools/scripts/*
 	# install fails with -j greater than 1
 	export MAKEFLAGS=-j1
 	make install DESTDIR=%d
 
 	# we don't want -lintl to appear in LIBS otherwise python-config will propagate it
 	perl -pi -e 's/-lintl //' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile
-	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile	
+	perl -pi -e 's,%b,%p/lib/python%type_raw[python]/config-%type_raw[python]-darwin,' %i/lib/python%type_raw[python]/config-%type_raw[python]-darwin/Makefile
 	# Fix all main things to be python-versioned filenames with unversioned symlinks to them.
 	pushd %i/bin
 		for f in idle3 pydoc3; do
@@ -176,6 +179,8 @@ InstallScript: <<
 	# install some docs and other useful tidbits
 	rm -rf Misc/RPM
 	/bin/cp -R Misc Tools %i/lib/python%type_raw[python]
+	pushd %i/lib/python%type_raw[python]
+	DYLD_LIBRARY_PATH=%i/lib %i/bin/python%type_raw[python] -m compileall -o 0 -o 1 -o 2 Tools || echo 'some files were not byte-compiled'
 
 # Doc tarball missing upstream.
 #	mkdir -p %i/share/doc/%n/html
@@ -189,7 +194,7 @@ SplitOff: <<
 		lib/python%type_raw[python]/config-%type_raw[python]-darwin/libpython%type_raw[python].dylib
 	<<
 	Shlibs: %p/lib/libpython%type_raw[python].dylib 3.9.0 %n (>= 3.9.9-1)
-	DocFiles: README.rst LICENSE 
+	DocFiles: README.rst LICENSE
 <<
 SplitOff2: <<
 	Package: python3
@@ -214,10 +219,10 @@ SplitOff2: <<
 		python 3.x interpreter you need.
 	<<
 <<
-DocFiles: README.rst LICENSE 
+DocFiles: README.rst LICENSE
 Description: Interpreted, object-oriented language
 DescDetail: <<
-	Python is often compared to Tcl, Perl, Scheme or Java. 
+	Python is often compared to Tcl, Perl, Scheme or Java.
 	This package installs unix python - not the OSX Framework version.
 	Builds a two-level namespace dynamic libpython (needed for koffice).
 
@@ -249,7 +254,7 @@ DescPackaging: <<
 	for libpython instead of %p/lib. Revert to using default library
 	location but make symlink in config dir.
 
-	Upstream no longer links extensions to libpython and use of 
+	Upstream no longer links extensions to libpython and use of
 	-undefined dynamic_lookup is recommended instead so remove those
 	patches.
 <<


### PR DESCRIPTION
The (mostly) current Python versions have not been updated for about a year; upgrading to the current patch/security releases and switching from openssl110 to openssl300. Also fixes a number of utility scripts to use the correct Fink python-pyNN. Builds tested with both pkgconfig and pkgconf; a number of network tests are hanging (as with earlier releases) on 10.14.6; on 13.2 everything building cleanly for arm64 and x86_64.
As 3.10 is also already on the second-to-last regular release, adding python311 as current version.