### PR TITLE
lighttpd: update to lighttpd 1.4.71

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/web/lighttpd.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/lighttpd.info
@@ -27,6 +27,29 @@ BuildDepends: <<
 Depends: daemonic, libpcre2-shlibs, openssl300-shlibs
 Provides: httpd
 Recommends: lighttpd-access, lighttpd-accesslog
+# C/R mods that have become obsolete
+Conflicts: <<
+  lighttpd-cml (<< 1.4.64-1),
+  lighttpd-compress (<< 1.4.56),
+  lighttpd-evasive (<< 1.4.68-1),
+  lighttpd-flv-streaming (<< 1.4.64-1),
+  lighttpd-geoip (<< 1.4.54),
+  lighttpd-mysql-vhost (<< 1.4.64-1),
+  lighttpd-secdownload (<< 1.4.68-1),
+  lighttpd-trigger-b4dl (<< 1.4.64-1),
+  lighttpd-usertrack (<< 1.4.68-1)
+<<
+Replaces: <<
+  lighttpd-cml (<< 1.4.64-1),
+  lighttpd-compress (<< 1.4.56),
+  lighttpd-evasive (<< 1.4.68-1),
+  lighttpd-flv-streaming (<< 1.4.64-1),
+  lighttpd-geoip (<< 1.4.54),
+  lighttpd-mysql-vhost (<< 1.4.64-1),
+  lighttpd-secdownload (<< 1.4.68-1),
+  lighttpd-trigger-b4dl (<< 1.4.64-1),
+  lighttpd-usertrack (<< 1.4.68-1)
+<<
 
 Source: https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-%v.tar.xz
 Source-Checksum: SHA256(b8b6915da20396fdc354df3324d5e440169b2e5ea7859e3a775213841325afac)
@@ -213,9 +236,11 @@ SplitOff6: <<
 SplitOff7: <<
   Package: lighttpd-compress
   Description: OBSOLETE: use lighttpd-deflate instead
+  Depends: <<
+    lighttpd-deflate (>= %v-%r)  
+  <<
   RuntimeDepends: <<
-    fink-obsolete-packages,
-    lighttpd-deflate (>= %v-%r)
+    fink-obsolete-packages
   <<
   InstallScript: <<
     mkdir -p %i/share/doc/installed-packages 
@@ -443,6 +468,22 @@ SplitOff25: <<
   Package: lighttpd-magnet
   Depends: %N (=%v-%r), lua51-shlibs
   Description: Plugin: mod_magnet
+  Conflicts: <<
+    lighttpd-cml (<< 1.4.64-1),
+    lighttpd-evasive (<< 1.4.68-1),
+    lighttpd-flv-streaming (<< 1.4.64-1),
+    lighttpd-secdownload (<< 1.4.68-1),
+    lighttpd-trigger-b4dl (<< 1.4.64-1),
+    lighttpd-usertrack (<< 1.4.68-1)
+  <<
+  Replaces: <<
+    lighttpd-cml (<< 1.4.64-1),
+    lighttpd-evasive (<< 1.4.68-1),
+    lighttpd-flv-streaming (<< 1.4.64-1),
+    lighttpd-secdownload (<< 1.4.68-1),
+    lighttpd-trigger-b4dl (<< 1.4.64-1),
+    lighttpd-usertrack (<< 1.4.68-1)
+  <<
   DescDetail: <<
     Control the request handling
   <<
@@ -493,9 +534,11 @@ SplitOff28: <<
 SplitOff29: <<
   Package: lighttpd-geoip
   Description: OBSOLETE: use lighttpd-maxminddb instead
-  RuntimeDepends: <<
-     fink-obsolete-packages,
+  Depends: <<
      lighttpd-maxminddb (>= %v-%r)
+  <<
+  RuntimeDepends: <<
+     fink-obsolete-packages
   <<
   InstallScript: <<
     mkdir -p %i/share/doc/installed-packages 
@@ -539,7 +582,7 @@ SplitOff32: <<
     lib/%N/mod_deflate.so
     etc/%N/mods-available/deflate.conf
   <<
-  ConfFiles: %p/etc/%N/mods-available/compress.conf
+  ConfFiles: %p/etc/%N/mods-available/deflate.conf
 <<
 
 SplitOff33: <<

--- a/10.9-libcxx/stable/main/finkinfo/web/lighttpd.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/lighttpd.info
@@ -1,23 +1,19 @@
 Package: lighttpd
-Version: 1.4.25
-Revision: 7
+Version: 1.4.71
+Revision: 1
 DocFiles: AUTHORS COPYING NEWS README
 Description: Lightning fast web server
 License: BSD
 Maintainer: Alexey Zakhlestin <indeyets@gmail.com>
-HomePage: http://lighttpd.net
+HomePage: https://lighttpd.net
 
 BuildDepends: <<
   autoconf2.6,
   automake1.15,
-  bzip2-dev,
   cyrus-sasl2.3-dev,
   fink (>= 0.32),
   fink-package-precedence,
-  gdbm6,
-  geoip-dev,
-  libiconv-dev,
-  libmemcache,
+  libmaxminddb-dev,
   libpcre2,
   libtool2,
   libxml2 (>= 2.9.1-1),
@@ -32,25 +28,18 @@ Depends: daemonic, libpcre2-shlibs, openssl300-shlibs
 Provides: httpd
 Recommends: lighttpd-access, lighttpd-accesslog
 
-Source: http://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-%v.tar.bz2
-Source-Checksum: SHA256(7e803089f18b179097cb33b64b37d8a3b537ce9c196c88e3fb09881b471c88ce)
-Source2: http://redmine.lighttpd.net/attachments/download/716/mod_geoip_for_1.4.c
-Source2-Checksum: SHA256(0847f26150bc205819666016ecd7085fad51261992f5ed566455d8e997c84c40)
-Source3: http://redmine.lighttpd.net/attachments/download/197/mod_useronline.c
-Source3-Checksum: SHA256(4aef05b78ede5d31babbedef23e4bc10965fe62d754b06e979ef4155d33aea64)
+Source: https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-%v.tar.xz
+Source-Checksum: SHA256(b8b6915da20396fdc354df3324d5e440169b2e5ea7859e3a775213841325afac)
 
 PatchFile: %n.patch
-PatchFile-MD5: 2e2d27342faa1ae46235c70845a33b4a
+PatchFile-MD5: cd3d98f5d61e581171f1e51a7ba51dce
 PatchScript: <<
   cat %{PatchFile} | sed 's|@PREFIX@|%p|g' | patch -p1
-  perl -pi -e 's/AM_C_PROTOTYPES/AC_C_PROTOTYPES\nAM_PROG_AR/' configure.ac
   glibtoolize --copy --force
   autoreconf -fi
-  mv ../mod_geoip_for_1.4.c src/mod_geoip.c
-  mv ../mod_useronline.c src/mod_useronline.c
 <<
 
