### PR TITLE
Ghostscript 10.01.2

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/lcms2mt2.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/lcms2mt2.info
@@ -2,10 +2,10 @@ Info2: <<
 Package: lcms2mt2
 # when updating version, check that mupdf still builds
 Version: 2.12
-Revision: 1
-Type: gsversion (9.54.0)
-Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9540/ghostscript-%type_raw[gsversion].tar.xz
-Source-Checksum: SHA256(c2b7b43cde600f4e70efb2cd95865f6d884a67315c3de235914697d8ccde6e3b)
+Revision: 2
+Type: gsversion (10.01.2)
+Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10012/ghostscript-%type_raw[gsversion].tar.xz
+Source-Checksum: SHA256(48d079242a2ca02a2e47a76a52cdfa818b2ad769c2bab00ad0497dd13560e7e7)
 BuildDepends: <<
 	fink (>= 0.32),
 	fink-package-precedence
@@ -14,7 +14,7 @@ Depends: %n-shlibs (= %v-%r)
 BuildDependsOnly: true
 SourceDirectory: ghostscript-%type_raw[gsversion]/lcms2mt
 PatchFile: %n.patch
-PatchFile-MD5: 0ce0b52ad7f6140128faf7d248345dff
+PatchFile-MD5: e07499de6f5c48ac192f6119fa04ca17
 PatchScript: <<
 	%{default_script}
 	chmod +x configure

--- a/10.9-libcxx/stable/main/finkinfo/graphics/lcms2mt2.patch
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/lcms2mt2.patch
@@ -10,17 +10,6 @@ diff -Nurd lcms2mt.orig/include/lcms2mt.h lcms2mt/include/lcms2mt.h
                                                 const cmsHTRANSFORM hTransform,
                                                 cmsUInt32Number InputFormat,
                                                 cmsUInt32Number OutputFormat);
-diff -Nurd lcms2mt.orig/lcms2mt.pc.in lcms2mt/lcms2mt.pc.in
---- lcms2mt.orig/lcms2mt.pc.in	2021-03-30 03:40:28.000000000 -0400
-+++ lcms2mt/lcms2mt.pc.in	2021-05-23 06:21:11.000000000 -0400
-@@ -6,6 +6,6 @@
- Name: @PACKAGE@
- Description: LCMS Color Management Library
- Version: @VERSION@
--Libs: -L${libdir} -llcms2 @LIB_PLUGINS@
-+Libs: -L${libdir} -llcms2mt @LIB_PLUGINS@
- Libs.private: @LIB_MATH@ @LIB_THREAD@
- Cflags: -I${includedir}
 diff -Nurd lcms2mt.orig/src/cmsxform.c lcms2mt/src/cmsxform.c
 --- lcms2mt.orig/src/cmsxform.c	2021-03-30 03:40:28.000000000 -0400
 +++ lcms2mt/src/cmsxform.c	2021-05-23 06:19:16.000000000 -0400

--- a/10.9-libcxx/stable/main/finkinfo/libs/libijs1-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libijs1-shlibs.info
@@ -1,10 +1,13 @@
 Package: libijs1-shlibs
 Version: 0.35
-Revision: 1
+Revision: 2
 Source: mirror:debian:pool/main/i/ijs/ijs_%v.orig.tar.gz
 Source-Checksum: SHA256(901fffb73e42dae343a8285a31d9c4e82dc3856d36be30adbdb564bdd27161d6)
 SourceDirectory: ijs-%v
-BuildDepends: fink-package-precedence
+BuildDepends: <<
+  fink-package-precedence,
+  automake1.15
+<<
 PatchFile: %n.patch
 PatchFile-MD5: 4ec4d7364322650a0e4fe5f38cc0c8f4
 SetCPPFLAGS: -MD
@@ -13,6 +16,10 @@ ConfigureParams: <<
 	--disable-static \
 	ac_cv_path_DB2PS= \
 	ac_cv_path_PS2PDF=
+<<
+PatchScript: <<
+	cp %p/share/automake-1.15/config.* ./
+	%{default_script}
 <<
 CompileScript: <<
 	%{default_script}
@@ -47,6 +54,9 @@ DescPackaging: <<
 	https://git.ghostscript.com/?p=ghostpdl.git;a=commitdiff;h=0c176a91d53c85cdacd7917c76d6f659125ac3f6
 
 	A bunch of other upstream patches as well.
