### PR TITLE
netcdf updates

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/nco.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/nco.info
@@ -1,6 +1,6 @@
 Info2:<<
 Package: nco
-Version: 4.9.5
+Version: 5.1.8
 Revision: 1
 Description: The NetCDF Operators
 License: GPL3
@@ -9,7 +9,7 @@ Maintainer: None <fink-devel@lists.sourceforge.net>
 # Prerequisites
 Depends: <<
 	libgsl25-shlibs,
-	netcdf-c18-shlibs,
+	netcdf-c19-shlibs,
 	udunits2,
 	udunits2-shlibs
 <<
@@ -18,7 +18,7 @@ BuildDepends: <<
 	fink (>= 0.28),
 	fink-package-precedence,
 	libgsl25-dev,
-	netcdf-c18,
+	netcdf-c19,
 	texinfo (>> 4.13),
 	udunits2-dev (>= 2.1.22-1)
 <<
@@ -94,7 +94,7 @@ Replaces: <<
 # Unpack Phase:
 Source: https://github.com/nco/nco/archive/%v.tar.gz
 SourceRename: %n-%v.tar.gz
-Source-Checksum: SHA256(874c6040371207799ca9c2f3919c045b309b251bf7992ec92521d89cf3bf515f)
+Source-Checksum: SHA256(f22c63a3cbe1947fbf06160a6ed7b6d1934aa242fbe3feeb8d1964eef266b7d5)
 
 # Patch Phase:
 PatchScript: <<
@@ -179,5 +179,5 @@ one to avoid many large executables). The -shlibs and -dev packages
 have thus been scrapped since version 4.7.0. See:
 https://sourceforge.net/p/fink/package-submissions/5063/
 <<
-Homepage: http://nco.sourceforge.net/
+Homepage: https://nco.sourceforge.net/
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/ncview.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/ncview.info
@@ -1,6 +1,6 @@
 Package: ncview
 Version: 2.1.9
-Revision: 1
+Revision: 2
 Description: Graphical display of NetCDF files
 DescDetail: <<
 Ncview is a visual browser for netCDF format files. Typically you would use 
@@ -14,8 +14,24 @@ Patchfile for implicitly declared functions no longer required. Still patch for 
 License: GPL/LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Homepage: https://cirrus.ucsd.edu/ncview/
-Depends: x11, libxt-shlibs, udunits2, app-defaults, netcdf-c18-shlibs, libpng16-shlibs, expat1-shlibs
-BuildDepends: netcdf-c18, x11-dev, libxt, udunits2-dev, libpng16, expat1, fink-buildenv-modules (>= 0.1.3-1)
+Depends: <<
+	x11,
+	libxt-shlibs,
+	udunits2,
+	app-defaults,
+	netcdf-c19-shlibs,
+	libpng16-shlibs,
+	expat1-shlibs
+<<
+BuildDepends: <<
+	netcdf-c19,
+	x11-dev,
+	libxt,
+	udunits2-dev,
+	libpng16,
+	expat1,
+	fink-buildenv-modules (>= 0.1.3-1)
+<<
 Source: https://cirrus.ucsd.edu/~pierce/%n/%n-%v.tar.gz
 Source-Checksum: SHA256(e2317ac094af62f0adcf68421d70658209436aae344640959ec8975a645891af)
 SourceDirectory: %n-%v

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c19.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c19.info
@@ -9,6 +9,7 @@ BuildDepends: <<
 	fink-package-precedence,
 	bzip2-dev,
 	hdf5.200.v1.12,
+	libblosc1-dev,
 	libcurl4,
 	libiconv-dev,
 	libxml2,
@@ -78,6 +79,7 @@ SplitOff: <<
   Depends: <<
 	bzip2-shlibs,
 	hdf5.200.v1.12-shlibs,
+	libblosc1-shlibs,
 	libcurl4-shlibs,
 	libxml2-shlibs,
 	libzip5-shlibs,
@@ -107,6 +109,7 @@ SplitOff2: <<
 	%N-shlibs (= %v-%r),
 	bzip2-shlibs,
 	hdf5.200.v1.12-shlibs,
+	libblosc1-shlibs,
 	libcurl4-shlibs,
 	libxml2-shlibs,
 	libzip5-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c19.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c19.info