-ConfigureParams: --libdir='${prefix}/lib/%n' --with-openssl=%p --with-ldap --with-mysql=%p/bin/mysql_config --with-bzip2 --with-gdbm --with-attr --enable-dependency-tracking --with-pcre --with-webdav-props --without-webdav-locks --with-lua --with-memcache
+ConfigureParams: --libdir='${prefix}/lib/%n' --with-openssl=%p --with-ldap --with-mysql=%p/bin/mysql_config --enable-dependency-tracking --with-pcre2 --with-webdav-props --without-webdav-locks --with-lua --with-maxminddb
 CompileScript: <<
 	./configure %c
 	make
@@ -123,21 +112,15 @@ fi
 <<
 
 DescDetail: <<
-lighttpd is a secure, fast, compliant and very flexible web-server which has
-been optimized for high-performance environments. It has a very low memory
-footprint compared to other webservers and takes care of cpu-load. Its
-advanced feature-set (FastCGI, CGI, Auth, Output-Compression, URL-Rewriting
-and many more) make lighttpd the perfect webserver-software for every server
-that is suffering load problems.
+lighttpd (pronounced /lighty/) is a secure, fast, compliant, and very flexible
+web server that has been optimized for high-performance environments. lighttpd
+uses memory and CPU efficiently and has lower resource use than other popular
+web servers. Its advanced feature-set (FastCGI, CGI, Auth, Output-Compression,
+URL-Rewriting and much more) make lighttpd the perfect web server for all
+systems, small and large.
 <<
 DescPackaging: <<
 liblightcomp.dylib is a private library only.
-
-Patched to fix http://trac.lighttpd.net/trac/changeset/1899
-
-dmacks patched response.c for openssl110, analogous to code in newer
-upstream version:
-https://redmine.lighttpd.net/projects/lighttpd/repository/revisions/master/entry/src/mod_openssl.c
 <<
 
 # SplitOffs follow
@@ -147,7 +130,6 @@ SplitOff: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_access
   Files: <<
-    lib/%N/mod_access.so
     share/doc/%N/doc/access.txt
     etc/%N/mods-available/access.conf
   <<
@@ -171,7 +153,6 @@ SplitOff3: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_alias
   Files: <<
-    lib/%N/mod_alias.so
     share/doc/%N/doc/alias.txt
     etc/%N/mods-available/alias.conf
   <<
@@ -204,8 +185,8 @@ SplitOff5: <<
 
 SplitOff6: <<
   Package: lighttpd-cml
-  Depends: %N (=%v-%r), lua51-shlibs, libmemcache-shlibs
-  Description: Plugin: mod_cml
+  Conflicts: lighttpd (>= 1.4.64)
+  Description: OBSOLETE: use lighttpd-magnet instead
   DescDetail: <<
     Cache Meta Language
   <<
@@ -219,8 +200,12 @@ SplitOff6: <<
 
 SplitOff7: <<
   Package: lighttpd-compress
-  Depends: %N (=%v-%r), bzip2-shlibs
-  Description: Plugin: mod_compress
+  Conflicts: lighttpd (>= 1.4.56)
+  Description: OBSOLETE: use lighttpd-deflate instead
+  RuntimeDepends: <<
+     fink-obsolete-packages,
+     lighttpd-deflate (>= %v-%r)
+  <<
   Files: <<
     lib/%N/mod_compress.so
     share/doc/%N/doc/compress.txt
@@ -237,7 +222,6 @@ SplitOff8: <<
     Enchanced Virtual Host support
   <<
   Files: <<
-    lib/%N/mod_evhost.so
     share/doc/%N/doc/evhost.txt
     etc/%N/mods-available/evhost.conf
   <<
@@ -249,7 +233,6 @@ SplitOff9: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_expire
   Files: <<
-    lib/%N/mod_expire.so
     share/doc/%N/doc/expire.txt
     etc/%N/mods-available/expire.conf
   <<
@@ -261,7 +244,6 @@ SplitOff10: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_fastcgi
   Files: <<
-    lib/%N/mod_fastcgi.so
     share/doc/%N/doc/fastcgi.txt
     share/doc/%N/doc/fastcgi-state.dot
     share/doc/%N/doc/fastcgi-state.txt
@@ -287,7 +269,6 @@ SplitOff12: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_redirect
   Files: <<
-    lib/%N/mod_redirect.so
     share/doc/%N/doc/redirect.txt
     etc/%N/mods-available/redirect.conf
   <<
@@ -299,7 +280,6 @@ SplitOff13: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_rewrite
   Files: <<
-    lib/%N/mod_rewrite.so
     share/doc/%N/doc/rewrite.txt
     etc/%N/mods-available/rewrite.conf
   <<
@@ -324,8 +304,8 @@ SplitOff14: <<
 
 SplitOff15: <<
   Package: lighttpd-secdownload
-  Depends: %N (=%v-%r)
-  Description: Plugin: mod_secdownload
+  Conflicts: lighttpd (>= 1.4.68)
+  Description: OBSOLETE: use lighttpd-magnet instead
   DescDetail: <<
     Secure Download
   <<
@@ -342,7 +322,6 @@ SplitOff16: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_setenv
   Files: <<
-    lib/%N/mod_setenv.so
     share/doc/%N/doc/setenv.txt
     etc/%N/mods-available/setenv.conf
   <<
@@ -354,7 +333,6 @@ SplitOff17: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_simple_vhost
   Files: <<
-    lib/%N/mod_simple_vhost.so
     share/doc/%N/doc/simple-vhost.txt
     etc/%N/mods-available/simple_vhost.conf
   <<
@@ -387,8 +365,8 @@ SplitOff19: <<
 
 SplitOff20: <<
   Package: lighttpd-trigger-b4dl
-  Depends: %N (=%v-%r), gdbm6-shlibs, libmemcache-shlibs
-  Description: Plugin: mod_trigger_b4_dl
+  Conflicts: lighttpd (>= 1.4.64)
+  Description: OBSOLETE: use lighttpd-magnet instead
   DescDetail: <<
     Trigger before download
   <<
@@ -414,8 +392,8 @@ SplitOff21: <<
 
 SplitOff22: <<
   Package: lighttpd-usertrack
-  Depends: %N (=%v-%r)
-  Description: Plugin: mod_usertrack
+  Conflicts: lighttpd (>= 1.4.68)
+  Description: OBSOLETE: use lighttpd-magnet instead
   DescDetail: <<
     Cookies
   <<
@@ -428,8 +406,8 @@ SplitOff22: <<
 
 SplitOff23: <<
   Package: lighttpd-evasive
-  Depends: %N (=%v-%r)
-  Description: Plugin: mod_evasive
+  Conflicts: lighttpd (>= 1.4.68)
+  Description: OBSOLETE: use lighttpd-magnet instead
   DescDetail: <<
     Limit of connections per ip
   <<
@@ -442,8 +420,8 @@ SplitOff23: <<
 
 SplitOff24: <<
   Package: lighttpd-flv-streaming
-  Depends: %N (=%v-%r)
-  Description: Plugin: mod_flv_streaming
+  Conflicts: lighttpd (>= 1.4.64)
+  Description: OBSOLETE: use lighttpd-magnet instead
   DescDetail: <<
     Flash Video
   <<
