### PR TITLE
pixman relies on GNU-as commands, but there is no GNU-as compatible a…

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/pixman.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/pixman.info
@@ -19,6 +19,7 @@ Source: http://xorg.freedesktop.org/archive/individual/lib/pixman-%v.tar.xz
 Source-Checksum: SHA256(5747d2ec498ad0f1594878cc897ef5eb6c29e91c53b899f7f71b506785fc1376)
 
 ConfigureParams: <<
+	(%m = arm64) --disable-arm-a64-neon \
 	--enable-dependency-tracking \
 	--disable-static \
 	--disable-gtk \
@@ -51,4 +52,8 @@ AKH: --disable-mmx due to assembler problem from Xcode 4.4 tools (via Murr):
 
 fatal error: error in backend: Unsupported asm: input constraint with a matching
       output constraint of incompatible type!
+
+Disable assembly on arm64 because there's no GNU-as compatible assembler
+for Apple ARM64
+https://gitlab.freedesktop.org/pixman/pixman/-/issues/59
 <<


### PR DESCRIPTION
…ssembler for Apple ARM64

closes #1021