+	
+	Copies updated config.guess and config.sub from automake, to 
+	support recent OS's and Apple silicon.
 <<
 Description: Raster image transport protocol
 Homepage: https://www.openprinting.org/download/ijs/

--- a/10.9-libcxx/stable/main/finkinfo/libs/libijs1-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libijs1-shlibs.info
@@ -4,22 +4,16 @@ Revision: 2
 Source: mirror:debian:pool/main/i/ijs/ijs_%v.orig.tar.gz
 Source-Checksum: SHA256(901fffb73e42dae343a8285a31d9c4e82dc3856d36be30adbdb564bdd27161d6)
 SourceDirectory: ijs-%v
-BuildDepends: <<
-  fink-package-precedence,
-  automake1.15
-<<
+BuildDepends: fink-package-precedence
 PatchFile: %n.patch
 PatchFile-MD5: 4ec4d7364322650a0e4fe5f38cc0c8f4
 SetCPPFLAGS: -MD
+UpdateConfigGuess: true
 ConfigureParams: <<
 	--enable-shared \
 	--disable-static \
 	ac_cv_path_DB2PS= \
 	ac_cv_path_PS2PDF=
-<<
-PatchScript: <<
-	cp %p/share/automake-1.15/config.* ./
-	%{default_script}
 <<
 CompileScript: <<
 	%{default_script}
@@ -55,8 +49,7 @@ DescPackaging: <<
 
 	A bunch of other upstream patches as well.
 	
-	Copies updated config.guess and config.sub from automake, to 
-	support recent OS's and Apple silicon.
+	Needs updated config.guess and config.sub to support Apple silicon.
 <<
 Description: Raster image transport protocol
 Homepage: https://www.openprinting.org/download/ijs/

--- a/10.9-libcxx/stable/main/finkinfo/text/ghostscript.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/ghostscript.info
@@ -3,11 +3,11 @@ Package: ghostscript%type_pkg[-nox]
 # LIBIDN2 FTBFS; see https://bugs.ghostscript.com/show_bug.cgi?id=698774
 Type: -nox (boolean)
 # when updating, also consider updating lcms2mt2 (same source tarball)
-Version: 9.54.0
+Version: 10.01.2
 Revision: 1
 Description: Interpreter for PostScript and PDF
-Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9540/ghostscript-%v.tar.xz
-Source-Checksum: SHA1(23cce513d4e80504da0778e4ce6f05db73ae2bee)
+Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10012/ghostscript-%v.tar.xz
+Source-Checksum: SHA256(48d079242a2ca02a2e47a76a52cdfa818b2ad769c2bab00ad0497dd13560e7e7)
 PatchFile: ghostscript.patch
 PatchFile-MD5: 3f6d782943d498f11434dcbb3eee5c78
 PatchFile-Checksum: SHA1(ffc3b471dd3bb77eed80c5c6ea958ace47ae5fad)
@@ -24,7 +24,7 @@ Depends: <<
 	libopenjp2.7-shlibs,
 	libpaper1-shlibs,
 	libpng16-shlibs,
-	libtiff5-shlibs,
+	libtiff6-shlibs,
 	(%type_raw[-nox] = .) libxt-shlibs,
 	(%type_raw[-nox] = .) x11,
 	(%type_raw[-nox] = .) x11-shlibs
@@ -46,7 +46,7 @@ BuildDepends: <<
 	libopenjp2.7,
 	libpaper1-dev,
 	libpng16,
-	libtiff5,
+	libtiff6,
 	(%type_raw[-nox] = .) libxt,
 	pkgconfig,
 	(%type_raw[-nox] = .) x11-dev


### PR DESCRIPTION
Updated Ghostscript plus associated packages:

- libijs1 requires updated config.guess and config.sub to build on Apple silicon. These are copied from automake1.15, which has been added as a build dependency. An alternative approach would be to use the updated source code from the Ghostscript tarball, similar to how lcms2mt is built.
- lcms2mt is updated to the latest upstream code. Even though the version number hasn't been updated upstream, the changes shouldn't affect compatibility. mupdf still builds and appears to work with this version
- Ghostscript is updated to the latest upstream version, 10.01.2. Libtiff has been bumped to libtiff6; otherwise everything, including the patchfile, is the same.

All have been tested on 13.4.1 on Apple silicon, and build with "-m".