### PR TITLE
Miktex tools update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/text/miktex-tools.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/miktex-tools.info
@@ -1,15 +1,17 @@
 Package: miktex-tools
-# 2.9.6600 has %p/MikTeX Console.app and no obvious way to return to standard path layout
-Version: 2.9.7440
+Version: 22.10
 Revision: 1
 Description: MiKTeX package manager tools 
 License: DFSG-Approved
 Maintainer: None <fink-devel@lists.sourceforge.net>
-Source: mirror:ctan:systems/win32/miktex/source/miktex-%v.tar.xz
-Source-Checksum: SHA256(c2b4ea16a3ab4ff73ac489bfb69232dae6fd43f59554203cf04f94395e12136f)
+#Source: mirror:ctan:systems/win32/miktex/source/miktex-%v.tar.xz
+Source: https://github.com/MiKTeX/miktex/archive/refs/tags/%v.tar.gz
+SourceRename: miktex-%v.tar.gz
+Source-Checksum: SHA256(f169555a518b5ff5557b28c9e259084182f5f38f080bc3570ae4f953f8f73e51)
 PatchFile: %n.patch
-PatchFile-MD5: dd666cac7e955158d3bb26b0ba0a413a
+PatchFile-MD5: ca319bfb5b395d5809e79b48c791b881
 Depends: <<
+	boost1.78-nopython-shlibs,
 	bzip2-shlibs,
 	cairo-shlibs,
 	expat1-shlibs,
@@ -27,7 +29,6 @@ Depends: <<
 	liblzma5-shlibs,
 	libmpfr6-shlibs,
 	libpng16-shlibs (>= 1.6.34),
-	libpotrace0-shlibs,
 	liburiparser1-shlibs,
 	openssl110-shlibs,
 	pixman-shlibs,
@@ -36,10 +37,10 @@ Depends: <<
 <<
 # libapr and libaprutil are checked for, but not used since we have an external liblog4cxx
 BuildDepends: <<
+	boost1.78-nopython,
 	bzip2-dev,
 	cairo,
 	cmake (>= 3.7.0),
-	dos2unix,
 	expat1,
 	fink (>= 0.34),
 	fink-package-precedence,
@@ -62,7 +63,6 @@ BuildDepends: <<
 	liblzma5,
 	libmpfr6,
 	libpng16 (>= 1.6.34),
-	libpotrace0,
 	liburiparser1,
 	libxslt-bin,
 	openssl110-dev,
@@ -104,6 +104,8 @@ CompileScript: <<
 		-DBZIP2_LIBRARY_RELEASE:FILEPATH=%p/lib/libbz2.dylib \
 		-DCMAKE_CXX_FLAGS="-MD" \
 		-DCMAKE_C_FLAGS="-MD" \
+		-DBoost_INCLUDE_DIR="%p/opt/boost-1_78/include" \
+		-DBoost_LOCALE_LIBRARY_RELEASE="%p/opt/boost-1_78/lib/libboost_locale-mt.dylib" \
 		-DCURL_INCLUDE_DIR:PATH=%p/include \
 		-DCURL_LIBRARY:FILEPATH=%p/lib/libcurl.dylib \
 		-DEXPAT_INCLUDE_DIR:PATH=%p/include \
@@ -144,7 +146,6 @@ CompileScript: <<
 		-DUSE_SYSTEM_PNG:BOOL=ON \
 		-DUSE_SYSTEM_POPPLER:BOOL=OFF \
 		-DUSE_SYSTEM_POPT:BOOL=ON \
-		-DUSE_SYSTEM_POTRACE:BOOL=ON \
 		-DUSE_SYSTEM_ZLIB:BOOL=ON \
 		-DUSE_SYSTEM_ZZIP:BOOL=ON \
 		-DWITH_UI_QT:BOOL=OFF \
@@ -170,28 +171,31 @@ InstallScript: <<
 	#rm -rf %i/texmfs
 	# remove unversioned dylibs (some are included private copies
 	# of libraries for which fink doesn't have a suitable version)
-	for DYLIB in app core extractor fmt kpathsea lua53 md5 mspack packagemanager poppler setup teckit texmf trace util web2c; do
-		rm %i/lib/libMiKTeX209-$DYLIB.dylib
+	for DYLIB in app core extractor fmt kpathsea loc lua53 md5 mspack packagemanager poppler ptexenc res setup teckit texmf trace util web2c; do
+		rm %i/lib/libmiktex-$DYLIB.dylib
 	done
 <<
 Shlibs: <<
-	!%p/lib/libMiKTeX209-app.4.dylib
-	!%p/lib/libMiKTeX209-core.19.dylib
-	!%p/lib/libMiKTeX209-extractor.1.dylib
-	!%p/lib/libMiKTeX209-fmt.1.dylib
-	!%p/lib/libMiKTeX209-kpathsea.3.dylib
-	!%p/lib/libMiKTeX209-lua53.1.dylib
-	!%p/lib/libMiKTeX209-md5.1.dylib
-	!%p/lib/libMiKTeX209-metapost.dylib
-	!%p/lib/libMiKTeX209-mspack.1.dylib
-	!%p/lib/libMiKTeX209-packagemanager.9.dylib
-	!%p/lib/libMiKTeX209-poppler.1.dylib
-	!%p/lib/libMiKTeX209-setup.5.dylib
-	!%p/lib/libMiKTeX209-teckit.1.dylib
-	!%p/lib/libMiKTeX209-texmf.4.dylib
-	!%p/lib/libMiKTeX209-trace.4.dylib
-	!%p/lib/libMiKTeX209-util.3.dylib
-	!%p/lib/libMiKTeX209-web2c.1.dylib
+	!%p/lib/libmiktex-app.6.dylib
+	!%p/lib/libmiktex-core.28.dylib
+	!%p/lib/libmiktex-extractor.2.dylib
+	!%p/lib/libmiktex-fmt.2.dylib
+	!%p/lib/libmiktex-kpathsea.5.dylib
+	!%p/lib/libmiktex-loc.1.dylib
+	!%p/lib/libmiktex-lua53.1.dylib
+	!%p/lib/libmiktex-md5.1.dylib
+	!%p/lib/libmiktex-metapost.dylib
+	!%p/lib/libmiktex-mspack.2.dylib
+	!%p/lib/libmiktex-packagemanager.11.dylib
+	!%p/lib/libmiktex-poppler.3.dylib
+	!%p/lib/libmiktex-ptexenc.2.dylib
+	!%p/lib/libmiktex-res.1.dylib
+	!%p/lib/libmiktex-setup.6.dylib
+	!%p/lib/libmiktex-teckit.2.dylib
+	!%p/lib/libmiktex-texmf.8.dylib
+	!%p/lib/libmiktex-trace.5.dylib
+	!%p/lib/libmiktex-util.5.dylib
+	!%p/lib/libmiktex-web2c.2.dylib
 <<
 DocFiles: CHANGELOG.md CONTRIBUTING.md COPYING.md HACKING.md README.md
 DescDetail: << 
@@ -226,14 +230,5 @@ DescPackaging: <<
 * poppler needs v0.59.0
 
 * Known to fail with xcode 7.3 (clang 703.0.29).
-
-In Libraries/MiKTeX/KPathSeaEmulation/include/miktex/KPSE/Emulation.h
-is a 'boolean' typedef that conflicts with libjpeg's public header
-(enum vs int) when compiling xetex-miktex.cpp. The documented
-HAVE_BOOL token disables both declarations or other other chaos that
-seems complicated to resolve cleanly. But Emulation.h sets HAVE_BOOL
-after setting its local typedef and libjpeg respects that, so just
-move the #include that leads to Emulation.h to prior to the one for
-jpeglib.h.
 <<
 Homepage: http://www.miktex.org

--- a/10.9-libcxx/stable/main/finkinfo/text/miktex-tools.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/miktex-tools.info
@@ -1,16 +1,15 @@
 Package: miktex-tools
 # 2.9.6600 has %p/MikTeX Console.app and no obvious way to return to standard path layout
-Version: 2.9.6530
-Revision: 4
+Version: 2.9.7440
+Revision: 1
 Description: MiKTeX package manager tools 
 License: DFSG-Approved
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:ctan:systems/win32/miktex/source/miktex-%v.tar.xz
-Source-Checksum: SHA256(dffa1571782c25c041b210dfb439cf79d420bbcdcc2bd5b6a76cc7e1dafd9acb)
+Source-Checksum: SHA256(c2b4ea16a3ab4ff73ac489bfb69232dae6fd43f59554203cf04f94395e12136f)
 PatchFile: %n.patch
-PatchFile-MD5: 8090c12011aa88d87681737e022f5722
+PatchFile-MD5: dd666cac7e955158d3bb26b0ba0a413a
 Depends: <<
-	botan1.10-shlibs,
 	bzip2-shlibs,
 	cairo-shlibs,
 	expat1-shlibs,
@@ -37,7 +36,6 @@ Depends: <<
 <<
 # libapr and libaprutil are checked for, but not used since we have an external liblog4cxx
 BuildDepends: <<
-	botan1.10,
 	bzip2-dev,
 	cairo,
 	cmake (>= 3.7.0),
@@ -56,7 +54,7 @@ BuildDepends: <<
 	libaprutil.0-dev,
 	libcurl4 (>= 7.56.1),
 	libgraphite2-dev,
-	libhunspell1.6-dev,
+	libhunspell1.7-dev,
 	libharfbuzz0-dev,
 	libicu72-dev,
 	libjpeg9,
@@ -88,10 +86,10 @@ CompileScript: <<
 	# manually compile zlib because we need 1.2.8 (10.11 has 1.2.5) but the
 	# build is broken finding the miktex-internal copy
 	# https://sourceforge.net/p/miktex/bugs/2528/
-	pushd Libraries/3rd/zlib
-		cmake $FINK_CMAKE_ARGS -DLINK_EVERYTHING_STATICALLY=TRUE .
-		make -w
-	popd
+	#pushd Libraries/3rd/zlib
+	#	cmake $FINK_CMAKE_ARGS -DLINK_EVERYTHING_STATICALLY=TRUE .
+	#	make -w
+	#popd
 	mkdir finkbuild
 	pushd finkbuild
 	cmake \