@@ -7,8 +7,13 @@ Maintainer: None <fink-devel@lists.sourceforge.net>
 Depends: %n-shlibs (= %v-%r)
 BuildDepends: <<
 	fink-package-precedence,
+	bzip2-dev,
 	hdf5.200.v1.12,
 	libcurl4,
+	libiconv-dev,
+	libxml2,
+	libzip5,
+	libzstd1-dev,
 	szip
 <<
 Conflicts: <<
@@ -71,8 +76,13 @@ InstallScript: <<
 SplitOff: <<
   Package: %N-shlibs
   Depends: <<
-  	hdf5.200.v1.12-shlibs,
-  	libcurl4-shlibs
+	bzip2-shlibs,
+	hdf5.200.v1.12-shlibs,
+	libcurl4-shlibs,
+	libxml2-shlibs,
+	libzip5-shlibs,
+	libzstd1-shlibs,
+	szip-shlibs
   <<
   Conflicts: netcdf-absoft-shlibs
   Replaces: <<
@@ -94,8 +104,14 @@ SplitOff: <<
 SplitOff2: <<
   Package: netcdf-bin
   Depends: <<
-  	%N-shlibs (= %v-%r),
-  	hdf5.200.v1.12-shlibs
+	%N-shlibs (= %v-%r),
+	bzip2-shlibs,
+	hdf5.200.v1.12-shlibs,
+	libcurl4-shlibs,
+	libxml2-shlibs,
+	libzip5-shlibs,
+	libzstd1-shlibs,
+	szip-shlibs
   <<
   Conflicts: netcdf-absoft-bin, netcdf7-bin
   Replaces: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c19.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-c19.info
