### PR TITLE
Remove read_only_stubs flag

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/editors/joe.info
+++ b/10.9-libcxx/stable/main/finkinfo/editors/joe.info
@@ -1,6 +1,6 @@
 Package: joe
 Version: 4.6
-Revision: 1
+Revision: 2
 Description: User friendly full screen text editor
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
@@ -19,7 +19,7 @@ Source2-Checksum: SHA256(56e6892c80e0c5d9fd668a94ac14d44fb26a5b5c50f61bb26a6f941
 SetCFLAGS: -g -O2 -fstack-protector -Wformat -Wformat-security -fPIE
 SetCPPFLAGS: -D_FORTIFY_SOURCE=2
 SetCXXFLAGS: -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -fPIE
-SetLDFLAGS: -Wl,-read_only_stubs -Wl,-bind_at_load -fPIE -Wl,-pie
+SetLDFLAGS: -Wl,-bind_at_load -fPIE -Wl,-pie
 PatchScript: <<
 	# fix implicit declaration error
 	perl -pi -e 's|\"types.h\"|$&\n\#include \<util.h\>|g' joe/tty.c

--- a/10.9-libcxx/stable/main/finkinfo/editors/ldapvi.info
+++ b/10.9-libcxx/stable/main/finkinfo/editors/ldapvi.info
@@ -1,6 +1,6 @@
 Package: ldapvi
 Version: 1.7
-Revision: 14
+Revision: 15
 Description: Perform an LDAP search/update with EDITOR
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
@@ -27,7 +27,7 @@ Source: http://www.lichteblau.com/download/%n-%v.tar.gz
 Source-Checksum: SHA256(6f62e92d20ff2ac0d06125024a914b8622e5b8a0a0c2d390bf3e7990cbd2e153)
 SetCFLAGS: -g -O2 -fstack-protector -fPIE
 SetCPPFLAGS: -D_FORTIFY_SOURCE=2 -Wno-return-type -I%p/include/ncursesw -MD
-SetLDFLAGS: -Wl,-read_only_stubs -Wl,-bind_at_load -Wl,-pie
+SetLDFLAGS: -Wl,-bind_at_load -Wl,-pie
 ConfigureParams: --with-libcrypto=none PKG_CONFIG_PATH="%p/lib/glib-2.0/pkgconfig-strict:$PKG_CONFIG_PATH"
 CompileScript: <<
 	rm configure

--- a/10.9-libcxx/stable/main/finkinfo/libs/lz4.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/lz4.info
@@ -1,6 +1,6 @@
 Package: lz4
 Version: 1.8.3
-Revision: 1
+Revision: 2
 Description: Fast LZ compression algorithm library
 License: GPL
 
@@ -18,7 +18,7 @@ NoSetCXXFLAGS: true
 # flags from gecko (modified)
 SetCFLAGS: -g -O2 -fstack-protector -Wformat -Werror=format-security
 SetCPPFLAGS: -D_FORTIFY_SOURCE=2 -MD
-SetLDFLAGS: -Wl,-read_only_stubs -Wl,-bind_at_load
+SetLDFLAGS: -Wl,-bind_at_load
 
 CompileScript: <<
   make PREFIX=%p DESTDIR=%d

--- a/10.9-libcxx/stable/main/finkinfo/libs/lzo2.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/lzo2.info
@@ -1,6 +1,6 @@
 Package: lzo2
 Version: 2.10
-Revision: 1
+Revision: 2
 Description: Data compression library
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
@@ -11,7 +11,7 @@ Source-Checksum: SHA256(c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b
 SetCFLAGS: -g -O2 -fstack-protector -Wformat -Werror=format-security -fPIE
 SetCPPFLAGS: -D_FORTIFY_SOURCE=2
 SetCXXFLAGS: -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIE
-SetLDFLAGS: -Wl,-read_only_stubs -Wl,-bind_at_load -fPIE -Wl,-pie
+SetLDFLAGS: -Wl,-bind_at_load -fPIE -Wl,-pie
 ConfigureParams: <<
  --disable-asm \
  --disable-dependency-tracking \

--- a/10.9-libcxx/stable/main/finkinfo/net/socat.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/socat.info
@@ -1,6 +1,6 @@
 Package: socat
 Version: 2.0.0-b9
-Revision: 3
+Revision: 4
 Description: Multipurp. relay for bidirect. data transfer
 License: GPL/OpenSSL
 Maintainer: None <fink-devel@lists.sourceforge.net>
@@ -22,7 +22,7 @@ PatchFile-MD5: 9c0faa85d7639af1e1d99f8d5e5077ba
 SetCFLAGS: -g -O2 -fstack-protector -Wformat -Werror=format-security -fPIE -D_GNU_SOURCE -MD
 SetCPPFLAGS: -D_FORTIFY_SOURCE=2
 SetCXXFLAGS: -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIE
-SetLDFLAGS: -Wl,-read_only_stubs -Wl,-bind_at_load -fPIE -Wl,-pie
+SetLDFLAGS: -Wl,-bind_at_load -fPIE -Wl,-pie
 ConfigureParams: --disable-libwrap --disable-interface
 CompileScript: <<
 	%{default_script}

--- a/10.9-libcxx/stable/main/finkinfo/web/lynx-cur.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/lynx-cur.info
@@ -1,7 +1,7 @@
 Package: lynx-cur
 # Development version. "lynx" package tracks official stable releases
 Version: 2.9.0dev.12
-Revision: 1
+Revision: 2
 Provides: www-browser, news-reader
 Replaces: lynx-ssl (<< 2.8.5-6), lynx
 BuildDepends: <<
@@ -46,7 +46,7 @@ PatchFile-MD5: b3d9e8b0888b30aae474941b3fc2cfe8
 SetCFLAGS: -MD -g -O2 -fstack-protector -Wformat -Werror=format-security -fPIE -Wno-deprecated-declarations
 SetCPPFLAGS: -D_FORTIFY_SOURCE=2 -I%p/include/ncursesw
 SetCXXFLAGS: -g -O2 -fstack-protector -Wformat -Werror=format-security -fPIE -Wno-deprecated-declarations
-SetLDFLAGS: -Wl,-read_only_stubs -Wl,-bind_at_load -fPIE -Wl,-pie
+SetLDFLAGS: -Wl,-bind_at_load -fPIE -Wl,-pie
 ConfigureParams: <<
 	--sysconfdir=%p/etc/lynx-cur \
 	--libdir=%p/etc/lynx-cur \

--- a/10.9-libcxx/stable/main/finkinfo/web/netrik.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/netrik.info
@@ -1,6 +1,6 @@
 Package: netrik
 Version: 1.16.1
-Revision: 4
+Revision: 5
 Description: Text mode WWW browser + vi like keybindings
 License: GPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
@@ -20,7 +20,7 @@ Provides: www-browser
 Source: mirror:sourceforge:%n/%n-%v.tar.gz
 Source-Checksum: SHA256(3e742d9ef866c12075e7771148e39a6892d0dcdf70f43aecafa09e0ed925b78a)
 SetCPPFLAGS: -D_FORTIFY_SOURCE=2 -I%p/include/ncursesw
-SetLDFLAGS: -Wl,-read_only_stubs -Wl,-bind_at_load -fPIE -Wl,-pie
+SetLDFLAGS: -Wl,-bind_at_load -fPIE -Wl,-pie
 CompileScript: <<
 	%{default_script}
 	fink-package-precedence .

--- a/10.9-libcxx/stable/main/finkinfo/web/nginx.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/nginx.info
@@ -1,6 +1,6 @@
 Package: nginx
 Version: 1.25.2
-Revision: 1
+Revision: 2
 Description: Small, powerful, scalable web/proxy server
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
@@ -41,7 +41,7 @@ PatchScript: <<
 SetCFLAGS: -g -O2 -fstack-protector -Wformat -Werror=format-security -fPIE
 SetCPPFLAGS: -D_FORTIFY_SOURCE=2 -MD
 SetCXXFLAGS: -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIE
-SetLDFLAGS: -Wl,-read_only_stubs -Wl,-bind_at_load -fPIE -Wl,-pie
+SetLDFLAGS: -Wl,-bind_at_load -fPIE -Wl,-pie
 ConfigureParams: <<
  --conf-path=%p/etc/%n/%n.conf\
  --error-log-path=%p/var/log/%n/error.log\


### PR DESCRIPTION
Remove read_only_stubs flag
This flag causes problems in Xcode 15 which does not seem to pass it correctly to ld.

gripped read_only_stubs from packages.  Two other packages have it commented out.