@@ -111,7 +109,7 @@ CompileScript: <<
 		-DEXPAT_INCLUDE_DIR:PATH=%p/include \
 		-DEXPAT_LIBRARY:FILEPATH=%p/lib/libexpat.dylib \
 		-DFLEX_EXECUTABLE:FILEPATH=/usr/bin/flex \
-		-DHUNSPELL_LIBRARY:FILEPATH=%p/lib/libhunspell-1.6.dylib \
+		-DHUNSPELL_LIBRARY:FILEPATH=%p/lib/libhunspell-1.7.dylib \
 		-DLIBLZMA_LIBRARY:FILEPATH=%p/lib/liblzma.dylib \
 		-DLOG4CXX_INCLUDE_DIR:PATH=%p/include \
 		-DLOG4CXX_LIBRARY:FILEPATH=%p/lib/liblog4cxx.dylib \
@@ -120,11 +118,9 @@ CompileScript: <<
 		-DMIKTEX_SYSTEM_VAR_CACHE_DIR:PATH=%p/var/cache \
 		-DMIKTEX_SYSTEM_VAR_LIB_DIR:PATH=%p/var/lib \
 		-DMIKTEX_SYSTEM_VAR_LOG_DIR:PATH=%p/var/log \
-		-DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python \
 		-DSED_EXECUTABLE:FILEPATH=/usr/bin/sed \
 		-DUSE_SYSTEM_APR:BOOL=ON \
 		-DUSE_SYSTEM_APRUTIL:BOOL=ON \
-		-DUSE_SYSTEM_BOTAN:BOOL=ON \
 		-DUSE_SYSTEM_BZIP2:BOOL=ON \
 		-DUSE_SYSTEM_CAIRO:BOOL=ON \
 		-DUSE_SYSTEM_CURL:BOOL=ON \
@@ -153,10 +149,10 @@ CompileScript: <<
 		-DUSE_SYSTEM_ZZIP:BOOL=ON \
 		-DWITH_UI_QT:BOOL=OFF \
 		-DXSLTPROC_EXECUTABLE:FILEPATH=%p/bin/xsltproc \
-		-DZLIB_INCLUDE_DIR:PATH=%b/Libraries/3rd/zlib/include \
-		-DZLIB_LIBRARY_RELEASE:FILEPATH=%b/Libraries/3rd/zlib/static/libSTATIC.a \
 		-LAH \
 		..
+#		-DZLIB_INCLUDE_DIR:PATH=%b/Libraries/3rd/zlib/source \
+#		-DZLIB_LIBRARY_RELEASE:FILEPATH=%b/Libraries/3rd/zlib/static/libSTATIC.a \
 	make -w
 	popd
 	fink-package-precedence --depfile-ext='\.d' .
@@ -174,29 +170,30 @@ InstallScript: <<
 	#rm -rf %i/texmfs
 	# remove unversioned dylibs (some are included private copies
 	# of libraries for which fink doesn't have a suitable version)
-	for DYLIB in app core extractor kpathsea lua52 md5 mspack packagemanager poppler setup teckit texmf trace util web2c; do
+	for DYLIB in app core extractor fmt kpathsea lua53 md5 mspack packagemanager poppler setup teckit texmf trace util web2c; do
 		rm %i/lib/libMiKTeX209-$DYLIB.dylib
 	done
 <<
 Shlibs: <<
-	!%p/lib/libMiKTeX209-app.2.dylib
-	!%p/lib/libMiKTeX209-core.3.dylib
+	!%p/lib/libMiKTeX209-app.4.dylib
+	!%p/lib/libMiKTeX209-core.19.dylib
 	!%p/lib/libMiKTeX209-extractor.1.dylib
-	!%p/lib/libMiKTeX209-kpathsea.1.dylib
-	!%p/lib/libMiKTeX209-lua52.1.dylib
+	!%p/lib/libMiKTeX209-fmt.1.dylib
+	!%p/lib/libMiKTeX209-kpathsea.3.dylib
+	!%p/lib/libMiKTeX209-lua53.1.dylib
 	!%p/lib/libMiKTeX209-md5.1.dylib
 	!%p/lib/libMiKTeX209-metapost.dylib
 	!%p/lib/libMiKTeX209-mspack.1.dylib
-	!%p/lib/libMiKTeX209-packagemanager.1.dylib
+	!%p/lib/libMiKTeX209-packagemanager.9.dylib
 	!%p/lib/libMiKTeX209-poppler.1.dylib
-	!%p/lib/libMiKTeX209-setup.1.dylib
+	!%p/lib/libMiKTeX209-setup.5.dylib
 	!%p/lib/libMiKTeX209-teckit.1.dylib
-	!%p/lib/libMiKTeX209-texmf.2.dylib
-	!%p/lib/libMiKTeX209-trace.1.dylib
-	!%p/lib/libMiKTeX209-util.1.dylib
+	!%p/lib/libMiKTeX209-texmf.4.dylib
+	!%p/lib/libMiKTeX209-trace.4.dylib
+	!%p/lib/libMiKTeX209-util.3.dylib
 	!%p/lib/libMiKTeX209-web2c.1.dylib
 <<
-DocFiles: CHANGELOG.md LICENSE.md README.md
+DocFiles: CHANGELOG.md CONTRIBUTING.md COPYING.md HACKING.md README.md
 DescDetail: << 
   The MiKTeX Tools package does not comprise a TeX system.
   The package should be regarded as an addition to the TeX system
@@ -226,7 +223,7 @@ mpm --admin --package-level=basic --upgrade
 DescPackaging: <<
 * Former maintainer: Sjors Gielen <fink@sjorsgielen.nl>
 
-* poppler needs v0.38.0
+* poppler needs v0.59.0
 
 * Known to fail with xcode 7.3 (clang 703.0.29).
 

--- a/10.9-libcxx/stable/main/finkinfo/text/miktex-tools.patch
+++ b/10.9-libcxx/stable/main/finkinfo/text/miktex-tools.patch
@@ -1,84 +1,56 @@
-diff -ruN miktex-2.9.7440-orig/CMakeLists.txt miktex-2.9.7440/CMakeLists.txt
---- miktex-2.9.7440-orig/CMakeLists.txt	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/CMakeLists.txt	2023-03-14 05:33:53.000000000 -0500
-@@ -137,8 +137,12 @@
-   set(MIKTEX_HOMEBREW TRUE)
+diff -ruN miktex-22.10-orig/CMakeLists.txt miktex-22.10/CMakeLists.txt
+--- miktex-22.10-orig/CMakeLists.txt	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/CMakeLists.txt	2023-03-15 05:21:50.000000000 -0500
+@@ -22,7 +22,7 @@
+ 
+ if(APPLE)
+     set(CMAKE_OSX_DEPLOYMENT_TARGET
+-        "10.12"
++        "10.9"
+         CACHE STRING
+         "The earliest version of MacOS X that MiKTeX will run on."
+     )
+@@ -141,8 +141,12 @@
+     set(MIKTEX_HOMEBREW TRUE)
  endif()
  
 -if(APPLE AND NOT MIKTEX_HOMEBREW)
--  set(MIKTEX_MACOS_BUNDLE TRUE)
-+if(${CMAKE_INSTALL_PREFIX} STREQUAL @FINK_PREFIX@)
-+  set(MIKTEX_FINK TRUE)
+-    set(MIKTEX_MACOS_BUNDLE TRUE)
++if(CMAKE_INSTALL_PREFIX STREQUAL "@FINK_PREFIX@")
++    set(MIKTEX_FINK TRUE)
 +endif()
 +
 +if(APPLE AND MIKTEX_FINK)
-+  set(MIKTEX_MACOS_BUNDLE FALSE)
++    set(MIKTEX_MACOS_BUNDLE FALSE)
  endif()
  
  ###############################################################################
-@@ -146,7 +150,9 @@
+@@ -150,7 +154,9 @@
  
  if(CMAKE_INSTALL_PREFIX STREQUAL "/usr")
-   set(MIKTEX_SELF_CONTAINED_DEFAULT FALSE)
+     set(MIKTEX_SELF_CONTAINED_DEFAULT FALSE)
 -elseif(CMAKE_INSTALL_PREFIX STREQUAL "/usr/local")
 +elseif(CMAKE_INSTALL_PREFIX STREQUAL "@FINK_PREFIX@")
-+  set(MIKTEX_SELF_CONTAINED_DEFAULT FALSE)
++    set(MIKTEX_SELF_CONTAINED_DEFAULT FALSE)
 +elseif(MIKTEX_FINK)
-   set(MIKTEX_SELF_CONTAINED_DEFAULT FALSE)
+     set(MIKTEX_SELF_CONTAINED_DEFAULT FALSE)
  elseif(MIKTEX_HOMEBREW)
-   set(MIKTEX_SELF_CONTAINED_DEFAULT FALSE)
-diff -ruN miktex-2.9.7440-orig/Documentation/CMakeLists.txt miktex-2.9.7440/Documentation/CMakeLists.txt
---- miktex-2.9.7440-orig/Documentation/CMakeLists.txt	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Documentation/CMakeLists.txt	2023-03-14 04:26:24.000000000 -0500
-@@ -26,7 +26,7 @@
+     set(MIKTEX_SELF_CONTAINED_DEFAULT FALSE)
+diff -ruN miktex-22.10-orig/Documentation/CMakeLists.txt miktex-22.10/Documentation/CMakeLists.txt
+--- miktex-22.10-orig/Documentation/CMakeLists.txt	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Documentation/CMakeLists.txt	2023-03-15 03:42:56.000000000 -0500
+@@ -15,7 +15,7 @@
  set(PROMPTWIN "C:\&gt; ")
  
  if(MIKTEX_UNIX_ALIKE)
