### PR TITLE
lcms2mt: update to latest upstream

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/lcms2mt2.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/lcms2mt2.info
@@ -2,10 +2,10 @@ Info2: <<
 Package: lcms2mt2
 # when updating version, check that mupdf still builds
 Version: 2.12
-Revision: 1
-Type: gsversion (9.54.0)
-Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9540/ghostscript-%type_raw[gsversion].tar.xz
-Source-Checksum: SHA256(c2b7b43cde600f4e70efb2cd95865f6d884a67315c3de235914697d8ccde6e3b)
+Revision: 2
+Type: gsversion (10.02.0)
+Source: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10020/ghostscript-%type_raw[gsversion].tar.xz
+Source-Checksum: SHA256(fa08ce016b30d26293dc322c6353691aced94fd3667a68ede7ff5395d71fcd0b)
 BuildDepends: <<
 	fink (>= 0.32),
 	fink-package-precedence
@@ -14,7 +14,7 @@ Depends: %n-shlibs (= %v-%r)
 BuildDependsOnly: true
 SourceDirectory: ghostscript-%type_raw[gsversion]/lcms2mt
 PatchFile: %n.patch
-PatchFile-MD5: 0ce0b52ad7f6140128faf7d248345dff
+PatchFile-MD5: e07499de6f5c48ac192f6119fa04ca17
 PatchScript: <<
 	%{default_script}
 	chmod +x configure

--- a/10.9-libcxx/stable/main/finkinfo/graphics/lcms2mt2.patch
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/lcms2mt2.patch
@@ -10,17 +10,6 @@ diff -Nurd lcms2mt.orig/include/lcms2mt.h lcms2mt/include/lcms2mt.h
                                                 const cmsHTRANSFORM hTransform,
                                                 cmsUInt32Number InputFormat,
                                                 cmsUInt32Number OutputFormat);
-diff -Nurd lcms2mt.orig/lcms2mt.pc.in lcms2mt/lcms2mt.pc.in
---- lcms2mt.orig/lcms2mt.pc.in	2021-03-30 03:40:28.000000000 -0400
-+++ lcms2mt/lcms2mt.pc.in	2021-05-23 06:21:11.000000000 -0400
-@@ -6,6 +6,6 @@
- Name: @PACKAGE@
- Description: LCMS Color Management Library
- Version: @VERSION@
--Libs: -L${libdir} -llcms2 @LIB_PLUGINS@
-+Libs: -L${libdir} -llcms2mt @LIB_PLUGINS@
- Libs.private: @LIB_MATH@ @LIB_THREAD@
- Cflags: -I${includedir}
 diff -Nurd lcms2mt.orig/src/cmsxform.c lcms2mt/src/cmsxform.c
 --- lcms2mt.orig/src/cmsxform.c	2021-03-30 03:40:28.000000000 -0400
 +++ lcms2mt/src/cmsxform.c	2021-05-23 06:19:16.000000000 -0400


### PR DESCRIPTION
An update to the latest upstream code, in sync with the recent update to Ghostscript.

Maintainer is @dmacks 