@@ -471,8 +449,8 @@ SplitOff25: <<
 
 SplitOff26: <<
   Package: lighttpd-mysql-vhost
-  Depends: %N (=%v-%r), mysql-unified-shlibs
-  Description: Plugin: mod_mysql_vhost
+  Conflicts: lighttpd (>= 1.4.64)
+  Description: OBSOLETE: use lighttpd-vhostdb-mysql instead
   Files: <<
     lib/%N/mod_mysql_vhost.so
     share/doc/%N/doc/mysqlvhost.txt
@@ -486,7 +464,6 @@ SplitOff27: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_scgi
   Files: <<
-    lib/%N/mod_scgi.so
     share/doc/%N/doc/scgi.txt
     etc/%N/mods-available/scgi.conf
   <<
@@ -507,10 +484,11 @@ SplitOff28: <<
 
 SplitOff29: <<
   Package: lighttpd-geoip
-  Depends: %N (=%v-%r), geoip, geoip-shlibs
-  Description: Plugin: mod_geoip
-  DescDetail: <<
-    Note: This is an *UNOFFICIAL* plugin
+  Conflicts: lighttpd (>= 1.4.64)
+  Description: OBSOLETE: use lighttpd-maxminddb instead
+  RuntimeDepends: <<
+     fink-obsolete-packages,
+     lighttpd-maxminddb (>= %v-%r)
   <<
   Files: <<
     lib/%N/mod_geoip.so
@@ -525,7 +503,6 @@ SplitOff30: <<
   Description: Plugin: mod_extforward
   DescDetail: <<
     Get real ip from X-Forwarded-For
-    Note: This is an *UNOFFICIAL* plugin
   <<
   Files: <<
     lib/%N/mod_extforward.so
@@ -536,8 +513,8 @@ SplitOff30: <<
 
 SplitOff31: <<
   Package: lighttpd-useronline
-  Depends: %N (=%v-%r)
-  Description: Plugin: mod_useronline
+  Conflicts: lighttpd (>= 1.4.56)
+  Description: OBSOLETE: use lighttpd-magnet instead
   DescDetail: <<
     Track online/active users by unique IPs
     Note: This is an *UNOFFICIAL* plugin
@@ -547,4 +524,29 @@ SplitOff31: <<
     etc/%N/mods-available/useronline.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/useronline.conf
+<<
+
+SplitOff32: <<
+  Package: lighttpd-deflate
+  Depends: %N (=%v-%r)
+  Description: Plugin: mod_deflate
+  Replaces: lighttpd-compress (<< 1.4.56)
+  Files: <<
+    lib/%N/mod_deflate.so
+    share/doc/%N/doc/compress.txt
+    etc/%N/mods-available/deflate.conf
+  <<
+  ConfFiles: %p/etc/%N/mods-available/compress.conf
+<<
+
+SplitOff33: <<
+  Package: lighttpd-maxminddb
+  Depends: %N (=%v-%r), libmaxminddb-shlibs
+  Description: Plugin: mod_maxminddb
+  Replaces: lighttpd-geoip (<< 1.4.54)
+  Files: <<
+    lib/%N/mod_maxminddb.so
+    etc/%N/mods-available/maxminddb.conf
+  <<
+  ConfFiles: %p/etc/%N/mods-available/maxminddb.conf
 <<

--- a/10.9-libcxx/stable/main/finkinfo/web/lighttpd.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/lighttpd.info
@@ -39,7 +39,18 @@ PatchScript: <<
   autoreconf -fi
 <<
 
-ConfigureParams: --libdir='${prefix}/lib/%n' --with-openssl=%p --with-ldap --with-mysql=%p/bin/mysql_config --enable-dependency-tracking --with-pcre2 --with-webdav-props --without-webdav-locks --with-lua --with-maxminddb
+ConfigureParams: <<
+	--libdir='${prefix}/lib/%n' \
+	--with-openssl=%p \
+	--with-ldap \
+	--with-mysql=%p/bin/mysql_config \
+	--enable-dependency-tracking \
+	--with-pcre2 \
+	--with-webdav-props \
+	--without-webdav-locks \
+	--with-lua \
+	--with-maxminddb
+<<
 CompileScript: <<
 	./configure %c
 	make

--- a/10.9-libcxx/stable/main/finkinfo/web/lighttpd.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/lighttpd.info
@@ -546,6 +546,14 @@ SplitOff33: <<
   Package: lighttpd-maxminddb
   Depends: %N (=%v-%r), libmaxminddb-shlibs
   Description: Plugin: mod_maxminddb
+  DescDetail: <<
+    Download and install a MaxMindDB from
+    https://dev.maxmind.com/geoip/geoip2/geolite2/#Downloads
+    
+    Once the database is installed, edit
+    %p/etc/%N/mods-available/maxminddb.conf to point to its location.
+  <<
+  Conflicts: lighttpd-geoip (<< 1.4.54)
   Replaces: lighttpd-geoip (<< 1.4.54)
   Files: <<
     lib/%N/mod_maxminddb.so

--- a/10.9-libcxx/stable/main/finkinfo/web/lighttpd.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/lighttpd.info
@@ -55,7 +55,7 @@ Source: https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-%v.tar.xz
 Source-Checksum: SHA256(b8b6915da20396fdc354df3324d5e440169b2e5ea7859e3a775213841325afac)
 
 PatchFile: %n.patch
-PatchFile-MD5: cd3d98f5d61e581171f1e51a7ba51dce
+PatchFile-MD5: 4a26526ea8a9fa2ce46ab3648ff29165
 PatchScript: <<
   cat %{PatchFile} | sed 's|@PREFIX@|%p|g' | patch -p1
   glibtoolize --copy --force

--- a/10.9-libcxx/stable/main/finkinfo/web/lighttpd.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/lighttpd.info
@@ -196,33 +196,31 @@ SplitOff5: <<
 
 SplitOff6: <<
   Package: lighttpd-cml
-  Conflicts: lighttpd (>= 1.4.64)
   Description: OBSOLETE: use lighttpd-magnet instead
+  RuntimeDepends: <<
+    fink-obsolete-packages,
+    lighttpd-magnet (>= %v-%r)
+  <<
   DescDetail: <<
     Cache Meta Language
   <<
-  Files: <<
-    lib/%N/mod_cml.so
-    share/doc/%N/doc/cml.txt
-    etc/%N/mods-available/cml.conf
+  InstallScript: <<
+    mkdir -p %i/share/doc/installed-packages 
+    touch %i/share/doc/installed-packages/%n 
   <<
-  ConfFiles: %p/etc/%N/mods-available/cml.conf
 <<
 
 SplitOff7: <<
   Package: lighttpd-compress
-  Conflicts: lighttpd (>= 1.4.56)
   Description: OBSOLETE: use lighttpd-deflate instead
   RuntimeDepends: <<
-     fink-obsolete-packages,
-     lighttpd-deflate (>= %v-%r)
+    fink-obsolete-packages,
+    lighttpd-deflate (>= %v-%r)
   <<