--  set(COMMONINSTALL "/usr/local/share/miktex-texmf")
-+  set(COMMONINSTALL "@FINK_PREFIX@/share/miktex-texmf")
-   set(USERDATA "~/.miktex/texmfs/data")
-   set(USERINSTALL "~/.miktex/texmfs/install")
-   set(EXESUFFIX "")
-diff -ruN miktex-2.9.7440-orig/Libraries/3rd/log4cxx/CMakeLists.txt miktex-2.9.7440/Libraries/3rd/log4cxx/CMakeLists.txt
---- miktex-2.9.7440-orig/Libraries/3rd/log4cxx/CMakeLists.txt	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Libraries/3rd/log4cxx/CMakeLists.txt	2023-03-14 04:27:51.000000000 -0500
-@@ -30,6 +30,7 @@
-   ${CMAKE_CURRENT_BINARY_DIR}/privateinclude
-   ${CMAKE_CURRENT_SOURCE_DIR}
-   ${CMAKE_CURRENT_SOURCE_DIR}/source/src/main/include
-+  ${APR_INCLUDE_DIR}
- )
- 
- set(public_include_directories
-diff -ruN miktex-2.9.7440-orig/Libraries/3rd/log4cxx/source/src/main/cpp/stringhelper.cpp miktex-2.9.7440/Libraries/3rd/log4cxx/source/src/main/cpp/stringhelper.cpp
---- miktex-2.9.7440-orig/Libraries/3rd/log4cxx/source/src/main/cpp/stringhelper.cpp	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Libraries/3rd/log4cxx/source/src/main/cpp/stringhelper.cpp	2023-03-14 04:29:39.000000000 -0500
-@@ -28,6 +28,7 @@
- #endif
- #include <log4cxx/private/log4cxx_private.h>
- #include <cctype>
-+#include <cstdlib>
- #include <apr.h>
- 
- #if defined(MIKTEX)
-diff -ruN miktex-2.9.7440-orig/Libraries/3rd/log4cxx/source/src/main/include/log4cxx/helpers/simpledateformat.h miktex-2.9.7440/Libraries/3rd/log4cxx/source/src/main/include/log4cxx/helpers/simpledateformat.h
---- miktex-2.9.7440-orig/Libraries/3rd/log4cxx/source/src/main/include/log4cxx/helpers/simpledateformat.h	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Libraries/3rd/log4cxx/source/src/main/include/log4cxx/helpers/simpledateformat.h	2023-03-14 04:30:02.000000000 -0500
-@@ -27,10 +27,9 @@
- 
- #include <log4cxx/helpers/dateformat.h>
- #include <vector>
-+#include <locale>
- #include <time.h>
- 
--namespace std { class locale; }
--
- namespace log4cxx
- {
-         namespace helpers
-diff -ruN miktex-2.9.7440-orig/Libraries/3rd/lua53/source/src/luaconf.h miktex-2.9.7440/Libraries/3rd/lua53/source/src/luaconf.h
---- miktex-2.9.7440-orig/Libraries/3rd/lua53/source/src/luaconf.h	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Libraries/3rd/lua53/source/src/luaconf.h	2023-03-14 04:46:00.000000000 -0500
+-    set(COMMONINSTALL "/usr/local/share/miktex-texmf")
++    set(COMMONINSTALL "@FINK_PREFIX@/share/miktex-texmf")
+     set(USERDATA "~/.miktex/texmfs/data")
+     set(USERINSTALL "~/.miktex/texmfs/install")
+     set(EXESUFFIX "")
+diff -ruN miktex-22.10-orig/Libraries/3rd/lua53/source/src/luaconf.h miktex-22.10/Libraries/3rd/lua53/source/src/luaconf.h
+--- miktex-22.10-orig/Libraries/3rd/lua53/source/src/luaconf.h	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Libraries/3rd/lua53/source/src/luaconf.h	2023-03-15 03:46:32.000000000 -0500
 @@ -203,7 +203,7 @@
  
  #else			/* }{ */
@@ -88,24 +60,36 @@ diff -ruN miktex-2.9.7440-orig/Libraries/3rd/lua53/source/src/luaconf.h miktex-2
  #define LUA_LDIR	LUA_ROOT "share/lua/" LUA_VDIR "/"
  #define LUA_CDIR	LUA_ROOT "lib/lua/" LUA_VDIR "/"
  #define LUA_PATH_DEFAULT  \
-diff -ruN miktex-2.9.7440-orig/Libraries/3rd/luajit/source/src/luaconf.h miktex-2.9.7440/Libraries/3rd/luajit/source/src/luaconf.h
---- miktex-2.9.7440-orig/Libraries/3rd/luajit/source/src/luaconf.h	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Libraries/3rd/luajit/source/src/luaconf.h	2023-03-14 04:45:51.000000000 -0500
+diff -ruN miktex-22.10-orig/Libraries/3rd/luajit/source/src/luaconf.h miktex-22.10/Libraries/3rd/luajit/source/src/luaconf.h
+--- miktex-22.10-orig/Libraries/3rd/luajit/source/src/luaconf.h	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Libraries/3rd/luajit/source/src/luaconf.h	2023-03-15 03:46:57.000000000 -0500
 @@ -35,7 +35,7 @@
  #ifndef LUA_LMULTILIB
  #define LUA_LMULTILIB	"lib"
  #endif
 -#define LUA_LROOT	"/usr/local"
-+#define LUA_LROOT	"@FINK_PREFIX@"
++#define LUA_LROOT	""@FINK_PREFIX@"
  #define LUA_LUADIR	"/lua/5.1/"
  #define LUA_LJDIR	"/luajit-2.1.0-beta1/"
  
-diff -ruN miktex-2.9.7440-orig/Libraries/3rd/poppler/source/poppler/GlobalParams.cc miktex-2.9.7440/Libraries/3rd/poppler/source/poppler/GlobalParams.cc
---- miktex-2.9.7440-orig/Libraries/3rd/poppler/source/poppler/GlobalParams.cc	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Libraries/3rd/poppler/source/poppler/GlobalParams.cc	2023-03-14 04:45:10.000000000 -0500
-@@ -1300,11 +1300,11 @@
- };
+diff -ruN miktex-22.10-orig/Libraries/3rd/poppler/source/poppler/GlobalParams.cc miktex-22.10/Libraries/3rd/poppler/source/poppler/GlobalParams.cc
+--- miktex-22.10-orig/Libraries/3rd/poppler/source/poppler/GlobalParams.cc	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Libraries/3rd/poppler/source/poppler/GlobalParams.cc	2023-03-15 03:48:07.000000000 -0500
+@@ -1065,7 +1065,7 @@
+                        { "ZapfDingbats", "d050000l.pfb", nullptr },
+                        { nullptr, nullptr, nullptr } };
  
+-static const char *displayFontDirs[] = { "/usr/share/ghostscript/fonts", "/usr/local/share/ghostscript/fonts", "/usr/share/fonts/default/Type1", "/usr/share/fonts/default/ghostscript", "/usr/share/fonts/type1/gsfonts", nullptr };
++static const char *displayFontDirs[] = { "@FINK_PREFIX@/share/ghostscript/fonts", "@FINK_PREFIX@/lib/X11/fonts/ghostscript/Type1", "@FINK_PREFIX@/share/fonts/default/ghostscript", "@FINK_PREFIX@/share/fonts/type1/gsfonts", nullptr };
+ 
+ void GlobalParams::setupBaseFonts(const char *dir)
+ {
+diff -ruN miktex-22.10-orig/Libraries/3rd/xpdf/source/xpdf/GlobalParams.cc miktex-22.10/Libraries/3rd/xpdf/source/xpdf/GlobalParams.cc
+--- miktex-22.10-orig/Libraries/3rd/xpdf/source/xpdf/GlobalParams.cc	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Libraries/3rd/xpdf/source/xpdf/GlobalParams.cc	2023-03-15 04:16:02.000000000 -0500
+@@ -113,11 +113,10 @@
+ };
+ #else
  static const char *displayFontDirs[] = {
 -  "/usr/share/ghostscript/fonts",
 -  "/usr/local/share/ghostscript/fonts",
@@ -113,24 +97,23 @@ diff -ruN miktex-2.9.7440-orig/Libraries/3rd/poppler/source/poppler/GlobalParams
 -  "/usr/share/fonts/default/ghostscript",
 -  "/usr/share/fonts/type1/gsfonts",
 +  "@FINK_PREFIX@/share/ghostscript/fonts",
-+  "@FINK_PREFIX@/share/ghostscript/fonts",
 +  "@FINK_PREFIX@/lib/X11/fonts/ghostscript/Type1",
 +  "@FINK_PREFIX@/share/fonts/default/ghostscript",
 +  "@FINK_PREFIX@/share/fonts/type1/gsfonts",
-   NULL
- };
- 
-diff -ruN miktex-2.9.7440-orig/Libraries/MiKTeX/Core/Session/unx/unxSession.cpp miktex-2.9.7440/Libraries/MiKTeX/Core/Session/unx/unxSession.cpp
---- miktex-2.9.7440-orig/Libraries/MiKTeX/Core/Session/unx/unxSession.cpp	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Libraries/MiKTeX/Core/Session/unx/unxSession.cpp	2023-03-14 04:43:01.000000000 -0500
-@@ -94,12 +94,12 @@
+ #if defined(__sun) && defined(__SVR4)
+   "/usr/sfw/share/ghostscript/fonts",
+ #endif
+diff -ruN miktex-22.10-orig/Libraries/MiKTeX/Core/Session/unx/unxStartupConfig.cpp miktex-22.10/Libraries/MiKTeX/Core/Session/unx/unxStartupConfig.cpp
+--- miktex-22.10-orig/Libraries/MiKTeX/Core/Session/unx/unxStartupConfig.cpp	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Libraries/MiKTeX/Core/Session/unx/unxStartupConfig.cpp	2023-03-15 03:52:53.000000000 -0500
+@@ -41,12 +41,12 @@
   * UserConfig:    $HOME/.miktex/texmfs/config
   * UserData:      $HOME/.miktex/texmfs/data
   * UserInstall:   $HOME/.miktex/texmfs/install
 - * CommonConfig:  /var/lib/miktex-texmf           (DEB,RPM)
 - *             or /var/local/lib/miktex-texmf     (TGZ)
 + * CommonConfig:  @FINK_PREFIX@/var/lib/miktex-texmf           (DEB,RPM)
-+ *             or @FINK_PREFIX@/var/local/lib/miktex-texmf     (TGZ)
++ *             or @FINK_PREFIX@/var/lib/miktex-texmf     (TGZ)
   *             or /opt/miktex/texmfs/config       (self-contained)
 - * CommonData:    /var/cache/miktex-texmf         (DEB,RPM,TGZ)
 + * CommonData:    @FINK_PREFIX@/var/cache/miktex-texmf         (DEB,RPM,TGZ)
