### PR TITLE
gmt6: fix for Apple Silicon

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/gmt6-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gmt6-shlibs.info
@@ -1,10 +1,12 @@
 Package: gmt6-shlibs
 # 6.2.0 requires glib2 >= 2.32 NEWGLIB24
 Version: 6.1.1
-Revision: 2
+Revision: 3
 Source: https://github.com/GenericMappingTools/gmt/releases/download/%v/gmt-%v-src.tar.xz
 Source-Checksum: SHA256(d476cba999340648146ef53ab4a3f64858cbd2f5511cdec9f7f06f3fb7896625)
 SourceDirectory: gmt-%v
+PatchFile: %n.patch
+PatchFile-MD5: 611be9177fcfcef644ca8e8354f9722a
 
 BuildDepends: <<
   cmake,
@@ -33,6 +35,7 @@ NoSetCPPFLAGS: true
 NoSetLDFLAGS: true
 
 PatchScript: <<
+  %{default_script}
 # Virtualize explicit '/sw' in sources
   perl -pi -e 's,/sw,%p,g' cmake/modules/*.cmake
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/gmt6-shlibs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/gmt6-shlibs.patch
@@ -1,0 +1,12 @@
+diff -Nurd gmt-6.1.1.orig/src/gmt_common_sighandler.c gmt-6.1.1/src/gmt_common_sighandler.c
+--- gmt-6.1.1.orig/src/gmt_common_sighandler.c	2020-09-01 21:29:44
++++ gmt-6.1.1/src/gmt_common_sighandler.c	2023-07-23 18:37:08
+@@ -58,6 +58,8 @@
+ # if __DARWIN_UNIX03
+ #  ifdef __x86_64__
+ #   define UC_IP(uc) ((void *) (uc)->uc_mcontext->__ss.__rip)
++#  elif __arm64__	/* Apple Silicon, e.g. M1 */
++#   define UC_IP(uc) ((void *) (uc)->uc_mcontext->__ss.__pc)
+ #  else
+ #   define UC_IP(uc) ((void *) (uc)->uc_mcontext->__ss.__eip)
+ #  endif


### PR DESCRIPTION
A quick patch to allow GMT6 to build on Apple Silicon - from GenericMappingTools/gmt#4584. Depends on #1042 to have fftw3 working on Apple Silicon.