-  Files: <<
-    lib/%N/mod_compress.so
-    share/doc/%N/doc/compress.txt
-    etc/%N/mods-available/compress.conf
+  InstallScript: <<
+    mkdir -p %i/share/doc/installed-packages 
+    touch %i/share/doc/installed-packages/%n 
   <<
-  ConfFiles: %p/etc/%N/mods-available/compress.conf
 <<
 
 SplitOff8: <<
@@ -315,17 +313,16 @@ SplitOff14: <<
 
 SplitOff15: <<
   Package: lighttpd-secdownload
-  Conflicts: lighttpd (>= 1.4.68)
   Description: OBSOLETE: use lighttpd-magnet instead
-  DescDetail: <<
-    Secure Download
+  DescDetail: See https://wiki.lighttpd.net/ModMagnetExamples#lua-examples-of-deprecated-lighttpd-modules
+  RuntimeDepends: <<
+    fink-obsolete-packages,
+    lighttpd-magnet (>= %v-%r)
   <<
-  Files: <<
-    lib/%N/mod_secdownload.so
-    share/doc/%N/doc/secdownload.txt
-    etc/%N/mods-available/secdownload.conf
+  InstallScript: <<
+    mkdir -p %i/share/doc/installed-packages 
+    touch %i/share/doc/installed-packages/%n 
   <<
-  ConfFiles: %p/etc/%N/mods-available/secdownload.conf
 <<
 
 SplitOff16: <<
@@ -376,17 +373,16 @@ SplitOff19: <<
 
 SplitOff20: <<
   Package: lighttpd-trigger-b4dl
-  Conflicts: lighttpd (>= 1.4.64)
   Description: OBSOLETE: use lighttpd-magnet instead
-  DescDetail: <<
-    Trigger before download
+  DescDetail: See https://wiki.lighttpd.net/ModMagnetExamples#lua-examples-of-deprecated-lighttpd-modules
+  RuntimeDepends: <<
+    fink-obsolete-packages,
+    lighttpd-magnet (>= %v-%r)
   <<
-  Files: <<
-    lib/%N/mod_trigger_b4_dl.so
-    share/doc/%N/doc/trigger_b4_dl.txt
-    etc/%N/mods-available/trigger_b4_dl.conf
+  InstallScript: <<
+    mkdir -p %i/share/doc/installed-packages 
+    touch %i/share/doc/installed-packages/%n 
   <<
-  ConfFiles: %p/etc/%N/mods-available/trigger_b4_dl.conf
 <<
 
 SplitOff21: <<
@@ -403,44 +399,44 @@ SplitOff21: <<
 
 SplitOff22: <<
   Package: lighttpd-usertrack
-  Conflicts: lighttpd (>= 1.4.68)
   Description: OBSOLETE: use lighttpd-magnet instead
-  DescDetail: <<
-    Cookies
+  DescDetail: See https://wiki.lighttpd.net/ModMagnetExamples#lua-examples-of-deprecated-lighttpd-modules
+  RuntimeDepends: <<
+    fink-obsolete-packages,
+    lighttpd-magnet (>= %v-%r)
   <<
-  Files: <<
-    lib/%N/mod_usertrack.so
-    etc/%N/mods-available/usertrack.conf
+  InstallScript: <<
+    mkdir -p %i/share/doc/installed-packages 
+    touch %i/share/doc/installed-packages/%n 
   <<
-  ConfFiles: %p/etc/%N/mods-available/usertrack.conf
 <<
 
 SplitOff23: <<
   Package: lighttpd-evasive
-  Conflicts: lighttpd (>= 1.4.68)
   Description: OBSOLETE: use lighttpd-magnet instead
-  DescDetail: <<
-    Limit of connections per ip
+  DescDetail: See https://wiki.lighttpd.net/ModMagnetExamples#lua-examples-of-deprecated-lighttpd-modules
+  RuntimeDepends: <<
+    fink-obsolete-packages,
+    lighttpd-magnet (>= %v-%r)
   <<
-  Files: <<
-    lib/%N/mod_evasive.so
-    etc/%N/mods-available/evasive.conf
+  InstallScript: <<
+    mkdir -p %i/share/doc/installed-packages 
+    touch %i/share/doc/installed-packages/%n 
   <<
-  ConfFiles: %p/etc/%N/mods-available/evasive.conf
 <<
 
 SplitOff24: <<
   Package: lighttpd-flv-streaming
-  Conflicts: lighttpd (>= 1.4.64)
   Description: OBSOLETE: use lighttpd-magnet instead
-  DescDetail: <<
-    Flash Video
+  DescDetail: See https://wiki.lighttpd.net/ModMagnetExamples#lua-examples-of-deprecated-lighttpd-modules
+  RuntimeDepends: <<
+    fink-obsolete-packages,
+    lighttpd-magnet (>= %v-%r)
   <<
-  Files: <<
-    lib/%N/mod_flv_streaming.so
-    etc/%N/mods-available/flv_streaming.conf
+  InstallScript: <<
+    mkdir -p %i/share/doc/installed-packages 
+    touch %i/share/doc/installed-packages/%n 
   <<
-  ConfFiles: %p/etc/%N/mods-available/flv_streaming.conf
 <<
 
 SplitOff25: <<
@@ -460,14 +456,15 @@ SplitOff25: <<
 
 SplitOff26: <<
   Package: lighttpd-mysql-vhost
-  Conflicts: lighttpd (>= 1.4.64)
   Description: OBSOLETE: use lighttpd-vhostdb-mysql instead
-  Files: <<
-    lib/%N/mod_mysql_vhost.so
-    share/doc/%N/doc/mysqlvhost.txt
-    etc/%N/mods-available/mysql_vhost.conf
+  RuntimeDepends: <<
+    fink-obsolete-packages
   <<
-  ConfFiles: %p/etc/%N/mods-available/mysql_vhost.conf
+    #lighttpd-vhostdb-mysql (>= %v-%r)
+  InstallScript: <<
+    mkdir -p %i/share/doc/installed-packages 
+    touch %i/share/doc/installed-packages/%n 
+  <<
 <<
 
 SplitOff27: <<
@@ -495,17 +492,15 @@ SplitOff28: <<
 
 SplitOff29: <<
   Package: lighttpd-geoip
-  Conflicts: lighttpd (>= 1.4.64)
   Description: OBSOLETE: use lighttpd-maxminddb instead
   RuntimeDepends: <<
      fink-obsolete-packages,
      lighttpd-maxminddb (>= %v-%r)
   <<
-  Files: <<
-    lib/%N/mod_geoip.so
-    etc/%N/mods-available/geoip.conf
+  InstallScript: <<
+    mkdir -p %i/share/doc/installed-packages 
+    touch %i/share/doc/installed-packages/%n 
   <<
-  ConfFiles: %p/etc/%N/mods-available/geoip.conf
 <<
 
 SplitOff30: <<
@@ -524,27 +519,24 @@ SplitOff30: <<
 
 SplitOff31: <<
   Package: lighttpd-useronline
