### PR TITLE
Openmpi3

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/openmpi.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/openmpi.info
@@ -1,7 +1,8 @@
 Info2: <<
 Package: openmpi
+# last version for this libN
 Version: 1.10.7
-Revision: 7
+Revision: 8
 GCC: 4.0
 Description: MPI implementation for parallel computing
 License: BSD
@@ -20,6 +21,16 @@ BuildDepends: <<
 	gcc%type_raw[gcc]-compiler,
 	hwloc-dev (>= 1.11.7-1),
 	xcode (>= 4.6)
+<<
+Conflicts: <<
+	openmpi,
+	openmpi3
+<<
+# bin, share/man/man1 moved to -bin after this %v
+Replaces: <<
+	openmpi,
+	openmpi3,
+	openmpi-bin (>> 1.11)
 <<
 Source: https://download.open-mpi.org/release/open-mpi/v1.10/openmpi-%v.tar.bz2
 Source-MD5: c87c613f9acb1a4eee21fa1ac8042579

--- a/10.9-libcxx/stable/main/finkinfo/devel/openmpi3.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/openmpi3.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: openmpi3
-Version: 4.1.3
+Version: 4.1.4
 Revision: 1
 GCC: 4.0
 Description: MPI implementation for parallel computing
@@ -29,7 +29,7 @@ Replaces: <<
 	openmpi3
 <<
 Source: https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-%v.tar.bz2
-Source-Checksum: SHA256(3d81d04c54efb55d3871a465ffb098d8d72c1f48ff1cbaf2580eb058567c0a3b)
+Source-Checksum: SHA256(92912e175fd1234368c8730c03f4996fe5942e7479bb1d10059405e7f2b3930d)
 ConfigureParams: <<
 	--datadir=%p/share \
 	--sysconfdir=%p/etc/%n \
@@ -51,18 +51,6 @@ NoSetLDFLAGS: true
 SetCC: /usr/bin/clang
 SetCXX: /usr/bin/clang++
 BuildDependsOnly: true
-PatchScript: <<
-	# Patch configure to not link like Puma on Yosemite
-	perl -pi.bak -e 's|10\.\[012\]\*|10.[012][,.]*|g' configure \
-		opal/mca/event/libevent2022/libevent/configure \
-		ompi/mca/io/romio321/romio/configure \
-		opal/mca/pmix/pmix3x/pmix/configure
-	# Patch configure to see BigSur and beyond (Darwin20/21)
-	perl -pi.bak2 -e 's|darwin\[91|darwin[912|g; s|	10.\*\)|	1[0123].*)|g' configure \
-		opal/mca/event/libevent2022/libevent/configure \
-		ompi/mca/io/romio321/romio/configure \
-		opal/mca/pmix/pmix3x/pmix/configure
-<<
 CompileScript: <<
 #!/bin/sh -ev
 	./configure %c

