### PR TITLE
xtide update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide-harmonics-us.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide-harmonics-us.info
@@ -1,5 +1,5 @@
 Package: xtide-harmonics-us
-Version: 20220109
+Version: 20230107
 Revision: 1
 Description: US harmonic data for XTide
 DescDetail: <<
@@ -19,7 +19,7 @@ Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 BuildDepends: fink (>= 0.32)
 
 Source: https://flaterco.com/files/xtide/harmonics-dwf-%v-free.tar.xz
-Source-Checksum: SHA256(175598e0d104dc2d61ad392216dbef879c4328941751aa4cb8a5f4a906e043b6)
+Source-Checksum: SHA256(1aed30ae78b01053494c05dede1af5f73ce9bf394f65995deb920b83828de18e)
 SourceDirectory: harmonics-dwf-%v
 
 CompileScript: printf "No compiling needed.\n" 

--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: xtide
-Version: 2.15.4
+Version: 2.15.5
 Revision: 1
-Type: harm (20220109)
+Type: harm (20230107)
 
 Description: Tide and current prediction software
 License: Public Domain
@@ -40,7 +40,7 @@ GCC: 4.0
 Recommends: xtide-coastline (>= 20110414-2)
 
 Source: https://flaterco.com/files/xtide/%n-%v.tar.xz
-Source-Checksum: SHA256(726622969bc94adab52a8e060b21e2a2434d463febd0d6d2920b25a12ca5093c)
+Source-Checksum: SHA256(b9460dcf167e8d9544dcb34a751516d14a97fc3f4aebc6a8bb5ca5f2710d7164)
 
 PatchScript: <<
 	perl -pi -e 's,(/etc/xtide\.conf),%p\1,g' libxtide/Global.cc README tide.1 xtide.1 xttpd.8


### PR DESCRIPTION
Updated packages for xtide (v. 2.15.5) and xtide-harmonics-us (v. 20230107) to the latest upstream versions. These are trivial updates, and appear to work correctly on MacOS 12.6.3 / Intel.
Package maintainer is @akhansen