### PR TITLE
transition openmotif4 to two_level libxt

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/ddd.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/ddd.info
@@ -1,10 +1,20 @@
 Package: ddd
 Version: 3.3.12
-Revision: 10
+Revision: 12
 GCC: 4.0
 Maintainer: None <fink-devel@lists.sourceforge.net>
-BuildDepends: fink-package-precedence, libxt-flat, openmotif4, libelf, libncurses5 (>= 5.4-20041023-1006)
-Depends: libxt-flat-shlibs, openmotif4-shlibs, libncurses5-shlibs (>= 5.4-20041023-1006)
+BuildDepends: <<
+	fink-package-precedence,
+	libelf,
+	libncurses5 (>= 5.9-20110507-1),
+	libxt,
+	openmotif4-2level
+<<
+Depends: <<
+	libncurses5-shlibs (>= 5.9-20110507-1),
+	libxt-shlibs,
+	openmotif4-2level-shlibs
+<<
 Source: mirror:gnu:%n/%n-%v.tar.gz
 Source-Checksum: SHA256(3ad6cd67d7f4b1d6b2d38537261564a0d26aaed077bf25c51efc1474d0e8b65c)
 PatchFile: %n.patch
@@ -43,8 +53,6 @@ There is a case problem: on a HFS+ filesystem, "ddd" and "Ddd" clash. We use
 a trick to get around this limitation, namely we add an extension".exe" to
 all executables while building, and only rename "ddd.exe" back to "ddd"
 when building the final deb file.
-
-Needs flat-namespace libXt for compatibility with openmotif4
 
 Upstream fix for Xcode9
 Unknown type name 'a_class'

--- a/10.9-libcxx/stable/main/finkinfo/editors/nedit.info
+++ b/10.9-libcxx/stable/main/finkinfo/editors/nedit.info
@@ -1,6 +1,6 @@
 Package: nedit
 Version: 5.7
-Revision: 2
+Revision: 3
 Epoch: 1
 #Source: http://www.nedit.org/ftp/v5_5/nedit-%v.tar.gz
 #Source: mirror:debian:pool/main/n/nedit/nedit_5.6~cvs20081118.orig.tar.gz
@@ -10,16 +10,16 @@ Source2: mirror:debian:pool/main/n/nedit/nedit_%v-2.debian.tar.xz
 Source2-Checksum: SHA256(4504cb1f05543737bd6459c0d4a3d567f8db4e07097b440845cb419e1f38ff3f)
 SourceDirectory: %n-%v
 Depends: <<
-	libxt-flat-shlibs,
-	openmotif4-shlibs,
+	libxt-shlibs,
+	openmotif4-2level-shlibs,
 	x11
 <<
 BuildDepends: <<
 	fink (>= 0.32),
 	fink-buildenv-modules,
 	fink-package-precedence,
-	libxt-flat,
-	openmotif4,
+	libxt,
+	openmotif4-2level,
 	x11-dev
 <<
 PatchFile: %n.patch
@@ -73,9 +73,6 @@ DescPackaging: <<
 	XQuartz-2.8.0 dropped libXp compile-time files (only retained
 	the runtime dylib); disable detection in order to get
 	deterministic results.
-<<
-DescPort: <<
-	Needs flat-namespace libXt for compatibility with openmotif4
 <<
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>

--- a/10.9-libcxx/stable/main/finkinfo/sci/afni.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/afni.info
@@ -1,10 +1,37 @@
 Package: afni
 Version: 2010.10.19.1028
-Revision: 6
+Revision: 7
 Maintainer: Andrew Davis <addavis@gmail.com>
-Depends: glib2-shlibs, netpbm-bin, libxt-flat-shlibs, openmotif4-shlibs, fontconfig2-shlibs, libgsl25-shlibs, libiconv, libjpeg9-shlibs, libjpeg-bin, libpng16-shlibs, xft2-shlibs, expat1-shlibs, x11-shlibs
-BuildDepends: glib2-dev, libxt-flat, openmotif4, fontconfig2-dev, libgsl25-dev, libiconv-dev, libiconv-bin, libjpeg9, libpng16, xft2-dev, expat1, x11, fink-buildenv-modules
-
+Depends: <<
+	expat1-shlibs,
+	fontconfig2-shlibs,
+	glib2-shlibs,
+	libgsl25-shlibs,
+	libiconv,
+	libjpeg-bin,
+	libjpeg9-shlibs,
+	libpng16-shlibs,
+	libxt-shlibs,
+	netpbm-bin,
+	openmotif4-2level-shlibs,
+	x11-shlibs,
+	xft2-shlibs
+<<
+BuildDepends: <<
+	expat1,
+	fink-buildenv-modules,
+	fontconfig2-dev,
+	glib2-dev,
+	libgsl25-dev,
+	libiconv-bin,
+	libiconv-dev,
+	libjpeg9,
+	libpng16,
+	libxt,
+	openmotif4-2level,
+	x11,
+	xft2-dev
+<<
 CustomMirror: <<
 Primary: http://afni.nimh.nih.gov/pub/dist/tgz/AFNI_ARCHIVE/
 <<
@@ -34,9 +61,6 @@ README and rc files located in: %p/share/doc/afni/
 Copy %p/share/doc/afni/AFNI.afnirc to ~/.afnirc and edit it appropriately
 AFNI_PLUGINPATH has been set to %p/lib/afni:%p/include/afni
 See README.setup and README.environment for documentation
-<<
-DescPort: <<
-	Needs flat-namespace libXt for compatibility with openmotif4
 <<
 
 DescPackaging: <<
@@ -76,6 +100,9 @@ sed 's|@PREFIX@|%p|g' < %{PatchFile} | sed 's|@INSTALLPREFIX@|%i|g' | sed 's|@PA
 # fix x11 path
 . %p/sbin/fink-buildenv-helper.sh
 perl -pi -e "s|/usr/X11R6|$X11_BASE_DIR|g" Makefile
+
+# don't hardcode full path
+perl -pi -e "s|/usr/include/math.h|math.h|g" avovk/cluster_floatNOMASK.c
 <<
 
 UseMaxBuildJobs: false

--- a/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/cernlib2006.info
@@ -2,18 +2,18 @@ Info3: <<
 Package: cernlib2006
 Type: gcc (12)
 Version: 2006b
-Revision: 32
+Revision: 33
 Description: Paw and other basic executables
 Depends: <<
   gcc%type_pkg[gcc]-shlibs,
   x11
 <<
 BuildDepends: <<
-  fink-package-precedence (>=0.31-1),
+  fink-package-precedence (>= 0.31-1),
   freetype219 (>= 2.10.2-1),
   gcc%type_pkg[gcc],
-  libxt-flat (>=1.1.5-2),
-  openmotif4 (>= 2.3.4-13),
+  libxt (>= 1.1.5-2),
+  openmotif4-2level,
   patchy4-gfortran (>= 4.15-14),
   x11-dev,
   xcode,
@@ -40,7 +40,7 @@ PatchScript: <<
       s|gcc-8|gcc-%type_pkg[gcc]|g;
       s|g++-6|g++-%type_pkg[gcc]|g;
     }" | patch -p1
-  perl -pi -e 's|-lXt|%p/lib/libXt-flat/libXt.6.dylib|g' scripts/cernlib
+  perl -pi -e 's|-lXt|%p/lib/libXt.dylib|g' scripts/cernlib
 
   # Revive older-gcc behaviors for some old code-practices
   perl -pi -e 's/-O0/-O0 -fallow-invalid-boz/ if /Fortran/' config/MacOSX.cf
@@ -150,11 +150,11 @@ SplitOff: <<
   Package: %N-paw++
   Provides: cernlib-paw++
   Depends: <<
-    x11,
+    %N (= %v-%r),
     gcc%type_pkg[gcc]-shlibs,
-    libxt-flat-shlibs (>=1.1.5-2),
-    openmotif4-shlibs (>= 2.3.4-13),
-    %N (=%v-%r)
+    libxt-shlibs (>= 1.1.5-2),
+    openmotif4-2level-shlibs,
+    x11
   <<
   InstallScript: <<
     install -d %i/bin
@@ -351,10 +351,6 @@ Additional patches were taken from the Fedora project
 this additional resource. The final touches for 64-bit compliance on Mac OS X
 were done by myself.
 This port is not officially supported by CERN. Use it at your own risk.
-
-To maintain compatibility with openmotif4 in the presence of Xquartz-2.7.10,
-where both libXt.6.dylib and libXt.7.dylib are incompatible non flat-namespace
-versions, build against new libxt-flat package and against appropriate openmotif4.
 <<
 DescPackaging: <<
 The CERNLIB is by default installed in a completely separate directory

--- a/10.9-libcxx/stable/main/finkinfo/sci/dx.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/dx.info
@@ -1,7 +1,7 @@
 Package: dx
 # not compatible with imagemagick 7 (debian doesn't have patches either)
 Version: 4.4.4
-Revision: 1516
+Revision: 1517
 Source:  http://opendx.sdsc.edu/source/%n-%v.tar.gz
 Source-Checksum: SHA256(a9915e17d49c5499edd3df69ffeac0b7ba24f8b38ddf7509712b48eb3c21f1ff)
 PatchFile: %n.patch
@@ -41,11 +41,11 @@ BuildDepends: <<
 	fink-package-precedence,
 	libmagickcore6.9.q16.2-dev,
 	libjpeg9,
-	libtiff5,
+	libtiff6,
 	libtool2,
-	libxt-flat,
+	libxt,
 	netcdf-c18,
-	openmotif4,
+	openmotif4-2level,
 	szip,
 	x11-dev
 <<
@@ -53,10 +53,10 @@ Depends: <<
 	hdf (>= 4.2.15-2),
 	libmagickcore6.9.q16.2-shlibs,
 	libjpeg9-shlibs,
-	libtiff5-shlibs,
-	libxt-flat-shlibs,
+	libtiff6-shlibs,
+	libxt-shlibs,
 	netcdf-c18-shlibs,
-	openmotif4-shlibs,
+	openmotif4-2level-shlibs,
 	szip-shlibs,
 	x11
 <<
@@ -127,8 +127,6 @@ akh: patch instances of "argc" to be an int rather than
      patch _im_image.c to deal with a change in the ImageMagick API (shocker!)
      cf.:
      https://bugs.launchpad.net/ubuntu/+source/transcode/+bug/539106
-
-Needs flat-namespace libXt for compatibility with openmotif4
 <<
 DescPackaging: <<
 	dmacks: Hack configure to use whatever libs ImageMagick

--- a/10.9-libcxx/stable/main/finkinfo/sci/geant4.9.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/geant4.9.info
@@ -1,7 +1,7 @@
 Info3: <<
 Package: geant4.9%type_pkg[cernlib]
 Version: 4.9.4
-Revision: 17
+Revision: 18
 Type: cernlib (. -cernlib), gcc (12)
 Description: Simulation of particle-matter interaction
 DescDetail: <<
@@ -26,11 +26,6 @@ X. The OpenGL framework provided by Mac OS X is used, too.
 
 Upstream hardcodes /sw in some places, and we fix this.
 <<
