### PR TITLE
packaging-py: v23.1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/packaging-py-20.9.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/packaging-py-20.9.info
@@ -1,0 +1,82 @@
+Info3: <<
+
+Package: packaging-py%type_pkg[python]
+# Future versions are py37+
+Version: 20.9
+
+Revision: 1
+Distribution: <<
+	(%type_pkg[python] = 34 ) 10.9,
+	(%type_pkg[python] = 34 ) 10.10,
+	(%type_pkg[python] = 34 ) 10.11,
+	(%type_pkg[python] = 34 ) 10.12,
+	(%type_pkg[python] = 34 ) 10.13,
+	(%type_pkg[python] = 34 ) 10.14,
+	(%type_pkg[python] = 34 ) 10.14.5,
+	(%type_pkg[python] = 34 ) 10.15,
+	(%type_pkg[python] = 35 ) 10.9,
+	(%type_pkg[python] = 35 ) 10.10,
+	(%type_pkg[python] = 35 ) 10.11,
+	(%type_pkg[python] = 35 ) 10.12,
+	(%type_pkg[python] = 35 ) 10.13,
+	(%type_pkg[python] = 35 ) 10.14,
+	(%type_pkg[python] = 35 ) 10.14.5,
+	(%type_pkg[python] = 35 ) 10.15,
+	(%type_pkg[python] = 36 ) 10.9,
+	(%type_pkg[python] = 36 ) 10.10,
+	(%type_pkg[python] = 36 ) 10.11,
+	(%type_pkg[python] = 36 ) 10.12,
+	(%type_pkg[python] = 36 ) 10.13,
+	(%type_pkg[python] = 36 ) 10.14,
+	(%type_pkg[python] = 36 ) 10.14.5,
+	(%type_pkg[python] = 36 ) 10.15
+<<
+Homepage: https://github.com/pypa/packaging
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+Type: python (2.7 3.4 3.5 3.60)
+Depends: <<
+	python%type_pkg[python],
+	pyparsing-py%type_pkg[python] (>= 2.0.2),
+	six-py%type_pkg[python]
+<<
+BuildDepends: setuptools-tng-py%type_pkg[python] (>= 32.3.0-1)
+
+Source: https://files.pythonhosted.org/packages/source/p/packaging/packaging-%v.tar.gz
+Source-Checksum: SHA256(5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5)
+
+Description: Core utilities for Python packages
+DescDetail: <<
+This module includes APIs for
+-  Version handling (`.version.Version`)
+-  Specifiers (`.specifiers.SpecifierSet`)
+-  Markers (`.markers.Marker`)
+-  Requirements (`.requirements.Requirement`)
+-  Utilities (`.utils`)
+<<
+
+CompileScript: <<
+  python%type_raw[python] setup.py build 
+<<
+
+InstallScript: <<
+  python%type_raw[python] setup.py install --root=%d
+<<
+
+InfoTest: <<
+  TestDepends: <<
+    coverage-py%type_pkg[python],
+    pytest-py%type_pkg[python],
+    pretend-py%type_pkg[python]
+  <<
+  TestScript: <<
+    PYTHONPATH=%b/build/lib:$PYTHONPATH %p/bin/python%type_raw[python] -B -m pytest || exit 2
+  <<
+  TestSuiteSize: medium
+<<
+
+DocFiles: README.rst CHANGELOG.rst CONTRIBUTING.rst LICENSE LICENSE.APACHE LICENSE.BSD
+
+License: BSD
+
+# Info3
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/packaging-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/packaging-py.info
@@ -1,48 +1,20 @@
 Info3: <<
 
 Package: packaging-py%type_pkg[python]
-# Future versions are py37+
-Version: 20.9
+Version: 23.1
 
 Revision: 1