--- a/10.9-libcxx/stable/main/finkinfo/devel/openmpi3.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/openmpi3.info
@@ -1,0 +1,206 @@
+Info2: <<
+Package: openmpi3
+Version: 4.1.2
+Revision: 1
+GCC: 4.0
+Description: MPI implementation for parallel computing
+License: BSD
+Maintainer: None <fink-devel@lists.sourceforge.net>
+Type: gcc (11)
+Depends: <<
+	%N-shlibs (= %v-%r),
+	gcc%type_raw[gcc]-compiler,
+	hwloc (>= 2.7.0-1)
+<<
+BuildDepends: <<
+	fink (>= 0.28),
+	fink-package-precedence,
+	flag-sort,
+	gcc%type_raw[gcc]-compiler,
+	hwloc15-dev (>= 2.7.0-2),
+	libevent2.1.7
+<<
+Conflicts: <<
+	openmpi,
+	openmpi3
+<<
+Replaces: <<
+	openmpi,
+	openmpi3
+<<
+Source: https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-%v.tar.bz2
+Source-Checksum: SHA256(9b78c7cf7fc32131c5cf43dd2ab9740149d9d87cadb2e2189f02685749a6b527)
+ConfigureParams: <<
+	--datadir=%p/share \
+	--sysconfdir=%p/etc/%n \
+	--sharedstatedir=%p/var/%n/shared \
+	--localstatedir=%p/var/%n/local \
+	--libdir=%p/lib/%n \
+	--infodir=%p/share/info \
+	--mandir=%p/share/man \
+	--enable-shared \
+	--enable-static \
+	--with-devel-headers \
+	--with-libevent=%p \
+	--with-hwloc=%p \
+	FCFLAGS=-O3 \
+	FC=gfortran-fsf-%type_raw[gcc]
+<<
+NoSetCPPFLAGS: true
+NoSetLDFLAGS: true
+SetCC: /usr/bin/clang
+SetCXX: /usr/bin/clang++
+BuildDependsOnly: true
+PatchScript: <<
+	# Patch configure to not link like Puma on Yosemite
+	perl -pi.bak -e 's|10\.\[012\]\*|10.[012][,.]*|g' configure \
+		opal/mca/event/libevent2022/libevent/configure \
+		ompi/mca/io/romio321/romio/configure \
+		opal/mca/pmix/pmix3x/pmix/configure
+	# Patch configure to see BigSur and beyond (Darwin20/21)
+	perl -pi.bak2 -e 's|darwin\[91|darwin[912|g; s|	10.\*\)|	1[0123].*)|g' configure \
+		opal/mca/event/libevent2022/libevent/configure \
+		ompi/mca/io/romio321/romio/configure \
+		opal/mca/pmix/pmix3x/pmix/configure
+<<
+CompileScript: <<
+#!/bin/sh -ev
+	./configure %c
+	#export CC="flag-sort -v -r $CC"
+	#export CXX="flag-sort -v -r $CXX"
+	/usr/bin/make -w CC="$CC" CXX="$CXX" CPP="$CC -E"
+	fink-package-precedence --prohibit-bdep=openmpi,openmpi3 .
+<<
+InfoTest: TestScript: make -w check || exit 2
+InstallScript: <<
+#!/bin/sh -ev
+	/usr/bin/make install DESTDIR=%d
+	# case-sensitive hackery
+	mv %i/bin/mpicc %i/bin/mpicc_tmp
+	if [ -f %i/bin/mpiCC ]; then
+		rm %i/bin/mpiCC
+		#rm %i/bin/mpiCC-vt
+		#rm %i/bin/vtCC
+		#rm %i/share/openmpi/mpiCC-vt-wrapper-data.txt
+		rm %i/share/openmpi/mpiCC-wrapper-data.txt
+		#rm %i/share/doc/vampirtrace/vtCC-wrapper-data.txt
+		rm %i/share/man/man1/mpiCC.1
+	fi
+	mv %i/bin/mpicc_tmp %i/bin/mpicc
+	# old compat symlinks in openmpi. Hide until we know they're needed in openmpi3
+	#ln -s %p/lib/%N/libopen-pal.40.dylib %i/lib/%N/libopal.40.dylib
+	#ln -s %p/lib/%N/libopen-pal.40.dylib %i/lib/%N/libopal.dylib
+	#ln -s %p/lib/%N/libopen-rte.40.dylib %i/lib/%N/liborte.40.dylib
+	#ln -s %p/lib/%N/libopen-rte.40.dylib %i/lib/%N/liborte.dylib
+
+	# remove published compiler flag that points to fink build dir.
+	perl -pi -e "s, \-L[^ ']*/%n-%v-%r/[^ ']*,,g" `find %i/lib/%N -name '*.la'`
+<<
+DocFiles: AUTHORS INSTALL LICENSE README VERSION
+SplitOff: <<
+	Package: %N-shlibs
+	Depends: <<
+		openmpi-common (>= %v-%r),
+		gcc%type_raw[gcc]-shlibs,
+		hwloc15-shlibs (>= 2.7.0-1)
+	<<
+	Files: <<
+		lib/%N/lib*.*.dylib
+		lib/openmpi3/openmpi/libompi_dbg_msgq.so
+	<<
+	Shlibs: <<
+		%p/lib/%N/libmpi.40.dylib 71.0.0 %n (>= 2.7.0-1)
+		%p/lib/%N/libmpi_mpifh.40.dylib 71.0.0 %n (>= 2.7.0-1)
+		%p/lib/%N/libmpi_usempi_ignore_tkr.40.dylib 71.0.0 %n (>= 2.7.0-1)
+		%p/lib/%N/libmpi_usempif08.40.dylib 71.0.0 %n (>= 2.7.0-1)
+		!%p/lib/%N/libompitrace.40.dylib
+		!%p/lib/%N/libopen-pal.40.dylib
+		!%p/lib/%N/libopen-rte.40.dylib
+		!%p/lib/%N/libpmix.2.dylib
+	<<
+#		!%p/lib/%N/libopen-trace-format.1.dylib
+#		!%p/lib/%N/libotfaux.0.dylib
+#		!%p/lib/%N/libvt-hyb.0.dylib
+#		!%p/lib/%N/libvt-mpi-unify.0.dylib
+#		!%p/lib/%N/libvt-mpi.0.dylib
+#		!%p/lib/%N/libvt-mt.0.dylib
+#		!%p/lib/%N/libvt.0.dylib
+	DocFiles: AUTHORS INSTALL LICENSE README VERSION
+	Description: Shared libraries for openmpi package
+<<
+SplitOff2: <<
+	Package: openmpi-bin
+	Depends: <<
+		%N-shlibs (>= %v-%r),
+		openmpi-common (>= %v-%r),
+		hwloc15-shlibs (>= 2.7.0-2),
+		libevent2.1.7-shlibs
+	<<
+	# bin, share/man/man1 moved from openmpi to openmpi-bin
+	Replaces: <<
+		openmpi (<< 1.10.8)
+	<<
+	Files: <<
+		bin
+		etc/openmpi3
+		share/man/man1
+	<<
+	DocFiles: AUTHORS INSTALL LICENSE README VERSION
+	Description: Binaries for openmpi package
+	PostInstScript: <<
+ if [ ! -h %p/bin/mpiCC ]; then
+	ln -s %p/bin/mpicc %p/bin/mpiCC
+	#ln -s %p/bin/mpicc-vt %p/bin/mpiCC-vt
+	#ln -s %p/bin/vtwrapper %p/bin/vtCC
+	ln -s %p/share/man/man1/mpicc.1 %p/share/man/man1/mpiCC.1
+ fi
+	<<
+	PreRmScript: <<
+ if [ -h %p/bin/mpiCC ]; then
+	rm -f %p/bin/mpiCC
+	#rm -f %p/bin/mpiCC-vt
+	#rm -f %p/bin/vtCC
+	rm -f %p/share/man/man1/mpiCC.1
+ fi
+	<<
+<<
+SplitOff3: <<
+	Package: openmpi-common
+	Files: <<
+		share/openmpi
+	<<
+	DocFiles: AUTHORS INSTALL LICENSE README VERSION
+	Description: Common files for openmpi package
+	PostInstScript: <<
+ if [ ! -f %p/share/openmpi/mpicc-wrapper-data.txt ]; then
+	ln -s %p/share/openmpi/mpicc-wrapper-data.txt %p/share/openmpi/mpiCC-wrapper-data.txt
+	#ln -s %p/share/doc/vampirtrace/vtc++-wrapper-data.txt %p/share/doc/vampirtrace/vtCC-wrapper-data.txt
+ fi
+	<<
+	PreRmScript: <<
+ if [ -h %p/share/openmpi/mpiCC-wrapper-data.txt ]; then
+	rm -f %p/share/openmpi/mpiCC-wrapper-data.txt
+	#rm -f %p/share/openmpi/mpiCC-vt-wrapper-data.txt
+	#rm -f %p/share/doc/vampirtrace/vtCC-wrapper-data.txt
+ fi
+	<<
+<<
+DescDetail: <<
+Open MPI is a project combining technologies and resources from
+several other projects (FT-MPI, LA-MPI, LAM/MPI, and PACX-MPI) in
+order to build the best MPI library available.
+<< 
+DescPackaging: <<
+Upstream now uses -flat_namespace linkages to solve
+https://github.com/open-mpi/ompi/issues/259.  This causes Fink to
+produce "serious warning" messages about the use of -flat_namespace,
+but these can be ignored.
+
+Use Debian's package numbering system for the library SplitOff.
+<<
+DescUsage: <<
+The Open-MPI system is started with the command...
+    orted --seed --persistent --scope public
+<<
+Homepage: https://www.open-mpi.org/
+<<

--- a/10.9-libcxx/stable/main/finkinfo/devel/openmpi3.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/openmpi3.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: openmpi3
-Version: 4.1.2
+Version: 4.1.3
 Revision: 1
 GCC: 4.0
 Description: MPI implementation for parallel computing
@@ -29,7 +29,7 @@ Replaces: <<
 	openmpi3
 <<
 Source: https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-%v.tar.bz2
-Source-Checksum: SHA256(9b78c7cf7fc32131c5cf43dd2ab9740149d9d87cadb2e2189f02685749a6b527)
+Source-Checksum: SHA256(3d81d04c54efb55d3871a465ffb098d8d72c1f48ff1cbaf2580eb058567c0a3b)
 ConfigureParams: <<
 	--datadir=%p/share \
 	--sysconfdir=%p/etc/%n \


### PR DESCRIPTION
Update for openmpi to v4.1.4, which is a new libN=3
Update deps as necessary.
The current base package `openmpi` includes both end user binaries and dev-files, which requires setting `BuildDependsOnly: false`. See #896.