-  Conflicts: lighttpd (>= 1.4.56)
-  Description: OBSOLETE: use lighttpd-magnet instead
-  DescDetail: <<
-    Track online/active users by unique IPs
-    Note: This is an *UNOFFICIAL* plugin
+  Description: OBSOLETE: No longer relevant
+  RuntimeDepends: <<
+     fink-obsolete-packages
   <<
-  Files: <<
-    lib/%N/mod_useronline.so
-    etc/%N/mods-available/useronline.conf
+  InstallScript: <<
+    mkdir -p %i/share/doc/installed-packages 
+    touch %i/share/doc/installed-packages/%n 
   <<
-  ConfFiles: %p/etc/%N/mods-available/useronline.conf
 <<
 
 SplitOff32: <<
   Package: lighttpd-deflate
   Depends: %N (=%v-%r)
   Description: Plugin: mod_deflate
+  Conflicts: lighttpd-compress (<< 1.4.56)
   Replaces: lighttpd-compress (<< 1.4.56)
   Files: <<
     lib/%N/mod_deflate.so
-    share/doc/%N/doc/compress.txt
     etc/%N/mods-available/deflate.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/compress.conf

--- a/10.9-libcxx/stable/main/finkinfo/web/lighttpd.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/lighttpd.info
@@ -141,7 +141,7 @@ SplitOff: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_access
   Files: <<
-    share/doc/%N/doc/access.txt
+    share/doc/%N/doc/outdated/access.txt
     etc/%N/mods-available/access.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/access.conf
@@ -153,7 +153,7 @@ SplitOff2: <<
   Description: Plugin: mod_accesslog
   Files: <<
     lib/%N/mod_accesslog.so
-    share/doc/%N/doc/accesslog.txt
+    share/doc/%N/doc/outdated/accesslog.txt
     etc/%N/mods-available/accesslog.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/accesslog.conf
@@ -164,7 +164,7 @@ SplitOff3: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_alias
   Files: <<
-    share/doc/%N/doc/alias.txt
+    share/doc/%N/doc/outdated/alias.txt
     etc/%N/mods-available/alias.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/alias.conf
@@ -176,7 +176,7 @@ SplitOff4: <<
   Description: Plugin: mod_auth
   Files: <<
     lib/%N/mod_auth.so
-    share/doc/%N/doc/authentication.txt
+    share/doc/%N/doc/outdated/authentication.txt
     etc/%N/mods-available/auth.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/auth.conf
@@ -188,7 +188,7 @@ SplitOff5: <<
   Description: Plugin: mod_cgi
   Files: <<
     lib/%N/mod_cgi.so
-    share/doc/%N/doc/cgi.txt
+    share/doc/%N/doc/outdated/cgi.txt
     etc/%N/mods-available/cgi.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/cgi.conf
@@ -231,7 +231,7 @@ SplitOff8: <<
     Enchanced Virtual Host support
   <<
   Files: <<
-    share/doc/%N/doc/evhost.txt
+    share/doc/%N/doc/outdated/evhost.txt
     etc/%N/mods-available/evhost.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/evhost.conf
@@ -242,7 +242,7 @@ SplitOff9: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_expire
   Files: <<
-    share/doc/%N/doc/expire.txt
+    share/doc/%N/doc/outdated/expire.txt
     etc/%N/mods-available/expire.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/expire.conf
@@ -253,9 +253,9 @@ SplitOff10: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_fastcgi
   Files: <<
-    share/doc/%N/doc/fastcgi.txt
-    share/doc/%N/doc/fastcgi-state.dot
-    share/doc/%N/doc/fastcgi-state.txt
+    share/doc/%N/doc/outdated/fastcgi.txt
+    share/doc/%N/doc/outdated/fastcgi-state.dot
+    share/doc/%N/doc/outdated/fastcgi-state.txt
     etc/%N/mods-available/fastcgi.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/fastcgi.conf
@@ -267,7 +267,7 @@ SplitOff11: <<
   Description: Plugin: mod_proxy
   Files: <<
     lib/%N/mod_proxy.so
-    share/doc/%N/doc/proxy.txt
+    share/doc/%N/doc/outdated/proxy.txt
     etc/%N/mods-available/proxy.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/proxy.conf
@@ -278,7 +278,7 @@ SplitOff12: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_redirect
   Files: <<
-    share/doc/%N/doc/redirect.txt
+    share/doc/%N/doc/outdated/redirect.txt
     etc/%N/mods-available/redirect.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/redirect.conf
@@ -289,7 +289,7 @@ SplitOff13: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_rewrite
   Files: <<
-    share/doc/%N/doc/rewrite.txt
+    share/doc/%N/doc/outdated/rewrite.txt
     etc/%N/mods-available/rewrite.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/rewrite.conf
@@ -304,8 +304,8 @@ SplitOff14: <<
   <<
   Files: <<
     lib/%N/mod_rrdtool.so
-    share/doc/%N/doc/rrdtool.txt
-    share/doc/%N/doc/rrdtool-graph.sh
+    share/doc/%N/doc/outdated/rrdtool.txt
+    share/doc/%N/doc/scripts/rrdtool-graph.sh
     etc/%N/mods-available/rrdtool.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/rrdtool.conf
@@ -330,7 +330,7 @@ SplitOff16: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_setenv
   Files: <<
-    share/doc/%N/doc/setenv.txt
+    share/doc/%N/doc/outdated/setenv.txt
     etc/%N/mods-available/setenv.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/setenv.conf
@@ -341,7 +341,7 @@ SplitOff17: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_simple_vhost
   Files: <<
-    share/doc/%N/doc/simple-vhost.txt
+    share/doc/%N/doc/outdated/simple-vhost.txt
     etc/%N/mods-available/simple_vhost.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/simple_vhost.conf
@@ -353,7 +353,7 @@ SplitOff18: <<
   Description: Plugin: mod_ssi
   Files: <<
     lib/%N/mod_ssi.so
-    share/doc/%N/doc/ssi.txt
+    share/doc/%N/doc/outdated/ssi.txt
     etc/%N/mods-available/ssi.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/ssi.conf
@@ -365,7 +365,7 @@ SplitOff19: <<
   Description: Plugin: mod_status
   Files: <<
     lib/%N/mod_status.so
-    share/doc/%N/doc/status.txt
+    share/doc/%N/doc/outdated/status.txt
     etc/%N/mods-available/status.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/status.conf
@@ -391,7 +391,7 @@ SplitOff21: <<
   Description: Plugin: mod_userdir
   Files: <<
     lib/%N/mod_userdir.so
-    share/doc/%N/doc/userdir.txt
+    share/doc/%N/doc/outdated/userdir.txt
     etc/%N/mods-available/userdir.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/userdir.conf
@@ -448,7 +448,7 @@ SplitOff25: <<
   <<
   Files: <<
     lib/%N/mod_magnet.so
-    share/doc/%N/doc/magnet.txt
+    share/doc/%N/doc/outdated/magnet.txt
     etc/%N/mods-available/magnet.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/magnet.conf