@@ -139,69 +122,120 @@ diff -ruN miktex-2.9.7440-orig/Libraries/MiKTeX/Core/Session/unx/unxSession.cpp 
 + * CommonInstall: @FINK_PREFIX@/share/miktex-texmf   (DEB,RPM,TGZ)
   *             or /opt/miktex/texmfs/install      (self-contained)
   */
- StartupConfig SessionImpl::DefaultConfig(MiKTeXConfiguration config, const PathName& commonPrefixArg, const PathName& userPrefixArg)
-diff -ruN miktex-2.9.7440-orig/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp miktex-2.9.7440/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp
---- miktex-2.9.7440-orig/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp	2023-03-14 04:33:05.000000000 -0500
-@@ -25,7 +25,7 @@
+ InternalStartupConfig SessionImpl::DefaultConfig(MiKTeXConfiguration config, VersionNumber setupVersion, const PathName& commonPrefixArg, const PathName& userPrefixArg)
+diff -ruN miktex-22.10-orig/Libraries/MiKTeX/Core/shared/CMakeLists.txt miktex-22.10/Libraries/MiKTeX/Core/shared/CMakeLists.txt
+--- miktex-22.10-orig/Libraries/MiKTeX/Core/shared/CMakeLists.txt	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Libraries/MiKTeX/Core/shared/CMakeLists.txt	2023-03-15 05:15:27.000000000 -0500
+@@ -136,7 +136,7 @@
+   endif()
+ endif()
+ 
+-if(MIKTEX_MACOS_BUNDLE)
++if(MIKTEX_MACOS_BUNDLE OR MIKTEX_FINK)
+   target_link_libraries(${core_dll_name}
+     PRIVATE
+       "-framework CoreServices"
+diff -ruN miktex-22.10-orig/Libraries/MiKTeX/Core/static/CMakeLists.txt miktex-22.10/Libraries/MiKTeX/Core/static/CMakeLists.txt
+--- miktex-22.10-orig/Libraries/MiKTeX/Core/static/CMakeLists.txt	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Libraries/MiKTeX/Core/static/CMakeLists.txt	2023-03-15 05:25:57.000000000 -0500
+@@ -102,7 +102,7 @@
+   endif()
+ endif()
+ 
+-if(MIKTEX_MACOS_BUNDLE)
++if(MIKTEX_MACOS_BUNDLE OR MIKTEX_FINK)
+   target_link_libraries(${core_lib_name}
+     PUBLIC
+       "-framework CoreServices"
+diff -ruN miktex-22.10-orig/Libraries/MiKTeX/Locale/shared/CMakeLists.txt miktex-22.10/Libraries/MiKTeX/Locale/shared/CMakeLists.txt
+--- miktex-22.10-orig/Libraries/MiKTeX/Locale/shared/CMakeLists.txt	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Libraries/MiKTeX/Locale/shared/CMakeLists.txt	2023-03-15 05:17:07.000000000 -0500
+@@ -57,7 +57,7 @@
+     ${res_dll_name}
+ )
+ 
+-if(MIKTEX_MACOS_BUNDLE)
++if(MIKTEX_MACOS_BUNDLE OR MIKTEX_FINK)
+   target_link_libraries(${loc_dll_name}
+     PRIVATE
+       ${CoreFoundation}
+diff -ruN miktex-22.10-orig/Libraries/MiKTeX/Locale/static/CMakeLists.txt miktex-22.10/Libraries/MiKTeX/Locale/static/CMakeLists.txt
+--- miktex-22.10-orig/Libraries/MiKTeX/Locale/static/CMakeLists.txt	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Libraries/MiKTeX/Locale/static/CMakeLists.txt	2023-03-15 04:47:30.000000000 -0500
+@@ -41,7 +41,7 @@
+     ${res_lib_name}
+ )
+ 
+-if(MIKTEX_MACOS_BUNDLE)
++if(MIKTEX_MACOS_BUNDLE OR MIKTEX_FINK)
+   target_link_libraries(${loc_lib_name}
+     PRIVATE
+       ${CoreFoundation}
+diff -ruN miktex-22.10-orig/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp miktex-22.10/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp
+--- miktex-22.10-orig/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp	2023-03-15 03:53:17.000000000 -0500
+@@ -27,7 +27,7 @@
  PathName SetupService::GetDefaultCommonInstallDir()
  {
    // TODO
 -  return PathName("/usr/local/miktex");
-+  return PathName("@FINK_PREFIX@/lib/miktex");
++  return PathName("@FINK_PREFIX@/miktex");
  }
  
  PathName SetupService::GetDefaultUserInstallDir()
-diff -ruN miktex-2.9.7440-orig/Programs/Bibliography/bibtex-x/source/bibtex.c miktex-2.9.7440/Programs/Bibliography/bibtex-x/source/bibtex.c
---- miktex-2.9.7440-orig/Programs/Bibliography/bibtex-x/source/bibtex.c	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Programs/Bibliography/bibtex-x/source/bibtex.c	2023-03-14 04:33:45.000000000 -0500
-@@ -229,7 +229,7 @@
- #if defined(MIKTEX)
- #  define main MIKTEXCEECALL Main
- #endif
--int                     main (int argc, char **argv)
-+int main (int argc, char **argv)
- BEGIN
-     extern Integer8_T       history;
-     int			    exit_status;
-diff -ruN miktex-2.9.7440-orig/Programs/DviWare/dvipdfm-x/source/dpxfile.c miktex-2.9.7440/Programs/DviWare/dvipdfm-x/source/dpxfile.c
---- miktex-2.9.7440-orig/Programs/DviWare/dvipdfm-x/source/dpxfile.c	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Programs/DviWare/dvipdfm-x/source/dpxfile.c	2023-03-14 04:34:27.000000000 -0500
+diff -ruN miktex-22.10-orig/Programs/DviWare/dvipdfm-x/source/dpxfile.c miktex-22.10/Programs/DviWare/dvipdfm-x/source/dpxfile.c
+--- miktex-22.10-orig/Programs/DviWare/dvipdfm-x/source/dpxfile.c	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Programs/DviWare/dvipdfm-x/source/dpxfile.c	2023-03-15 03:54:14.000000000 -0500
 @@ -82,7 +82,7 @@
  static int
  miktex_get_acrobat_font_dir (char *buf)
  {
 -  strcpy(buf, "/usr/share/ghostscript/Resource/Font/");
-+  strcpy(buf, "@FINK_PREFIX@/share/ghostscript/fonts/");
++  strcpy(buf, "@FINK_PREFIX@/share/ghostscript/Resource/Font/");
    return  1;
  }
  
-diff -ruN miktex-2.9.7440-orig/Programs/Editors/TeXworks/miktex/DefaultBinaryPaths.h miktex-2.9.7440/Programs/Editors/TeXworks/miktex/DefaultBinaryPaths.h
---- miktex-2.9.7440-orig/Programs/Editors/TeXworks/miktex/DefaultBinaryPaths.h	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Programs/Editors/TeXworks/miktex/DefaultBinaryPaths.h	2023-03-14 04:39:59.000000000 -0500
+diff -ruN miktex-22.10-orig/Programs/Editors/TeXworks/miktex/DefaultBinaryPaths.h miktex-22.10/Programs/Editors/TeXworks/miktex/DefaultBinaryPaths.h
+--- miktex-22.10-orig/Programs/Editors/TeXworks/miktex/DefaultBinaryPaths.h	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Programs/Editors/TeXworks/miktex/DefaultBinaryPaths.h	2023-03-15 03:54:33.000000000 -0500
 @@ -1 +1 @@
 -#define DEFAULT_BIN_PATHS "/usr/local/bin"
 +#define DEFAULT_BIN_PATHS "@FINK_PREFIX@/bin"
-diff -ruN miktex-2.9.7440-orig/Programs/Editors/TeXworks/source/src/TWUtils.cpp miktex-2.9.7440/Programs/Editors/TeXworks/source/src/TWUtils.cpp
---- miktex-2.9.7440-orig/Programs/Editors/TeXworks/source/src/TWUtils.cpp	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Programs/Editors/TeXworks/source/src/TWUtils.cpp	2023-03-14 04:42:21.000000000 -0500
-@@ -54,10 +54,10 @@
- #if defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN)
- // compile-time default paths - customize by defining in the .pro file
- #ifndef TW_DICPATH
--#define TW_DICPATH "/usr/share/hunspell" PATH_LIST_SEP "/usr/share/myspell/dicts"
-+#define TW_DICPATH "@FINK_PREFIX@/share/hunspell" PATH_LIST_SEP "@FINK_PREFIX@/share/myspell/dicts"
- #endif
+diff -ruN miktex-22.10-orig/Programs/Editors/TeXworks/source/src/TWUtils.cpp miktex-22.10/Programs/Editors/TeXworks/source/src/TWUtils.cpp
+--- miktex-22.10-orig/Programs/Editors/TeXworks/source/src/TWUtils.cpp	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Programs/Editors/TeXworks/source/src/TWUtils.cpp	2023-03-15 03:55:46.000000000 -0500
+@@ -55,9 +55,9 @@
+ #include <QStringList>
+ #include <QTextCodec>
+ 
+-#if defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN)
++#if defined(Q_OS_UNIX) || defined(Q_OS_DARWIN)
  #ifndef TW_HELPPATH
 -#define TW_HELPPATH "/usr/local/share/texworks-help"
 +#define TW_HELPPATH "@FINK_PREFIX@/share/texworks-help"
  #endif
  #endif
  
-diff -ruN miktex-2.9.7440-orig/Programs/MiKTeX/initexmf/initexmf.cpp miktex-2.9.7440/Programs/MiKTeX/initexmf/initexmf.cpp
---- miktex-2.9.7440-orig/Programs/MiKTeX/initexmf/initexmf.cpp	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Programs/MiKTeX/initexmf/initexmf.cpp	2023-03-14 04:35:56.000000000 -0500
-@@ -1402,7 +1402,7 @@
+diff -ruN miktex-22.10-orig/Programs/Editors/TeXworks/source/src/utils/ResourcesLibrary.cpp miktex-22.10/Programs/Editors/TeXworks/source/src/utils/ResourcesLibrary.cpp
+--- miktex-22.10-orig/Programs/Editors/TeXworks/source/src/utils/ResourcesLibrary.cpp	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Programs/Editors/TeXworks/source/src/utils/ResourcesLibrary.cpp	2023-03-15 04:02:49.000000000 -0500
+@@ -37,10 +37,10 @@
+ 
+ #define TEXWORKS_NAME "TeXworks"
+ 
+-#if defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN)
++#if defined(Q_OS_UNIX) || defined(Q_OS_DARWIN)
+ // compile-time default paths - customize by defining in the .pro file
+ #	ifndef TW_DICPATH
+-#		define TW_DICPATH "/usr/share/hunspell" PATH_LIST_SEP "/usr/share/myspell/dicts"
++#		define TW_DICPATH "@FINK_PREFIX@/share/hunspell" PATH_LIST_SEP "/usr/share/myspell/dicts"
+ #	endif
+ #endif
+ 
+diff -ruN miktex-22.10-orig/Programs/MiKTeX/miktex/topics/links/commands/LinksManager.cpp miktex-22.10/Programs/MiKTeX/miktex/topics/links/commands/LinksManager.cpp
+--- miktex-22.10-orig/Programs/MiKTeX/miktex/topics/links/commands/LinksManager.cpp	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Programs/MiKTeX/miktex/topics/links/commands/LinksManager.cpp	2023-03-15 04:08:26.000000000 -0500
+@@ -332,7 +332,7 @@
  #if defined(MIKTEX_WINDOWS)
    { "arctrl" MIKTEX_EXE_FILE_SUFFIX, { "pdfclose", "pdfdde", "pdfopen" } },
  #endif
@@ -210,29 +244,9 @@ diff -ruN miktex-2.9.7440-orig/Programs/MiKTeX/initexmf/initexmf.cpp miktex-2.9.
  
    { MIKTEX_AFM2TFM_EXE, { "afm2tfm" } },
  #if defined(MIKTEX_WINDOWS)
-diff -ruN miktex-2.9.7440-orig/Programs/TeXAndFriends/xetex/xetex-miktex.cpp miktex-2.9.7440/Programs/TeXAndFriends/xetex/xetex-miktex.cpp
---- miktex-2.9.7440-orig/Programs/TeXAndFriends/xetex/xetex-miktex.cpp	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Programs/TeXAndFriends/xetex/xetex-miktex.cpp	2023-03-14 04:36:21.000000000 -0500
-@@ -18,6 +18,7 @@
-    USA. */
- 
- #include "miktex-first.h"
-+#include "xetex-miktex.h"
- 
- #include <poppler-config.h>
- #include <hb-icu.h>
-@@ -27,8 +28,6 @@
- #include <TECkit_Engine.h>
- #include <zlib.h>
- 
--#include "xetex-miktex.h"
--
- using namespace MiKTeX::Core;
- 
- XETEXPROGCLASS::unicodescalar*& buffer = XETEXPROG.buffer;
-diff -ruN miktex-2.9.7440-orig/Programs/Validation/chktex/source/OpSys.c miktex-2.9.7440/Programs/Validation/chktex/source/OpSys.c
---- miktex-2.9.7440-orig/Programs/Validation/chktex/source/OpSys.c	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/Programs/Validation/chktex/source/OpSys.c	2023-03-14 04:36:53.000000000 -0500
+diff -ruN miktex-22.10-orig/Programs/Validation/chktex/source/OpSys.c miktex-22.10/Programs/Validation/chktex/source/OpSys.c
+--- miktex-22.10-orig/Programs/Validation/chktex/source/OpSys.c	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/Programs/Validation/chktex/source/OpSys.c	2023-03-15 04:13:11.000000000 -0500
 @@ -98,7 +98,7 @@
  
  #ifndef SYSCONFDIR
@@ -242,22 +256,22 @@ diff -ruN miktex-2.9.7440-orig/Programs/Validation/chktex/source/OpSys.c miktex-
  #  elif defined(__MSDOS__)
  #    define SYSCONFDIR "\\emtex\\data\\"
  #  else
-diff -ruN miktex-2.9.7440-orig/cmake/modules/RuntimePaths.cmake miktex-2.9.7440/cmake/modules/RuntimePaths.cmake
---- miktex-2.9.7440-orig/cmake/modules/RuntimePaths.cmake	2020-05-17 14:37:59.000000000 -0500
-+++ miktex-2.9.7440/cmake/modules/RuntimePaths.cmake	2023-03-14 04:39:38.000000000 -0500
-@@ -28,10 +28,10 @@
+diff -ruN miktex-22.10-orig/cmake/modules/RuntimePaths.cmake miktex-22.10/cmake/modules/RuntimePaths.cmake
+--- miktex-22.10-orig/cmake/modules/RuntimePaths.cmake	2022-10-17 02:21:39.000000000 -0500
++++ miktex-22.10/cmake/modules/RuntimePaths.cmake	2023-03-15 04:13:40.000000000 -0500
+@@ -17,10 +17,10 @@
  endif()
  
  if(MIKTEX_UNIX_ALIKE)
--  set(MIKTEX_SYSTEM_ETC_FONTS_CONFD_DIR "/etc/fonts/conf.d" CACHE PATH "System-wide directory for font configuration data.")
--  set(MIKTEX_SYSTEM_LINK_TARGET_DIR "/usr/local/bin" CACHE PATH "System-wide directory in which to create symbolic links to MiKTeX binaries.")
--  set(MIKTEX_SYSTEM_VAR_CACHE_DIR "/var/cache" CACHE PATH "Directory for application cache data.")
--  set(MIKTEX_SYSTEM_VAR_LIB_DIR "/var/lib" CACHE PATH "Directory for state information.")
--  set(MIKTEX_SYSTEM_VAR_LOG_DIR "/var/log" CACHE PATH "Directory for log files.")
-+  set(MIKTEX_SYSTEM_ETC_FONTS_CONFD_DIR "@FINK_PREFIX@/etc/fonts/conf.d" CACHE PATH "System-wide directory for font configuration data.")
-+  set(MIKTEX_SYSTEM_LINK_TARGET_DIR "@FINK_PREFIX@/bin" CACHE PATH "System-wide directory in which to create symbolic links to MiKTeX binaries.")
-+  set(MIKTEX_SYSTEM_VAR_CACHE_DIR "@FINK_PREFIX@/var/cache" CACHE PATH "Directory for application cache data.")
-+  set(MIKTEX_SYSTEM_VAR_LIB_DIR "@FINK_PREFIX@/var/lib" CACHE PATH "Directory for state information.")
-+  set(MIKTEX_SYSTEM_VAR_LOG_DIR "@FINK_PREFIX@/var/log" CACHE PATH "Directory for log files.")
-   set(MIKTEX_USER_LINK_TARGET_DIR "~/bin" CACHE STRING "Per-user directory in which to create symbolic links to MiKTeX binaries.")
+-    set(MIKTEX_SYSTEM_ETC_FONTS_CONFD_DIR "/etc/fonts/conf.d" CACHE PATH "System-wide directory for font configuration data.")
+-    set(MIKTEX_SYSTEM_LINK_TARGET_DIR "/usr/local/bin" CACHE PATH "System-wide directory in which to create symbolic links to MiKTeX binaries.")
+-    set(MIKTEX_SYSTEM_VAR_CACHE_DIR "/var/cache" CACHE PATH "Directory for application cache data.")
+-    set(MIKTEX_SYSTEM_VAR_LIB_DIR "/var/lib" CACHE PATH "Directory for state information.")
+-    set(MIKTEX_SYSTEM_VAR_LOG_DIR "/var/log" CACHE PATH "Directory for log files.")
++    set(MIKTEX_SYSTEM_ETC_FONTS_CONFD_DIR "@FINK_PREFIX@/etc/fonts/conf.d" CACHE PATH "System-wide directory for font configuration data.")
++    set(MIKTEX_SYSTEM_LINK_TARGET_DIR "@FINK_PREFIX@/bin" CACHE PATH "System-wide directory in which to create symbolic links to MiKTeX binaries.")
++    set(MIKTEX_SYSTEM_VAR_CACHE_DIR "@FINK_PREFIX@/var/cache" CACHE PATH "Directory for application cache data.")
++    set(MIKTEX_SYSTEM_VAR_LIB_DIR "@FINK_PREFIX@/var/lib" CACHE PATH "Directory for state information.")
++    set(MIKTEX_SYSTEM_VAR_LOG_DIR "@FINK_PREFIX@/var/log" CACHE PATH "Directory for log files.")
+     set(MIKTEX_USER_LINK_TARGET_DIR "~/bin" CACHE STRING "Per-user directory in which to create symbolic links to MiKTeX binaries.")
  endif()

--- a/10.9-libcxx/stable/main/finkinfo/text/miktex-tools.patch
+++ b/10.9-libcxx/stable/main/finkinfo/text/miktex-tools.patch
@@ -1,27 +1,35 @@
-diff -Nurd miktex-2.9.6530.orig/CMakeLists.txt miktex-2.9.6530/CMakeLists.txt
---- miktex-2.9.6530.orig/CMakeLists.txt	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/CMakeLists.txt	2023-03-14 02:37:20.000000000 -0400
-@@ -124,7 +124,7 @@
+diff -ruN miktex-2.9.7440-orig/CMakeLists.txt miktex-2.9.7440/CMakeLists.txt
+--- miktex-2.9.7440-orig/CMakeLists.txt	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/CMakeLists.txt	2023-03-14 05:33:53.000000000 -0500
+@@ -137,8 +137,12 @@
+   set(MIKTEX_HOMEBREW TRUE)
+ endif()
+ 
+-if(APPLE AND NOT MIKTEX_HOMEBREW)
+-  set(MIKTEX_MACOS_BUNDLE TRUE)
++if(${CMAKE_INSTALL_PREFIX} STREQUAL @FINK_PREFIX@)
++  set(MIKTEX_FINK TRUE)
++endif()
++
++if(APPLE AND MIKTEX_FINK)
++  set(MIKTEX_MACOS_BUNDLE FALSE)
+ endif()
+ 
+ ###############################################################################
+@@ -146,7 +150,9 @@
  
  if(CMAKE_INSTALL_PREFIX STREQUAL "/usr")
    set(MIKTEX_SELF_CONTAINED_DEFAULT FALSE)
 -elseif(CMAKE_INSTALL_PREFIX STREQUAL "/usr/local")
 +elseif(CMAKE_INSTALL_PREFIX STREQUAL "@FINK_PREFIX@")
++  set(MIKTEX_SELF_CONTAINED_DEFAULT FALSE)
++elseif(MIKTEX_FINK)
    set(MIKTEX_SELF_CONTAINED_DEFAULT FALSE)
  elseif(MIKTEX_HOMEBREW)
    set(MIKTEX_SELF_CONTAINED_DEFAULT FALSE)
-@@ -1900,7 +1900,7 @@
- add_subdirectory(${MIKTEX_REL_CWEB_DIR})
- add_subdirectory(${MIKTEX_REL_DEFAULTS_DIR})
- add_subdirectory(${MIKTEX_REL_DEVNAG_DIR})
--add_subdirectory(${MIKTEX_REL_DOC_DIR})
-+#add_subdirectory(${MIKTEX_REL_DOC_DIR})
- add_subdirectory(${MIKTEX_REL_DVICOPY_DIR})
- add_subdirectory(${MIKTEX_REL_DVIPDFMX_DIR})
- add_subdirectory(${MIKTEX_REL_DVIPNG_DIR})
-diff -Nurd miktex-2.9.6530.orig/Documentation/CMakeLists.txt miktex-2.9.6530/Documentation/CMakeLists.txt
---- miktex-2.9.6530.orig/Documentation/CMakeLists.txt	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Documentation/CMakeLists.txt	2023-03-14 02:37:20.000000000 -0400
+diff -ruN miktex-2.9.7440-orig/Documentation/CMakeLists.txt miktex-2.9.7440/Documentation/CMakeLists.txt
+--- miktex-2.9.7440-orig/Documentation/CMakeLists.txt	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Documentation/CMakeLists.txt	2023-03-14 04:26:24.000000000 -0500
 @@ -26,7 +26,7 @@
  set(PROMPTWIN "C:\&gt; ")
  
@@ -31,55 +39,9 @@ diff -Nurd miktex-2.9.6530.orig/Documentation/CMakeLists.txt miktex-2.9.6530/Doc
    set(USERDATA "~/.miktex/texmfs/data")
    set(USERINSTALL "~/.miktex/texmfs/install")
    set(EXESUFFIX "")
-diff -Nurd miktex-2.9.6530.orig/Documentation/Manual/installing.xml miktex-2.9.6530/Documentation/Manual/installing.xml
---- miktex-2.9.6530.orig/Documentation/Manual/installing.xml	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Documentation/Manual/installing.xml	2023-03-14 02:37:20.000000000 -0400
-@@ -289,15 +289,15 @@
- <listitem><para>Packages installed for the user (&UserInstall;).</para></listitem>
- </varlistentry>
- <varlistentry>
--<term><filename>/usr/local/var/lib/miktex-texmf</filename></term>
-+<term><filename>@FINK_PREFIX@/var/lib/miktex-texmf</filename></term>
- <listitem><para>System-wide configuration data (&CommonConfig;).</para></listitem>
- </varlistentry>
- <varlistentry>
--<term><filename>/usr/local/var/cache/miktex-texmf</filename></term>
-+<term><filename>@FINK_PREFIX@/var/cache/miktex-texmf</filename></term>
- <listitem><para>System-wide recoverable data (&CommonData;).</para></listitem>
- </varlistentry>
- <varlistentry>
--<term><filename>/usr/local/share/miktex-texmf</filename></term>
-+<term><filename>@FINK_PREFIX@/share/miktex-texmf</filename></term>
- <listitem><para>Packages installed for all users (&CommonInstall;).</para></listitem>
- </varlistentry>
- </variablelist>
-@@ -306,19 +306,19 @@
- 
- <variablelist>
- <varlistentry>
--<term><filename>/usr/local/bin</filename></term>
-+<term><filename>@FINK_PREFIX@/bin</filename></term>
- <listitem><para>&MiKTeX; binaries</para></listitem>
- </varlistentry>
- <varlistentry>
--<term><filename>/usr/local/lib/miktex</filename></term>
-+<term><filename>@FINK_PREFIX@/lib/miktex</filename></term>
- <listitem><para>&MiKTeX; internal binaries</para></listitem>
- </varlistentry>
- <varlistentry>
--<term><filename>/usr/local/lib</filename></term>
-+<term><filename>@FINK_PREFIX@/lib</filename></term>
- <listitem><para>&MiKTeX; shared objects</para></listitem>
- </varlistentry>
- <varlistentry>
--<term><filename>/usr/local/share/man/man<replaceable>N</replaceable></filename></term>
-+<term><filename>@FINK_PREFIX@/share/man/man<replaceable>N</replaceable></filename></term>
- <listitem><para>&MiKTeX; man pages</para></listitem>
- </varlistentry>
- </variablelist>
-diff -Nurd miktex-2.9.6530.orig/Libraries/3rd/log4cxx/CMakeLists.txt miktex-2.9.6530/Libraries/3rd/log4cxx/CMakeLists.txt
---- miktex-2.9.6530.orig/Libraries/3rd/log4cxx/CMakeLists.txt	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Libraries/3rd/log4cxx/CMakeLists.txt	2023-03-14 02:37:20.000000000 -0400
+diff -ruN miktex-2.9.7440-orig/Libraries/3rd/log4cxx/CMakeLists.txt miktex-2.9.7440/Libraries/3rd/log4cxx/CMakeLists.txt
+--- miktex-2.9.7440-orig/Libraries/3rd/log4cxx/CMakeLists.txt	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Libraries/3rd/log4cxx/CMakeLists.txt	2023-03-14 04:27:51.000000000 -0500
 @@ -30,6 +30,7 @@
    ${CMAKE_CURRENT_BINARY_DIR}/privateinclude
    ${CMAKE_CURRENT_SOURCE_DIR}
@@ -88,23 +50,9 @@ diff -Nurd miktex-2.9.6530.orig/Libraries/3rd/log4cxx/CMakeLists.txt miktex-2.9.
  )
  
  set(public_include_directories
-diff -Nurd miktex-2.9.6530.orig/Libraries/3rd/log4cxx/shared/CMakeLists.txt miktex-2.9.6530/Libraries/3rd/log4cxx/shared/CMakeLists.txt
---- miktex-2.9.6530.orig/Libraries/3rd/log4cxx/shared/CMakeLists.txt	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Libraries/3rd/log4cxx/shared/CMakeLists.txt	2023-03-14 02:37:20.000000000 -0400
-@@ -51,8 +51,8 @@
- 
- target_link_libraries(${log4cxx_dll_name}
-   PRIVATE
--    ${apr_dll_name}
--    ${apr_util_dll_name}
-+	${APR_LIBRARY}
-+	${APRUTIL_LIBRARY}
-     ${system_libraries}
- )
- 
-diff -Nurd miktex-2.9.6530.orig/Libraries/3rd/log4cxx/source/src/main/cpp/stringhelper.cpp miktex-2.9.6530/Libraries/3rd/log4cxx/source/src/main/cpp/stringhelper.cpp
---- miktex-2.9.6530.orig/Libraries/3rd/log4cxx/source/src/main/cpp/stringhelper.cpp	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Libraries/3rd/log4cxx/source/src/main/cpp/stringhelper.cpp	2023-03-14 02:37:20.000000000 -0400
+diff -ruN miktex-2.9.7440-orig/Libraries/3rd/log4cxx/source/src/main/cpp/stringhelper.cpp miktex-2.9.7440/Libraries/3rd/log4cxx/source/src/main/cpp/stringhelper.cpp
+--- miktex-2.9.7440-orig/Libraries/3rd/log4cxx/source/src/main/cpp/stringhelper.cpp	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Libraries/3rd/log4cxx/source/src/main/cpp/stringhelper.cpp	2023-03-14 04:29:39.000000000 -0500
 @@ -28,6 +28,7 @@
  #endif
  #include <log4cxx/private/log4cxx_private.h>
@@ -113,9 +61,9 @@ diff -Nurd miktex-2.9.6530.orig/Libraries/3rd/log4cxx/source/src/main/cpp/string
  #include <apr.h>
  
  #if defined(MIKTEX)
-diff -Nurd miktex-2.9.6530.orig/Libraries/3rd/log4cxx/source/src/main/include/log4cxx/helpers/simpledateformat.h miktex-2.9.6530/Libraries/3rd/log4cxx/source/src/main/include/log4cxx/helpers/simpledateformat.h
---- miktex-2.9.6530.orig/Libraries/3rd/log4cxx/source/src/main/include/log4cxx/helpers/simpledateformat.h	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Libraries/3rd/log4cxx/source/src/main/include/log4cxx/helpers/simpledateformat.h	2023-03-14 02:37:20.000000000 -0400
+diff -ruN miktex-2.9.7440-orig/Libraries/3rd/log4cxx/source/src/main/include/log4cxx/helpers/simpledateformat.h miktex-2.9.7440/Libraries/3rd/log4cxx/source/src/main/include/log4cxx/helpers/simpledateformat.h
+--- miktex-2.9.7440-orig/Libraries/3rd/log4cxx/source/src/main/include/log4cxx/helpers/simpledateformat.h	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Libraries/3rd/log4cxx/source/src/main/include/log4cxx/helpers/simpledateformat.h	2023-03-14 04:30:02.000000000 -0500
 @@ -27,10 +27,9 @@
  
  #include <log4cxx/helpers/dateformat.h>
@@ -128,77 +76,61 @@ diff -Nurd miktex-2.9.6530.orig/Libraries/3rd/log4cxx/source/src/main/include/lo
  namespace log4cxx
  {
          namespace helpers
-diff -Nurd miktex-2.9.6530.orig/Libraries/3rd/zlib/CMakeLists.txt miktex-2.9.6530/Libraries/3rd/zlib/CMakeLists.txt
---- miktex-2.9.6530.orig/Libraries/3rd/zlib/CMakeLists.txt	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Libraries/3rd/zlib/CMakeLists.txt	2023-03-14 02:37:20.000000000 -0400
-@@ -17,7 +17,10 @@
- ## Foundation, 59 Temple Place - Suite 330, Boston, MA 02111-1307,
- ## USA.
+diff -ruN miktex-2.9.7440-orig/Libraries/3rd/lua53/source/src/luaconf.h miktex-2.9.7440/Libraries/3rd/lua53/source/src/luaconf.h
+--- miktex-2.9.7440-orig/Libraries/3rd/lua53/source/src/luaconf.h	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Libraries/3rd/lua53/source/src/luaconf.h	2023-03-14 04:46:00.000000000 -0500
+@@ -203,7 +203,7 @@
  
-+cmake_minimum_required(VERSION 3.6)
-+
- set(MIKTEX_CURRENT_FOLDER "${MIKTEX_IDE_3RD_LIBRARIES_FOLDER}/zlib")
-+set(CMAKE_MODULE_PATH "@FINK_BUILD_DIR@/cmake/modules")
+ #else			/* }{ */
  
- include_directories(BEFORE
-   ${CMAKE_CURRENT_BINARY_DIR}
-@@ -42,6 +45,7 @@
-     -DHAVE_ZLIB_H=1
- )
- 
-+include(IgnoreWarnings)
- ignore_warnings()
- 
- set(public_headers
-@@ -91,4 +95,5 @@
-   add_subdirectory(shared)
- endif()
- 
-+include(UseStaticCRT)
- add_subdirectory(static)
-diff -Nurd miktex-2.9.6530.orig/Libraries/3rd/zlib/static/CMakeLists.txt miktex-2.9.6530/Libraries/3rd/zlib/static/CMakeLists.txt
---- miktex-2.9.6530.orig/Libraries/3rd/zlib/static/CMakeLists.txt	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Libraries/3rd/zlib/static/CMakeLists.txt	2023-03-14 02:37:20.000000000 -0400
-@@ -23,17 +23,3 @@
- 
- set_property(TARGET ${zlib_lib_name} PROPERTY FOLDER ${MIKTEX_CURRENT_FOLDER})
- 
--target_compile_definitions(${zlib_lib_name}
--  INTERFACE
--    ${interface_definitions}
--)
--
--target_include_directories(${zlib_lib_name}
--  PUBLIC
--    ${public_include_directories}
--)
--
--target_link_libraries(${zlib_lib_name}
--  PUBLIC
--    ${utf8wrap_lib_name}
--)
-diff -Nurd miktex-2.9.6530.orig/Libraries/MiKTeX/Core/Session/miktex.cpp miktex-2.9.6530/Libraries/MiKTeX/Core/Session/miktex.cpp
---- miktex-2.9.6530.orig/Libraries/MiKTeX/Core/Session/miktex.cpp	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Libraries/MiKTeX/Core/Session/miktex.cpp	2023-03-14 02:37:20.000000000 -0400
-@@ -136,7 +136,7 @@
-     path = GetSpecialPath(SpecialPath::BinDirectory);
- #else
-     // FIXME: hard-coded path
--    path = "/usr/local/bin";
-+    path = "@FINK_PREFIX@/bin";
+-#define LUA_ROOT	"/usr/local/"
++#define LUA_ROOT	"@FINK_PREFIX@"
+ #define LUA_LDIR	LUA_ROOT "share/lua/" LUA_VDIR "/"
+ #define LUA_CDIR	LUA_ROOT "lib/lua/" LUA_VDIR "/"
+ #define LUA_PATH_DEFAULT  \
+diff -ruN miktex-2.9.7440-orig/Libraries/3rd/luajit/source/src/luaconf.h miktex-2.9.7440/Libraries/3rd/luajit/source/src/luaconf.h
+--- miktex-2.9.7440-orig/Libraries/3rd/luajit/source/src/luaconf.h	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Libraries/3rd/luajit/source/src/luaconf.h	2023-03-14 04:45:51.000000000 -0500
+@@ -35,7 +35,7 @@
+ #ifndef LUA_LMULTILIB
+ #define LUA_LMULTILIB	"lib"
  #endif
-     break;
-   case SpecialPath::LogDirectory:
-diff -Nurd miktex-2.9.6530.orig/Libraries/MiKTeX/Core/Session/unx/unxSession.cpp miktex-2.9.6530/Libraries/MiKTeX/Core/Session/unx/unxSession.cpp
---- miktex-2.9.6530.orig/Libraries/MiKTeX/Core/Session/unx/unxSession.cpp	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Libraries/MiKTeX/Core/Session/unx/unxSession.cpp	2023-03-14 02:37:20.000000000 -0400
-@@ -68,12 +68,12 @@
+-#define LUA_LROOT	"/usr/local"
++#define LUA_LROOT	"@FINK_PREFIX@"
+ #define LUA_LUADIR	"/lua/5.1/"
+ #define LUA_LJDIR	"/luajit-2.1.0-beta1/"
+ 
+diff -ruN miktex-2.9.7440-orig/Libraries/3rd/poppler/source/poppler/GlobalParams.cc miktex-2.9.7440/Libraries/3rd/poppler/source/poppler/GlobalParams.cc
+--- miktex-2.9.7440-orig/Libraries/3rd/poppler/source/poppler/GlobalParams.cc	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Libraries/3rd/poppler/source/poppler/GlobalParams.cc	2023-03-14 04:45:10.000000000 -0500
+@@ -1300,11 +1300,11 @@
+ };
+ 
+ static const char *displayFontDirs[] = {
+-  "/usr/share/ghostscript/fonts",
+-  "/usr/local/share/ghostscript/fonts",
+-  "/usr/share/fonts/default/Type1",
+-  "/usr/share/fonts/default/ghostscript",
+-  "/usr/share/fonts/type1/gsfonts",
++  "@FINK_PREFIX@/share/ghostscript/fonts",
++  "@FINK_PREFIX@/share/ghostscript/fonts",
++  "@FINK_PREFIX@/lib/X11/fonts/ghostscript/Type1",
++  "@FINK_PREFIX@/share/fonts/default/ghostscript",
++  "@FINK_PREFIX@/share/fonts/type1/gsfonts",
+   NULL
+ };
+ 
+diff -ruN miktex-2.9.7440-orig/Libraries/MiKTeX/Core/Session/unx/unxSession.cpp miktex-2.9.7440/Libraries/MiKTeX/Core/Session/unx/unxSession.cpp
+--- miktex-2.9.7440-orig/Libraries/MiKTeX/Core/Session/unx/unxSession.cpp	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Libraries/MiKTeX/Core/Session/unx/unxSession.cpp	2023-03-14 04:43:01.000000000 -0500
+@@ -94,12 +94,12 @@
   * UserConfig:    $HOME/.miktex/texmfs/config
   * UserData:      $HOME/.miktex/texmfs/data
   * UserInstall:   $HOME/.miktex/texmfs/install
 - * CommonConfig:  /var/lib/miktex-texmf           (DEB,RPM)
+- *             or /var/local/lib/miktex-texmf     (TGZ)
 + * CommonConfig:  @FINK_PREFIX@/var/lib/miktex-texmf           (DEB,RPM)
-  *             or /var/local/lib/miktex-texmf     (TGZ)
++ *             or @FINK_PREFIX@/var/local/lib/miktex-texmf     (TGZ)
   *             or /opt/miktex/texmfs/config       (self-contained)
 - * CommonData:    /var/cache/miktex-texmf         (DEB,RPM,TGZ)
 + * CommonData:    @FINK_PREFIX@/var/cache/miktex-texmf         (DEB,RPM,TGZ)
@@ -208,30 +140,21 @@ diff -Nurd miktex-2.9.6530.orig/Libraries/MiKTeX/Core/Session/unx/unxSession.cpp
   *             or /opt/miktex/texmfs/install      (self-contained)
   */
  StartupConfig SessionImpl::DefaultConfig(MiKTeXConfiguration config, const PathName& commonPrefixArg, const PathName& userPrefixArg)
-@@ -130,7 +130,7 @@
-     if (!PathName::Match("*miktex*", prefix.GetData()))
-     {
-       // TODO: log funny installation prefix
--    }
-+    } //share/texmf-local
-     ret.commonConfigRoot = prefix / "texmfs" / "config";
-     ret.commonDataRoot = prefix / "texmfs" / "data";
-     ret.commonInstallRoot = prefix / "texmfs" / "install";
-diff -Nurd miktex-2.9.6530.orig/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp miktex-2.9.6530/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp
---- miktex-2.9.6530.orig/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp	2023-03-14 02:37:20.000000000 -0400
+diff -ruN miktex-2.9.7440-orig/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp miktex-2.9.7440/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp
+--- miktex-2.9.7440-orig/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Libraries/MiKTeX/Setup/unx/unxSetupService.cpp	2023-03-14 04:33:05.000000000 -0500
 @@ -25,7 +25,7 @@
  PathName SetupService::GetDefaultCommonInstallDir()
  {
    // TODO
--  return "/usr/local/miktex";
-+  return "@FINK_PREFIX@/lib/miktex";
+-  return PathName("/usr/local/miktex");
++  return PathName("@FINK_PREFIX@/lib/miktex");
  }
  
  PathName SetupService::GetDefaultUserInstallDir()
-diff -Nurd miktex-2.9.6530.orig/Programs/Bibliography/bibtex-x/source/bibtex.c miktex-2.9.6530/Programs/Bibliography/bibtex-x/source/bibtex.c
---- miktex-2.9.6530.orig/Programs/Bibliography/bibtex-x/source/bibtex.c	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Programs/Bibliography/bibtex-x/source/bibtex.c	2023-03-14 02:37:20.000000000 -0400
+diff -ruN miktex-2.9.7440-orig/Programs/Bibliography/bibtex-x/source/bibtex.c miktex-2.9.7440/Programs/Bibliography/bibtex-x/source/bibtex.c
+--- miktex-2.9.7440-orig/Programs/Bibliography/bibtex-x/source/bibtex.c	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Programs/Bibliography/bibtex-x/source/bibtex.c	2023-03-14 04:33:45.000000000 -0500
 @@ -229,7 +229,7 @@
  #if defined(MIKTEX)
  #  define main MIKTEXCEECALL Main
@@ -241,10 +164,10 @@ diff -Nurd miktex-2.9.6530.orig/Programs/Bibliography/bibtex-x/source/bibtex.c m
  BEGIN
      extern Integer8_T       history;
      int			    exit_status;
-diff -Nurd miktex-2.9.6530.orig/Programs/DviWare/dvipdfm-x/source/dpxfile.c miktex-2.9.6530/Programs/DviWare/dvipdfm-x/source/dpxfile.c
---- miktex-2.9.6530.orig/Programs/DviWare/dvipdfm-x/source/dpxfile.c	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Programs/DviWare/dvipdfm-x/source/dpxfile.c	2023-03-14 02:37:20.000000000 -0400
-@@ -91,7 +91,7 @@
+diff -ruN miktex-2.9.7440-orig/Programs/DviWare/dvipdfm-x/source/dpxfile.c miktex-2.9.7440/Programs/DviWare/dvipdfm-x/source/dpxfile.c
+--- miktex-2.9.7440-orig/Programs/DviWare/dvipdfm-x/source/dpxfile.c	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Programs/DviWare/dvipdfm-x/source/dpxfile.c	2023-03-14 04:34:27.000000000 -0500
+@@ -82,7 +82,7 @@
  static int
  miktex_get_acrobat_font_dir (char *buf)
  {
@@ -253,10 +176,32 @@ diff -Nurd miktex-2.9.6530.orig/Programs/DviWare/dvipdfm-x/source/dpxfile.c mikt
    return  1;
  }
  
-diff -Nurd miktex-2.9.6530.orig/Programs/MiKTeX/initexmf/initexmf.cpp miktex-2.9.6530/Programs/MiKTeX/initexmf/initexmf.cpp
---- miktex-2.9.6530.orig/Programs/MiKTeX/initexmf/initexmf.cpp	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Programs/MiKTeX/initexmf/initexmf.cpp	2023-03-14 02:37:20.000000000 -0400
-@@ -1548,7 +1548,7 @@
+diff -ruN miktex-2.9.7440-orig/Programs/Editors/TeXworks/miktex/DefaultBinaryPaths.h miktex-2.9.7440/Programs/Editors/TeXworks/miktex/DefaultBinaryPaths.h
+--- miktex-2.9.7440-orig/Programs/Editors/TeXworks/miktex/DefaultBinaryPaths.h	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Programs/Editors/TeXworks/miktex/DefaultBinaryPaths.h	2023-03-14 04:39:59.000000000 -0500
+@@ -1 +1 @@
+-#define DEFAULT_BIN_PATHS "/usr/local/bin"
++#define DEFAULT_BIN_PATHS "@FINK_PREFIX@/bin"
+diff -ruN miktex-2.9.7440-orig/Programs/Editors/TeXworks/source/src/TWUtils.cpp miktex-2.9.7440/Programs/Editors/TeXworks/source/src/TWUtils.cpp
+--- miktex-2.9.7440-orig/Programs/Editors/TeXworks/source/src/TWUtils.cpp	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Programs/Editors/TeXworks/source/src/TWUtils.cpp	2023-03-14 04:42:21.000000000 -0500
+@@ -54,10 +54,10 @@
+ #if defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN)
+ // compile-time default paths - customize by defining in the .pro file
+ #ifndef TW_DICPATH
+-#define TW_DICPATH "/usr/share/hunspell" PATH_LIST_SEP "/usr/share/myspell/dicts"
++#define TW_DICPATH "@FINK_PREFIX@/share/hunspell" PATH_LIST_SEP "@FINK_PREFIX@/share/myspell/dicts"
+ #endif
+ #ifndef TW_HELPPATH
+-#define TW_HELPPATH "/usr/local/share/texworks-help"
++#define TW_HELPPATH "@FINK_PREFIX@/share/texworks-help"
+ #endif
+ #endif
+ 
+diff -ruN miktex-2.9.7440-orig/Programs/MiKTeX/initexmf/initexmf.cpp miktex-2.9.7440/Programs/MiKTeX/initexmf/initexmf.cpp
+--- miktex-2.9.7440-orig/Programs/MiKTeX/initexmf/initexmf.cpp	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Programs/MiKTeX/initexmf/initexmf.cpp	2023-03-14 04:35:56.000000000 -0500
+@@ -1402,7 +1402,7 @@
  #if defined(MIKTEX_WINDOWS)
    { "arctrl" MIKTEX_EXE_FILE_SUFFIX, { "pdfclose", "pdfdde", "pdfopen" } },
  #endif
@@ -265,9 +210,9 @@ diff -Nurd miktex-2.9.6530.orig/Programs/MiKTeX/initexmf/initexmf.cpp miktex-2.9
  
    { MIKTEX_AFM2TFM_EXE, { "afm2tfm" } },
  #if defined(MIKTEX_WINDOWS)
-diff -Nurd miktex-2.9.6530.orig/Programs/TeXAndFriends/xetex/xetex-miktex.cpp miktex-2.9.6530/Programs/TeXAndFriends/xetex/xetex-miktex.cpp
---- miktex-2.9.6530.orig/Programs/TeXAndFriends/xetex/xetex-miktex.cpp	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Programs/TeXAndFriends/xetex/xetex-miktex.cpp	2023-03-14 02:37:52.000000000 -0400
+diff -ruN miktex-2.9.7440-orig/Programs/TeXAndFriends/xetex/xetex-miktex.cpp miktex-2.9.7440/Programs/TeXAndFriends/xetex/xetex-miktex.cpp
+--- miktex-2.9.7440-orig/Programs/TeXAndFriends/xetex/xetex-miktex.cpp	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Programs/TeXAndFriends/xetex/xetex-miktex.cpp	2023-03-14 04:36:21.000000000 -0500
 @@ -18,6 +18,7 @@
     USA. */
  
@@ -276,17 +221,18 @@ diff -Nurd miktex-2.9.6530.orig/Programs/TeXAndFriends/xetex/xetex-miktex.cpp mi
  
  #include <poppler-config.h>
  #include <hb-icu.h>
-@@ -27,7 +28,6 @@
+@@ -27,8 +28,6 @@
  #include <TECkit_Engine.h>
  #include <zlib.h>
  
 -#include "xetex-miktex.h"
- 
+-
  using namespace MiKTeX::Core;
  
-diff -Nurd miktex-2.9.6530.orig/Programs/Validation/chktex/source/OpSys.c miktex-2.9.6530/Programs/Validation/chktex/source/OpSys.c
---- miktex-2.9.6530.orig/Programs/Validation/chktex/source/OpSys.c	2017-11-20 13:08:35.000000000 -0500
-+++ miktex-2.9.6530/Programs/Validation/chktex/source/OpSys.c	2023-03-14 02:37:20.000000000 -0400
+ XETEXPROGCLASS::unicodescalar*& buffer = XETEXPROG.buffer;
+diff -ruN miktex-2.9.7440-orig/Programs/Validation/chktex/source/OpSys.c miktex-2.9.7440/Programs/Validation/chktex/source/OpSys.c
+--- miktex-2.9.7440-orig/Programs/Validation/chktex/source/OpSys.c	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/Programs/Validation/chktex/source/OpSys.c	2023-03-14 04:36:53.000000000 -0500
 @@ -98,7 +98,7 @@
  
  #ifndef SYSCONFDIR
@@ -296,3 +242,22 @@ diff -Nurd miktex-2.9.6530.orig/Programs/Validation/chktex/source/OpSys.c miktex
  #  elif defined(__MSDOS__)
  #    define SYSCONFDIR "\\emtex\\data\\"
  #  else
+diff -ruN miktex-2.9.7440-orig/cmake/modules/RuntimePaths.cmake miktex-2.9.7440/cmake/modules/RuntimePaths.cmake
+--- miktex-2.9.7440-orig/cmake/modules/RuntimePaths.cmake	2020-05-17 14:37:59.000000000 -0500
++++ miktex-2.9.7440/cmake/modules/RuntimePaths.cmake	2023-03-14 04:39:38.000000000 -0500
+@@ -28,10 +28,10 @@
+ endif()
+ 
+ if(MIKTEX_UNIX_ALIKE)
+-  set(MIKTEX_SYSTEM_ETC_FONTS_CONFD_DIR "/etc/fonts/conf.d" CACHE PATH "System-wide directory for font configuration data.")
+-  set(MIKTEX_SYSTEM_LINK_TARGET_DIR "/usr/local/bin" CACHE PATH "System-wide directory in which to create symbolic links to MiKTeX binaries.")
+-  set(MIKTEX_SYSTEM_VAR_CACHE_DIR "/var/cache" CACHE PATH "Directory for application cache data.")
+-  set(MIKTEX_SYSTEM_VAR_LIB_DIR "/var/lib" CACHE PATH "Directory for state information.")
+-  set(MIKTEX_SYSTEM_VAR_LOG_DIR "/var/log" CACHE PATH "Directory for log files.")
++  set(MIKTEX_SYSTEM_ETC_FONTS_CONFD_DIR "@FINK_PREFIX@/etc/fonts/conf.d" CACHE PATH "System-wide directory for font configuration data.")
++  set(MIKTEX_SYSTEM_LINK_TARGET_DIR "@FINK_PREFIX@/bin" CACHE PATH "System-wide directory in which to create symbolic links to MiKTeX binaries.")
++  set(MIKTEX_SYSTEM_VAR_CACHE_DIR "@FINK_PREFIX@/var/cache" CACHE PATH "Directory for application cache data.")
++  set(MIKTEX_SYSTEM_VAR_LIB_DIR "@FINK_PREFIX@/var/lib" CACHE PATH "Directory for state information.")
++  set(MIKTEX_SYSTEM_VAR_LOG_DIR "@FINK_PREFIX@/var/log" CACHE PATH "Directory for log files.")
+   set(MIKTEX_USER_LINK_TARGET_DIR "~/bin" CACHE STRING "Per-user directory in which to create symbolic links to MiKTeX binaries.")
+ endif()


### PR DESCRIPTION
Bump miktex-tools to the latest release.
The jpeg typedef fix is no longer needed because the file is gone.
Still not OpenSSL3 friendly.

Asking @dmacks because he recently tested/updated our current .info