### PR TITLE
fftw3 - add support for Apple silicon and fix preprocessor

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/fftw3.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/fftw3.info
@@ -1,13 +1,15 @@
 Info2: <<
 Package: fftw3
 Version: 3.3.10
-Revision: 2
+Revision: 3
 Maintainer: None <fink-devel@lists.sourceforge.net>
 
 Type: gcc (11)
 
 Source:  https://www.fftw.org/fftw-%v.tar.gz
 Source-Checksum: SHA256(56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467)
+PatchFile: %n.patch
+PatchFile-MD5: aa44173ecfe7a85cbc78c76ddcff971c
 BuildDepends:  gcc%type_raw[gcc]-compiler
 Depends: %N-shlibs (= %v-%r)
 BuildDependsOnly: True
@@ -18,15 +20,17 @@ ConfigureParams: <<
 	--enable-threads \
 	--disable-mpi \
 	--enable-fortran \
-	--enable-sse2 \
-	--enable-avx \
-	--enable-avx2 \
+	( "%m" != "arm64" ) --enable-sse2 \
+	( "%m" != "arm64" ) --enable-avx \
+	( "%m" != "arm64" ) --enable-avx2 \
+	( "%m" = "arm64" ) --enable-armv8-cntvct-el0 \
 	--mandir='${prefix}/share/man' \
 	--infodir='${prefix}/share/info'
 <<
 GCC: 4.0
 InfoTest: TestScript: touch %b/INSTALL_MAKE_CHECK; make check || exit 2
 PatchScript: <<
+%{default_script}
 # Patch configure to not link like Puma on Yosemite
 perl -pi.bak -e 's|10\.\[012\]\*|10.[012][,.]*|g' configure
 <<
@@ -34,7 +38,7 @@ CompileScript: <<
  #!/bin/sh -ev
  gcclib=`%p/bin/gfortran-fsf-%type_raw[gcc] --print-lib`
  FLIBDIR=`dirname $gcclib`
- CPP=`which cpp` CC=%p/bin/gcc-fsf-%type_raw[gcc] CFLAGS="-I`xcrun --sdk macosx --show-sdk-path`/usr/include" F77=%p/bin/gfortran-fsf-%type_raw[gcc] FLIBS="-L${FLIBDIR}" ./configure %c
+ CPP="%p/bin/gcc-fsf-%type_raw[gcc] -E" CC=%p/bin/gcc-fsf-%type_raw[gcc] CPPFLAGS="-I`xcrun --sdk macosx --show-sdk-path`/usr/include" F77=%p/bin/gfortran-fsf-%type_raw[gcc] FLIBS="-L${FLIBDIR}" ./configure %c
  make
 <<
 InstallScript: <<
@@ -46,7 +50,11 @@ InstallScript: <<
  make clean
  gcclib=`%p/bin/gfortran-fsf-%type_raw[gcc] --print-lib`
  FLIBDIR=`dirname $gcclib`
- CPP=`which cpp` CC=%p/bin/gcc-fsf-%type_raw[gcc] CFLAGS="-I`xcrun --sdk macosx --show-sdk-path`/usr/include" F77=%p/bin/gfortran-fsf-%type_raw[gcc] FLIBS="-L${FLIBDIR}" ./configure %c --enable-float --enable-sse
+ if [ "%m" = "arm64" ]; then
+  CPP="%p/bin/gcc-fsf-%type_raw[gcc] -E" CC=%p/bin/gcc-fsf-%type_raw[gcc] CPPFLAGS="-I`xcrun --sdk macosx --show-sdk-path`/usr/include" F77=%p/bin/gfortran-fsf-%type_raw[gcc] FLIBS="-L${FLIBDIR}" ./configure %c --enable-float
+ else
+  CPP="%p/bin/gcc-fsf-%type_raw[gcc] -E" CC=%p/bin/gcc-fsf-%type_raw[gcc] CPPFLAGS="-I`xcrun --sdk macosx --show-sdk-path`/usr/include" F77=%p/bin/gfortran-fsf-%type_raw[gcc] FLIBS="-L${FLIBDIR}" ./configure %c --enable-float --enable-sse
+ fi
  make
  if [ -f %b/INSTALL_MAKE_CHECK ]; then
    make check 

--- a/10.9-libcxx/stable/main/finkinfo/sci/fftw3.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/fftw3.patch
@@ -1,0 +1,12 @@
+diff -Nurd fftw-3.3.10.orig/kernel/cycle.h fftw-3.3.10/kernel/cycle.h
+--- fftw-3.3.10.orig/kernel/cycle.h	2023-07-16 16:02:45
++++ fftw-3.3.10/kernel/cycle.h	2023-07-16 16:04:25
+@@ -539,7 +539,7 @@
+ #define HAVE_TICK_COUNTER
+ #endif
+ 
+-#if defined(__aarch64__) && defined(HAVE_ARMV8_CNTVCT_EL0) && !defined(HAVE_ARMV8_PMCCNTR_EL0)
++#if defined(__aarch64__) && (defined(__APPLE__) || defined(HAVE_ARMV8_CNTVCT_EL0)) && !defined(HAVE_ARMV8_PMCCNTR_EL0)
+ typedef uint64_t ticks;
+ static inline ticks getticks(void)
+ {


### PR DESCRIPTION
First, a bug fix: 
- rather than invoking Apple's preprocessor directly, preprocess via GCC (by calling "gcc-fsf-11 -E"). If we don't do this, we end up with a bunch of errors when checking header usability.
- Also, header paths are CPPFLAGS, not CFLAGS.

And then we add support for Apple silicon:
- an upstream patch for using the Arm `CNTVCT_EL0` counter on Apple silicon (FFTW/fftw3#267)
- remove the Intel-specific command-line arguments when compiling on Apple silicon
- specify support for the `CNTVCT_EL0` counter. Strictly speaking, this probably isn't necessary, as the first patch should enable this support automatically on MacOS. Alternatively, we could specify this argument and omit the patchfile. Probably comes under the heading of "belt and braces"...

This all requires a working installation of GCC 11. Since I'm now using MacOS 13.4.1 on Apple silicon, I'm using #1033. It compiles and passes all tests with "-m".