-Distribution: <<
-	(%type_pkg[python] = 34 ) 10.9,
-	(%type_pkg[python] = 34 ) 10.10,
-	(%type_pkg[python] = 34 ) 10.11,
-	(%type_pkg[python] = 34 ) 10.12,
-	(%type_pkg[python] = 34 ) 10.13,
-	(%type_pkg[python] = 34 ) 10.14,
-	(%type_pkg[python] = 34 ) 10.14.5,
-	(%type_pkg[python] = 34 ) 10.15,
-	(%type_pkg[python] = 35 ) 10.9,
-	(%type_pkg[python] = 35 ) 10.10,
-	(%type_pkg[python] = 35 ) 10.11,
-	(%type_pkg[python] = 35 ) 10.12,
-	(%type_pkg[python] = 35 ) 10.13,
-	(%type_pkg[python] = 35 ) 10.14,
-	(%type_pkg[python] = 35 ) 10.14.5,
-	(%type_pkg[python] = 35 ) 10.15,
-	(%type_pkg[python] = 36 ) 10.9,
-	(%type_pkg[python] = 36 ) 10.10,
-	(%type_pkg[python] = 36 ) 10.11,
-	(%type_pkg[python] = 36 ) 10.12,
-	(%type_pkg[python] = 36 ) 10.13,
-	(%type_pkg[python] = 36 ) 10.14,
-	(%type_pkg[python] = 36 ) 10.14.5,
-	(%type_pkg[python] = 36 ) 10.15
-<<
 Homepage: https://github.com/pypa/packaging
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
-Type: python (2.7 3.4 3.5 3.6 3.7 3.8 3.9 3.10)
+Type: python (3.7 3.8 3.9 3.10)
 Depends: <<
 	python%type_pkg[python],
-	pyparsing-py%type_pkg[python] (>= 2.0.2),
-	six-py%type_pkg[python]
+	pyparsing-py%type_pkg[python] (>= 2.0.2)
 <<
-BuildDepends: setuptools-tng-py%type_pkg[python] (>= 32.3.0-1)
+BuildDepends: bootstrap-modules-py%type_pkg[python]
 
 Source: https://files.pythonhosted.org/packages/source/p/packaging/packaging-%v.tar.gz
-Source-Checksum: SHA256(5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5)
+Source-Checksum: SHA256(a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f)
 
 Description: Core utilities for Python packages
 DescDetail: <<
@@ -55,26 +27,27 @@ This module includes APIs for
 <<
 
 CompileScript: <<
-  python%type_raw[python] setup.py build 
+  PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m build --wheel --no-isolation --skip-dependency-check
 <<
 
 InstallScript: <<
-  python%type_raw[python] setup.py install --root=%d
+  PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m installer --destdir %d dist/*.whl
 <<
 
 InfoTest: <<
   TestDepends: <<
-    coverage-py%type_pkg[python],
-    pytest-py%type_pkg[python],
+    coverage-py%type_pkg[python] (>= 5.0.0),
+    pip-py%type_pkg[python] (>= 9.0.2),
+    pytest-py%type_pkg[python] (>= 6.2.0),
     pretend-py%type_pkg[python]
   <<
   TestScript: <<
-    PYTHONPATH=%b/build/lib:$PYTHONPATH %p/bin/python%type_raw[python] -B -m pytest || exit 2
+    PYTHONPATH=%b/src:$PYTHONPATH %p/bin/python%type_raw[python] -B -m pytest || exit 2
   <<
   TestSuiteSize: medium
 <<
 
-DocFiles: README.rst CHANGELOG.rst CONTRIBUTING.rst LICENSE LICENSE.APACHE LICENSE.BSD
+DocFiles: README.rst LICENSE LICENSE.APACHE LICENSE.BSD
 
 License: BSD
 


### PR DESCRIPTION
@dhomeier update for packaging-py, which is the latest upstream.
This only supports py37+ now, so I pushed off the earlier version to a new .info file.
The new release no longer uses setuptools but requires the boostrap-modules-py package.

Tested on 10.14.6 with py37-py310. I need this update for hatchling-py, which is a new backend for packages that use the pep517 system, that I need for an apipkg-py update that I need for another pkg that I need for...

Also tested hatchling-py and a couple other pymods that use packaging-py and they all still build/pass.