@@ -1,0 +1,147 @@
+Package: netcdf-c19
+Version: 4.9.2
+Revision: 1
+BuildDependsOnly: true
+Maintainer: None <fink-devel@lists.sourceforge.net>
+
+Depends: %n-shlibs (= %v-%r)
+BuildDepends: <<
+	fink-package-precedence,
+	hdf5.200.v1.12,
+	libcurl4,
+	szip
+<<
+Conflicts: <<
+	netcdf-absoft,
+	netcdf, netcdf7,
+	netcdf-c7,
+	netcdf-c11,
+	netcdf-c13,
+	netcdf-c15,
+	netcdf-c18,
+	netcdf-c19
+<<
+Replaces: <<
+	netcdf-absoft,
+	netcdf,
+	netcdf7,
+	netcdf-c7,
+	netcdf-c11,
+	netcdf-c13,
+	netcdf-c15,
+	netcdf-c18,
+	netcdf-c19
+<<
+
+Source: https://downloads.unidata.ucar.edu/netcdf-c/%v/netcdf-c-%v.tar.gz
+Source-Checksum: SHA256(cf11babbbdb9963f09f55079e0b019f6d0371f52f8e1264a5ba8e9fdab1a6c48)
+SetCFLAGS: -O2
+SetCPPFLAGS: -I%p/opt/hdf5.v1.12/include
+SetLDFLAGS: -lsz -Wl,-dead_strip_dylibs -L%p/opt/hdf5.v1.12/lib
+
+ConfigureParams: <<
+  --enable-shared --disable-static \
+  --mandir='${prefix}/share/man' \
+  --docdir='${prefix}/share/doc/%n' \
+  --disable-pnetcdf
+<<
+
+CompileScript: <<
+	#!/bin/sh -ev
+	%{default_script}
+	fink-package-precedence .
+<<
+InfoTest: <<
+	TestConfigureParams: --enable-extra-example-tests --disable-dap-remote-tests
+  	TestDepends: sed
+	TestScript: make -j1 check || exit 2
+<<
+InstallScript: <<
+  #!/bin/sh -ev
+  make install DESTDIR=%d
+  # Remove unwanted files from test suite
+  rm -f %i/bin/ocprint %i/lib/libmisc.* %i/lib/libh5bzip2.*
+  # Add C and CDL examples
+  mkdir -p %i/share/doc/%N/examples
+  cp -pr examples/C* %i/share/doc/%N/examples
+  rm -rf %i/share/doc/%N/examples/C/.{deps,libs}
+  rm -rf %i/share/doc/%N/examples/C/*/.{deps,libs}
+  rm -f %i/share/doc/%N/examples/C/*/*.la
+<<
+SplitOff: <<
+  Package: %N-shlibs
+  Depends: <<
+  	hdf5.200.v1.12-shlibs,
+  	libcurl4-shlibs
+  <<
+  Conflicts: netcdf-absoft-shlibs
+  Replaces: <<
+  	netcdf-absoft-shlibs, 
+  	netcdf (<= 3.5.0-6), 
+  	netcdf-absoft (<= 3.5.1-2), 
+  	netcdf-shlibs
+  <<
+  Suggests: netcdf-bin (>= 4.3.0)
+  Files: <<
+	lib/libnetcdf.*.dylib
+  <<
+  Shlibs: <<
+    %p/lib/libnetcdf.19.dylib 22.0.0 %n (>= 4.9.2-1)
+  <<
+  DocFiles: COPYRIGHT README* RELEASE_NOTES.md
+  Description: Array-based data access, C library
+<<
+SplitOff2: <<
+  Package: netcdf-bin
+  Depends: <<
+  	%N-shlibs (= %v-%r),
+  	hdf5.200.v1.12-shlibs
+  <<
+  Conflicts: netcdf-absoft-bin, netcdf7-bin
+  Replaces: <<
+  	netcdf-absoft-bin, 
+  	netcdf7-bin, 
+  	netcdf (<= 3.5.0-6), 
+  	netcdf-absoft (<= 3.5.1-2)
+  <<
+  Files: bin/nc{copy,dump,gen,gen3} share/man/man1
+  DocFiles: COPYRIGHT README* RELEASE_NOTES.md
+  Description: Array-based data access, user programs
+<<
+DocFiles: COPYRIGHT README* RELEASE_NOTES.md
+Description: Array-based data access, C headers and docs
+DescDetail: <<
+The netCDF (network Common Data Form) library defines a machine-independent
+format for representing scientific data. Together, the interface, library,
+and format support the creation, access, and sharing of scientific data.
+
+This package provides libraries, documentation and examples for interfacing
+with C code. 
+For libraries, documentation and examples for interfacing
+with C++ install the`netcdf-cxx4' package.
+For libraries, documentation and examples for interfacing
+with Fortran 77 (and Fortran 90) code install the `netcdf-fortran8' package.
+<<
+DescPackaging: <<
+Included examples in documents directory.
+
+Disable remote DAP tests since we aren't supposed to be accessing remote data
+during the build phase.
+
+Feed -lsz to LDFLAGS so that the build finds libsz.
+
+Disable building the static library.
+
+Bump revision when HDF5 version is updated.
+
+Former Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
+<<
+DescPort: <<
+CFLAGS=-O2 is essential to avoid debugging mode flags (-g).
+<<
+DescUsage: <<
+Parallel netCDF now requires a parallel HDF5, which Fink doesn't
+currently have, so this package doesn't build that option.
+<<
+Homepage: https://www.unidata.ucar.edu/software/netcdf/
+License: BSD

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-cxx4.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-cxx4.info
@@ -67,7 +67,11 @@ InstallScript: <<
 <<
 SplitOff: <<
   Package: %N-shlibs
-  Depends: netcdf-c19-shlibs
+  Depends: <<
+	netcdf-c19-shlibs,
+	hdf5.200.v1.12-shlibs,
+	szip-shlibs
+  <<
   Conflicts: netcdf-absoft-shlibs
   Replaces: <<
   		netcdf-absoft-shlibs, 

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-cxx4.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-cxx4.info
@@ -1,17 +1,17 @@
 Package: netcdf-cxx4
 Version: 4.3.1
-Revision: 2
+Revision: 3
 BuildDependsOnly: true
 GCC: 4.0
 Maintainer: None <fink-devel@lists.sourceforge.net>
 
 Depends: <<
 	%n-shlibs (= %v-%r), 
-	netcdf-bin (>= 4.7.4-1)
+	netcdf-bin (>= 4.9.2-1)
 <<
 BuildDepends: <<
-	netcdf-c18,
-	hdf5.200.v1.10,
+	netcdf-c19,
+	hdf5.200.v1.12,
 	doxygen, 
 	fink-package-precedence, 
  	libcurl4,
@@ -28,16 +28,19 @@ Replaces: <<
 	netcdf7
 <<
 