-DescPort: <<
-To maintain compatibility with openmotif4 in the presence of Xquartz-2.7.10,
-where both libXt.6.dylib and libXt.7.dylib are incompatible non flat-namespace
-versions, build against the libxt-flat package.
-<<
 Homepage: http://geant4.cern.ch/
 Maintainer: Remi Mommsen <remigius.mommsen@cern.ch>
 DocFiles: ReleaseNotes/*
@@ -38,17 +33,17 @@ License: BSD
 BuildDependsOnly: true
 Depends: <<
  %n-shlibs (=%v-%r),
- openmotif4-bin (>= 2.3.4-13)
+ openmotif4-2level-bin
 <<
 BuildDepends: <<
  clhep2 (>= 2.1.0.1),
  fink (>= 0.27.2),
- fink-package-precedence (>=0.31-1),
- libxt-flat (>=1.1.5-2),
- openmotif4-bin (>= 2.3.4-13),
+ fink-package-precedence (>= 0.31-1),
+ libxt (>= 1.1.5-2),
+ openmotif4-2level-bin,
  x11-dev,
- ('%type_pkg[cernlib]' = '-cernlib') cernlib2006-geant321 (>= 2006b-32),
- ('%type_pkg[cernlib]' = '-cernlib') cernlib2006-dev (>= 2006b-32),
+ ('%type_pkg[cernlib]' = '-cernlib') cernlib2006-geant321 (>= 2006b-33),
+ ('%type_pkg[cernlib]' = '-cernlib') cernlib2006-dev (>= 2006b-33),
  ('%type_pkg[cernlib]' = '-cernlib') gcc%type_pkg[gcc]
 <<
 Conflicts: <<
@@ -90,7 +85,7 @@ PatchScript: <<
   # Upstream hardcodes /sw, replace that by the active prefix.
   /usr/bin/sed -i -re "s|/sw|%p|g" Configure
   /usr/bin/sed -i -re "s|/usr/X11R6|/opt/X11|g" Configure config/sys/Darwin-g++.gmk fink.sh
-  /usr/bin/sed -i -re "s|-lXt |%p/lib/libXt-flat/libXt.6.dylib |g" Configure config/sys/Darwin-g++.gmk
+  /usr/bin/sed -i -re "s|-lXt |%p/lib/libXt.dylib |g" Configure config/sys/Darwin-g++.gmk
 <<
 CompileScript: <<
   #!/bin/sh -ev
@@ -136,8 +131,8 @@ SplitOff: <<
    Depends: <<
      x11,
      clhep2-shlibs (>= 2.1.0.1),
-     libxt-flat-shlibs (>=1.1.5-2),
-     openmotif4-shlibs (>= 2.3.4-13)
+     libxt-shlibs (>= 1.1.5-2),
+     openmotif4-2level-shlibs
    <<
    Conflicts: <<
      geant4.9-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/sci/geomview195-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/geomview195-shlibs.info
@@ -1,15 +1,15 @@
 Package: geomview195-shlibs
 Version: 1.9.5
-Revision: 3
+Revision: 4
 GCC: 4.0
 Depends: <<
-	libxt-flat-shlibs,
+	libxt-shlibs,
 	x11-shlibs
 <<
 BuildDepends: <<
 	fink-package-precedence,
-	libxt-flat,
-	openmotif4,
+	libxt,
+	openmotif4-2level,
 	x11-dev
 <<
 Replaces: geomview
@@ -53,8 +53,8 @@ SplitOff2: <<
 	Package: geomview
 	Depends: <<
 		%N (>= %v-%r),
-		libxt-flat-shlibs,
-		openmotif4-shlibs,
+		libxt-shlibs,
+		openmotif4-2level-shlibs,
 		ghostscript,
 		x11
 	<<
@@ -66,9 +66,6 @@ SplitOff2: <<
 	<<
 	InfoDocs: geomview
 	DocFiles: AUTHORS COPYING ChangeLog NEWS README
-<<
-DescPort: <<
-	Needs flat-namespace libXt for compatibility with openmotif4
 <<
 License: LGPL
 Description: Interactive 3D viewing program

--- a/10.9-libcxx/stable/main/finkinfo/sci/grace.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/grace.info
@@ -1,6 +1,6 @@
 Package: grace
 Version: 5.1.25
-Revision: 6
+Revision: 7
 
 Source: ftp://plasma-gate.weizmann.ac.il/pub/%N/src/%n5/%n-%v.tar.gz
 Source-Checksum: SHA256(751ab9917ed0f6232073c193aba74046037e185d73b77bab0f5af3e3ff1da2ac)
@@ -9,27 +9,27 @@ Depends: <<
 	fftw3-shlibs,
 	libjpeg9-shlibs,
 	libpng16-shlibs,
-	libxt-flat-shlibs (>=1.1.5-2),
+	libxt-shlibs (>= 1.1.5-2),
 	netcdf-c18-shlibs,
-	openmotif4-shlibs (>= 2.3.4-13),
+	openmotif4-2level-shlibs,
 	pdflib6-shlibs,
 	t1lib5-nox-shlibs,
-	xbae-shlibs (>= 4.60.4-6),
-	x11-shlibs
+	x11-shlibs,
+	xbae-shlibs (>= 4.60.4-8)
 <<
 BuildDepends: <<
 	fftw3,
+	fink (>= 0.32),
+	fink-package-precedence (>= 0.31-1),
 	libjpeg9,
 	libpng16,
-	libxt-flat (>=1.1.5-2),
+	libxt (>=1.1.5-2),
 	netcdf-c18,
-	openmotif4 (>=2.3.4-13),
+	openmotif4-2level,
 	pdflib6,
 	t1lib5-nox,
 	x11-dev,
-	xbae (>= 4.60.4-6),
-	fink (>=0.32),
-	fink-package-precedence (>=0.31-1)
+	xbae (>= 4.60.4-8)
 <<
 RuntimeDepends: x11
 
@@ -43,11 +43,13 @@ PatchScript: <<
 <<
 
 ConfigureParams: <<
---enable-grace-home=%p/lib/X11/grace --enable-editres \
---disable-xmhtml --without-bundled-xbae  \
---enable-netcdf \
---x-i=/opt/X11/include --x-l=/opt/X11/lib \
-ac_cv_lib_Xp_main=no
+	--enable-grace-home=%p/lib/X11/grace \
+	--enable-editres \
+	--disable-xmhtml \
+	--without-bundled-xbae  \
+	--enable-netcdf \
+	--x-i=/opt/X11/include --x-l=/opt/X11/lib \
+	ac_cv_lib_Xp_main=no
 <<
 CompileScript: <<
 	#!/bin/sh -ev
@@ -108,11 +110,6 @@ to force the issue.
 
 Apply Debian patches (via J. Howarth) to allow building against fftw3,
 among other things.
-
-To maintain compatibility with openmotif4 in the presence of Xquartz-2.7.10,
-where both libXt.6.dylib and libXt.7.dylib are incompatible non flat-namespace
-versions, build against new libxt-flat package against appropriate minimum openmotif4
-and Xbae.  Also use appropriate fink-package-precedence versioning to scan for this issue.
 <<
 DescPackaging: <<
 We removed doc/ as a vaild subdirectory in configure because the build insists

--- a/10.9-libcxx/stable/main/finkinfo/sci/mbsystem.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/mbsystem.info
@@ -1,6 +1,6 @@
 Package: mbsystem
 Version: 5.7.8
-Revision: 1
+Revision: 2
 
 Source: https://github.com/dwcaress/MB-System/archive/%v.tar.gz
 SourceRename: %n-%v.tar.gz
@@ -8,24 +8,26 @@ SourceDirectory: MB-System-%v
 Source-Checksum: SHA256(aa3f7c7f79a933d22ff7410284c3c7de9ba9416c14f271bec231b2307101abad)
 
 BuildDepends: <<
-  gmt6-dev (>= 6.1.0),
-  openmotif4,
-  netcdf-c18,
-  x11-dev,
-  libproj19,
   fftw3,
-  gdal3-dev
+  gdal3-dev,
+  gmt6-dev (>= 6.1.0),
+  libproj19,
+  libxt,
+  netcdf-c18,
+  openmotif4-2level,
+  x11-dev
 <<
 Depends: <<
-  gmt6 (>= 6.1.0),
-  openmotif4-shlibs,
-  netcdf-c18-shlibs,
-  x11,
-  gv,
-  proj-bin (>= 7.2.0),
-  libproj19-shlibs,
   gdal3-shlibs,
-  parallel-forkmanager-pm5182 | parallel-forkmanager-pm5184 | parallel-forkmanager-pm5282 | parallel-forkmanager-pm5302 | parallel-forkmanager-pm5303
+  gmt6 (>= 6.1.0),
+  gv,
+  libproj19-shlibs,
+  libxt-shlibs,
+  netcdf-c18-shlibs,
+  openmotif4-2level-shlibs,
+  parallel-forkmanager-pm5182 | parallel-forkmanager-pm5184 | parallel-forkmanager-pm5282 | parallel-forkmanager-pm5302 | parallel-forkmanager-pm5303,
+  proj-bin (>= 7.2.0),
+  x11
 <<
 ConfigureParams: <<
 	--disable-static \
@@ -46,14 +48,24 @@ SetLDFLAGS:-L/opt/X11/lib
 GCC: 4.0
 
 InfoTest: <<
-   TestDepends: python3 | python37 | python38 | python39 | python310
-   TestConfigureParams: --enable-test
-   TestScript: <<
-     make check || exit 2
-     # now disable install in test directories:
-     sed -i -e 's|install: install-recursive|install:|' test/Makefile
-     sed -i -e 's|install: install-recursive|install:|' third_party/Makefile
-   <<
+	TestDepends: python3 | python37 | python38 | python39 | python310
+	TestConfigureParams: --enable-test
+	TestScript: <<
+	#!/bin/sh -ev
+	# tests look for `python3`, but we don't care which python3. So scan for one and point tests to that
+	if [ ! -f /usr/bin/python3 ]; then
+		mkdir %b/finkbin
+		export PATH=%b/finkbin:$PATH
+		for py_exe in python3 python3.7 python3.8 python3.9 python3.10; do
+			[ -x %p/bin/$py_exe ] && ln -s %p/bin/$py_exe %b/finkbin/python3 && break
+		done
+		ls -l %b/finkbin
+	fi # /usr/bin/python3 check
+	make check || exit 2
+	# now disable install in test directories:
+	sed -i -e 's|install: install-recursive|install:|' test/Makefile
+	sed -i -e 's|install: install-recursive|install:|' third_party/Makefile
+	<<
 <<
 
 Shlibs: <<
@@ -69,6 +81,9 @@ Shlibs: <<
 SplitOff: <<
  Package: %N-dev
  BuildDependsOnly: True
+ Depends: <<
+   %N (= %v-%r)
+ <<
  Files: <<
    include
    lib/*.la
@@ -115,11 +130,6 @@ Also, if you want the scripts to open the Apple Preview application,
 set your MB_PS_VIEWER to open or you can use mbdefaults to set a viewer:
 
   mbdefaults -D open
-
-If you encounter errors using the graphical programs like mbedit, try running 
-the following command (or add it to your .profile:
-
-  export DYLD_LIBRARY_PATH=/opt/X11/lib/flat_namespace
 <<
 
 License: GPL

--- a/10.9-libcxx/stable/main/finkinfo/sci/molmol.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/molmol.info
@@ -1,6 +1,6 @@
 Package: molmol
 Version: 2k.2.0
-Revision: 1058
+Revision: 1059
 CustomMirror: <<
  eur-DE: ftp://ftp.uni-frankfurt.de/pub/Mirrors2/gentoo.org/
  eur-PL: ftp://ftp.prz.rzeszow.pl/pub/gentoo/source/
@@ -52,9 +52,9 @@ Depends: <<
 	libjpeg9-shlibs(>= 9-3),
 	libpng16-shlibs,
 	libtiff6-shlibs,
-	libxt-flat-shlibs,
-	mesa-libglw-openmotif4-shlibs,
-	openmotif4-shlibs,
+	libxt-shlibs,
+	mesa-libglw-openmotif4-shlibs (>= 7.8.2-4),
+	openmotif4-2level-shlibs,
 	x11
 <<
 BuildDepends: <<
@@ -63,9 +63,9 @@ BuildDepends: <<
 	libjpeg9 (>= 9-3),
 	libpng16,
 	libtiff6,
-	libxt-flat,
-	mesa-libglw-openmotif4,
-	openmotif4,
+	libxt,
+	mesa-libglw-openmotif4 (>= 7.8.2-4),
+	openmotif4-2level,
 	x11-dev
 <<
 UseMaxBuildJobs: false
@@ -113,10 +113,7 @@ NT/95/98/2000 and is freely available.  It does not work properly with RNA.
 .
 Invoke with command "molmol"
 .
-molmol files and documentation located in /sw/share/molmol.
-<<
-DescPort: <<
-	Needs flat-namespace libXt for compatibility with openmotif4
+molmol files and documentation located in %p/share/molmol.
 <<
 DescPackaging: <<
 	XQuartz-2.8.0 dropped libXp compile-time files (only retained

--- a/10.9-libcxx/stable/main/finkinfo/sci/orrery.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/orrery.info
@@ -1,22 +1,22 @@
 Package: orrery
 Version: 0.9.7
-Revision: 1
+Revision: 2
 Description: Solar system digital model via geomview
 License: GPL
 Maintainer:  Dave Morrison <drm@finkproject.org>
 GCC: 4.0
 BuildDepends: <<
 	fink-package-precedence,
-	geomview195-dev,
-	libxt-flat,
+	geomview195-dev (>= 1.9.5-4),
+	libxt,
 	tcltk-dev,
 	x11-dev
 <<
 Depends: <<
-	geomview (>= 1.9.5-1),
+	geomview (>= 1.9.5-4),
 	geomview195-shlibs,
 	libjpeg-bin,
-	libxt-flat-shlibs,
+	libxt-shlibs,
 	tcltk-shlibs,
 	x11-shlibs
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/xephem.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xephem.info
@@ -2,19 +2,19 @@
 Info2: <<
 Package: xephem
 Version: 3.7.7
-Revision: 3
+Revision: 4
 BuildDepends: <<
 	fink-buildenv-modules,
 	fink-package-precedence,
-	libxt-flat,
-	openmotif4,
-	openssl110-dev,
+	libxt,
+	openmotif4-2level,
+	openssl300-dev,
 	x11-dev
 <<
 Depends: <<
-	libxt-flat-shlibs,
-	openmotif4-shlibs,
-	openssl110-shlibs,
+	libxt-shlibs,
+	openmotif4-2level-shlibs,
+	openssl300-shlibs,
 	x11-shlibs
 <<
 Source: http://www.clearskyinstitute.com/xephem/%n-%v.tgz
@@ -75,8 +75,6 @@ xephem -env TELHOME=/data_install_path
 <<
 DescPackaging: <<
 Builds and uses its own versions of many support libraries.
-
-Needs flat-namespace libXt for compatibility with openmotif4
 
 Hardcoded data directory %p/lib/xephem; additional catalogue and other data
 files installable in ~/Library/XEphem at the user level; in a location given

--- a/10.9-libcxx/stable/main/finkinfo/sci/xmakemol.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xmakemol.info
@@ -1,6 +1,6 @@
 Package: xmakemol
 Version: 5.16
-Revision: 5
+Revision: 6
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: http://savannah.nongnu.org/download/%n/%n-%v.tar.gz
 Source-Checksum: SHA256(9c498221ab839124f86a94b6115bdf66d966f954131b3afbb523b85edf0f8766)
@@ -9,17 +9,17 @@ Depends: <<
 	gifsicle,
 	imagemagick (>= 5.5.1-13),
 	libgl,
-	libxt-flat-shlibs,
-	mesa-libglw-openmotif4-shlibs,
-	openmotif4-shlibs,
+	libxt-shlibs,
+	mesa-libglw-openmotif4-shlibs (>= 7.8.2-4),
+	openmotif4-2level-shlibs,
 	x11
 <<
 BuildDepends: <<
 	fink-package-precedence,
 	freeglut2,
-	libxt-flat,
-	mesa-libglw-openmotif4,
-	openmotif4,
+	libxt,
+	mesa-libglw-openmotif4 (>= 7.8.2-4),
+	openmotif4-2level,
 	x11-dev
 <<
 
@@ -53,9 +53,6 @@ bundled utility xmake_anim.pl
 <<
 DescPackaging: <<
  Originally packaged by Matt Stephenson.
-<<
-DescPort: <<
-	Needs flat-namespace libXt for compatibility with openmotif4
 <<
 License: GPL
 Homepage: http://savannah.nongnu.org/projects/xmakemol

--- a/10.9-libcxx/stable/main/finkinfo/text/texlive.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/texlive.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: texlive%type_pkg[-nox]
 Type: -nox (boolean)
 Version: 20210325
-Revision: 10
+Revision: 11
 GCC: 4.0
 Description: Bundle package for TeX Live
 Depends: %N-base (= %v-%r), texinfo (>= 6.5), debianutils
@@ -10,8 +10,8 @@ BuildDepends: <<
  (%type_raw[-nox] = .) cairo (>= 1.12.14-1),
  (%type_raw[-nox] = .) gd3 (>= 2.3.2-2),
  (%type_raw[-nox] = .) libiconv-dev,
- (%type_raw[-nox] = .) libxt-flat,
- (%type_raw[-nox] = .) openmotif4,
+ (%type_raw[-nox] = .) libxt,
+ (%type_raw[-nox] = .) openmotif4-2level,
  (%type_raw[-nox] = .) x11, 
  fink (>= 0.32.2),
  fink-package-precedence,
@@ -322,8 +322,8 @@ SplitOff: <<
   (%type_raw[-nox] = .) cairo-shlibs (>= 1.12.14-1),
   (%type_raw[-nox] = .) gd3-shlibs (>= 2.3.2-2),
   (%type_raw[-nox] = .) ghostscript, 
-  (%type_raw[-nox] = .) libxt-flat-shlibs,
-  (%type_raw[-nox] = .) openmotif4-shlibs,
+  (%type_raw[-nox] = .) libxt-shlibs,
+  (%type_raw[-nox] = .) openmotif4-2level-shlibs,
   (%type_raw[-nox] = .) libiconv,
   (%type_raw[-nox] = .) x11-shlibs,
   (%type_raw[-nox] = .) x11, 
@@ -418,8 +418,6 @@ fi
 <<
 DescPackaging: <<
 Allow ghostscript to satisfy Depends on -nox build.
-
-Needs flat-namespace libXt for compatibility with openmotif4
 <<
 License: Restrictive/Distributable
 Maintainer: Tomoaki Okayama <okayama@users.sourceforge.net>

--- a/10.9-libcxx/stable/main/finkinfo/text/xpdf.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/xpdf.info
@@ -1,27 +1,27 @@
 Package: xpdf
 # version 4.00 switches to Qt (4.03 supports both qt4 and qt5)
 Version: 3.04
-Revision: 5
+Revision: 6
 GCC: 4.0
 #Source: https://dl.xpdfreader.com/%n-%v.tar.gz
 Source: https://dl.xpdfreader.com/old/%n-%v.tar.gz
 Source-Checksum: SHA256(11390c74733abcb262aaca4db68710f13ffffd42bfe2a0861a5dfc912b2977e5)
 Depends: <<
-	freetype219-shlibs (>= 2.10.2-1),
+	freetype219-shlibs (>= 2.12.1-4),
 	ghostscript-fonts,
 	libpaper1-shlibs,
 	libpng16-shlibs,
-	libxt-flat-shlibs,
-	openmotif4-shlibs,
+	libxt-shlibs,
+	openmotif4-2level-shlibs,
 	x11
 <<
 BuildDepends: <<
 	fink-package-precedence,
-	freetype219  (>= 2.10.2-1),
+	freetype219  (>= 2.12.1-4),
 	libpaper1-dev,
 	libpng16,
-	libxt-flat,
-	openmotif4,
+	libxt,
+	openmotif4-2level,
 	x11-dev
 <<
 Conflicts: poppler-bin
@@ -74,8 +74,6 @@ DescPort: <<
 	Upstream detection of freetype is ignorant of the fact that
 	freetype publishes the correct flags and that the flags are
 	not simple enough for just a normal header compiler-test.
-
-	Needs flat-namespace libXt for compatibility with openmotif4
 
 	XQuartz-2.8.0 dropped libXp compile-time files (only retained
 	the runtime dylib); disable detection in order to get

--- a/10.9-libcxx/stable/main/finkinfo/x11/mesa-libglw.info
+++ b/10.9-libcxx/stable/main/finkinfo/x11/mesa-libglw.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: mesa-libglw-%type_pkg[motif]
 Version: 7.8.2
-Revision: 3
+Revision: 4
 BuildDependsOnly: True
 Type: motif (openmotif4)
 #Source: mirror:sourceforge:mesa3d/MesaLib-%v.tar.bz2
@@ -12,21 +12,22 @@ PatchFile-MD5: f98c591ab85e31396fe7e6cb04ca244d
 SourceDirectory: Mesa-%v
 Depends: <<
 	%N-shlibs (= %v-%r),
-	%type_pkg[motif]-shlibs,
-	libxt-flat-shlibs,
+	%type_pkg[motif]-2level-shlibs,
+	libxt-shlibs,
 	x11
 <<
 BuildDepends: <<
-	%type_pkg[motif],
+	%type_pkg[motif]-2level,
 	fink-buildenv-modules (>= 0.1.3-1),
 	fink-package-precedence,
-	libxt-flat,
+	libxt,
 	x11-dev
 <<
 BuildConflicts: <<
 	(%type_pkg[motif] != lesstif) lesstif,
 	(%type_pkg[motif] != openmotif3) openmotif3,
-	(%type_pkg[motif] != openmotif4) openmotif4
+	openmotif4,
+	(%type_pkg[motif] != openmotif4) openmotif4-2level
 <<
 Conflicts: <<
 	mesa-libglw,
@@ -59,15 +60,12 @@ InstallScript: <<
 SplitOff: <<
 	Package: %N-shlibs
 	Depends: <<
-		%type_pkg[motif]-shlibs,
-		libxt-flat-shlibs,
+		%type_pkg[motif]-2level-shlibs,
+		libxt-shlibs,
 		x11
 	<<
 	Files: %p/lib/libGLw-%type_pkg[motif].*.dylib 
 	Shlibs: %p/lib/libGLw-%type_pkg[motif].1.dylib 1.0.0 %n (>=7.0.2-3)
-<<
-DescPort: <<
-	Needs flat-namespace libXt for compatibility with openmotif4
 <<
 License: BSD
 Description: Xt / Motif OpenGL widgets

--- a/10.9-libcxx/stable/main/finkinfo/x11/openmotif4-2level-implicit_declaration.patch
+++ b/10.9-libcxx/stable/main/finkinfo/x11/openmotif4-2level-implicit_declaration.patch
@@ -1,0 +1,33 @@
+diff -ruN motif-2.3.8-orig/configure motif-2.3.8/configure
+--- motif-2.3.8-orig/configure	2017-12-05 06:49:56.000000000 -0600
++++ motif-2.3.8/configure	2023-07-16 13:24:40.000000000 -0500
+@@ -13172,6 +13172,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <X11/Intrinsic.h>
+ int main() {
+ Boolean brc;
+@@ -14654,8 +14655,9 @@
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <stdlib.h>
+ #include <stdio.h>
+-int sprintf(); main() { exit(sprintf(".")); }
++int main() { char buf[1]; int i = sprintf(buf, ""); return 0; }
+ _ACEOF
+ if ac_fn_c_try_run "$LINENO"; then :
+   ac_cv_func_void_sprintf=no
+diff -ruN motif-2.3.8-orig/demos/unsupported/xmform/xmform.c motif-2.3.8/demos/unsupported/xmform/xmform.c
+--- motif-2.3.8-orig/demos/unsupported/xmform/xmform.c	2016-03-15 21:10:08.000000000 -0500
++++ motif-2.3.8/demos/unsupported/xmform/xmform.c	2023-07-16 13:00:03.000000000 -0500
+@@ -50,6 +50,7 @@
+ xmform*bottomShadowColor:        black
+ ***-------------------------------------------------------------------*/
+ 
++#include <stdlib.h>
+ #include <Xm/Xm.h>
+ #include <Xm/Form.h>
+ #include <Xm/PushB.h>

