### PR TITLE
Boost icu upgrade

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/boost1.53..info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/boost1.53..info
@@ -1,5 +1,6 @@
 Info2: <<
 Package: boost1.53.%type_pkg[python]
+# libicu72 does not get detected
 Version: 1.53.0
 Revision: 8
 Type: python (nopython systempython python2.7)

--- a/10.9-libcxx/stable/main/finkinfo/libs/boost1.53..info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/boost1.53..info
@@ -1,8 +1,7 @@
 Info2: <<
 Package: boost1.53.%type_pkg[python]
-# libicu72 does not get detected
 Version: 1.53.0
-Revision: 9
+Revision: 10
 Type: python (nopython systempython python2.7)
 # Do not propagate past 10.10 if at all possible. Use boost1.55 or later.
 Distribution: <<
@@ -32,7 +31,7 @@ Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
 Depends: %N-shlibs (= %v-%r)
 BuildDepends: <<
 	fink (>= 0.34.4),
-	libicu55-dev,
+	libicu72-dev,
 	(%type_num[python]) %type_pkg[python]
 <<
 BuildDependsOnly: True
@@ -152,7 +151,7 @@ CompileScript: <<
 
  PYTHON=$PYTHON ./bootstrap.sh --without-libraries=python --without-libraries=mpi --includedir=%p/include/boost-1_53
 
- PYTHON=$PYTHON ./b2 -d2 --toolset=darwin $USEPYTHON --prefix=%p $LIBDIR --includedir=%p/include/boost-1_53 $UNDEFINED --compatibility_version=1.53.0 --current_version=1.53.0 --build-type=complete --layout=tagged variant=release threading=single,multi link=shared cxxflags="-MD -I%p/include" linkflags="-L%p/lib"
+ PYTHON=$PYTHON ./b2 -d2 --toolset=darwin $USEPYTHON --prefix=%p $LIBDIR --includedir=%p/include/boost-1_53 $UNDEFINED --compatibility_version=1.53.0 --current_version=1.53.0 --build-type=complete --layout=tagged variant=release threading=single,multi link=shared cxxflags="-std=c++11 -MD -I%p/include" linkflags="-L%p/lib"
 <<
 
 InstallScript: <<
@@ -211,7 +210,7 @@ InstallScript: <<
 
 Splitoff: <<
  Package: %N-shlibs
- Depends: ( %type_num[python] ) %type_pkg[python]-shlibs, libicu55-shlibs
+ Depends: ( %type_num[python] ) %type_pkg[python]-shlibs, libicu72-shlibs
 
  Files: <<
   ( %type_raw[python] = systempython ) lib/libboost_python-1_53.dylib

--- a/10.9-libcxx/stable/main/finkinfo/libs/boost1.53..info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/boost1.53..info
@@ -2,7 +2,7 @@ Info2: <<
 Package: boost1.53.%type_pkg[python]
 # libicu72 does not get detected
 Version: 1.53.0
-Revision: 8
+Revision: 9
 Type: python (nopython systempython python2.7)
 # Do not propagate past 10.10 if at all possible. Use boost1.55 or later.
 Distribution: <<
@@ -152,7 +152,7 @@ CompileScript: <<
 
  PYTHON=$PYTHON ./bootstrap.sh --without-libraries=python --without-libraries=mpi --includedir=%p/include/boost-1_53
 
- PYTHON=$PYTHON ./b2 -d2 --toolset=darwin $USEPYTHON --prefix=%p $LIBDIR --includedir=%p/include/boost-1_53 $UNDEFINED --compatibility_version=1.53.0 --current_version=1.53.0 --build-type=complete --layout=tagged variant=release threading=single,multi link=shared
+ PYTHON=$PYTHON ./b2 -d2 --toolset=darwin $USEPYTHON --prefix=%p $LIBDIR --includedir=%p/include/boost-1_53 $UNDEFINED --compatibility_version=1.53.0 --current_version=1.53.0 --build-type=complete --layout=tagged variant=release threading=single,multi link=shared cxxflags="-MD -I%p/include" linkflags="-L%p/lib"
 <<
 
 InstallScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/boost1.55.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/boost1.55.info