-Source: https://github.com/Unidata/netcdf-cxx4/archive/v%v.tar.gz
-SourceRename: %n-%v.tar.gz
+Source: https://downloads.unidata.ucar.edu/netcdf-cxx/%v/%n-%v.tar.gz
+#SourceRename: %n-%v.tar.gz
 Source-Checksum: SHA256(e3fe3d2ec06c1c2772555bf1208d220aab5fee186d04bd265219b0bc7a978edc)
 
-PatchScript: perl -pi -e 's/(10\.\[012\])\*/\1\,.\*/' configure
-
-SetCPPFLAGS: -I%p/opt/hdf5.v1.10/include
+PatchScript: <<
+perl -pi -e 's/(10\.\[012\])\*/\1\,.\*/' configure
+#perl -pi -e 's|echo -n|/bin/echo -n|' configure
+sed -i '/^echo -n %v>VERSION/d' configure
+<<
+SetCPPFLAGS: -I%p/opt/hdf5.v1.12/include
 SetCFLAGS: -O2
-SetCXXFLAGS:-O2
-SetLDFLAGS: -L%p/opt/hdf5.v1.10/lib -lsz -lnetcdf -lhdf5 -Wl,-dead_strip_dylibs
+SetCXXFLAGS: -O2
+SetLDFLAGS: -L%p/opt/hdf5.v1.12/lib -lsz -lnetcdf -lhdf5 -Wl,-dead_strip_dylibs
 
 ConfigureParams: <<
   --enable-shared --disable-static \
@@ -64,14 +67,14 @@ InstallScript: <<
 <<
 SplitOff: <<
   Package: %N-shlibs
-  Depends: netcdf-c18-shlibs
+  Depends: netcdf-c19-shlibs
   Conflicts: netcdf-absoft-shlibs
   Replaces: <<
   		netcdf-absoft-shlibs, 
   		netcdf (<= 3.5.0-6), 
   		netcdf-absoft (<= 3.5.1-2)
   <<
-  Suggests: netcdf-bin (>= 4.7.4)
+  Suggests: netcdf-bin (>= 4.9.2)
   Files: <<
   	lib/libnetcdf_c++4.1.dylib 
   <<
@@ -110,7 +113,7 @@ DescPort: <<
 CXXFLAGS=-O2 is essential to avoid debugging mode flags (-g).
 <<
 DescUsage: <<
-When building by hand, make sure netcdf-c18 is installed.
+When building by hand, make sure netcdf-c19 is installed.
 <<
-Homepage: http://www.unidata.ucar.edu/software/netcdf/
+Homepage: https://www.unidata.ucar.edu/software/netcdf/
 License: OSI-Approved

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-fortran8.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-fortran8.info
@@ -1,16 +1,16 @@
 Info2: <<
 Package: netcdf-fortran8
-Version: 4.5.4
+Version: 4.6.1
 Revision: 1
 BuildDependsOnly: true
 Maintainer: None <fink-devel@lists.sourceforge.net>
 
-Type: gcc (11)
+Type: gcc (12)
 
 Depends: %n-shlibs (= %v-%r), gcc%type_pkg[gcc]-compiler
 BuildDepends: <<
-	netcdf-c18 (>= 4.7.4),
-	netcdf-bin (>= 4.7.4),
+	netcdf-c19 (>= 4.9.2),
+	netcdf-bin (>= 4.9.2),
 	libcurl4, 
 	szip,
 	flag-sort,
@@ -33,11 +33,15 @@ Replaces: <<
 	netcdf-fortran7
 <<
 
-SourceRename: netcdf-fortran-%v.tar.gz
-Source: https://github.com/Unidata/netcdf-fortran/archive/v%v.tar.gz
-Source-Checksum: SHA256(1a8613cb639e83e2df5a8e6c21fa48a0c64b053c244abddecec66cfcac03a48a)
+#SourceRename: netcdf-fortran-%v.tar.gz
+Source: https://downloads.unidata.ucar.edu/netcdf-fortran/%v/netcdf-fortran-%v.tar.gz
+Source-Checksum: SHA256(b50b0c72b8b16b140201a020936aa8aeda5c79cf265c55160986cd637807a37a)
 