--- a/10.9-libcxx/stable/main/finkinfo/x11/openmotif4-2level.info
+++ b/10.9-libcxx/stable/main/finkinfo/x11/openmotif4-2level.info
@@ -1,8 +1,8 @@
-Package: openmotif4
-Version: 2.3.4
-Revision: 16
-Source: mirror:sourceforge:motif/motif-%v-src.tgz
-Source-Checksum: SHA256(637efa09608e0b8f93465dbeb7c92e58ebb14c4bc1b488040eb79a65af3efbe0)
+Package: openmotif4-2level
+Version: 2.3.8
+Revision: 1
+Source: mirror:sourceforge:motif/files/motif-%v.tar.gz
+Source-Checksum: SHA256(859b723666eeac7df018209d66045c9853b50b4218cecadb794e2359619ebce7)
 BuildDepends: <<
 	autoconf2.6,
 	automake1.15,
@@ -15,7 +15,7 @@ BuildDepends: <<
 	libjpeg9 (>= 9-3),
 	libpng16,
 	libtool2 (>= 2.4.7-1),
-	libxt-flat,
+	libxt,
 	pkgconfig,
 	x11-dev,
 	xft2-dev (>= 2.2.0-5)
@@ -40,66 +40,100 @@ Replaces: <<
 BuildDependsOnly: True
 SourceDirectory: motif-%v
 PatchFile: %n.patch
-PatchFile-MD5: 28da1ef4dbb48438b2cf716eb7939d67
-PatchFile2: %n_implicit_declaration.patch
-PatchFile2-MD5: 0bcb664825032fa7be97c4a6f0b89f7c
+PatchFile-Checksum: SHA256(257df65945066f5341bfb5f1cb620ad341d1bbd79428b2b5aaf4e9cee27f6796)
+PatchFile2: %n-implicit_declaration.patch
+PatchFile2-Checksum: SHA256(dc0f7717473f9dfa82b5377b2855c654e9cf55a2166f005e099dbc2ff0aab0b3)
+
 PatchScript: <<
-	%{default_script}
-	# 
+	patch -p1 < %{PatchFile}
 	find . -name Makefile.am | xargs perl -pi -e 's/INCLUDES/AM_CPPFLAGS/; s/-version-info/-no-undefined -version-info/'
 	# hardcoded path to an x11-supplied data file...possible
 	# platform dependence
-	perl -pi -e 's,/usr/lib/X11/rgb.txt,/opt/X11/share/X11/rgb.txt,' doc/man/man3/XmColorSelector.3 lib/Xm/ColorS.c tests/Toolkit/Manual/ColorM1.c
+	perl -pi -e 's,/usr/lib/X11/rgb.txt,/opt/X11/share/X11/rgb.txt,' doc/man/man3/XmColorSelector.3 lib/Xm/ColorS.c
 	# also wants fc's font directory, but doesn't use it, so not
 	# bothering to figure out what --with-default-fonts should be
+	libtoolize
+	aclocal -I .
+	autoconf
+	autoheader
+	touch NEWS AUTHORS
+	automake --add-missing
+	patch -p1 < %{PatchFile2}
 <<
 UseMaxBuildJobs: false
 SetCC: flag-sort -r gcc
 SetCXX: flag-sort -r g++
 SetCPPFLAGS: -DXNO_MTSAFE_STRINGAPI -DXNO_MTSAFE_PWDAPI -DXNO_MTSAFE_TIMEAPI
-ConfigureParams: --disable-static --with-fontconfig-config="pkg-config fontconfig" --disable-printing
+ConfigureParams: <<
+	--libdir=%p/opt/openmotif4-2level/lib \
+	--disable-static \
+	--with-fontconfig-config="pkg-config fontconfig" \
+	--disable-printing
+<<
 CompileScript: <<
-	./autogen.sh %c
+	./configure %c
 	make -w
 	fink-package-precedence --prohibit-bdep=%N .
 <<
 InstallScript: <<
+	#!/bin/sh -ev
 	make install DESTDIR=%d
+	# install convenience symlinks to put useful stuff directly into %p
+	mkdir -p %i/lib
+	for dylib in Mrm Uil Xm; do
+		ln -s %p/opt/openmotif4-2level/lib/lib$dylib.dylib %i/lib/lib$dylib.dylib
+	done
+	# prepare for u-a
 	mv %i/share/man/man3/Object.3 %i/share/man/man3/Object.3.openmotif
 <<
 DocFiles: BUGREPORT COPYING README RELEASE RELNOTES TODO
-SplitOff: <<
+Splitoff: <<
+	Package: %N-common
+	Description: Common files for openmotif4-2level
+	Files: <<
+		include/X11/bitmaps
+		opt/openmotif4-2level/lib/X11/bindings
+	<<
+<<
+SplitOff2: <<
 	Package: %N-shlibs
 	Depends: <<
+		%N-common (>= %v-%r),
 		fontconfig2-shlibs (>= 2.14.2-1),
 		freetype219-shlibs (>= 2.12.1-4),
 		libiconv,
 		libjpeg9-shlibs (>= 9-3),
 		libpng16-shlibs,
-		libxt-flat-shlibs,
+		libxt-shlibs,
 		x11,
 		xft2-shlibs (>= 2.2.0-5)
 	<<
 # when lesstif is upgraded to lesstif3 (motif 2.2) this will conflict
 #  Conflicts: lesstif3-shlibs
-	Files: lib/libXm.*.dylib lib/libUil.*.dylib lib/libMrm.*.dylib
+	Files: <<
+		opt/openmotif4-2level/lib/libXm.*.dylib
+		opt/openmotif4-2level/lib/libUil.*.dylib
+		opt/openmotif4-2level/lib/libMrm.*.dylib
+	<<
 	DocFiles: COPYING
 	Shlibs: <<
-		%p/lib/libXm.4.dylib 5.0.0 %n (>= 2.3.0-1)
-		%p/lib/libUil.4.dylib 5.0.0 %n (>= 2.3.0-1)
-		%p/lib/libMrm.4.dylib 5.0.0 %n (>= 2.3.0-1)
+		%p/opt/openmotif4-2level/lib/libXm.4.dylib 5.0.0 %n (>= 2.3.0-1)
+		%p/opt/openmotif4-2level/lib/libUil.4.dylib 5.0.0 %n (>= 2.3.0-1)
+		%p/opt/openmotif4-2level/lib/libMrm.4.dylib 5.0.0 %n (>= 2.3.0-1)
 	<<
 <<
-SplitOff2: <<
+SplitOff3: <<
 	Package: %N-bin
+	Description: End user executables for openmotif4
 	Depends: <<
+		%N-common (>= %v-%r),
 		%N-shlibs (>= %v-%r),
 		fontconfig2-shlibs (>= 2.14.2-1),
 		freetype219-shlibs (>= 2.12.1-4),
 		libiconv,
 		libjpeg9-shlibs (>= 9-3),
 		libpng16-shlibs,
-		libxt-flat-shlibs,
+		libxt-shlibs,
 		x11,
 		xft2-shlibs (>= 2.2.0-5)
 	<<
@@ -115,28 +149,39 @@ SplitOff2: <<
 		openmotif4-bin,
 		openmotif4-2level-bin
 	<<
-	Files: bin share/man/man1 share/man/man4 lib/X11
+	Files: <<
+		bin
+		share/man/man1
+		share/man/man4
+		opt/openmotif4-2level/lib/X11
+	<<
 	DocFiles: COPYING
+	DescDetail: <<
+		End user programs for openmotif4.
+		Includes the 'mwm' window manager and the 'uil' motif user
+		interface language compiler. 
+	<<
 <<
 PostInstScript: <<
-	update-alternatives --install %p/share/man/man3/Object.3 Object.3 %p/share/man/man3/Object.3.openmotif 65
+	update-alternatives --install %p/share/man/man3/Object.3 Object.3 %p/share/man/man3/Object.3.openmotif 75
 <<
 PreRmScript: <<
 	if [ $1 != "upgrade" ]; then
 		update-alternatives --remove Object.3 %p/share/man/man3/Object.3.openmotif
 	fi
 <<
-#
 Description: Official Implementation of OSF/Motif
-DescUsage: <<
- Clients which link both libXm and libXt from XFree86 >= 4.2 might need
- to use the -force_flat_namespace linker flag (to avoid errors of the
- form "Error: attempt to add non-widget child .. " upon launch).
-<<
 DescPackaging: <<
 	This package provides version 2.2 of the motif API. (libraries
 	versioned "3") Thus, it will not conflict with lesstif-shlibs
 	until lesstif is upgraded to v3 libs.
+	
+	Install into %p/opt to allow to coexist with the older motif4
+	version that needs to link to libxt-flat. Not all packages work if
+	built against libxt-flat then use this version linking to
+	libxt-2level. Although the libraries are hidden, we send includedir
+	straight to %p to simplify finding the headers. Convenience symlinks
+	are also put elsewhere in %p as needed.
 
 	man pages that conflict with other packages are managed with
 	update-alternatives.
@@ -178,7 +223,7 @@ DescPackaging: <<
 	https://github.com/XQuartz/XQuartz/issues/124
 <<
 DescPort: <<
-	Needs flat-namespace libXt
+	No longer needs flat-namespace libXt!
 <<
 License: LGPL
 Homepage: http://motif.ics.com/motif/