@@ -1,5 +1,6 @@
 Info2: <<
 Package: boost1.55-%type_pkg[python]
+# libicu72 does not get detected
 Version: 1.55.0
 Revision: 11
 Type: python (nopython systempython python2.7), boost (55)

--- a/10.9-libcxx/stable/main/finkinfo/libs/boost1.55.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/boost1.55.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: boost1.55-%type_pkg[python]
 # libicu72 does not get detected
 Version: 1.55.0
-Revision: 11
+Revision: 12
 Type: python (nopython systempython python2.7), boost (55)
 Distribution: 10.9, 10.10, 10.11, 10.12, 10.13, 10.14, 10.14.5, 10.15
 Description: Boost C++ Libraries: static and source libs
@@ -147,7 +147,7 @@ esac
 
 PYTHON=$PYTHON ./bootstrap.sh --without-libraries=python --includedir=%p/opt/boost-1_%type_pkg[boost]/include/boost
 
-PYTHON=$PYTHON ./b2 -d2 --toolset=darwin $USEPYTHON --prefix=%p $LIBDIR --includedir=%p/opt/boost-1_%type_pkg[boost]/include/boost $UNDEFINED --compatibility_version=1.%type_pkg[boost].0 --current_version=1.%type_pkg[boost].0 --build-type=complete --layout=tagged variant=release threading=single,multi link=shared
+PYTHON=$PYTHON ./b2 -d2 --toolset=darwin $USEPYTHON --prefix=%p $LIBDIR --includedir=%p/opt/boost-1_%type_pkg[boost]/include/boost $UNDEFINED --compatibility_version=1.%type_pkg[boost].0 --current_version=1.%type_pkg[boost].0 --build-type=complete --layout=tagged variant=release threading=single,multi link=shared cxxflags="-MD -I%p/include" linkflags="-L%p/lib"
 <<
 
 InstallScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/boost1.55.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/boost1.55.info
@@ -1,8 +1,7 @@
 Info2: <<
 Package: boost1.55-%type_pkg[python]
-# libicu72 does not get detected
 Version: 1.55.0
-Revision: 12
+Revision: 13
 Type: python (nopython systempython python2.7), boost (55)
 Distribution: 10.9, 10.10, 10.11, 10.12, 10.13, 10.14, 10.14.5, 10.15
 Description: Boost C++ Libraries: static and source libs
@@ -12,7 +11,7 @@ Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
 Depends: %N-shlibs (= %v-%r)
 BuildDepends: <<
 	fink (>= 0.34.4),
-	libicu55-dev,
+	libicu72-dev,
 	openmpi (>= 1.8.1-3),
 	(%type_num[python]) %type_pkg[python]
 <<
@@ -147,7 +146,7 @@ esac
 
 PYTHON=$PYTHON ./bootstrap.sh --without-libraries=python --includedir=%p/opt/boost-1_%type_pkg[boost]/include/boost
 
-PYTHON=$PYTHON ./b2 -d2 --toolset=darwin $USEPYTHON --prefix=%p $LIBDIR --includedir=%p/opt/boost-1_%type_pkg[boost]/include/boost $UNDEFINED --compatibility_version=1.%type_pkg[boost].0 --current_version=1.%type_pkg[boost].0 --build-type=complete --layout=tagged variant=release threading=single,multi link=shared cxxflags="-MD -I%p/include" linkflags="-L%p/lib"
+PYTHON=$PYTHON ./b2 -d2 --toolset=darwin $USEPYTHON --prefix=%p $LIBDIR --includedir=%p/opt/boost-1_%type_pkg[boost]/include/boost $UNDEFINED --compatibility_version=1.%type_pkg[boost].0 --current_version=1.%type_pkg[boost].0 --build-type=complete --layout=tagged variant=release threading=single,multi link=shared cxxflags="-std=c++11 -MD -I%p/include" linkflags="-L%p/lib"
 <<
 
 InstallScript: <<
