### PR TITLE
Libharu new libversion

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/emboss-6.5.7.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/emboss-6.5.7.info
@@ -1,13 +1,13 @@
 Package: emboss
 Version: 6.5.7
-Revision: 109
+Revision: 110
 Depends: <<
 	%N-libajax6-shlibs (>= %v-%r),
 	%N-libnucleus6-shlibs (>= %v-%r),
 	dpkg-base-files,
 	expat1-shlibs,
 	gd3-shlibs,
-	libharu2.3.0-shlibs,
+	libharu2.4-shlibs,
 	libpcre1-shlibs,
 	libplplot18-5.15.0-shlibs,
 	libpng16-shlibs,
@@ -21,7 +21,7 @@ BuildDepends: <<
 	fink-package-precedence,
 	expat1,
 	gd3,
-	libharu2.3.0-dev,
+	libharu2.4-dev,
 	libpcre1,
 	libplplot18-5.15.0-dev,
 	libpng16,
@@ -105,7 +105,7 @@ SplitOff10: <<
 	Depends: <<
 		expat1-shlibs,
 		gd3-shlibs,
-		libharu2.3.0-shlibs,
+		libharu2.4-shlibs,
 		libpcre1-shlibs,
 		libplplot18-5.15.0-shlibs,
 		libpng16-shlibs,
@@ -151,7 +151,7 @@ SplitOff20: <<
 		%N-libajax6-shlibs (>= %v-%r),
 		expat1-shlibs,
 		gd3-shlibs,
-		libharu2.3.0-shlibs,
+		libharu2.4-shlibs,
 		libpcre1-shlibs,
 		libplplot18-5.15.0-shlibs,
 		libpng16-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/sci/emboss-6.6.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/emboss-6.6.0.info
@@ -1,14 +1,14 @@
 Info2: <<
 Package: emboss
 Version: 6.6.0
-Revision: 3
+Revision: 4
 Type: release (6.6.0)
 Depends: <<
 	%N%type_raw[release]-shlibs (>= %v-%r),
 	dpkg-base-files,
 	expat1-shlibs,
 	gd3-shlibs,
-	libharu2.3.0-shlibs,
+	libharu2.4-shlibs,
 	libpcre1-shlibs,
 	libplplot18-5.15.0-shlibs,
 	libpng16-shlibs,
@@ -22,7 +22,7 @@ BuildDepends: <<
 	fink-package-precedence,
 	expat1,
 	gd3,
-	libharu2.3.0-dev,
+	libharu2.4-dev,
 	libpcre1,
 	libplplot18-5.15.0-dev,
 	libpng16,
@@ -106,7 +106,7 @@ SplitOff: <<
 	Depends: <<
 		expat1-shlibs,
 		gd3-shlibs,
-		libharu2.3.0-shlibs,
+		libharu2.4-shlibs,
 		libpcre1-shlibs,
 		libplplot18-5.15.0-shlibs,
 		libpng16-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/sci/libplplot18-5.15.0-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/libplplot18-5.15.0-shlibs.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: libplplot18-5.15.0-shlibs
 Version: 5.15.0
-Revision: 3
+Revision: 4
 
 BuildDepends: <<
 	aquaterm-dev,
@@ -14,7 +14,7 @@ BuildDepends: <<
 	freetype219 (>= 2.10.4-1),
 	glib2-dev (>= 2.22.4-9),
 	lasi1-dev,
-	libharu2.3.0-dev,
+	libharu2.4-dev,
 	libtool2,
 	pango1-xft2-ft219-dev (>= 1.24.5-11),
 	pkgconfig,
@@ -30,7 +30,7 @@ Depends: <<
 	glib2-shlibs (>= 2.22.4-9),
 	lasi1-shlibs,
 	libcsiro1-5.15.0-shlibs (>= %v-%r),
-	libharu2.3.0-shlibs,
+	libharu2.4-shlibs,
 	libtool2-shlibs,
 	pango1-xft2-ft219-shlibs (>= 1.24.5-11),
 	qhull8.0-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/sci/saga-haru.patch