--- a/10.9-libcxx/stable/main/finkinfo/x11/openmotif4-2level.patch
+++ b/10.9-libcxx/stable/main/finkinfo/x11/openmotif4-2level.patch
@@ -1,0 +1,1580 @@
+diff -Nurd motif-2.3.8.orig/Makefile.am motif-2.3.8/Makefile.am
+--- motif-2.3.8.orig/Makefile.am	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/Makefile.am	2023-02-26 00:32:00.000000000 +0000
+@@ -27,7 +27,6 @@
+              include \
+              tools \
+              clients \
+-             doc \
+-             demos
++             doc
+ AUTOMAKE_OPTIONS = 1.4
+ ACLOCAL_AMFLAGS = -I .
+diff -Nurd motif-2.3.8.orig/ac_find_xft.m4 motif-2.3.8/ac_find_xft.m4
+--- motif-2.3.8.orig/ac_find_xft.m4	2017-03-27 23:24:31.000000000 +0100
++++ motif-2.3.8/ac_find_xft.m4	2023-02-26 00:32:00.000000000 +0000
+@@ -75,7 +75,8 @@
+ LIBS="$LIBS $freetype_lib"
+ saved_CPPFLAGS="$CPPFLAGS"
+ CPPFLAGS="$CPPFLAGS $FREETYPE_CFLAGS"
+-AC_CHECK_HEADERS(freetype/freetype.h)
++AC_CHECK_HEADERS(ft2build.h)	# modern ft detection...
++ac_cv_header_freetype_freetype_h=yes # propagated via legacy variables
+ 
+ FINDXFT_HAVE_FREETYPE="no"
+ case "$ac_cv_header_freetype_freetype_h" in
+diff -Nurd motif-2.3.8.orig/clients/mwm/WmFunction.c motif-2.3.8/clients/mwm/WmFunction.c
+--- motif-2.3.8.orig/clients/mwm/WmFunction.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/clients/mwm/WmFunction.c	2023-02-26 00:32:09.000000000 +0000
+@@ -78,6 +78,7 @@
+ /*
+  * include extern functions
+  */
++#include "WmCmd.h"
+ #include "WmFunction.h"
+ #include "WmCEvent.h"
+ #ifdef WSM
+diff -Nurd motif-2.3.8.orig/clients/mwm/WmInitWs.c motif-2.3.8/clients/mwm/WmInitWs.c
+--- motif-2.3.8.orig/clients/mwm/WmInitWs.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/clients/mwm/WmInitWs.c	2023-02-26 00:32:09.000000000 +0000
+@@ -134,6 +134,9 @@
+  * Function Declarations:
+  */
+ 
++/* Internal routines "borrowed" from libXm.  Don't try this at home! */
++extern int _XmVirtKeysLoadFallbackBindings(Display *display, String *binding);
++
+ #include "WmInitWs.h"
+ 
+ #if ((!defined(WSM)) || defined(MWM_QATS_PROTOCOL))
+diff -Nurd motif-2.3.8.orig/clients/mwm/WmMenu.c motif-2.3.8/clients/mwm/WmMenu.c
+--- motif-2.3.8.orig/clients/mwm/WmMenu.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/clients/mwm/WmMenu.c	2023-02-26 00:32:00.000000000 +0000
+@@ -842,8 +842,8 @@
+ static MenuItem *MakeClientCommandMenuItem (String label, String funcArgs)
+ {
+     return(MakeMenuItem(label, F_InvokeCommand, funcArgs,
+-			(KeySym)(unsigned)NULL, (unsigned int)0,
+-			(KeyCode)(unsigned)NULL, (String)NULL));
++			(KeySym)(uintptr_t) NULL, (unsigned int)0,
++			(KeyCode)(uintptr_t) NULL, (String)(uintptr_t)NULL));
+ }
+ 
+ 
+@@ -2197,7 +2197,7 @@
+ 	    if (newMenuSpec == (MenuSpec *) NULL)
+ 	    {
+ 		newMenuSpec = MakeMenuSpec(funcarg_buf,
+-					   tree == NULL ? (CARD32)NULL
++					   tree == NULL ? (CARD32)(uintptr_t)NULL
+ 					                : tree->commandID);
+ 		if (duplicate_globals) newMenuSpec->clientLocal = TRUE;
+ 		else 		       newMenuSpec->clientLocal = FALSE;
+diff -Nurd motif-2.3.8.orig/clients/mwm/WmResParse.c motif-2.3.8/clients/mwm/WmResParse.c
+--- motif-2.3.8.orig/clients/mwm/WmResParse.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/clients/mwm/WmResParse.c	2023-02-26 00:32:09.000000000 +0000
+@@ -114,6 +114,10 @@
+ #include "WmImage.h"
+ #include "WmXSMP.h"
+ 
++/* Internal routines "borrowed" from libXm.  Don't try this at home! */
++extern Boolean _XmVirtKeysLoadFileBindings(char *fileName, String *binding);
++extern int _XmVirtKeysLoadFallbackBindings(Display *display, String *binding);
++
+ #ifdef MOTIF_ONE_DOT_ONE
+ extern char   *getenv ();
+ #endif
+@@ -169,7 +173,7 @@
+     {"mod3",	Mod3Mask},
+     {"mod4",	Mod4Mask},
+     {"mod5",	Mod5Mask},
+-    {NULL,      (unsigned int)NULL},
++    {NULL,      (unsigned int)(uintptr_t)NULL},
+ };
+ 
+ #define ALT_INDEX 3
+@@ -332,14 +336,14 @@
+     {"btn5up",      ButtonRelease,  ParseImmed,    Button5,  FALSE},
+     {"btn5click",   ButtonRelease,  ParseImmed,    Button5,  TRUE},
+     {"btn5click2",  ButtonPress,    ParseImmed,    Button5,  TRUE},
+-    { NULL, (unsigned int)NULL, (Boolean(*)())NULL, (unsigned int)NULL, (Boolean)(unsigned)NULL}
++    { NULL, (unsigned int)(uintptr_t)NULL, (Boolean(*)())NULL, (unsigned int)(uintptr_t)NULL, (Boolean)(uintptr_t)NULL}
+ };
+ 
+ 
+ static EventTableEntry keyEvents[] = {
+ 
+     {"key",         KeyPress,    ParseKeySym,    0,  FALSE},
+-    { NULL, (unsigned int)NULL, (Boolean(*)())NULL, (unsigned int)NULL, (Boolean)(unsigned)NULL}
++    { NULL, (unsigned int)(uintptr_t)NULL, (Boolean(*)())NULL, (unsigned int)(uintptr_t)NULL, (Boolean)(uintptr_t)NULL}
+ };
+ 
+ #ifdef PANELIST
+@@ -4122,7 +4126,7 @@
+          */
+ 
+ #ifndef NO_MULTIBYTE
+-	if ((wmFunction == F_Exec))
++	if (wmFunction == F_Exec)
+ 	{
+ 	    lastlen = 0;
+ 	    p = *pArgs;
+diff -Nurd motif-2.3.8.orig/clients/mwm/WmWinConf.c motif-2.3.8/clients/mwm/WmWinConf.c
+--- motif-2.3.8.orig/clients/mwm/WmWinConf.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/clients/mwm/WmWinConf.c	2023-02-26 00:32:00.000000000 +0000
+@@ -687,7 +687,7 @@
+ {
+     KeySym keysym;
+     Boolean control;
+-    int warpX, warpY, currentX, currentY, newX, newY;
++    int warpX, warpY, currentX = 0, currentY, newX, newY;
+     int junk, keyMult;
+     Window junk_win;
+     XEvent KeyEvent;
+diff -Nurd motif-2.3.8.orig/clients/mwm/WmWinList.c motif-2.3.8/clients/mwm/WmWinList.c
+--- motif-2.3.8.orig/clients/mwm/WmWinList.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/clients/mwm/WmWinList.c	2023-02-26 00:32:09.000000000 +0000
+@@ -59,7 +59,8 @@
+ #endif /* WSM */
+ #include "WmEvent.h"
+ 
+-
++/* avoid implicit declaration */
++extern Time GetTimestamp ();
+ 
+ /*
+  * Global Variables:
+diff -Nurd motif-2.3.8.orig/clients/mwm/WmWsmLib/recv.c motif-2.3.8/clients/mwm/WmWsmLib/recv.c
+--- motif-2.3.8.orig/clients/mwm/WmWsmLib/recv.c	2017-03-27 23:24:31.000000000 +0100
++++ motif-2.3.8/clients/mwm/WmWsmLib/recv.c	2023-02-26 00:32:09.000000000 +0000
+@@ -31,6 +31,9 @@
+ #include <X11/Xatom.h>
+ #include <Xm/TransferP.h>	/* for XmeNamedSource() */
+ 
++/* avoid implicit declaration */
++extern Time GetTimestamp ();
++
+ #ifdef JUNK
+ static Boolean ConvertProc(
+ Widget, Atom *, Atom *, XtPointer, unsigned long, int, Atom *,
+diff -Nurd motif-2.3.8.orig/clients/mwm/WmWsmLib/send.c motif-2.3.8/clients/mwm/WmWsmLib/send.c
+--- motif-2.3.8.orig/clients/mwm/WmWsmLib/send.c	2017-03-27 23:24:31.000000000 +0100
++++ motif-2.3.8/clients/mwm/WmWsmLib/send.c	2023-02-26 00:32:09.000000000 +0000
+@@ -30,6 +30,9 @@
+ #include "wsm_proto.h"
+ #include "utm_send.h"
+ 
++/* avoid implict declaration */
++extern Time GetTimestamp ();
++
+ typedef struct _RequestInfo {
+     WSMReplyCallbackFunc reply_callback; /* The reply callback func */
+     XtPointer reply_data;	/* The user data for the callback func */
+diff -Nurd motif-2.3.8.orig/clients/uil/Uil.h motif-2.3.8/clients/uil/Uil.h
+--- motif-2.3.8.orig/clients/uil/Uil.h	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/clients/uil/Uil.h	2023-02-26 00:32:09.000000000 +0000
+@@ -38,6 +38,8 @@
+ #ifndef Uil_h
+ #define Uil_h
+ 
++int yyerror();
++
+ /*
+ **
+ **  INCLUDE FILES
+diff -Nurd motif-2.3.8.orig/clients/uil/UilDefI.h motif-2.3.8/clients/uil/UilDefI.h
+--- motif-2.3.8.orig/clients/uil/UilDefI.h	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/clients/uil/UilDefI.h	2023-02-26 00:32:09.000000000 +0000
+@@ -404,6 +404,9 @@
+ /* uilp2reslv.c */
+ extern void sem_resolve_forward_refs  _ARGUMENTS(( void ));
+ 
++/* uilparser.c */
++int yyparse ();
++
+ /* uilsarcomp.c */
+ extern sym_value_entry_type *sem_create_cstr  _ARGUMENTS(( void ));
+ extern sym_value_entry_type *sem_create_wchar_str  _ARGUMENTS(( void ));
+@@ -446,6 +449,7 @@
+ extern void sar_set_object_flags  _ARGUMENTS(( yystype *current_frame , unsigned char mask ));
+ extern void sar_unset_object_flags  _ARGUMENTS(( yystype *current_frame , unsigned char mask ));
+ extern void sar_set_list_type  _ARGUMENTS(( yystype *current_frame ));
++extern int sar_get_units_type _ARGUMENTS(( yystype *current_frame ));
+ extern void sar_set_object_class  _ARGUMENTS(( yystype *current_frame ));
+ extern void sar_set_object_variant  _ARGUMENTS(( yystype *current_frame ));
+ extern yystype *sem_find_object  _ARGUMENTS(( yystype *current_frame ));
+diff -Nurd motif-2.3.8.orig/configure.ac motif-2.3.8/configure.ac
+--- motif-2.3.8.orig/configure.ac	2017-12-05 12:43:54.000000000 +0000
++++ motif-2.3.8/configure.ac	2023-02-26 00:32:00.000000000 +0000
+@@ -1,14 +1,8 @@
+ dnl Process this file with autoconf to produce a configure script.
+-AC_INIT
++AC_INIT([motif],[2.3.8])
+ AC_CONFIG_SRCDIR([lib/Xm/Form.c])
+ AC_PREREQ(2.52)
+ AC_CONFIG_AUX_DIR(.)
+-AC_CHECK_FILE(/usr/X/include/X11/X.h,
+-  AC_PREFIX_DEFAULT(/usr/X),
+-  AC_PREFIX_DEFAULT(/usr))
+-AC_CHECK_FILE(/usr/X11R6/include/X11/X.h,
+-  AC_PREFIX_DEFAULT(/usr/X11R6),
+-  AC_PREFIX_DEFAULT(/usr))
+ 
+ dnl AM_MAINTAINER_MODE
+ AC_CANONICAL_TARGET
+@@ -22,7 +16,7 @@
+ AC_SUBST(AGE)
+ 
+ dnl This is really dumb but it seems to be bug
+-AM_INIT_AUTOMAKE(motif,2.3.8,no-define)
++AM_INIT_AUTOMAKE([no-define])
+ 
+ LIBTOOL_VERSION=$CURRENT:$REVISION:$AGE
+ 
+@@ -61,15 +55,18 @@
+ 
+ dnl Checks for Xos_r.h
+ 
++save_CPPFLAGS=$CPPFLAGS
++CPPFLAGS="$CPPFLAGS $X_CFLAGS"
+ AC_CHECK_HEADERS([X11/Xos_r.h])
+ AC_CHECK_HEADERS([X11/Xpoll.h])
++CPPFLAGS=$save_CPPFLAGS
+ 
+ dnl Compile in EditRes support if we can find Xmu
+ 
+ save_LIBS="$LIBS"
+ save_CFLAGS="$CFLAGS"
+-LIBS="$X_LIBS $LIBS"
+-CFLAGS="$X_CFLAGS $CFLAGS"
++LIBS="$LIBS $X_LIBS"
++CFLAGS="$CFLAGS $X_CFLAGS"
+ AC_CHECK_HEADERS(X11/Xmu/Editres.h,
+ AC_CHECK_LIB(Xmu, _XEditResCheckMessages,
+ X_XMU=-lXmu
+@@ -94,8 +91,11 @@
+ AC_CHECK_HEADERS(fcntl.h limits.h malloc.h sys/malloc.h strings.h sys/file.h sys/time.h unistd.h wchar.h)
+ AC_CHECK_HEADERS(wctype.h, AC_DEFINE(HAS_WIDECHAR_FUNCTIONS,1,System supports wchar))
+ AC_CHECK_HEADER(langinfo.h,,AC_DEFINE(CSRG_BASED,1,System Has langinfo.h))
++save_CPPFLAGS=$CPPFLAGS
++CPPFLAGS="$CPPFLAGS $X_CFLAGS"
+ AC_CHECK_HEADER(X11/Xos_r.h,,AC_DEFINE(NEED_XOS_R_H,1,System Missing Xos_r.h))
+ AC_CHECK_HEADER(X11/Xpoll.h,,AC_DEFINE(NEED_XPOLL_H,1,system Missing X11/Xpoll.h))
++CPPFLAGS=$save_CPPFLAGS
+ dnl Checks for typedefs, structures, and compiler characteristics.
+ AC_C_CONST
+ AC_TYPE_MODE_T
+@@ -123,7 +123,10 @@
+ AC_CHECK_FUNCS(putenv,,AC_DEFINE(NO_PUTENV, 1, No PUTENV))
+ AC_CHECK_FUNCS(regcomp,,AC_DEFINE(NO_REGCOMP, 1, no regcmp))
+ AC_CHECK_FUNCS(memmove,,AC_DEFINE(NO_MEMMOVE, 1, no memmove))
++save_CPPFLAGS=$CPPFLAGS
++CPPFLAGS="$CPPFLAGS $X_CFLAGS"
+ AC_CHECK_TYPE(XICProc,,AC_DEFINE(NO_XICPROC, 1, XICProc isn't defined), [#include <X11/Xlib.h>])
++CPPFLAGS=$save_CPPFLAGS
+ 
+ AC_ARG_ENABLE(message-catalog, [  --enable-message-catalog
+                           Enable building of the message catalog (default=no)])
+@@ -160,9 +163,6 @@
+ if test x$GCC = xyes
+ then
+     CFLAGS="$CFLAGS -Wall -g -fno-strict-aliasing -Wno-unused -Wno-comment"
+-    if test ` $CC -dumpversion | sed -e 's/\(^.\).*/\1/'` = "4" ; then
+-        CFLAGS="$CFLAGS -fno-tree-ter"
+-    fi
+ fi
+ AC_DEFINE(NO_OL_COMPAT, 1, "No OL Compatability")
+ 
+@@ -251,9 +251,19 @@
+ if test "$enable_printing" = "yes"
+ then
+   AC_MSG_CHECKING([for libXp])
++  save_CPPFLAGS=$CPPFLAGS
++  save_LDFLAGS=$LDFLAGS
++  save_LIBS=$LIBS	# AC_CHECK_LIB adds -l if found
++  CPPFLAGS="$CPPFLAGS $X_CFLAGS"
++  LDFLAGS="$LDFLAGS $X_LIBS"
+   AC_CHECK_HEADERS(X11/extensions/Print.h,
+     AC_CHECK_LIB(Xp, XpCreateContext, ,enable_printing="no"),
+   enable_printing="no")
++  CPPFLAGS=$save_CPPFLAGS
++  LDFLAGS=$save_LDFLAGS
++  LIBS=$save_LIBS	# -lXp propagated by alt variable (below)...no
++			# x11 -L in LIBS, so later tests that use LIBS
++			# fail because -lXp cannot be resolved
+ fi
+ 
+ if test "$enable_printing" = "yes"
+diff -Nurd motif-2.3.8.orig/lib/Mrm/Mrmhier.c motif-2.3.8/lib/Mrm/Mrmhier.c
+--- motif-2.3.8.orig/lib/Mrm/Mrmhier.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Mrm/Mrmhier.c	2023-02-26 00:32:00.000000000 +0000
+@@ -259,10 +259,10 @@
+ 	    case MrmSUCCESS:
+ 	      break;
+ 	    case MrmNOT_VALID:
+-	      sprintf (err_stg, _MrmMMsg_0113);
++	      sprintf (err_stg, "%s", _MrmMMsg_0113);
+ 	      break;
+ 	    default:
+-	      sprintf (err_stg, _MrmMMsg_0114);
++	      sprintf (err_stg, "%s", _MrmMMsg_0114);
+ 	      break;
+ 	    }
+ 	}
+diff -Nurd motif-2.3.8.orig/lib/Mrm/Mrmicon.c motif-2.3.8/lib/Mrm/Mrmicon.c
+--- motif-2.3.8.orig/lib/Mrm/Mrmicon.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Mrm/Mrmicon.c	2023-02-26 00:32:00.000000000 +0000
+@@ -1170,7 +1170,7 @@
+ 		}
+ 		break;
+ 	      default:
+-		sprintf(err_msg, _MrmMMsg_0040);
++		sprintf(err_msg, "%s", _MrmMMsg_0040);
+ 		return Urm__UT_Error ("Urm__RelizeColorTable",
+ 				      err_msg, NULL, NULL, MrmFAILURE) ;
+ 	      }
+@@ -1246,7 +1246,7 @@
+ 	      break;
+ 	    default:
+ 	      result = MrmFAILURE;
+-	      sprintf (err_msg, _MrmMMsg_0040);
++	      sprintf (err_msg, "%s", _MrmMMsg_0040);
+ 	      Urm__UT_Error ("Urm__RelizeColorTable",
+ 			     err_msg, NULL, NULL, MrmFAILURE) ;
+ 	    }
+diff -Nurd motif-2.3.8.orig/lib/Mrm/Mrmlread.c motif-2.3.8/lib/Mrm/Mrmlread.c
+--- motif-2.3.8.orig/lib/Mrm/Mrmlread.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Mrm/Mrmlread.c	2023-02-26 00:32:00.000000000 +0000
+@@ -685,7 +685,7 @@
+ 	 XBlackPixelOfScreen(XDefaultScreenOfDisplay(display)));
+       break;
+     default:
+-      sprintf(err_msg, _MrmMMsg_0040);
++      sprintf(err_msg, "%s", _MrmMMsg_0040);
+       result = Urm__UT_Error ("MrmFetchColorLiteral",
+ 			      err_msg, NULL, NULL, MrmFAILURE) ;
+       _MrmAppUnlock(app);
+diff -Nurd motif-2.3.8.orig/lib/Mrm/Mrmwcrw.c motif-2.3.8/lib/Mrm/Mrmwcrw.c
+--- motif-2.3.8.orig/lib/Mrm/Mrmwcrw.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Mrm/Mrmwcrw.c	2023-02-26 00:32:00.000000000 +0000
+@@ -1336,7 +1336,7 @@
+ 	       */ 
+ 	      if (reptype == MrmRtypeColor)
+ 		{
+-		  Pixel pix;
++		  Pixel pix = 0;
+ 		  RGMColorDescPtr colorptr;
+ 		  Colormap cmap;
+ 
+@@ -1385,7 +1385,7 @@
+ 			}
+ 		      break;
+ 		    default:
+-		      sprintf (err_msg, _MrmMMsg_0040);
++		      sprintf (err_msg, "%s", _MrmMMsg_0040);
+ 		      result = Urm__UT_Error ("Urm__CW_ConvertValue",
+ 					      err_msg, NULL, NULL, MrmFAILURE) ;
+ 		    };
+@@ -2421,7 +2421,7 @@
+ 	    }
+ 	  break;
+ 	default:
+-	  sprintf(err_msg, _MrmMMsg_0040);
++	  sprintf(err_msg, "%s", _MrmMMsg_0040);
+ 	  return Urm__UT_Error ("Urm__CW_ConvertValue",
+ 				err_msg, NULL, NULL, MrmFAILURE) ;
+ 	};
+diff -Nurd motif-2.3.8.orig/lib/Xm/BaseClass.c motif-2.3.8/lib/Xm/BaseClass.c
+--- motif-2.3.8.orig/lib/Xm/BaseClass.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Xm/BaseClass.c	2023-02-26 00:32:00.000000000 +0000
+@@ -558,7 +558,7 @@
+   static ExtToContextRec extToContextMap[16];
+   Cardinal		 i;
+   ExtToContext		 curr;
+-  XContext		 context = (XContext) NULL;
++  XContext		 context = (XContext)(uintptr_t) NULL;
+   
+   _XmProcessLock();
+   for (i = 0, curr = &extToContextMap[0];
+diff -Nurd motif-2.3.8.orig/lib/Xm/DataF.c motif-2.3.8/lib/Xm/DataF.c
+--- motif-2.3.8.orig/lib/Xm/DataF.c	2017-10-30 20:20:09.000000000 +0000
++++ motif-2.3.8/lib/Xm/DataF.c	2023-02-26 00:32:00.000000000 +0000
+@@ -9218,7 +9218,7 @@
+       /* CR03685 */
+       SGI_hack_XmImRegister((Widget)tf);
+ #else
+-      XmImRegister((Widget)tf, (unsigned int) NULL);
++      XmImRegister((Widget)tf, (unsigned int)(uintptr_t) NULL);
+ #endif
+       df_GetXYFromPos(tf, XmTextF_cursor_position(tf), &xmim_point.x, &xmim_point.y);
+       n = 0;
+@@ -10729,7 +10729,7 @@
+            diff_values = True;
+            if (XmTextF_wc_value(new_tf) == NULL) {
+               XmTextF_wc_value(new_tf) = (wchar_t*) XtMalloc(sizeof(wchar_t));
+-              *XmTextF_wc_value(new_tf) = (wchar_t)NULL;
++              *XmTextF_wc_value(new_tf) = (wchar_t)(uintptr_t)NULL;
+            }
+            df_ValidateString(new_tf, (char*)XmTextF_wc_value(new_tf), True);
+         } else if (XmTextF_value(new_tf) != XmTextF_value(old_tf)) {
+@@ -11875,7 +11875,7 @@
+        /* CR03685 */
+        SGI_hack_XmImRegister((Widget)tf);
+ #else
+-       XmImRegister((Widget)tf, (unsigned int) NULL);
++       XmImRegister((Widget)tf, (unsigned int)(uintptr_t) NULL);
+ #endif
+        df_GetXYFromPos(tf, XmTextF_cursor_position(tf), &xmim_point.x, 
+ 		       &xmim_point.y);
+diff -Nurd motif-2.3.8.orig/lib/Xm/DragBS.c motif-2.3.8/lib/Xm/DragBS.c
+--- motif-2.3.8.orig/lib/Xm/DragBS.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Xm/DragBS.c	2023-02-26 00:32:00.000000000 +0000
+@@ -198,9 +198,9 @@
+ static unsigned long	firstProtectRequest;
+ static Window		errorWindow;
+ 
+-static XContext 	displayToMotifWindowContext = (XContext) NULL;
+-static XContext 	displayToTargetsContext = (XContext) NULL;
+-static XContext		displayToAtomsContext = (XContext) NULL;
++static XContext 	displayToMotifWindowContext = (XContext)(uintptr_t) NULL;
++static XContext 	displayToTargetsContext = (XContext)(uintptr_t) NULL;
++static XContext		displayToAtomsContext = (XContext)(uintptr_t) NULL;
+ 
+ 
+ /*****************************************************************************
+@@ -285,7 +285,7 @@
+     XContext	loc_context;
+ 
+     _XmProcessLock();
+-    if (displayToMotifWindowContext == (XContext) NULL) {
++    if (displayToMotifWindowContext == (XContext)(uintptr_t) NULL) {
+         displayToMotifWindowContext = XUniqueContext();
+     }
+     loc_context = displayToMotifWindowContext;
+@@ -316,7 +316,7 @@
+     XContext loc_context;
+ 
+     _XmProcessLock();
+-    if (displayToMotifWindowContext == (XContext) NULL) {
++    if (displayToMotifWindowContext == (XContext)(uintptr_t) NULL) {
+         displayToMotifWindowContext = XUniqueContext();
+     }
+     loc_context = displayToMotifWindowContext;
+@@ -359,7 +359,7 @@
+     XContext		loc_context;
+ 
+     _XmProcessLock();
+-    if (displayToTargetsContext == (XContext) NULL) {
++    if (displayToTargetsContext == (XContext)(uintptr_t) NULL) {
+         displayToTargetsContext = XUniqueContext();
+     }
+     loc_context = displayToTargetsContext;
+@@ -390,7 +390,7 @@
+     XContext	loc_context;
+ 
+     _XmProcessLock();
+-    if (displayToTargetsContext == (XContext) NULL) {
++    if (displayToTargetsContext == (XContext)(uintptr_t) NULL) {
+         displayToTargetsContext = XUniqueContext();
+     }
+     loc_context = displayToTargetsContext;
+@@ -445,7 +445,7 @@
+     XContext		loc_context;
+ 
+     _XmProcessLock();
+-    if (displayToAtomsContext == (XContext) NULL) {
++    if (displayToAtomsContext == (XContext)(uintptr_t) NULL) {
+ 	displayToAtomsContext = XUniqueContext();
+     }
+     loc_context = displayToAtomsContext;
+@@ -476,7 +476,7 @@
+     XContext loc_context;
+ 
+     _XmProcessLock();
+-    if (displayToAtomsContext == (XContext) NULL) {
++    if (displayToAtomsContext == (XContext)(uintptr_t) NULL) {
+         displayToAtomsContext = XUniqueContext();
+     }
+     loc_context = displayToAtomsContext;
+diff -Nurd motif-2.3.8.orig/lib/Xm/DragIcon.c motif-2.3.8/lib/Xm/DragIcon.c
+--- motif-2.3.8.orig/lib/Xm/DragIcon.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Xm/DragIcon.c	2023-02-26 00:32:00.000000000 +0000
+@@ -738,7 +738,7 @@
+ #undef Offset
+ #define Offset(x) (XtOffsetOf( struct _XmDragIconRec, drag.x))
+ 
+-static XContext _XmTextualDragIconContext = (XContext) NULL;
++static XContext _XmTextualDragIconContext = (XContext)(uintptr_t) NULL;
+ 
+ static XtResource resources[]=
+ {
+@@ -1218,7 +1218,7 @@
+    use_alt = dpy -> display.enable_drag_icon;
+ 
+    _XmProcessLock();
+-   if (_XmTextualDragIconContext == (XContext) NULL)
++   if (_XmTextualDragIconContext == (XContext)(uintptr_t) NULL)
+       _XmTextualDragIconContext = XUniqueContext();
+    loc_context = _XmTextualDragIconContext;
+    _XmProcessUnlock();
+diff -Nurd motif-2.3.8.orig/lib/Xm/DropSMgr.c motif-2.3.8/lib/Xm/DropSMgr.c
+--- motif-2.3.8.orig/lib/Xm/DropSMgr.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Xm/DropSMgr.c	2023-02-26 00:32:00.000000000 +0000
+@@ -4275,7 +4275,7 @@
+ 	                         XtDisplayOfObject(widget)));
+     info = DSMWidgetToInfo(dsm, widget);
+ 
+-    if ((info == NULL)) {
++    if (info == NULL) {
+ 	_XmAppUnlock(app);
+ 	return False;
+     }
+diff -Nurd motif-2.3.8.orig/lib/Xm/FontS.c motif-2.3.8/lib/Xm/FontS.c
+--- motif-2.3.8.orig/lib/Xm/FontS.c	2017-08-22 02:44:27.000000000 +0100
++++ motif-2.3.8/lib/Xm/FontS.c	2023-02-26 00:32:00.000000000 +0000
+@@ -2764,7 +2764,7 @@
+ 	XmStringFree(label);
+ 
+ 	XtAddCallback(button,
+-		      XmNactivateCallback, ChangeEncoding, (XtPointer) i);
++		      XmNactivateCallback, ChangeEncoding, (XtPointer)(uintptr_t) i);
+ 
+ 	if (streq(*encodings, ENCODING_STRING(fsw)))
+ 	{
+@@ -2926,7 +2926,7 @@
+     fsw = (XmFontSelectorWidget) w;
+     cf = XmFontS_font_info(fsw)->current_font;
+ 
+-    if ((int) data == 0)
++    if ((int)(uintptr_t) data == 0)
+ 	{
+ 	XtFree(ENCODING_STRING(fsw));
+ 	ENCODING_STRING(fsw) = XtNewString(ANY_ENCODING);
+@@ -2934,7 +2934,7 @@
+     else
+ 	{
+ 	XtFree(ENCODING_STRING(fsw));
+-	ENCODING_STRING(fsw) = XtNewString(ENCODING_LIST(fsw)[(int) data - 1]);
++	ENCODING_STRING(fsw) = XtNewString(ENCODING_LIST(fsw)[(int)(uintptr_t) data - 1]);
+ 	}
+ 
+     UpdateFamilies(fsw);
+@@ -3692,7 +3692,7 @@
+ 	    num_largs = 0;
+ 	    XtSetArg(largs[num_largs], XmNmenuHistory, button); num_largs++;
+ 	    XtSetValues(XmFontS_option_menu(set_fsw), largs, num_largs);
+-	    ChangeEncoding((Widget) set_fsw, (XtPointer) current, NULL);
++	    ChangeEncoding((Widget) set_fsw, (XtPointer)(uintptr_t) current, NULL);
+ 	}
+ 	else
+ 	{
+diff -Nurd motif-2.3.8.orig/lib/Xm/I18List.c motif-2.3.8/lib/Xm/I18List.c
+--- motif-2.3.8.orig/lib/Xm/I18List.c	2016-03-16 19:51:57.000000000 +0000
++++ motif-2.3.8/lib/Xm/I18List.c	2023-02-26 00:32:00.000000000 +0000
+@@ -2388,7 +2388,7 @@
+     Arg args[5];
+     Cardinal num_args=0;
+     register int i, height, max_width, rows_per_screen;
+-    register int slide_pos, slide_size, col_width=0, min=0;
++    register int slide_pos = 0, slide_size, col_width=0, min=0;
+ 
+     /*
+      * Get maximum width of data to display
+diff -Nurd motif-2.3.8.orig/lib/Xm/IconG.c motif-2.3.8/lib/Xm/IconG.c
+--- motif-2.3.8.orig/lib/Xm/IconG.c	2016-03-16 02:14:09.000000000 +0000
++++ motif-2.3.8/lib/Xm/IconG.c	2023-02-26 00:32:00.000000000 +0000
+@@ -267,8 +267,8 @@
+ 
+ /* those are created in ClassInitialize and filled by the
+    IconConverter. */
+-static XContext 	largeIconContext = (XContext) NULL;
+-static XContext		smallIconContext = (XContext) NULL;
++static XContext 	largeIconContext = (XContext)(uintptr_t) NULL;
++static XContext		smallIconContext = (XContext)(uintptr_t) NULL;
+ 
+ static XPointer dummy;
+ #define OwnLargeMask(widget) \
+diff -Nurd motif-2.3.8.orig/lib/Xm/MainW.c motif-2.3.8/lib/Xm/MainW.c
+--- motif-2.3.8.orig/lib/Xm/MainW.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Xm/MainW.c	2023-02-26 00:32:00.000000000 +0000
+@@ -1270,7 +1270,7 @@
+     /* The first rectangle is the one that makes the scrollbar goes up */
+     (*vrect)[0].x = w->core.x - mw->swindow.vScrollBar->core.x ;
+     /* just translate to the scrollbar coordinate */
+-    (*vrect)[0].y =- mw->swindow.vScrollBar->core.y ;
++    (*vrect)[0].y -= mw->swindow.vScrollBar->core.y ;
+     (*vrect)[0].width = w->core.width ;
+ 
+     /* The second rectangle is the one that makes the scrollbar goes down */
+diff -Nurd motif-2.3.8.orig/lib/Xm/Obso2_0.c motif-2.3.8/lib/Xm/Obso2_0.c
+--- motif-2.3.8.orig/lib/Xm/Obso2_0.c	2017-03-27 23:24:31.000000000 +0100
++++ motif-2.3.8/lib/Xm/Obso2_0.c	2023-02-26 00:32:00.000000000 +0000
+@@ -1573,7 +1573,7 @@
+   Stuff from Desktop.c
+ **********************/
+ 
+-static XContext	actualClassContext = (XContext) NULL;
++static XContext	actualClassContext = (XContext)(uintptr_t) NULL;
+ 
+ 
+ /*ARGSUSED*/
+@@ -1600,7 +1600,7 @@
+ {
+ 	  WidgetClass		actualClass;
+ 
+-	  if (actualClassContext == (XContext) NULL)
++	  if (actualClassContext == (XContext)(uintptr_t) NULL)
+ 	    actualClassContext = XUniqueContext();
+ 	  
+ 	  /*
+@@ -1634,7 +1634,7 @@
+     WidgetClass previous;
+     WidgetClass oldActualClass;
+ 
+-    if (actualClassContext == (XContext) NULL)
++    if (actualClassContext == (XContext)(uintptr_t) NULL)
+       actualClassContext = XUniqueContext();
+     
+     /*
+@@ -1681,7 +1681,7 @@
+         Cardinal *num_args )
+ {
+     XmDesktopObject	worldObject;
+-    static XContext	worldObjectContext = (XContext) NULL;
++    static XContext	worldObjectContext = (XContext)(uintptr_t) NULL;
+     XmWidgetExtData     ext;
+     Display		*display;
+     
+@@ -1690,7 +1690,7 @@
+     ** the display is closed, so that we don't get bad data if a second 
+     ** display with the same id is opened.
+     */
+-    if (worldObjectContext == (XContext) NULL)
++    if (worldObjectContext == (XContext)(uintptr_t) NULL)
+       worldObjectContext = XUniqueContext();
+ 
+     display = XtDisplayOfObject(shell);
+diff -Nurd motif-2.3.8.orig/lib/Xm/Protocols.c motif-2.3.8/lib/Xm/Protocols.c
+--- motif-2.3.8.orig/lib/Xm/Protocols.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Xm/Protocols.c	2023-02-26 00:32:00.000000000 +0000
+@@ -118,7 +118,7 @@
+  *
+  ***************************************************************************/
+ 
+-static XContext	allProtocolsMgrContext = (XContext) NULL;
++static XContext	allProtocolsMgrContext = (XContext)(uintptr_t) NULL;
+ 
+ 
+ #define Offset(field) XtOffsetOf( struct _XmProtocolRec, protocol.field)
+@@ -356,7 +356,7 @@
+ 	  display = XtDisplay(shell);
+ 	  
+ 	  _XmProcessLock();
+-	  if (allProtocolsMgrContext == (XContext) NULL)
++	  if (allProtocolsMgrContext == (XContext)(uintptr_t) NULL)
+ 	    allProtocolsMgrContext = XUniqueContext();
+ 	  _XmProcessUnlock();
+ 	  
+diff -Nurd motif-2.3.8.orig/lib/Xm/ResConvert.c motif-2.3.8/lib/Xm/ResConvert.c
+--- motif-2.3.8.orig/lib/Xm/ResConvert.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Xm/ResConvert.c	2023-02-26 00:32:00.000000000 +0000
+@@ -993,7 +993,7 @@
+     char *delim )
+ {
+     char *fontName;
+-    char *fontTag;
++    char *fontTag = NULL;
+     char *fontPtr;
+     String params[2];
+     Cardinal num_params;
+diff -Nurd motif-2.3.8.orig/lib/Xm/SlideC.c motif-2.3.8/lib/Xm/SlideC.c
+--- motif-2.3.8.orig/lib/Xm/SlideC.c	2017-03-27 23:24:31.000000000 +0100
++++ motif-2.3.8/lib/Xm/SlideC.c	2023-02-26 00:32:00.000000000 +0000
+@@ -110,14 +110,14 @@
+ /* notify that initialize called    XtArgsProc        */ NULL,
+ /* NULL                             XtProc            */ NULL,
+ /* NULL                             XtPointer         */ NULL,
+-/* NULL                             Cardinal          */ (Cardinal)NULL,
++/* NULL                             Cardinal          */ (Cardinal)(uintptr_t)NULL,
+ /* resources for subclass fields    XtResourceList    */ resources,
+ /* number of entries in resources   Cardinal          */ XtNumber(resources),
+ /* resource class quarkified        XrmClass          */ NULLQUARK,
+-/* NULL                             Boolean           */ (Boolean)(unsigned)NULL,
+-/* NULL                             XtEnum            */ (XtEnum)(unsigned)NULL,
+-/* NULL				    Boolean           */ (Boolean)(unsigned)NULL,
+-/* NULL                             Boolean           */ (Boolean)(unsigned)NULL,
++/* NULL                             Boolean           */ (Boolean)(uintptr_t)NULL,
++/* NULL                             XtEnum            */ (XtEnum)(uintptr_t)NULL,
++/* NULL				    Boolean           */ (Boolean)(uintptr_t)NULL,
++/* NULL                             Boolean           */ (Boolean)(uintptr_t)NULL,
+ /* free data for subclass pointers  XtWidgetProc      */ destroy,
+ /* NULL                             XtProc            */ NULL,
+ /* NULL			            XtProc            */ NULL,
+diff -Nurd motif-2.3.8.orig/lib/Xm/Synthetic.c motif-2.3.8/lib/Xm/Synthetic.c
+--- motif-2.3.8.orig/lib/Xm/Synthetic.c	2016-03-16 02:10:08.000000000 +0000
++++ motif-2.3.8/lib/Xm/Synthetic.c	2023-02-26 00:32:00.000000000 +0000
+@@ -186,7 +186,7 @@
+   
+   for (i = 0; i < num_resources; i++)
+     resources[i].resource_name = 
+-      (String) XrmPermStringToQuark (resources[i].resource_name);
++      (String)(uintptr_t) XrmPermStringToQuark (resources[i].resource_name);
+ }
+ 
+ /**********************************************************************
+@@ -230,7 +230,7 @@
+       for (j = 0; j < num_resources; j++) 
+ 	{
+ 	  if ((resources[j].export_proc) &&
+-	      (XrmQuark)(resources[j].resource_name) == quark) 
++	      (XrmQuark)(uintptr_t)(resources[j].resource_name) == quark) 
+ 	    {
+ 	      value_size = resources[j].resource_size;
+ 
+@@ -505,7 +505,7 @@
+       for (j = 0; j < num_resources; j++) 
+ 	{
+ 	  if ((resources[j].import_proc) &&
+-	      (XrmQuark)(resources[j].resource_name) == quark) 
++	      (XrmQuark)(uintptr_t)(resources[j].resource_name) == quark) 
+ 	    {
+ 	      value = args[i].value;
+ 	      
+diff -Nurd motif-2.3.8.orig/lib/Xm/TabBox.c motif-2.3.8/lib/Xm/TabBox.c
+--- motif-2.3.8.orig/lib/Xm/TabBox.c	2017-08-26 04:08:22.000000000 +0100
++++ motif-2.3.8/lib/Xm/TabBox.c	2023-02-26 00:32:00.000000000 +0000
+@@ -7602,7 +7602,7 @@
+ {
+     XmTabbedStackList       list = XmTabBox_tab_list(tab);
+     int             i, count = _XmTabbedStackListCount(list), row = 0, col,
+-                    shadow = tab->manager.shadow_thickness, x,
++                    shadow = tab->manager.shadow_thickness, x = 0,
+                     height, offset, idx, below, corner, cnt, first, last,
+                     x1, x2;
+     XmTabAttributes info;
+diff -Nurd motif-2.3.8.orig/lib/Xm/Text.c motif-2.3.8/lib/Xm/Text.c
+--- motif-2.3.8.orig/lib/Xm/Text.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Xm/Text.c	2023-02-26 00:32:00.000000000 +0000
+@@ -631,14 +631,14 @@
+ static void 
+ _XmCreateCutBuffers(Widget w)
+ {
+-  static XContext context = (XContext)NULL;
++  static XContext context = (XContext)(uintptr_t)NULL;
+   char * tmp = NULL;
+   Display *dpy = XtDisplay(w);
+   Screen *screen = XtScreen(w);
+   XContext local_context;
+ 
+   _XmProcessLock();
+-  if (context == (XContext)NULL) context = XUniqueContext();
++  if (context == (XContext)(uintptr_t)NULL) context = XUniqueContext();
+ 
+   local_context = context;
+   _XmProcessUnlock();
+@@ -3016,7 +3016,7 @@
+   if (!tw->text.editable && editable) {
+     OutputData o_data = tw->text.output->data;
+     
+-    XmImRegister(widget, (unsigned int) NULL);
++    XmImRegister(widget, (unsigned int)(uintptr_t) NULL);
+     
+     (*tw->text.output->PosToXY)(tw, tw->text.cursor_position,
+ 				&xmim_point.x, &xmim_point.y);
+diff -Nurd motif-2.3.8.orig/lib/Xm/TextF.c motif-2.3.8/lib/Xm/TextF.c
+--- motif-2.3.8.orig/lib/Xm/TextF.c	2017-08-22 01:27:47.000000000 +0100
++++ motif-2.3.8/lib/Xm/TextF.c	2023-02-26 00:32:09.000000000 +0000
+@@ -35,6 +35,7 @@
+ #include <limits.h>		/* required for MB_LEN_MAX definition */
+ #include <string.h>
+ #include <ctype.h>
++#include <wchar.h>
+ #include "XmI.h"
+ #include <X11/ShellP.h>
+ #include <X11/VendorP.h>
+@@ -91,8 +92,6 @@
+  * the other missing functions as _Xmwc... routines.  The new functions are
+  * added static to this file.
+  */
+-#define wcslen(c) _Xwcslen(c)
+-#define wcscpy(d,s) _Xwcscpy(d,s)
+ #define wcsncpy(d,s,l) _Xwcsncpy(d,s,l)
+ 
+ static wchar_t* _Xmwcschr(const wchar_t *ws, wchar_t wc)
+@@ -112,7 +111,7 @@
+         wchar_t *save = ws1;
+ 
+         for (; *ws1; ++ws1);
+-        while (*ws1++ = *ws2++);
++        while ((*ws1++ = *ws2++));
+         return save;
+ }
+ #define wcscat(w1,w2) _Xmwcscat(w1,w2)
+@@ -7360,7 +7359,7 @@
+   XmTextFieldSetEditable((Widget)tf, TextF_Editable(tf));
+   
+   if (TextF_Editable(tf)) {
+-    XmImRegister((Widget)tf, (unsigned int) NULL);
++    XmImRegister((Widget)tf, (unsigned int)(uintptr_t) NULL);
+     GetXYFromPos(tf, TextF_CursorPosition(tf), &xmim_point.x, &xmim_point.y);
+     (void)TextFieldGetDisplayRect((Widget)tf, &xmim_area);
+     n = 0;
+@@ -8232,7 +8231,7 @@
+       diff_values = True;
+       if (TextF_WcValue(new_tf) == NULL) {
+ 	TextF_WcValue(new_tf) = (wchar_t*) XtMalloc(sizeof(wchar_t));
+-	*TextF_WcValue(new_tf) = (wchar_t)NULL;
++	*TextF_WcValue(new_tf) = (wchar_t)(uintptr_t)NULL;
+       }
+       ValidateString(new_tf, (char*)TextF_WcValue(new_tf), True);
+     } else if (TextF_Value(new_tf) != TextF_Value(old_tf)) {
+@@ -10145,7 +10144,7 @@
+    * give the IM the relevent values. */
+   
+   if (!TextF_Editable(tf) && editable) { 
+-    XmImRegister((Widget)tf, (unsigned int) NULL);
++    XmImRegister((Widget)tf, (unsigned int)(uintptr_t) NULL);
+     
+     GetXYFromPos(tf, TextF_CursorPosition(tf), &xmim_point.x, 
+ 		 &xmim_point.y);
+diff -Nurd motif-2.3.8.orig/lib/Xm/TextFunc.c motif-2.3.8/lib/Xm/TextFunc.c
+--- motif-2.3.8.orig/lib/Xm/TextFunc.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Xm/TextFunc.c	2023-02-26 00:32:00.000000000 +0000
+@@ -738,9 +738,9 @@
+     _XmAppUnlock(app);
+     return ret_val;
+   } else {
+-    Dimension *baselines;
++    Dimension *baselines = NULL;
+     int temp_bl;
+-    int line_count;
++    int line_count = 0;
+     XmPrimitiveClassExt           *wcePtr;
+     XmTextWidget tw = (XmTextWidget) widget;
+ 
+@@ -769,9 +769,9 @@
+ int 
+ XmTextGetCenterline(Widget widget)
+ {
+-  Dimension *baselines;
++  Dimension *baselines = NULL;
+   int temp_bl;
+-  int line_count;
++  int line_count = 0;
+   XmPrimitiveClassExt           *wcePtr;
+   XmTextWidget tw = (XmTextWidget) widget;
+ 
+diff -Nurd motif-2.3.8.orig/lib/Xm/TextIn.c motif-2.3.8/lib/Xm/TextIn.c
+--- motif-2.3.8.orig/lib/Xm/TextIn.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Xm/TextIn.c	2023-02-26 00:32:00.000000000 +0000
+@@ -1675,7 +1675,7 @@
+ 	     String *params,
+ 	     Cardinal *num_params)
+ {
+-  XmTextPosition position, left, right, cursorPos;
++  XmTextPosition position = 0, left, right, cursorPos;
+   XmTextWidget tw = (XmTextWidget) w;
+   InputData data = tw->text.input->data;
+   XmTextScanDirection  cursorDir;                              /* PIR1858 */
+diff -Nurd motif-2.3.8.orig/lib/Xm/VendorS.c motif-2.3.8/lib/Xm/VendorS.c
+--- motif-2.3.8.orig/lib/Xm/VendorS.c	2017-08-31 04:12:38.000000000 +0100
++++ motif-2.3.8/lib/Xm/VendorS.c	2023-02-26 00:32:00.000000000 +0000
+@@ -1580,8 +1580,8 @@
+         ttp->post_delay = 5000;
+         ttp->post_duration = 5000;
+         ttp->enable = False;
+-        ttp->timer = (int) NULL;
+-        ttp->duration_timer = (int) NULL;
++        ttp->timer = (int)(uintptr_t) NULL;
++        ttp->duration_timer = (int)(uintptr_t) NULL;
+         ttp->leave_time = 0;
+         ttp->slider = ttp->label = NULL;
+  
+diff -Nurd motif-2.3.8.orig/lib/Xm/XmExtUtil.c motif-2.3.8/lib/Xm/XmExtUtil.c
+--- motif-2.3.8.orig/lib/Xm/XmExtUtil.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Xm/XmExtUtil.c	2023-02-26 00:32:00.000000000 +0000
+@@ -779,7 +779,8 @@
+ 	WidgetClass p = wc;
+ 
+     _XmProcessLock();
+-	for(; (p) && (p != sc); p = p->core_class.superclass);
++	for(; (p) && (p != sc); p = p->core_class.superclass)
++	;
+     _XmProcessUnlock();
+ 
+ 	return (p == sc);
+diff -Nurd motif-2.3.8.orig/lib/Xm/XmIm.c motif-2.3.8/lib/Xm/XmIm.c
+--- motif-2.3.8.orig/lib/Xm/XmIm.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Xm/XmIm.c	2023-02-26 00:32:00.000000000 +0000
+@@ -2510,7 +2510,7 @@
+   (void) add_ref(&xic_info->widget_refs, widget);
+   
+   /* Set the current XIC for this widget. */
+-  if (xim_info->current_xics == (XContext) NULL)
++  if (xim_info->current_xics == (XContext)(uintptr_t) NULL)
+     xim_info->current_xics = XUniqueContext();
+   (void) XSaveContext(XtDisplay(widget), (XID) widget, 
+ 		      xim_info->current_xics, (XPointer) xic_info);
+diff -Nurd motif-2.3.8.orig/lib/Xm/XmString.c motif-2.3.8/lib/Xm/XmString.c
+--- motif-2.3.8.orig/lib/Xm/XmString.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Xm/XmString.c	2023-02-26 00:32:00.000000000 +0000
+@@ -7176,7 +7176,7 @@
+   int ret_val;
+ 
+   _XmProcessLock();
+-  if ((string == NULL)) {
++  if (string == NULL) {
+ 	_XmProcessUnlock();
+ 	return(0);
+   }
+diff -Nurd motif-2.3.8.orig/lib/Xm/XpmI.h motif-2.3.8/lib/Xm/XpmI.h
+--- motif-2.3.8.orig/lib/Xm/XpmI.h	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/lib/Xm/XpmI.h	2023-02-26 00:32:00.000000000 +0000
+@@ -302,7 +302,7 @@
+ FUNC(xpmHashIntern, int, (xpmHashTable *table, char *tag, void *data));
+ 
+ #define HashAtomData(i) ((void *)i)
+-#define HashColorIndex(slot) ((unsigned int)((*slot)->data))
++#define HashColorIndex(slot) ((unsigned int)(uintptr_t)((*slot)->data))
+ #define USE_HASHTABLE (cpp > 2 && ncolors > 4)
+ 
+ /* I/O utility */
+diff -Nurd motif-2.3.8.orig/lib/Xm/Xpmparse.c motif-2.3.8/lib/Xm/Xpmparse.c
+--- motif-2.3.8.orig/lib/Xm/Xpmparse.c	2017-03-27 23:24:31.000000000 +0100
++++ motif-2.3.8/lib/Xm/Xpmparse.c	2023-02-26 00:32:00.000000000 +0000
+@@ -387,7 +387,7 @@
+ 	     */
+ 	    if (USE_HASHTABLE) {
+ 		ErrorStatus =
+-		    xpmHashIntern(hashtable, color->string, HashAtomData(a));
++		    xpmHashIntern(hashtable, color->string, HashAtomData((uintptr_t)a));
+ 		if (ErrorStatus != XpmSuccess) {
+ 		    xpmFreeColorTable(colorTable, ncolors);
+ 		    return (ErrorStatus);
+@@ -475,7 +475,7 @@
+ 	     */
+ 	    if (USE_HASHTABLE) {
+ 		ErrorStatus =
+-		    xpmHashIntern(hashtable, color->string, HashAtomData(a));
++		    xpmHashIntern(hashtable, color->string, HashAtomData((uintptr_t)a));
+ 		if (ErrorStatus != XpmSuccess) {
+ 		    xpmFreeColorTable(colorTable, ncolors);
+ 		    return (ErrorStatus);
+diff -Nurd motif-2.3.8.orig/tools/wml/Makefile.am motif-2.3.8/tools/wml/Makefile.am
+--- motif-2.3.8.orig/tools/wml/Makefile.am	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/tools/wml/Makefile.am	2023-02-26 00:32:00.000000000 +0000
+@@ -26,16 +26,13 @@
+ wmluiltok_SOURCES = wmluiltok.l
+ wmluiltok_LDADD = @LEXLIB@
+ 
+-wml_SOURCES = wml.c
+-wml_LDADD = -L. -lwml
+-wml_DEPENDENCIES = libwml.a
+ 
++wmldbcreate_SOURCES = wmldbcreate.c
+ wmldbcreate_LDADD = ../../lib/Xm/libXm.la
+ 
+ INCLUDES = -I../../lib -I$(srcdir)/../../lib -I$(srcdir)/../../include ${X_CFLAGS} 
+ 
+-noinst_LIBRARIES = libwml.a
+-libwml_a_SOURCES = wmlparse.y wml.c wmloutkey.c wmlouth.c wmloutmm.c wmloutp1.c wmlresolve.c wmlsynbld.c wmlutils.c
++wml_SOURCES = wmlparse.y wml.c wmloutkey.c wmlouth.c wmloutmm.c wmloutp1.c wmlresolve.c wmlsynbld.c wmlutils.c
+ 
+ wmlparse.c: wmllex.c
+ 
+@@ -43,7 +40,7 @@
+ 
+ wmlsynbld.c: wmlparse.h
+ 
+-$(srcdir)/wmldbcreate.c: $(WMLTARGETS) UilLexPars.h
++wmldbcreate.c: $(WMLTARGETS) UilLexPars.h
+ 
+ UilLexPars.h: UilLexPars.c
+ 
+@@ -66,7 +63,7 @@
+ 	./wmldbcreate -o motif.wmd
+ 
+ clean-local:
+-	$(RM) $(WMLTARGETS) $(WMDTABLE) $(REPORT) lex.yy.c libwml.a wml \
++	$(RM) $(WMLTARGETS) $(WMDTABLE) $(REPORT) lex.yy.c wml \
+ 	*.mm *.sdml *.txt wmlparse.c wmlparse.h wmluiltok wmllex.c \
+ 	tokens.dat DONE wmluiltok.c Uil.c Uil.h wml.report UilLexPars.[ch] ylwrap
+  
+diff -Nurd motif-2.3.8.orig/tools/wml/wml.h motif-2.3.8/tools/wml/wml.h
+--- motif-2.3.8.orig/tools/wml/wml.h	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/tools/wml/wml.h	2023-02-26 00:32:09.000000000 +0000
+@@ -624,7 +624,7 @@
+ 
+ extern DynamicHandleListDefPtr	wml_tok_sens_ptr;
+ extern DynamicHandleListDefPtr	wml_tok_insens_ptr;
+-
++extern int dup2 ();
+ 
+ 
+ 
+@@ -658,6 +658,10 @@
+ extern void wmlAddClassResource ();
+ extern void wmlAddClassResourceAttribute ();
+ extern void wmlAddClassControl ();
++extern void wmlAddClassChild ();
++extern void wmlCreateChild ();
++extern void wmlCreateOrAppendCtrlList ();
++extern void wmlAddCtrlListControl ();
+ extern void wmlAddCtrList ();
+ extern void wmlCreateResource ();
+ extern void wmlCreateDatatype ();
+@@ -671,6 +675,9 @@
+ extern void wmlCreateCharset ();
+ extern void wmlAddCharsetAttribute ();
+ extern void LexIssueError ();
++int yylex ();
++int yyerror ();
++int yyparse ();
+ 
+ /*      May be, declaration of functions must be next:
+ extern void wmlAddClassChild ();
+@@ -708,3 +715,5 @@
+  * Define in wmloutp1 or wmloutp2
+  */
+ extern void wmlOutput ();
++extern void wmlOutputKeyWordFiles ();
++extern void wmlOutputMmFiles ();
+diff -Nurd motif-2.3.8.orig/tools/wml/wmlouth.c motif-2.3.8/tools/wml/wmlouth.c
+--- motif-2.3.8.orig/tools/wml/wmlouth.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/tools/wml/wmlouth.c	2023-02-26 00:32:00.000000000 +0000
+@@ -219,12 +219,12 @@
+     printf ("\nCouldn't open UilSymGen.h");
+     return;
+     }
+-fprintf (outfil, canned_warn);
++fprintf (outfil, "%s", canned_warn);
+ 
+ /*
+  * Write the sym_k..._object literals
+  */
+-fprintf (outfil, canned1);
++fprintf (outfil, "%s", canned1);
+ for ( ndx=0 ; ndx<wml_obj_class_ptr->cnt ; ndx++ )
+     {
+     clsobj = (WmlClassDefPtr) wml_obj_class_ptr->hvec[ndx].objptr;
+@@ -238,7 +238,7 @@
+ /*
+  * Define the sym_k_..._reason literals
+  */
+-fprintf (outfil, canned3);
++fprintf (outfil, "%s", canned3);
+ for ( ndx=0 ; ndx<wml_obj_reason_ptr->cnt ; ndx++ )
+     {
+     resobj = (WmlResourceDefPtr) wml_obj_reason_ptr->hvec[ndx].objptr;
+@@ -252,7 +252,7 @@
+ /*
+  * Define the sym_k_..._arg literals
+  */
+-fprintf (outfil, canned4);
++fprintf (outfil, "%s", canned4);
+ for ( ndx=0 ; ndx<wml_obj_arg_ptr->cnt ; ndx++ )
+     {
+     resobj = (WmlResourceDefPtr) wml_obj_arg_ptr->hvec[ndx].objptr;
+@@ -266,7 +266,7 @@
+ /*
+  * Define the sym_k_..._enumset structs and literals
+  */
+-fprintf (outfil, canned5);
++fprintf (outfil, "%s", canned5);
+ for ( ndx=0 ; ndx<wml_obj_enumset_ptr->cnt ; ndx++ )
+     {
+     enumsetobj = (WmlEnumSetDefPtr) wml_obj_enumset_ptr->hvec[ndx].objptr;
+@@ -280,7 +280,7 @@
+ /*
+  * Define the sym_k_..._enumval literals
+  */
+-fprintf (outfil, canned6);
++fprintf (outfil, "%s", canned6);
+ for ( ndx=0 ; ndx<wml_obj_enumval_ptr->cnt ; ndx++ )
+     {
+     enumvalobj = (WmlEnumValueDefPtr) wml_obj_enumval_ptr->hvec[ndx].objptr;
+@@ -295,7 +295,7 @@
+  * Define the sym_k_..._charsize literals
+  * Define the sym_k_..._charset literals
+  */
+-fprintf (outfil, canned7);
++fprintf (outfil, "%s", canned7);
+ for ( ndx=0 ; ndx<wml_obj_charset_ptr->cnt ; ndx++ )
+     {
+     charsetobj = (WmlCharSetDefPtr) wml_obj_charset_ptr->hvec[ndx].objptr;
+@@ -309,7 +309,7 @@
+ /*
+  * Define the sym_k_..._child literals
+  */
+-fprintf (outfil, canned8);
++fprintf (outfil, "%s", canned8);
+ for ( ndx=0 ; ndx<wml_obj_child_ptr->cnt ; ndx++ )
+     {
+     childobj = (WmlChildDefPtr) wml_obj_child_ptr->hvec[ndx].objptr;
+@@ -373,12 +373,12 @@
+     printf ("\nCouldn't open UilSymChCL.h");
+     return;
+     }
+-fprintf (outfil, canned_warn);
++fprintf (outfil, "%s", canned_warn);
+ 
+ /*
+  * Create table entries, similar to writing sym_k...
+  */
+-fprintf (outfil, canned1);
++fprintf (outfil, "%s", canned1);
+ for ( ndx=0 ; ndx<wml_obj_child_ptr->cnt ; ndx++ )
+     {
+     childobj = (WmlChildDefPtr) wml_obj_child_ptr->hvec[ndx].objptr;
+@@ -386,7 +386,7 @@
+     fprintf (outfil, "    sym_k_%s_object,\n",
+ 	     classobj->tkname);
+     }
+-fprintf (outfil, canned1a);
++fprintf (outfil, "%s", canned1a);
+ 
+ /*
+  * close the output file
+@@ -440,12 +440,12 @@
+     printf ("\nCouldn't open UilSymArTy.h");
+     return;
+     }
+-fprintf (outfil, canned_warn);
++fprintf (outfil, "%s", canned_warn);
+ 
+ /*
+  * Create table entries, similar to writing sym_k...
+  */
+-fprintf (outfil, canned1);
++fprintf (outfil, "%s", canned1);
+ for ( ndx=0 ; ndx<wml_obj_arg_ptr->cnt ; ndx++ )
+     {
+     resobj = (WmlResourceDefPtr) wml_obj_arg_ptr->hvec[ndx].objptr;
+@@ -453,7 +453,7 @@
+     fprintf (outfil, "    sym_k_%s_value,\n",
+ 	     datobj->tkname);
+     }
+-fprintf (outfil, canned1a);
++fprintf (outfil, "%s", canned1a);
+ 
+ /*
+  * close the output file
+@@ -503,19 +503,19 @@
+     printf ("\nCouldn't open UilSymRArg.h");
+     return;
+     }
+-fprintf (outfil, canned_warn);
++fprintf (outfil, "%s", canned_warn);
+ 
+ /*
+  * Create table entries, similar to writing sym_k...
+  */
+-fprintf (outfil, canned1);
++fprintf (outfil, "%s", canned1);
+ for ( ndx=0 ; ndx<wml_obj_arg_ptr->cnt ; ndx++ )
+     {
+     resobj = (WmlResourceDefPtr) wml_obj_arg_ptr->hvec[ndx].objptr;
+     fprintf (outfil, "    %d,\n",
+ 	     resobj->related_code);
+     }
+-fprintf (outfil, canned1a);
++fprintf (outfil, "%s", canned1a);
+ 
+ /*
+  * close the output file
+@@ -615,12 +615,12 @@
+     printf ("\nCouldn't open UilUrmClas.h");
+     return;
+     }
+-fprintf (outfil, canned_warn);
++fprintf (outfil, "%s", canned_warn);
+ 
+ /*
+  * Write entries for widgets
+  */
+-fprintf (outfil, canned1);
++fprintf (outfil, "%s", canned1);
+ for ( ndx=0 ; ndx<wml_obj_class_ptr->cnt ; ndx++ )
+     {
+     clsobj = (WmlClassDefPtr) wml_obj_class_ptr->hvec[ndx].objptr;
+@@ -631,7 +631,7 @@
+     else 
+ 	fprintf (outfil, "  \"%s\",\t\n", synobj->convfunc);
+     }
+-fprintf (outfil, canned2);
++fprintf (outfil, "%s", canned2);
+ 
+ /*
+  * Write entries for gadget variants of widget classes
+@@ -655,7 +655,7 @@
+ 		     synobj->name);
+ 	}
+     }
+-fprintf (outfil, canned3);
++fprintf (outfil, "%s", canned3);
+ 
+ /*
+  * Write entries for non-dialog widgets
+@@ -679,7 +679,7 @@
+ 		     synobj->name);
+ 	}
+     }
+-fprintf (outfil, canned4);
++fprintf (outfil, "%s", canned4);
+ 
+ /*
+  * Write entries for the resource a widget's controls map to
+@@ -695,7 +695,7 @@
+     else
+ 	fprintf (outfil, "  sym_k_%s_arg,\n", mapresobj->tkname);
+     }
+-fprintf (outfil, canned5);
++fprintf (outfil, "%s", canned5);
+ 
+ /*
+  * Write entries for arguments
+@@ -708,7 +708,7 @@
+     fprintf (outfil, "  %s,\n",
+ 	     synres->resliteral);
+     }
+-fprintf (outfil, canned6);
++fprintf (outfil, "%s", canned6);
+ 
+ /*
+  * Write entries for reasons
+@@ -721,7 +721,7 @@
+     fprintf (outfil, "  %s,\n",
+ 	     synres->resliteral);
+     }
+-fprintf (outfil, canned7);
++fprintf (outfil, "%s", canned7);
+ 
+ /*
+  * close the output file
+@@ -775,13 +775,13 @@
+     printf ("\nCouldn't open UilConst.h");
+     return;
+     }
+-fprintf (outfil, canned_warn);
++fprintf (outfil, "%s", canned_warn);
+ 
+ /*
+  * Process the arguments in code order. We start with 1, and write out
+  * the mask after processing 8 codes.
+  */
+-fprintf (outfil, canned1);
++fprintf (outfil, "%s", canned1);
+ strcpy (maskbuf, "0");
+ for ( ndx=0 ; ndx<wml_obj_arg_ptr->cnt ; ndx++ )
+     {
+@@ -799,7 +799,7 @@
+     }
+ if ( bitno != 8 )
+     fprintf (outfil, "%s", maskbuf);
+-fprintf (outfil, canned1a);
++fprintf (outfil, "%s", canned1a);
+ 
+ /*
+  * close the output file
+@@ -872,8 +872,8 @@
+     printf ("\nCouldn't open UilSymReas.h");
+     return;
+     }
+-fprintf (outfil, canned_warn);
+-fprintf (outfil, canned1);
++fprintf (outfil, "%s", canned_warn);
++fprintf (outfil, "%s", canned1);
+ 
+ /*
+  * Generate the bit vectors for each class. Outer loop on the reason code,
+@@ -919,13 +919,13 @@
+ /*
+  * Write the vector of vectors.
+  */
+-fprintf (outfil, canned2);
++fprintf (outfil, "%s", canned2);
+ for ( resndx=0 ; resndx<wml_obj_reason_ptr->cnt ; resndx++ )
+     {
+     resobj = (WmlResourceDefPtr) wml_obj_reason_ptr->hvec[resndx].objptr;
+     fprintf (outfil, "  reason_class_vec%d,\n", resobj->sym_code);
+     }
+-fprintf (outfil, canned3);
++fprintf (outfil, "%s", canned3);
+ 
+ /*
+  * close the output file
+@@ -998,8 +998,8 @@
+     printf ("\nCouldn't open UilSymArTa.h");
+     return;
+     }
+-fprintf (outfil, canned_warn);
+-fprintf (outfil, canned1);
++fprintf (outfil, "%s", canned_warn);
++fprintf (outfil, "%s", canned1);
+ 
+ /*
+  * Generate the bit vectors for each class. Outer loop on the argument code,
+@@ -1045,13 +1045,13 @@
+ /*
+  * Write the vector of vectors.
+  */
+-fprintf (outfil, canned2);
++fprintf (outfil, "%s", canned2);
+ for ( resndx=0 ; resndx<wml_obj_arg_ptr->cnt ; resndx++ )
+     {
+     resobj = (WmlResourceDefPtr) wml_obj_arg_ptr->hvec[resndx].objptr;
+     fprintf (outfil, "  arg_class_vec%d,\n", resobj->sym_code);
+     }
+-fprintf (outfil, canned3);
++fprintf (outfil, "%s", canned3);
+ 
+ /*
+  * close the output file
+@@ -1123,8 +1123,8 @@
+     printf ("\nCouldn't open UilSymChTa.h");
+     return;
+     }
+-fprintf (outfil, canned_warn);
+-fprintf (outfil, canned1);
++fprintf (outfil, "%s", canned_warn);
++fprintf (outfil, "%s", canned1);
+ 
+ /*
+  * Generate the bit vectors for each class. Outer loop on the child code,
+@@ -1168,13 +1168,13 @@
+ /*
+  * Write the vector of vectors.
+  */
+-fprintf (outfil, canned2);
++fprintf (outfil, "%s", canned2);
+ for ( childndx=0 ; childndx<wml_obj_child_ptr->cnt ; childndx++ )
+     {
+     childobj = (WmlChildDefPtr) wml_obj_child_ptr->hvec[childndx].objptr;
+     fprintf (outfil, "  child_class_vec%d,\n", childobj->sym_code);
+     }
+-fprintf (outfil, canned3);
++fprintf (outfil, "%s", canned3);
+ 
+ /*
+  * close the output file
+@@ -1245,8 +1245,8 @@
+     printf ("\nCouldn't open UilSymCtl.h");
+     return;
+     }
+-fprintf (outfil, canned_warn);
+-fprintf (outfil, canned1);
++fprintf (outfil, "%s", canned_warn);
++fprintf (outfil, "%s", canned1);
+ 
+ /*
+  * Generate the bit vectors for each class. Outer loop on the class code,
+@@ -1290,13 +1290,13 @@
+ /*
+  * Write the vector of vectors.
+  */
+-fprintf (outfil, canned2);
++fprintf (outfil, "%s", canned2);
+ for ( ctlndx=0 ; ctlndx<wml_obj_class_ptr->cnt ; ctlndx++ )
+     {
+     clsobj = (WmlClassDefPtr) wml_obj_class_ptr->hvec[ctlndx].objptr;
+     fprintf (outfil, "  object_class_vec%d,\n", clsobj->sym_code);
+     }
+-fprintf (outfil, canned3);
++fprintf (outfil, "%s", canned3);
+ 
+ /*
+  * close the output file
+@@ -1432,7 +1432,7 @@
+     printf ("\nCouldn't open UilSymNam.h");
+     return;
+     }
+-fprintf (outfil, canned_warn);
++fprintf (outfil, "%s", canned_warn);
+ 
+ /*
+  * Write entries for widgets
+@@ -1511,7 +1511,7 @@
+     fprintf (outfil, "    \"%s\",\n",
+ 	     synch->name);
+     }
+-fprintf (outfil, canned7);
++fprintf (outfil, "%s", canned7);
+ 
+ /*
+  * close the output file
+@@ -1615,12 +1615,12 @@
+     printf ("\nCouldn't open UilSymEnum.h");
+     return;
+     }
+-fprintf (outfil, canned_warn);
++fprintf (outfil, "%s", canned_warn);
+ 
+ /*
+  * Generate the enumeration value vectors for each enumeration set.
+  */
+-fprintf (outfil, canned1);
++fprintf (outfil, "%s", canned1);
+ for ( ndx=0 ; ndx<wml_obj_enumset_ptr->cnt ; ndx++ )
+     {
+     enumsetobj = (WmlEnumSetDefPtr) wml_obj_enumset_ptr->hvec[ndx].objptr;
+@@ -1637,7 +1637,7 @@
+ /*
+  * Generate the enumeration set tables
+  */
+-fprintf (outfil, canned3);
++fprintf (outfil, "%s", canned3);
+ for ( ndx=0 ; ndx<wml_obj_enumset_ptr->cnt ; ndx++ )
+     {
+     enumsetobj = (WmlEnumSetDefPtr) wml_obj_enumset_ptr->hvec[ndx].objptr;
+@@ -1649,7 +1649,7 @@
+ /*
+  * Create enumset table entries for arguments, similar to writing sym_k...
+  */
+-fprintf (outfil, canned4);
++fprintf (outfil, "%s", canned4);
+ for ( ndx=0 ; ndx<wml_obj_arg_ptr->cnt ; ndx++ )
+     {
+     resobj = (WmlResourceDefPtr) wml_obj_arg_ptr->hvec[ndx].objptr;
+@@ -1663,13 +1663,13 @@
+ /*
+  * Create the enumval values table.
+  */
+-fprintf (outfil, canned5);
++fprintf (outfil, "%s", canned5);
+ for ( ndx=0 ; ndx<wml_obj_enumval_ptr->cnt ; ndx++ )
+     {
+     evobj = (WmlEnumValueDefPtr) wml_obj_enumval_ptr->hvec[ndx].objptr;
+     fprintf (outfil, "  %s,\n", evobj->syndef->enumlit);
+     }
+-fprintf (outfil, canned5a);
++fprintf (outfil, "%s", canned5a);
+ 
+ /*
+  * close the output file
+@@ -1807,12 +1807,12 @@
+     printf ("\nCouldn't open UilSymCSet.h");
+     return;
+     }
+-fprintf (outfil, canned_warn);
++fprintf (outfil, "%s", canned_warn);
+ 
+ /*
+  * Generate the standards name table
+  */
+-fprintf (outfil, canned1);
++fprintf (outfil, "%s", canned1);
+ for ( ndx=0 ; ndx<wml_obj_charset_ptr->cnt ; ndx++ )
+     {
+     csobj = (WmlCharSetDefPtr) wml_obj_charset_ptr->hvec[ndx].objptr;
+@@ -1830,7 +1830,7 @@
+ /*
+  * Generate the writing direction table
+  */
+-fprintf (outfil, canned2);
++fprintf (outfil, "%s", canned2);
+ for ( ndx=0 ; ndx<wml_obj_charset_ptr->cnt ; ndx++ )
+     {
+     csobj = (WmlCharSetDefPtr) wml_obj_charset_ptr->hvec[ndx].objptr;
+@@ -1852,7 +1852,7 @@
+ /*
+  * Generate the parsing direction table
+  */
+-fprintf (outfil, canned3);
++fprintf (outfil, "%s", canned3);
+ for ( ndx=0 ; ndx<wml_obj_charset_ptr->cnt ; ndx++ )
+     {
+     csobj = (WmlCharSetDefPtr) wml_obj_charset_ptr->hvec[ndx].objptr;
+@@ -1874,7 +1874,7 @@
+ /*
+  * Generate the character size table
+  */
+-fprintf (outfil, canned4);
++fprintf (outfil, "%s", canned4);
+ for ( ndx=0 ; ndx<wml_obj_charset_ptr->cnt ; ndx++ )
+     {
+     csobj = (WmlCharSetDefPtr) wml_obj_charset_ptr->hvec[ndx].objptr;
+@@ -1900,7 +1900,7 @@
+ /*
+  * Generate the $LANG name recognition table
+  */
+-fprintf (outfil, canned5);
++fprintf (outfil, "%s", canned5);
+ lang_max = 0;
+ for ( ndx=0 ; ndx<wml_obj_charset_ptr->cnt ; ndx++ )
+     {
+@@ -1930,7 +1930,7 @@
+ /*
+  * Generate the $LANG code lookup table, in upper case
+  */
+-fprintf (outfil, canned6);
++fprintf (outfil, "%s", canned6);
+ for ( ndx=0 ; ndx<wml_obj_charset_ptr->cnt ; ndx++ )
+     {
+     csobj = (WmlCharSetDefPtr) wml_obj_charset_ptr->hvec[ndx].objptr;
+diff -Nurd motif-2.3.8.orig/tools/wml/wmloutkey.c motif-2.3.8/tools/wml/wmloutkey.c
+--- motif-2.3.8.orig/tools/wml/wmloutkey.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/tools/wml/wmloutkey.c	2023-02-26 00:32:00.000000000 +0000
+@@ -568,16 +568,16 @@
+     printf ("\nCouldn't open UilKeyTab.h");
+     return;
+     }
+-fprintf (outfil, canned_warn);
++fprintf (outfil, "%s", canned_warn);
+ 
+ /*
+  * Print the case sensitive and insensitive tables
+  */
+-fprintf (outfil, canned1);
++fprintf (outfil, "%s", canned1);
+ wmlOutputUilKeyTabBody (outfil, wml_tok_sens_ptr, &maxlen, &maxkey);
+ fprintf (outfil, canned2, maxlen, maxkey);
+ wmlOutputUilKeyTabBody (outfil, wml_tok_insens_ptr, &maxlen, &maxkey);
+-fprintf (outfil, canned3);
++fprintf (outfil, "%s", canned3);
+ 
+ /*
+  * close the output file
+@@ -806,8 +806,8 @@
+     printf ("\nCouldn't open UilTokName.h");
+     return;
+     }
+-fprintf (outfil, canned_warn);
+-fprintf (outfil, canned1);
++fprintf (outfil, "%s", canned_warn);
++fprintf (outfil, "%s", canned1);
+ 
+ /*
+  * Print the token name entries
+diff -Nurd motif-2.3.8.orig/tools/wml/wmloutmm.c motif-2.3.8/tools/wml/wmloutmm.c
+--- motif-2.3.8.orig/tools/wml/wmloutmm.c	2017-08-17 01:38:43.000000000 +0100
++++ motif-2.3.8/tools/wml/wmloutmm.c	2023-02-26 00:32:00.000000000 +0000
+@@ -203,9 +203,9 @@
+ /*
+  * Write out header information
+  */
+-fprintf (outfil, canned1);
++fprintf (outfil, "%s", canned1);
+ fprintf (outfil, "%s\n", name);
+-fprintf (outfil, canned2);
++fprintf (outfil, "%s", canned2);
+ 
+ /*
+  * Alphabetize the controls, reason, and argument lists
+@@ -281,7 +281,7 @@
+     else
+ 	fprintf (outfil, "\n");
+     }
+-fprintf (outfil, canned3);
++fprintf (outfil, "%s", canned3);
+ 
+ /*
+  * Write out the argument table
+@@ -317,7 +317,7 @@
+     }    
+     argndx += 1;
+     }
+-fprintf (outfil, canned4);
++fprintf (outfil, "%s", canned4);
+ 
+ }
+ 

--- a/10.9-libcxx/stable/main/finkinfo/x11/xbae.info
+++ b/10.9-libcxx/stable/main/finkinfo/x11/xbae.info
@@ -1,13 +1,13 @@
 Package: xbae
 Version: 4.60.4
-Revision: 7
+Revision: 8
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Source: mirror:sourceforge:%n/%n-%v.tar.gz
 Source-Checksum: SHA256(eb72702ed0a36d043f2075a9d5a4545556da1b8dab4d67d85fca92f37aeb04a8)
 BuildDepends: <<
 	fink-package-precedence,
-	libxt-flat,
-	openmotif4,
+	libxt,
+	openmotif4-2level,
 	x11-dev
 <<
 Depends: %N-shlibs (= %v-%r) 
@@ -43,8 +43,8 @@ SplitOff: <<
 	Package: %N-shlibs
 	Replaces: xbae (<< 4.9.1-3)
 	Depends: <<
-		libxt-flat-shlibs,
-		openmotif4-shlibs,
+		libxt-shlibs,
+		openmotif4-2level-shlibs,
 		x11
 	<<
 	Files: lib/*.*.dylib
@@ -81,9 +81,6 @@ DescPackaging: <<
 	XQuartz-2.8.0 dropped libXp compile-time files (only retained
 	the runtime dylib); disable detection in order to get
 	deterministic results.
-<<
-DescPort: <<
-	Needs flat-namespace libXt for compatibility with openmotif4
 <<
 License: BSD
 Homepage: http://xbae.sourceforge.net


### PR DESCRIPTION
Based on @PovlAbrahamsen work on #1003 , this moves all packages using openmotif4-2.3.4 and libxt-flat to openmotif4-2.3.8 and two_level libxt.

Openmotif4 couldn't just be updated in place because some packages built against flat libxt/openmotif would fail if then running against the two_level libraries.

So I made a new package `openmotif4-2level` for v2.3.8 linking to libxt, that puts the libraries into a hidden directory so they can coexist with the older `openmotif4` v2.3.4 linking to libxt-flat. The dev and bin packages go straight into %p and C/R with the older openmotif4.

This PR is all packages and 1 library using libxt-flat, now transitioned to the new openmotif4-2level and libxt.