@@ -224,7 +223,7 @@ fi
 Splitoff: <<
 	Package: %N-shlibs
 	Depends: <<
-		libicu55-shlibs,
+		libicu72-shlibs,
 		openmpi-shlibs (>= 1.8.1-3),
 		( %type_num[python] ) %type_pkg[python]-shlibs
 	<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/boost1.58.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/boost1.58.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: boost1.58-%type_pkg[python]
 Version: 1.58.0
-Revision: 10
+Revision: 11
 Type: python (nopython systempython python2.7 python3.4 python3.5), boost (58)
 Distribution: 10.9, 10.10, 10.11, 10.12, 10.13, 10.14, 10.14.5, 10.15
 Description: Boost C++ Libraries: static and source libs
@@ -164,7 +164,7 @@ export PYTHON=$PYTHON
     --with-icu=%p
 
 LIBDIR2=$LIBDIR2 ./b2 -d2 \
-    cxxflags="-std=c++11 -MD -I%p/include" \
+    cxxflags="-std=c++11 -MD -I%p/include" linkflags="-L%p/lib" \
     $USEPYTHON \
     --prefix=%p \
     $LIBDIR \

--- a/10.9-libcxx/stable/main/finkinfo/libs/boost1.58.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/boost1.58.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: boost1.58-%type_pkg[python]
 Version: 1.58.0
-Revision: 9
+Revision: 10
 Type: python (nopython systempython python2.7 python3.4 python3.5), boost (58)
 Distribution: 10.9, 10.10, 10.11, 10.12, 10.13, 10.14, 10.14.5, 10.15
 Description: Boost C++ Libraries: static and source libs
@@ -14,7 +14,7 @@ BuildDepends: <<
 	fink (>= 0.34.4),
 	fink-package-precedence,
 	(%type_pkg[python] = nopython) libiconv-dev,
-	(%type_pkg[python] = nopython) libicu55-dev,
+	(%type_pkg[python] = nopython) libicu72-dev,
 	(%type_num[python]) %type_pkg[python]
 <<
 BuildDependsOnly: True
@@ -276,7 +276,7 @@ Splitoff: <<
 	Depends: <<
 		bzip2-shlibs,
 		libiconv,
-		libicu55-shlibs,
+		libicu72-shlibs,
 		( %type_num[python] ) %type_pkg[python]-shlibs
 	<<
 	Files: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/boost1.63.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/boost1.63.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: boost1.63-%type_pkg[python]
 Version: 1.63.0
-Revision: 6
+Revision: 7
 Type: python (nopython systempython python2.7 python3.6), boost (63)
 Distribution: <<
 	( %type_pkg[python] = systempython ) 10.9,
@@ -178,7 +178,7 @@ export PYTHON=$PYTHON
 	--with-icu=%p
 
 LIBDIR2=$LIBDIR2 ./b2 -d2 \
-	cxxflags="-std=c++11 -MD -I%p/include" \
+	cxxflags="-std=c++11 -MD -I%p/include" linkflags="-L%p/lib" \
 	$MAKEFLAGS \
 	$USEPYTHON \
 	--prefix=%p \

--- a/10.9-libcxx/stable/main/finkinfo/libs/boost1.63.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/boost1.63.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: boost1.63-%type_pkg[python]
 Version: 1.63.0
-Revision: 5
+Revision: 6
 Type: python (nopython systempython python2.7 python3.6), boost (63)
 Distribution: <<
 	( %type_pkg[python] = systempython ) 10.9,
@@ -31,7 +31,7 @@ BuildDepends: <<
 	fink (>= 0.34.4),
 	fink-package-precedence,
 	(%type_pkg[python] = nopython) libiconv-dev,