-PatchScript: perl -pi -e 's/(10\.\[012\])\*/\1\,.\*/' configure
+PatchScript: <<
+	perl -pi -e 's/(10\.\[012\])\*/\1\,.\*/' configure
+	perl -pi -e "s|^FC_NOFLAGS=.*|FC_NOFLAGS=%p/lib/gcc%type_raw[gcc]/bin/gfortran|" configure
+	perl -pi -e 's/FC_VERSION="\$FC"/FC_VERSION="\$FC_NOFLAGS"/' configure
+<<
 
 SetCFLAGS: -O2
 SetLDFLAGS: -lsz -Wl,-dead_strip_dylibs
@@ -72,9 +76,9 @@ InstallScript: <<
 <<
 SplitOff: <<
 	Package: %N-shlibs
-	Depends: netcdf-c18-shlibs (>= 4.7.4), gcc%type_pkg[gcc]-shlibs
+	Depends: netcdf-c19-shlibs (>= 4.9.2), gcc%type_pkg[gcc]-shlibs
 	Files: lib/libnetcdff.*.dylib
-	Shlibs: %p/lib/libnetcdff.7.dylib 9.0.0 %n (>= 4.5.4-1)
+	Shlibs: %p/lib/libnetcdff.7.dylib 10.0.0 %n (>= 4.6.1-1)
 	DocFiles: COPYRIGHT README.md RELEASE_NOTES.md F03Interfaces_LICENSE
 	Description: Array-based data access, Fortran library
 <<
@@ -111,6 +115,6 @@ or packages built with an earlier gfortran because it picked up
 DescPort: <<
 FFLAGS=-O2 FCFLAGS=-O2 is essential to avoid debugging mode flags (-g).
 <<
-Homepage: http://www.unidata.ucar.edu/software/netcdf/
+Homepage: https://www.unidata.ucar.edu/software/netcdf/
 License: OSI-Approved
 <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/netcdf-fortran8.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/netcdf-fortran8.info
@@ -7,10 +7,14 @@ Maintainer: None <fink-devel@lists.sourceforge.net>
 
 Type: gcc (12)
 
-Depends: %n-shlibs (= %v-%r), gcc%type_pkg[gcc]-compiler
+Depends: <<
+	%n-shlibs (= %v-%r),
+	gcc%type_pkg[gcc]-compiler
+<<
 BuildDepends: <<
 	netcdf-c19 (>= 4.9.2),
 	netcdf-bin (>= 4.9.2),
+	doxygen,
 	libcurl4, 
 	szip,
 	flag-sort,
@@ -33,7 +37,6 @@ Replaces: <<
 	netcdf-fortran7
 <<
 
-#SourceRename: netcdf-fortran-%v.tar.gz
 Source: https://downloads.unidata.ucar.edu/netcdf-fortran/%v/netcdf-fortran-%v.tar.gz
 Source-Checksum: SHA256(b50b0c72b8b16b140201a020936aa8aeda5c79cf265c55160986cd637807a37a)
 
@@ -76,7 +79,11 @@ InstallScript: <<
 <<
 SplitOff: <<
 	Package: %N-shlibs
-	Depends: netcdf-c19-shlibs (>= 4.9.2), gcc%type_pkg[gcc]-shlibs
+	Depends: <<
+		netcdf-c19-shlibs (>= 4.9.2),
+		gcc%type_pkg[gcc]-shlibs,
+		szip-shlibs
+	<<
 	Files: lib/libnetcdff.*.dylib
 	Shlibs: %p/lib/libnetcdff.7.dylib 10.0.0 %n (>= 4.6.1-1)
 	DocFiles: COPYRIGHT README.md RELEASE_NOTES.md F03Interfaces_LICENSE


### PR DESCRIPTION
New upstream versions of NetCDF:

- NetCDF-C version 4.9.2 bumps library version to 19. Existing packages already have conflicts set up for netcdf-c19.
- NetCDF-Fortran8 version 4.6.1: use gcc 12, library compatibility version increased.
- NetCDF-CXX4: use new C library; having a file called "VERSION" conflicts with system headers, so we have to make sure that configure doesn't create this file (which doesn't appear to be used anyway)...
- NCO: new upstream version 5.1.8; use new NetCDF library
- ncview: use new NetCDF library

These have been built on MacOS 13.6 on x86_64 with "-m", and appear to work correctly.