### PR TITLE
frei0r: dependency fixes

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/frei0r-dev.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/frei0r-dev.info
@@ -7,11 +7,14 @@ Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
 BuildDepends: <<
 	autoconf2.6,
 	automake1.15,
-	cairo,
+	cairo (>= 1.12.8-1),
 	fink-package-precedence,
+	fontconfig2-dev (>= 2.10.0-1),
+	freetype219 (>= 2.12.1-4),
 	libgavl1,
 	libtool2,
-	pkgconfig
+	pkgconfig,
+	x11-dev
 <<
 BuildDependsOnly: true
 Source: https://github.com/dyne/frei0r/archive/refs/tags/v%v.tar.gz
@@ -21,8 +24,8 @@ GCC: 4.0
 
 PatchScript: <<
 	# don't require opencv
-	perl -pi -e 's|PKG_CHECK_MODULES\(OPENCV|#$&|g' configure.ac
-	# Use correct file names (fixed upstream)
+	perl -pi -e 's/opencv/opencv_DO_NOT_DETECT/ if /PKG_CHECK_MODULES/' configure.ac
+	mkdir m4
 	autoreconf -vfi
 <<
 InstallScript: <<
@@ -33,7 +36,7 @@ DocFiles: AUTHORS COPYING ChangeLog README.md
 Splitoff: <<
 	Package: frei0r
 	Depends: <<
-		cairo-shlibs,
+		cairo-shlibs (>= 1.12.8-1),
 		libgavl1-shlibs
 	<<
 	Description: Minimalistic API video effects plugins


### PR DESCRIPTION
Resolve some FTBFS:
* The new version changed the opencv detection recipe.
* pkgconfig(cairo) entails a few other packages even though their specific .h are not accessed at compile-time.