-	(%type_pkg[python] = nopython) libicu55-dev,
+	(%type_pkg[python] = nopython) libicu72-dev,
 	(%type_num[python]) %type_pkg[python]
 <<
 BuildDependsOnly: True
@@ -298,7 +298,7 @@ Splitoff: <<
 	Depends: <<
 		(%type_pkg[python] = nopython) bzip2-shlibs,
 		(%type_pkg[python] = nopython) libiconv,
-		(%type_pkg[python] = nopython) libicu55-shlibs,
+		(%type_pkg[python] = nopython) libicu72-shlibs,
 		( %type_num[python] ) %type_pkg[python]-shlibs
 	<<
 	Files: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/boost1.68.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/boost1.68.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: boost1.68-%type_pkg[python]
 Version: 1.68.0
-Revision: 2
+Revision: 3
 Type: python (nopython systempython python2.7 python3.7 python3.10), boost (68)
 Distribution: <<
 	( %type_pkg[python] = systempython ) 10.9,
@@ -23,7 +23,7 @@ BuildDepends: <<
 	fink (>= 0.34.4),
 	fink-package-precedence,
 	(%type_pkg[python] = nopython) libiconv-dev,
-	(%type_pkg[python] = nopython) libicu55-dev,
+	(%type_pkg[python] = nopython) libicu72-dev,
 	(%type_pkg[python] = nopython) liblzma5,
 	(%type_num[python]) %type_pkg[python]
 <<
@@ -312,7 +312,7 @@ Splitoff: <<
 	Depends: <<
 		(%type_pkg[python] = nopython) bzip2-shlibs,
 		(%type_pkg[python] = nopython) libiconv,
-		(%type_pkg[python] = nopython) libicu55-shlibs,
+		(%type_pkg[python] = nopython) libicu72-shlibs,
 		(%type_pkg[python] = nopython) liblzma5-shlibs,
 		( %type_num[python] ) %type_pkg[python]-shlibs
 	<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/boost1.78.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/boost1.78.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: boost1.78-%type_pkg[python]
 Version: 1.78.0
-Revision: 1
+Revision: 2
 Type: python (nopython python3.10), boost (78)
 Description: Boost C++ Libraries: static and source libs
 License: BSD
@@ -13,7 +13,7 @@ BuildDepends: <<
 	fink (>= 0.34.4),
 	fink-package-precedence,
 	(%type_pkg[python] = nopython) libiconv-dev,
-	(%type_pkg[python] = nopython) libicu55-dev,
+	(%type_pkg[python] = nopython) libicu72-dev,
 	(%type_pkg[python] = nopython) liblzma5,
 	(%type_pkg[python] = nopython) libzstd1-dev,
 	(%type_num[python]) %type_pkg[python]
@@ -265,7 +265,7 @@ Splitoff: <<
 	Depends: <<
 		(%type_pkg[python] = nopython) bzip2-shlibs,
 		(%type_pkg[python] = nopython) libiconv,
-		(%type_pkg[python] = nopython) libicu55-shlibs,
+		(%type_pkg[python] = nopython) libicu72-shlibs,
 		(%type_pkg[python] = nopython) liblzma5-shlibs,
 		(%type_pkg[python] = nopython) libzstd1-shlibs,
 		( %type_num[python] ) %type_pkg[python]-shlibs


### PR DESCRIPTION
As part of a sweep to upgrade as many packages as possible to the latest libicuXX libversion, this is my quick pass at the boost* package sets.

I did not investigate further what caused the non-detection in the oldest boost libversions (1.53 and 1.55). But one clue is I'm fairly sure that libicu as of 6x-ish requires c++11, so older boost might not be using that. Given those boost are already dist-restricted and not used, probably not worth any time thinking more about it. We'll just have to dist-restrict (rather than kill off altogether) the libicu55 headers package in the future.