@@ -472,7 +472,7 @@ SplitOff27: <<
   Depends: %N (=%v-%r)
   Description: Plugin: mod_scgi
   Files: <<
-    share/doc/%N/doc/scgi.txt
+    share/doc/%N/doc/outdated/scgi.txt
     etc/%N/mods-available/scgi.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/scgi.conf
@@ -484,7 +484,7 @@ SplitOff28: <<
   Description: Plugin: mod_webdav
   Files: <<
     lib/%N/mod_webdav.so
-    share/doc/%N/doc/webdav.txt
+    share/doc/%N/doc/outdated/webdav.txt
     etc/%N/mods-available/webdav.conf
   <<
   ConfFiles: %p/etc/%N/mods-available/webdav.conf

--- a/10.9-libcxx/stable/main/finkinfo/web/lighttpd.patch
+++ b/10.9-libcxx/stable/main/finkinfo/web/lighttpd.patch
@@ -331,3 +331,21 @@ diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-availabl
 +global {
 +  server.modules += ("mod_webdav")
 +}
+diff -ruN lighttpd-1.4.71-orig/fink/etc/mods-available/maxminddb.conf lighttpd-1.4.71/fink/etc/mods-available/maxminddb.conf
+--- lighttpd-1.4.71-orig/fink/etc/mods-available/maxminddb.conf	1969-12-31 18:00:00.000000000 -0600
++++ lighttpd-1.4.71/fink/etc/mods-available/maxminddb.conf	2023-09-14 06:28:36.000000000 -0500
+@@ -0,0 +1,14 @@
++global {
++  server.modules += ("mod_maxminddb")
++
++  maxminddb.activate = "enable"
++  # DB downloaded from https://dev.maxmind.com/geoip/geoip2/geolite2/#Downloads
++  maxminddb.db = "@PREFIX@/share/GeoIP2/database.mmdb"
++  maxminddb.env = (
++         "GEOIP_COUNTRY_CODE"   => "country/iso_code",
++         "GEOIP_COUNTRY_NAME"   => "country/names/en",
++         "GEOIP_CITY_NAME"      => "city/names/en",
++         "GEOIP_CITY_LATITUDE"  => "location/latitude",
++         "GEOIP_CITY_LONGITUDE" => "location/longitude",
++  )
++}

--- a/10.9-libcxx/stable/main/finkinfo/web/lighttpd.patch
+++ b/10.9-libcxx/stable/main/finkinfo/web/lighttpd.patch
@@ -1,29 +1,7 @@
-diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/configure.ac lighttpd-1.4.25/configure.ac
---- lighttpd-1.4.25.orig/configure.ac	2009-11-21 18:11:50.000000000 +0300
-+++ lighttpd-1.4.25/configure.ac	2009-11-26 14:08:48.000000000 +0300
-@@ -23,9 +23,7 @@
- AC_PROG_MAKE_SET
- 
- dnl check environment
--AC_AIX
- AC_ISC_POSIX
--AC_MINIX
- 
- dnl AC_CANONICAL_HOST
- case $host_os in
-@@ -577,7 +575,7 @@
- 
- 
- do_build="mod_cgi mod_fastcgi mod_extforward mod_proxy mod_evhost mod_simple_vhost mod_access mod_alias mod_setenv mod_usertrack mod_auth mod_status mod_accesslog"
--do_build="$do_build mod_rrdtool mod_secdownload mod_expire mod_compress mod_dirlisting mod_indexfile mod_userdir mod_webdav mod_staticfile mod_scgi mod_flv_streaming"
-+do_build="$do_build mod_rrdtool mod_secdownload mod_expire mod_compress mod_dirlisting mod_indexfiles mod_userdir mod_webdav mod_staticfile mod_scgi mod_flv_streaming mod_geoip"
- 
- plugins="mod_rewrite mod_redirect mod_ssi mod_trigger_b4_dl"
- features="regex-conditionals"
 diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/lighttpd.conf lighttpd-1.4.25/fink/etc/lighttpd.conf
 --- lighttpd-1.4.25.orig/fink/etc/lighttpd.conf	1970-01-01 03:00:00.000000000 +0300
 +++ lighttpd-1.4.25/fink/etc/lighttpd.conf	2009-11-26 14:08:48.000000000 +0300
-@@ -0,0 +1,97 @@
+@@ -0,0 +1,92 @@
 +finkroot    = "@PREFIX@/"
 +configpath  = finkroot + "etc/lighttpd/"
 +logpath     = finkroot + "var/log/lighttpd/"
@@ -37,7 +15,6 @@ diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/lighttpd.conf
 +server.errorlog       = logpath + "error.log"
 +server.modules        = () # these will be defined in separate config-files
 +server.tag            = "lighttpd"
-+server.event-handler  = "freebsd-kqueue"
 +server.pid-file       = finkroot + "var/run/lighttpd.pid"
 +
 +server.username            = "www"
@@ -112,15 +89,11 @@ diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/lighttpd.conf
 +
 +
 +
-+$HTTP["url"] =~ "\.pdf$" {
-+  server.range-requests = "disable"
-+}
-+
 +### .php, .pl, .fcgi are most often handled by mod_fastcgi or mod_cgi
 +#static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
 +
 +#including enabled modules and their configurations
-+include_shell "cat " + configpath + "mods-enabled/* 2>/dev/null"
++include configpath + "mods-enabled/*"
 diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/access.conf lighttpd-1.4.25/fink/etc/mods-available/access.conf
 --- lighttpd-1.4.25.orig/fink/etc/mods-available/access.conf	1970-01-01 03:00:00.000000000 +0300
 +++ lighttpd-1.4.25/fink/etc/mods-available/access.conf	2009-11-26 14:08:48.000000000 +0300
@@ -190,33 +163,16 @@ diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-availabl
 +  #cgi.assign = ( ".pl"  => "/usr/bin/perl",
 +  #               ".cgi" => "/usr/bin/perl" )
 +}
-diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/cml.conf lighttpd-1.4.25/fink/etc/mods-available/cml.conf
---- lighttpd-1.4.25.orig/fink/etc/mods-available/cml.conf	1970-01-01 03:00:00.000000000 +0300
-+++ lighttpd-1.4.25/fink/etc/mods-available/cml.conf	2009-11-26 14:08:48.000000000 +0300
+diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/compress.conf lighttpd-1.4.25/fink/etc/mods-available/compress.conf
+--- lighttpd-1.4.25.orig/fink/etc/mods-available/deflate.conf	1970-01-01 03:00:00.000000000 +0300
++++ lighttpd-1.4.25/fink/etc/mods-available/deflate.conf	2009-11-26 14:08:48.000000000 +0300
 @@ -0,0 +1,7 @@
 +global {
-+  server.modules += ("mod_cml")
++  server.modules += ("mod_deflate")
 +
-+  index-file.names  += ("index.cml")
-+  cml.extension      = ".cml"
-+  # cml.memcache-hosts = ( "127.0.0.1:11211" )
-+}
-diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/compress.conf lighttpd-1.4.25/fink/etc/mods-available/compress.conf
---- lighttpd-1.4.25.orig/fink/etc/mods-available/compress.conf	1970-01-01 03:00:00.000000000 +0300
-+++ lighttpd-1.4.25/fink/etc/mods-available/compress.conf	2009-11-26 14:08:48.000000000 +0300
-@@ -0,0 +1,6 @@
-+global {
-+  server.modules += ("mod_compress")
-+
-+  compress.cache-dir         = "/tmp/lighttpd/cache/compress/"
-+  compress.filetype          = ("text/plain", "text/html")
-+}
-diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/evasive.conf lighttpd-1.4.25/fink/etc/mods-available/evasive.conf
---- lighttpd-1.4.25.orig/fink/etc/mods-available/evasive.conf	1970-01-01 03:00:00.000000000 +0300
-+++ lighttpd-1.4.25/fink/etc/mods-available/evasive.conf	2009-11-26 14:08:48.000000000 +0300
-@@ -0,0 +1,3 @@
-+global {
-+  server.modules += ("mod_evasive")
++  deflate.allowed-encodings = ("gzip", "deflate")
++  deflate.cache-dir         = "/tmp/lighttpd/cache/compress/"
++  deflate.mimetypes         = ("text/plain", "text/html")
 +}
 diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/evhost.conf lighttpd-1.4.25/fink/etc/mods-available/evhost.conf
 --- lighttpd-1.4.25.orig/fink/etc/mods-available/evhost.conf	1970-01-01 03:00:00.000000000 +0300
@@ -270,42 +226,12 @@ diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-availabl
 +  #                               )
 +  #                            )
 +}
-diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/flv_streaming.conf lighttpd-1.4.25/fink/etc/mods-available/flv_streaming.conf
---- lighttpd-1.4.25.orig/fink/etc/mods-available/flv_streaming.conf	1970-01-01 03:00:00.000000000 +0300
-+++ lighttpd-1.4.25/fink/etc/mods-available/flv_streaming.conf	2009-11-26 14:08:48.000000000 +0300
-@@ -0,0 +1,3 @@
-+global {
-+  server.modules += ("mod_flv_streaming")
-+}
-diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/geoip.conf lighttpd-1.4.25/fink/etc/mods-available/geoip.conf
---- lighttpd-1.4.25.orig/fink/etc/mods-available/geoip.conf	1970-01-01 03:00:00.000000000 +0300
-+++ lighttpd-1.4.25/fink/etc/mods-available/geoip.conf	2009-11-26 14:08:48.000000000 +0300
-@@ -0,0 +1,6 @@
-+global {
-+  server.modules += ("mod_geoip")
-+
-+  geoip.db-filename = "@PREFIX@/share/GeoIP/GeoIP.dat"
-+  geoip.memory-cache = "enable"
-+}
 diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/magnet.conf lighttpd-1.4.25/fink/etc/mods-available/magnet.conf
 --- lighttpd-1.4.25.orig/fink/etc/mods-available/magnet.conf	1970-01-01 03:00:00.000000000 +0300
 +++ lighttpd-1.4.25/fink/etc/mods-available/magnet.conf	2009-11-26 14:08:48.000000000 +0300
 @@ -0,0 +1,3 @@
 +global {
 +  server.modules += ("mod_magnet")
-+}
-diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/mysql_vhost.conf lighttpd-1.4.25/fink/etc/mods-available/mysql_vhost.conf
---- lighttpd-1.4.25.orig/fink/etc/mods-available/mysql_vhost.conf	1970-01-01 03:00:00.000000000 +0300
-+++ lighttpd-1.4.25/fink/etc/mods-available/mysql_vhost.conf	2009-11-26 14:08:48.000000000 +0300
-@@ -0,0 +1,9 @@
-+global {
-+  server.modules += ("mod_mysql_vhost")
-+
-+  mysql-vhost.sock           = "/tmp/mysql.sock"
-+  # mysql-vhost.db             = "lighttpd"
-+  # mysql-vhost.user           = "lighttpd"
-+  # mysql-vhost.pass           = "secret"
-+  # mysql-vhost.sql            = "SELECT docroot FROM domains WHERE domain='?';"
 +}
 diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/proxy.conf lighttpd-1.4.25/fink/etc/mods-available/proxy.conf
 --- lighttpd-1.4.25.orig/fink/etc/mods-available/proxy.conf	1970-01-01 03:00:00.000000000 +0300
@@ -352,13 +278,6 @@ diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-availabl
 +global {
 +  server.modules += ("mod_scgi")
 +}
-diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/secdownload.conf lighttpd-1.4.25/fink/etc/mods-available/secdownload.conf
---- lighttpd-1.4.25.orig/fink/etc/mods-available/secdownload.conf	1970-01-01 03:00:00.000000000 +0300
-+++ lighttpd-1.4.25/fink/etc/mods-available/secdownload.conf	2009-11-26 14:08:48.000000000 +0300
-@@ -0,0 +1,3 @@
-+global {
-+  server.modules += ("mod_secdownload")
-+}
 diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/setenv.conf lighttpd-1.4.25/fink/etc/mods-available/setenv.conf
 --- lighttpd-1.4.25.orig/fink/etc/mods-available/setenv.conf	1970-01-01 03:00:00.000000000 +0300
 +++ lighttpd-1.4.25/fink/etc/mods-available/setenv.conf	2009-11-26 14:08:48.000000000 +0300
@@ -395,20 +314,6 @@ diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-availabl
 +  status.status-url = "/server-status"
 +  status.config-url = "/server-config"
 +}
-diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/trigger_b4_dl.conf lighttpd-1.4.25/fink/etc/mods-available/trigger_b4_dl.conf
---- lighttpd-1.4.25.orig/fink/etc/mods-available/trigger_b4_dl.conf	1970-01-01 03:00:00.000000000 +0300
-+++ lighttpd-1.4.25/fink/etc/mods-available/trigger_b4_dl.conf	2009-11-26 14:08:48.000000000 +0300
-@@ -0,0 +1,10 @@
-+global {
-+  server.modules += ("mod_trigger_b4_dl")
-+
-+  # trigger-before-download.gdbm-filename = "/home/weigon/testbase/trigger.db"
-+  # trigger-before-download.memcache-hosts = ( "127.0.0.1:11211" )
-+  # trigger-before-download.trigger-url = "^/trigger/"
-+  # trigger-before-download.download-url = "^/download/"
-+  # trigger-before-download.deny-url = "http://127.0.0.1/index.html"
-+  # trigger-before-download.trigger-timeout = 10
-+}
 diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/userdir.conf lighttpd-1.4.25/fink/etc/mods-available/userdir.conf
 --- lighttpd-1.4.25.orig/fink/etc/mods-available/userdir.conf	1970-01-01 03:00:00.000000000 +0300
 +++ lighttpd-1.4.25/fink/etc/mods-available/userdir.conf	2009-11-26 14:08:48.000000000 +0300
@@ -419,26 +324,6 @@ diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-availabl
 +  userdir.basepath = "/Users/"
 +  userdir.path = "Sites"
 +}
-diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/useronline.conf lighttpd-1.4.25/fink/etc/mods-available/useronline.conf
---- lighttpd-1.4.25.orig/fink/etc/mods-available/useronline.conf	1970-01-01 03:00:00.000000000 +0300
-+++ lighttpd-1.4.25/fink/etc/mods-available/useronline.conf	2009-11-26 14:26:43.000000000 +0300
-@@ -0,0 +1,9 @@
-+global {
-+  server.modules += ("mod_useronline")
-+
-+  useronline.enable = 1
-+  # useronline.online-age = 300
-+  # useronline.active-age = 100
-+  # useronline.max-ips = 1024
-+  # useronline.status-name = "myWonderfulSite"
-+}
-diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/usertrack.conf lighttpd-1.4.25/fink/etc/mods-available/usertrack.conf
---- lighttpd-1.4.25.orig/fink/etc/mods-available/usertrack.conf	1970-01-01 03:00:00.000000000 +0300
-+++ lighttpd-1.4.25/fink/etc/mods-available/usertrack.conf	2009-11-26 14:08:48.000000000 +0300
-@@ -0,0 +1,3 @@
-+global {
-+  server.modules += ("mod_usertrack")
-+}
 diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-available/webdav.conf lighttpd-1.4.25/fink/etc/mods-available/webdav.conf
 --- lighttpd-1.4.25.orig/fink/etc/mods-available/webdav.conf	1970-01-01 03:00:00.000000000 +0300
 +++ lighttpd-1.4.25/fink/etc/mods-available/webdav.conf	2009-11-26 14:08:48.000000000 +0300
@@ -446,34 +331,3 @@ diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/fink/etc/mods-availabl
 +global {
 +  server.modules += ("mod_webdav")
 +}
-diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/src/Makefile.am lighttpd-1.4.25/src/Makefile.am
---- lighttpd-1.4.25.orig/src/Makefile.am	2009-11-07 20:42:30.000000000 +0300
-+++ lighttpd-1.4.25/src/Makefile.am	2009-11-26 14:22:06.000000000 +0300
-@@ -264,6 +264,15 @@
- mod_accesslog_la_LDFLAGS = -module -export-dynamic -avoid-version -no-undefined
- mod_accesslog_la_LIBADD = $(common_libadd)
- 
-+lib_LTLIBRARIES += mod_geoip.la
-+mod_geoip_la_SOURCES = mod_geoip.c
-+mod_geoip_la_LDFLAGS = -module -export-dynamic -avoid-version -no-undefined
-+mod_geoip_la_LIBADD = $(common_libadd) -lGeoIP
-+
-+lib_LTLIBRARIES += mod_useronline.la
-+mod_useronline_la_SOURCES = mod_useronline.c
-+mod_useronline_la_LDFLAGS = -module -export-dynamic -avoid-version -no-undefined
-+mod_useronline_la_LIBADD = $(common_libadd)
- 
- hdr = server.h buffer.h network.h log.h keyvalue.h \
-       response.h request.h fastcgi.h chunk.h \
-diff --unidirectional-new-file -u -r lighttpd-1.4.25.orig/src/response.c lighttpd-1.4.25/src/response.c
---- lighttpd-1.4.25.orig/src/response.c	2009-11-05 16:25:15.000000000 -0500
-+++ lighttpd-1.4.25/src/response.c	2018-01-03 15:22:43.000000000 -0500
-@@ -165,7 +165,7 @@
- 		buffer_append_string(envds->key, xobjsn);
- 		buffer_copy_string_len(
- 			envds->value,
--			(const char *)xe->value->data, xe->value->length
-+			(const char *)X509_NAME_ENTRY_get_data(xe)->data, X509_NAME_ENTRY_get_data(xe)->length
- 		);
- 		/* pick one of the exported values as "authed user", for example
- 		 * ssl.verifyclient.username   = "SSL_CLIENT_S_DN_UID" or "SSL_CLIENT_S_DN_emailAddress"


### PR DESCRIPTION
lighttpd: update to lighttpd 1.4.71

lighttpd 1.4.25 was released in Nov 2009, over 13 years ago!!!

There are a number of important security and bug fixes that are missing in fink lighttpd.info, besides many improvements.  

Modern lighttpd releases are (generally) still portable to run on very old systems.  The current version of lighttpd is also available for Macs in https://github.com/macports/macports-ports, under https://github.com/macports/macports-ports/tree/master/www/lighttpd

lighttpd release notes over the years announce deprecation and migration paths of some modules which may have been in lighttpd 1.4.25, but are no longer in current lighttpd releases.

mod_cml -> mod_magnet
mod_compress -> mod_deflate
mod_geoip -> mod_maxminddb

lighttpd mod_magnet works with any version of lua 5.1 or later, but I have left the dependency in lighttpd.info at lua51.

lighttpd builds a number of modules into the base lighttpd executable instead of having separate .so (or .dylib) for each module.  (Each modules takes at least (5) 4k pages in memory, and the 12 small modules now built-in to lighttpd use about the same amount of memory as a single small .so.  I have modified lighttpd.info to remove the .so from the module, though the documentation may still be present.

A long time ago, but after lighttpd 1.4.25, some of the documentation in the lighttpd source tree was moved from `doc/*.txt` to `doc/outdated/*.txt` as some of those docs were not maintained and may be out-of-date.  This might require changes to fink lighttpd.info.

mod_secdownload, mod_trigger_before_dl, mod_usertrack, mod_flv_streaming, mod_evasive have all be removed, but replacements are available using lighttpd mod_magnet and lua scripts https://wiki.lighttpd.net/ModMagnetExamples#lua-examples-of-deprecated-lighttpd-modules

mod_mysql_vhost -> mod_vhostdb, mod_vhostdb_mysql but note that I did not (yet?) add mod_vhostdb and mod_vhostdb_mysql, or the alternative mod_vhostdb_dbi with DBI dependencies and SplitOffs to fink lighttpd.info.  Should I add mod_vhostdb, mod_vhostdb_mysql, mod_vhostdb_dbi to lighttpd.info?  mod_vhostdb_ldap?  mod_vhostdb_pgsql?  I somehow doubt that an old Mac is being used as server and requires these databases instead of using mod_evhost with maybe an additional symlink tree on local disk.

The third-party mod_useronline is not provided by lighttpd, but could possibly be re-implemented with a lighttpd mod_magnet and a lua script.  It is not likely to be widely used, if still used at all.

I am not familiar with fink packaging, so I would like to mention some "newer" modules in lighttpd not in fink lighttpd.info: mod_sockproxy, mod_vhostdb_*, mod_wstunnel.  mod_h2 is a separate module for HTTP/2 support.  TLS support in lighttpd is separate from the lighttpd base (which had openssl as part of the lighttpd executable in lighttpd 1.4.25).  Separate TLS modules include mod_openssl, mod_gnutls, mod_mbdetls, mod_wolfssl, mod_nss.  It is likely that fink lighttpd.info needs to be updated to include a SplitOff for at least mod_openssl.