+++ b/10.9-libcxx/stable/main/finkinfo/sci/saga-haru.patch
@@ -1,0 +1,270 @@
+commit 212685a1d3eb78d3d2dc6b3d67371b5e981d1bdc
+Author: oconrad <olaf.conrad@uni-hamburg.de>
+Date:   Mon Aug 22 12:03:52 2022 +0200
+
+    docs_pdf, libHaru: fixes typo related changes in current libharu interface, relates to bug reported with "[saga-gis:bugs] #296 8.3.1 fails to compile in arch linux with doc_pdf.cpp.o"
+
+diff --git a/saga-gis/src/tools/docs/docs_pdf/MLB_Interface.cpp b/saga-gis/src/tools/docs/docs_pdf/MLB_Interface.cpp
+index 119dc7e18..352964029 100644
+--- a/saga-gis/src/tools/docs/docs_pdf/MLB_Interface.cpp
++++ b/saga-gis/src/tools/docs/docs_pdf/MLB_Interface.cpp
+@@ -1,6 +1,3 @@
+-/**********************************************************
+- * Version $Id: TLB_Interface.cpp 1921 2014-01-09 10:24:11Z oconrad $
+- *********************************************************/
+ 
+ ///////////////////////////////////////////////////////////
+ //                                                       //
+@@ -49,16 +46,9 @@
+ ///////////////////////////////////////////////////////////
+ 
+ //---------------------------------------------------------
++#include <saga_api/saga_api.h>
+ 
+-
+-///////////////////////////////////////////////////////////
+-//														 //
+-//           The Tool Link Library Interface             //
+-//														 //
+-///////////////////////////////////////////////////////////
+-
+-//---------------------------------------------------------
+-#include "MLB_Interface.h"
++#include <hpdf_version.h>
+ 
+ 
+ //---------------------------------------------------------
+@@ -66,23 +56,25 @@ CSG_String Get_Info(int i)
+ {
+ 	switch( i )
+ 	{
+-	case TLB_INFO_Name:	default:
++	case TLB_INFO_Name: default:
+ 		return( _TL("PDF") );
+ 
+ 	case TLB_INFO_Category:
+ 		return( _TL("Reports") );
+ 
+ 	case TLB_INFO_Author:
+-		return( SG_T("SAGA User Group (c) 2010") );
++		return( "SAGA User Group (c) 2010" );
+ 
+ 	case TLB_INFO_Description:
+ 		return( _TW(
+-			"Reports in Portable Document Format (PDF). PDF export is based on "
+-			"<a target=\"_blank\" href=\"libharu.org\">libharu</a>."
+-		));
++			"Create reports in the Portable Document Format (PDF). "
++			"The export tools are using the free open source library "
++			"<a target=\"_blank\" href=\"libharu.org\">libHaru</a> "
++			"version ") + CSG_String(HPDF_VERSION_TEXT)
++		);
+ 
+ 	case TLB_INFO_Version:
+-		return( SG_T("1.0") );
++		return( "1.0" );
+ 
+ 	case TLB_INFO_Menu_Path:
+ 		return( _TL("File|Reports") );
+@@ -101,9 +93,12 @@ CSG_Tool *		Create_Tool(int i)
+ {
+ 	switch( i )
+ 	{
+-	case  0:	return( new CShapes_Report );
+-	case  1:	return( new CShapes_Summary );
+-	case  2:	return( new CProfile_Cross_Sections );
++	case  0: return( new CShapes_Report );
++	case  1: return( new CShapes_Summary );
++	case  2: return( new CProfile_Cross_Sections );
++
++	case  3: return( NULL );
++	default: return( TLB_INTERFACE_SKIP_TOOL );
+ 	}
+ 
+ 	return( NULL );
+diff --git a/saga-gis/src/tools/docs/docs_pdf/Profile_Cross_Sections.h b/saga-gis/src/tools/docs/docs_pdf/Profile_Cross_Sections.h
+index 15f812679..a9e25882c 100644
+--- a/saga-gis/src/tools/docs/docs_pdf/Profile_Cross_Sections.h
++++ b/saga-gis/src/tools/docs/docs_pdf/Profile_Cross_Sections.h
+@@ -1,6 +1,3 @@
+-/**********************************************************
+- * Version $Id: Profile_Cross_Sections.h 911 2011-02-14 16:38:15Z reklov_w $
+- *********************************************************/
+ /*******************************************************************************
+     CrossSections.h
+     Copyright (C) Victor Olaya
+diff --git a/saga-gis/src/tools/docs/docs_pdf/Shapes_Report.h b/saga-gis/src/tools/docs/docs_pdf/Shapes_Report.h
+index fa349574d..2bab96d85 100644
+--- a/saga-gis/src/tools/docs/docs_pdf/Shapes_Report.h
++++ b/saga-gis/src/tools/docs/docs_pdf/Shapes_Report.h
+@@ -1,6 +1,3 @@
+-/**********************************************************
+- * Version $Id: Shapes_Report.h 1922 2014-01-09 10:28:46Z oconrad $
+- *********************************************************/
+ 
+ ///////////////////////////////////////////////////////////
+ //                                                       //
+@@ -51,6 +48,8 @@
+ ///////////////////////////////////////////////////////////
+ 
+ //---------------------------------------------------------
++#ifndef HEADER_INCLUDED__Shapes_Report_H
++#define HEADER_INCLUDED__Shapes_Report_H
+ 
+ 
+ ///////////////////////////////////////////////////////////
+@@ -60,11 +59,7 @@
+ ///////////////////////////////////////////////////////////
+ 
+ //---------------------------------------------------------
+-#ifndef HEADER_INCLUDED__Shapes_Report_H
+-#define HEADER_INCLUDED__Shapes_Report_H
+-
+-//---------------------------------------------------------
+-#include "MLB_Interface.h"
++#include <saga_api/saga_api.h>
+ 
+ 
+ ///////////////////////////////////////////////////////////
+@@ -94,7 +89,7 @@ private:
+ 
+ 	CSG_Rect				m_rTitle, m_rShape, m_rTable;
+ 
+-	CSG_Shapes					*m_pShapes;
++	CSG_Shapes				*m_pShapes;
+ 
+ 	class CSG_Doc_PDF		*m_pPDF;
+ 
+diff --git a/saga-gis/src/tools/docs/docs_pdf/Shapes_Summary.h b/saga-gis/src/tools/docs/docs_pdf/Shapes_Summary.h
+index f87441aeb..97610cbd3 100644
+--- a/saga-gis/src/tools/docs/docs_pdf/Shapes_Summary.h
++++ b/saga-gis/src/tools/docs/docs_pdf/Shapes_Summary.h
+@@ -1,6 +1,3 @@
+-/**********************************************************
+- * Version $Id: Shapes_Summary.h 911 2011-02-14 16:38:15Z reklov_w $
+- *********************************************************/
+ /*******************************************************************************
+     Summarize.h
+     Copyright (C) Victor Olaya
+@@ -89,6 +86,7 @@ private:
+ 
+ };
+ 
++
+ ///////////////////////////////////////////////////////////
+ //														 //
+ //														 //
+diff --git a/saga-gis/src/tools/docs/docs_pdf/doc_pdf.cpp b/saga-gis/src/tools/docs/docs_pdf/doc_pdf.cpp
+index f08f17bca..e5c5d538e 100644
+--- a/saga-gis/src/tools/docs/docs_pdf/doc_pdf.cpp
++++ b/saga-gis/src/tools/docs/docs_pdf/doc_pdf.cpp
+@@ -1,6 +1,3 @@
+-/**********************************************************
+- * Version $Id: doc_pdf.cpp 1921 2014-01-09 10:24:11Z oconrad $
+- *********************************************************/
+ 
+ ///////////////////////////////////////////////////////////
+ //                                                       //
+@@ -53,15 +50,6 @@
+ //                                                       //
+ ///////////////////////////////////////////////////////////
+ 
+-//---------------------------------------------------------
+-
+-
+-///////////////////////////////////////////////////////////
+-//														 //
+-//														 //
+-//														 //
+-///////////////////////////////////////////////////////////
+-
+ //---------------------------------------------------------
+ #ifndef _SAGA_DONOTUSE_HARU
+ 
+@@ -101,6 +89,11 @@
+ #define PDF_GET_G(c)			(float)(SG_GET_G(c) / 255.0)
+ #define PDF_GET_B(c)			(float)(SG_GET_B(c) / 255.0)
+ 
++//---------------------------------------------------------
++// libHaru version compatibility (fixed typos in hpdf_types.h)!
++#define HPDF_PROJECTING_SQUARE_END HPDF_PROJECTING_SCUARE_END // SCUARE -> SQUARE
++#define HPDF_BYTE_TYPE_TRAIL       HPDF_BYTE_TYPE_TRIAL       // TRIAL  -> TRAIL
++
+ 
+ ///////////////////////////////////////////////////////////
+ //														 //
+diff --git a/saga-gis/src/tools/docs/docs_pdf/doc_pdf.h b/saga-gis/src/tools/docs/docs_pdf/doc_pdf.h
+index 57d6a79ae..b4d4c04ed 100644
+--- a/saga-gis/src/tools/docs/docs_pdf/doc_pdf.h
++++ b/saga-gis/src/tools/docs/docs_pdf/doc_pdf.h
+@@ -1,6 +1,3 @@
+-/**********************************************************
+- * Version $Id: doc_pdf.h 1921 2014-01-09 10:24:11Z oconrad $
+- *********************************************************/
+ 
+ ///////////////////////////////////////////////////////////
+ //                                                       //
+@@ -53,15 +50,6 @@
+ //                                                       //
+ ///////////////////////////////////////////////////////////
+ 
+-//---------------------------------------------------------
+-
+-
+-///////////////////////////////////////////////////////////
+-//														 //
+-//														 //
+-//														 //
+-///////////////////////////////////////////////////////////
+-
+ //---------------------------------------------------------
+ #ifndef HEADER_INCLUDED__doc_pdf_H
+ #define HEADER_INCLUDED__doc_pdf_H
+@@ -74,7 +62,7 @@
+ ///////////////////////////////////////////////////////////
+ 
+ //---------------------------------------------------------
+-#include "MLB_Interface.h"
++#include <saga_api/saga_api.h>
+ 
+ 
+ ///////////////////////////////////////////////////////////
+@@ -178,7 +166,7 @@ TSG_PDF_Title_Level;
+ ///////////////////////////////////////////////////////////
+ 
+ //---------------------------------------------------------
+-class docs_pdf_EXPORT CSG_Doc_PDF
++class CSG_Doc_PDF
+ {
+ public:
+ 	CSG_Doc_PDF(void);
+commit c1decfde9c9dcaec7304642552ec1494dfec66d2
+Author: oconrad <olaf.conrad@uni-hamburg.de>
+Date:   Mon Aug 22 12:14:33 2022 +0200
+
+    docs_pdf, libHaru: fixes typo related changes in current libharu interface, relates to bug reported with "[saga-gis:bugs] #296 8.3.1 fails to compile in arch linux with doc_pdf.cpp.o"
+
+diff --git a/saga-gis/src/tools/docs/docs_pdf/doc_pdf.cpp b/saga-gis/src/tools/docs/docs_pdf/doc_pdf.cpp
+index e5c5d538e..ff8ff955f 100644
+--- a/saga-gis/src/tools/docs/docs_pdf/doc_pdf.cpp
++++ b/saga-gis/src/tools/docs/docs_pdf/doc_pdf.cpp
+@@ -91,8 +91,10 @@
+ 
+ //---------------------------------------------------------
+ // libHaru version compatibility (fixed typos in hpdf_types.h)!
++#if HPDF_MAJOR_VERSION == 2 && HPDF_MINOR_VERSION < 4
+ #define HPDF_PROJECTING_SQUARE_END HPDF_PROJECTING_SCUARE_END // SCUARE -> SQUARE
+ #define HPDF_BYTE_TYPE_TRAIL       HPDF_BYTE_TYPE_TRIAL       // TRIAL  -> TRAIL
++#endif
+ 
+ 
+ ///////////////////////////////////////////////////////////
+@@ -699,7 +701,7 @@ bool CSG_Doc_PDF::_Set_Style_FillStroke(int Style, int Fill_Color, int Line_Colo
+ 			}
+ 			else if( Style & PDF_STYLE_LINE_END_SQUARE )
+ 			{
+-				HPDF_Page_SetLineCap(m_pPage, HPDF_PROJECTING_SCUARE_END);
++				HPDF_Page_SetLineCap(m_pPage, HPDF_PROJECTING_SQUARE_END);
+ 			}
+ 			else // if( Style & PDF_STYLE_LINE_END_BUTT )
+ 			{

--- a/10.9-libcxx/stable/main/finkinfo/sci/saga.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/saga.info
@@ -1,12 +1,12 @@
 Info2: <<
 
-# FTBGS with opencv2.4 and above. Possible fix:
+# FTBFS with opencv2.4 and above. Possible fix:
 #   https://github.com/saga-gis/saga-gis/commit/8b89b6eb6d8413e510c0bb87b68b79ad526ccbcb
 # so newer upstream releases should have it.
 # FTBFS with libproj19 (newer upstream saga releases might work)
 Package: saga
 Version: 4.0.1
-Revision: 5
+Revision: 6
 Description: System for Automated Geoscientific Analyses
 DescDetail: <<
   
@@ -16,7 +16,7 @@ Homepage: http://www.saga-gis.org
 Maintainer: BABA Yoshihiko <babayoshihiko@mac.com>
 Depends: <<
     %n-shlibs (>= %v-%r),
-    libharu2.3.0-shlibs,
+    libharu2.4-shlibs,
     wxwidgets320-osxcocoa-shlibs
 <<
 BuildDepends: << 
@@ -26,7 +26,7 @@ BuildDepends: <<
     fink-package-precedence,
     gdal3-dev,
     libjasper.1,
-    libharu2.3.0-dev,
+    libharu2.4-dev,
     libodbc3-dev,
     libproj9,
     libtool2 (>= 2.4.2-4),
@@ -45,6 +45,15 @@ Source2: http://web.fastermac.net/~MacPgmr/SAGA/create_saga_app.sh
 Source2-Checksum: SHA256(e80472456d92cd95a60ebc8d2226551862c765435edb286c7ab3c1e8cf7f8014)
 Source3: http://web.fastermac.net/~MacPgmr/SAGA/saga_gui.icns
 Source3-Checksum: SHA256(a0c28212d090b58b634218dfb3e5a1e6e5ae228c9d2270b7f8a66459d53842f2)
+
+# Fixes for newer libharu from upstream github:
+#   212685a1d3eb78d3d2dc6b3d67371b5e981d1bdc
+#   c1decfde9c9dcaec7304642552ec1494dfec66d2
+PatchFile: %n-haru.patch
+PatchFile-MD5: 99ce4d9e26172a5a740681069540a294
+PatchScript: <<
+	patch -p2 < %{PatchFile}
+<<
 
 # Compile Phase.
 SetCXXFLAGS: -I%p/include/wx-3.2 -std=c++11
@@ -74,7 +83,7 @@ SplitOff: <<
   Description: Shared libraries for SAGA
   Depends: <<
     gdal3-shlibs,
-    libharu2.3.0-shlibs,
+    libharu2.4-shlibs,
     libodbc3-shlibs,
     libproj9-shlibs,
     opencv3.2-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/text/libharu2.2.1-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/libharu2.2.1-shlibs.info
@@ -1,6 +1,6 @@
 Package: libharu2.2.1-shlibs
 Version: 2.2.1
-Revision: 6
+Revision: 7
 Description: PDF generation library
 License: BSD
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
@@ -11,8 +11,14 @@ BuildDepends: <<
 	fink-package-precedence,
 	libpng16
 <<
-Conflicts: libhpdf2.2.1-shlibs
-Replaces: libhpdf2.2.1-shlibs
+Conflicts: <<
+	libhpdf2.2.1-shlibs, libhpdf2.2.1,
+	libharu2.2.1-dev (<< 2.2.1-7)
+<<
+Replaces: <<
+	libhpdf2.2.1-shlibs, libhpdf2.2.1,
+	libharu2.2.1-dev (<< 2.2.1-7)
+<<
 Source: http://libharu.org/files/libharu-%v.tar.gz
 Source-Checksum: SHA256(45fd57044042c0e290ad0f11fc19eeb31b50c4b9edadf9d89dd5a7d9ae4865a7)
 ### fix for libpng15
@@ -39,30 +45,14 @@ CompileScript: <<
 	%{default_script}
 	fink-package-precedence --prohibit-bdep=libharu2.2.1-dev .
 <<
-InstallScript: make install DESTDIR=%d
+InstallScript: <<
+	make install DESTDIR=%d
+	rm -r %i/include
+	rm %i/lib/libhpdf.{dylib,la}
+<<
 DocFiles: README
 Shlibs: <<
 	%p/lib/libhpdf-2.2.1.dylib 0.0.0 %n (>= 2.2.1-1)
-<<
-SplitOff: <<
-	Package: libharu2.2.1-dev
-	Description: PDF generation library (dev pkg)
-	Files: include lib/libhpdf.dylib lib/libhpdf.la
-	Depends: %N (= %v-%r)
-	BuildDependsOnly: true
-	Conflicts: <<
-		libhpdf2.2.1,
-		libharu2.2.1-dev,
-		libharu2.3.0-dev,
-		libharu2.4-dev
-	<<
-	Replaces: <<
-		libhpdf2.2.1,
-		libharu2.2.1-dev,
-		libharu2.3.0-dev,
-		libharu2.4-dev
-	<<
-	DocFiles: README
 <<
 Homepage: http://libharu.org/
 DescDetail: <<

--- a/10.9-libcxx/stable/main/finkinfo/text/libharu2.2.1-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/libharu2.2.1-shlibs.info
@@ -1,6 +1,6 @@
 Package: libharu2.2.1-shlibs
 Version: 2.2.1
-Revision: 5
+Revision: 6
 Description: PDF generation library
 License: BSD
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
@@ -17,7 +17,7 @@ Source: http://libharu.org/files/libharu-%v.tar.gz
 Source-Checksum: SHA256(45fd57044042c0e290ad0f11fc19eeb31b50c4b9edadf9d89dd5a7d9ae4865a7)
 ### fix for libpng15
 ### http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/media-libs/libharu/files/libharu-2.2.1-libpng-1.5.patch?revision=1.1
-### Fixed in 2.2.1+
+### Fixed after 2.2.1
 PatchFile: %n.patch
 PatchFile-MD5: cd55bb18b107f3a790191601a64cbd53
 PatchScript: <<
@@ -40,7 +40,7 @@ CompileScript: <<
 	fink-package-precedence --prohibit-bdep=libharu2.2.1-dev .
 <<
 InstallScript: make install DESTDIR=%d
-DocFiles: INSTALL README
+DocFiles: README
 Shlibs: <<
 	%p/lib/libhpdf-2.2.1.dylib 0.0.0 %n (>= 2.2.1-1)
 <<
@@ -50,8 +50,19 @@ SplitOff: <<
 	Files: include lib/libhpdf.dylib lib/libhpdf.la
 	Depends: %N (= %v-%r)
 	BuildDependsOnly: true
-	Conflicts: libhpdf2.2.1, libharu2.2.1-dev, libharu2.3.0-dev
-	Replaces: libhpdf2.2.1, libharu2.2.1-dev, libharu2.3.0-dev
+	Conflicts: <<
+		libhpdf2.2.1,
+		libharu2.2.1-dev,
+		libharu2.3.0-dev,
+		libharu2.4-dev
+	<<
+	Replaces: <<
+		libhpdf2.2.1,
+		libharu2.2.1-dev,
+		libharu2.3.0-dev,
+		libharu2.4-dev
+	<<
+	DocFiles: README
 <<
 Homepage: http://libharu.org/
 DescDetail: <<

--- a/10.9-libcxx/stable/main/finkinfo/text/libharu2.2.1-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/libharu2.2.1-shlibs.info
@@ -1,4 +1,5 @@
 Package: libharu2.2.1-shlibs
+# shlibs-only stub of older libversion
 Version: 2.2.1
 Revision: 7
 Description: PDF generation library

--- a/10.9-libcxx/stable/main/finkinfo/text/libharu2.3.0-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/libharu2.3.0-shlibs.info
@@ -1,4 +1,5 @@
 Package: libharu2.3.0-shlibs
+# shlibs-only stub of older libversion
 Version: 2.3.0
 Revision: 3
 Description: PDF generation library

--- a/10.9-libcxx/stable/main/finkinfo/text/libharu2.3.0-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/libharu2.3.0-shlibs.info
@@ -1,6 +1,6 @@
 Package: libharu2.3.0-shlibs
 Version: 2.3.0
-Revision: 2
+Revision: 3
 Description: PDF generation library
 License: BSD
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
@@ -12,6 +12,12 @@ BuildDepends: <<
 	automake1.15,
 	fink-package-precedence,
 	libpng16
+<<
+Conflicts: <<
+	libharu2.3.0-dev (<< 2.3.0-3)
+<<
+Replaces: <<
+	libharu2.3.0-dev (<< 2.3.0-3)
 <<
 Source: https://github.com/libharu/libharu/archive/refs/tags/RELEASE_2_3_0.tar.gz
 Source-Checksum: SHA256(8f9e68cc5d5f7d53d1bc61a1ed876add1faf4f91070dbc360d8b259f46d9a4d2)
@@ -39,30 +45,14 @@ CompileScript: <<
 	%{default_script}
 	fink-package-precedence --prohibit-bdep=libharu2.3.0-dev .
 <<
-InstallScript: make install DESTDIR=%d
+InstallScript: <<
+	make install DESTDIR=%d
+	rm -r %i/include
+	rm %i/lib/libhpdf.{dylib,la}
+<<
 DocFiles: CHANGES README
 Shlibs: <<
 	%p/lib/libhpdf-2.3.0.dylib 0.0.0 %n (>= 2.3.0-1)
-<<
-SplitOff: <<
-	Package: libharu2.3.0-dev
-	Description: PDF generation library (dev pkg)
-	Files: include lib/libhpdf.dylib lib/libhpdf.la
-	Depends: %N (= %v-%r)
-	BuildDependsOnly: true
-	Conflicts: <<
-		libhpdf2.2.1,
-		libharu2.2.1-dev,
-		libharu2.3.0-dev,
-		libharu2.4-dev
-	<<
-	Replaces: <<
-		libhpdf2.2.1,
-		libharu2.2.1-dev,
-		libharu2.3.0-dev,
-		libharu2.4-dev
-	<<
-	DocFiles: CHANGES README
 <<
 Homepage: http://libharu.org/
 DescDetail: <<

--- a/10.9-libcxx/stable/main/finkinfo/text/libharu2.4-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/libharu2.4-shlibs.info
@@ -1,6 +1,6 @@
-Package: libharu2.3.0-shlibs
-Version: 2.3.0
-Revision: 2
+Package: libharu2.4-shlibs
+Version: 2.4.4
+Revision: 1
 Description: PDF generation library
 License: BSD
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
@@ -8,46 +8,43 @@ Depends: <<
 	libpng16-shlibs
 <<
 BuildDepends: <<
-	autoconf2.6,
-	automake1.15,
+	cmake,
+	fink-buildenv-modules,
 	fink-package-precedence,
 	libpng16
 <<
-Source: https://github.com/libharu/libharu/archive/refs/tags/RELEASE_2_3_0.tar.gz
-Source-Checksum: SHA256(8f9e68cc5d5f7d53d1bc61a1ed876add1faf4f91070dbc360d8b259f46d9a4d2)
+Source: https://github.com/libharu/libharu/archive/refs/tags/v%v.tar.gz
+Source-Checksum: SHA256(227ab0ae62979ad65c27a9bc36d85aa77794db3375a0a30af18acdf4d871aee6)
 SourceRename: libharu-%v.tar.gz
-SourceDirectory: libharu-RELEASE_2_3_0
+# scrap the bindings sets, inertially from previous packages
 PatchFile: %n.patch
-PatchFile-MD5: 554f094e02d594b5f9038db5e243cd7e
-PatchScript: <<
-	mv configure.in configure.ac
-	autoreconf -vfi
-	%{default_script}
-<<
-UseMaxBuildJobs: false
-ConfigureParams: <<
-	--disable-static \
-	--enable-dependency-tracking \
-	--with-png=%p \
-	--with-zlib=${SDK_PATH}/usr
-<<
+PatchFile-MD5: 562a10a40a0b5b4aaf4139419f6ea185
 CompileScript: <<
-	#!/bin/sh -ev
-	if [ "$(uname -r | cut -d. -f1)" -ge 18 ]; then
-		SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
-	fi
-	%{default_script}
-	fink-package-precedence --prohibit-bdep=libharu2.3.0-dev .
+#!/bin/sh -ev
+	. %p/sbin/fink-buildenv-cmake.sh
+	mkdir finkbuild
+	pushd finkbuild
+		cmake \
+			$FINK_CMAKE_ARGS \
+			-DCMAKE_C_FLAGS=-MD \
+		..
+		make -w
+	popd
+	fink-package-precedence --depfile-ext='\.d' --prohibit-bdep=libharu2.4-dev .
 <<
-InstallScript: make install DESTDIR=%d
-DocFiles: CHANGES README
+InstallScript: <<
+#!/bin/sh -ev
+	pushd finkbuild
+		make install DESTDIR=%d
+<<
+DocFiles: CHANGES README.md
 Shlibs: <<
-	%p/lib/libhpdf-2.3.0.dylib 0.0.0 %n (>= 2.3.0-1)
+	%p/lib/libhpdf.2.4.dylib 2.4.0 %n (>= 2.4.4-1)
 <<
 SplitOff: <<
-	Package: libharu2.3.0-dev
+	Package: libharu2.4-dev
 	Description: PDF generation library (dev pkg)
-	Files: include lib/libhpdf.dylib lib/libhpdf.la
+	Files: include lib/libhpdf.dylib
 	Depends: %N (= %v-%r)
 	BuildDependsOnly: true
 	Conflicts: <<
@@ -62,7 +59,7 @@ SplitOff: <<
 		libharu2.3.0-dev,
 		libharu2.4-dev
 	<<
-	DocFiles: CHANGES README
+	DocFiles: CHANGES README.md
 <<
 Homepage: http://libharu.org/
 DescDetail: <<

--- a/10.9-libcxx/stable/main/finkinfo/text/libharu2.4-shlibs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/text/libharu2.4-shlibs.patch
@@ -1,0 +1,12 @@
+diff -Nurd libharu-2.4.4.orig/CMakeLists.txt libharu-2.4.4/CMakeLists.txt
+--- libharu-2.4.4.orig/CMakeLists.txt	2023-09-18 15:47:01.000000000 -0400
++++ libharu-2.4.4/CMakeLists.txt	2023-11-20 17:41:46.000000000 -0500
+@@ -140,8 +140,6 @@
+ install(FILES ${haru_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ 
+ # install various files
+-install(FILES README.md CHANGES INSTALL DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/libharu)
+-install(DIRECTORY bindings DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/libharu)
+ 
+ # =======================================================================
+ # print out some information


### PR DESCRIPTION
Update to latest upstream, migrate all reverse-depends  to the latest libversion, and convert older now-unused older libversions to -shlibs-only stubs.