### PR TITLE
Pytest 7

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/argcomplete-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/argcomplete-py.info
@@ -1,0 +1,71 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+Package: argcomplete-py%type_pkg[python]
+Version: 3.2.2
+Revision: 1
+Description: Bash tab completion for argparse
+License: BSD
+Maintainer: None <fink-devel@lists.sourceforge.net>
+Type: python (3.8 3.9 3.10)
+
+Source: https://files.pythonhosted.org/packages/source/a/argcomplete/argcomplete-%v.tar.gz
+Source-Checksum: SHA256(f3e49e8ea59b4026ee29548e24488af46e30c9de57d48638e24f54a1ea1000a2)
+
+Depends: <<
+	python%type_pkg[python],
+	typing-extensions-py%type_pkg[python] (>= 3.6.4),
+	zipp-py%type_pkg[python] (>= 0.5.0-1)
+<<
+BuildDepends: <<
+	setuptools-tng-py%type_pkg[python] (>= 56),
+	setuptools-scm-py%type_pkg[python]
+<<
+
+CompileScript: <<
+	%p/bin/python%type_raw[python] setup.py build
+<<
+
+# tests are all wonky
+#InfoTest: <<
+#	TestDepends: <<
+#		pexpect-py%type_pkg[python]
+#	<<
+#	TestScript: <<
+#		#!/bin/sh -ev
+#		# https://build.opensuse.org/package/view_file/openSUSE:Factory/python-argcomplete/python-argcomplete.spec?expand=1
+#		export LANG=en_US.UTF-8
+#		export TERM=xterm-mono
+#		perl -pi -e 's|coverage |%p/bin/coverage%type_raw[python] |g' Makefile
+#		sed -i -e "1s|#!.*python.*|#!%p/bin/python%type_raw[python]|" test/prog test/*.py scripts/*
+#		sed -i -e "s|python3 |%p/bin/python%type_raw[python] |g" test/test.py
+#		make test || exit 2
+#		PYTHONPATH=%b/build/lib %p/bin/coverage%type_raw[python] run --source=argcomplete --omit=argcomplete/packages/_shlex.py ./test/test.py -v || exit 2
+#	<<
+#<<
+
+InstallScript: <<
+	#!/bin/sh -ev
+	%p/bin/python%type_raw[python] setup.py install --root=%d
+	for i in register-python-argcomplete python-argcomplete-check-easy-install-script activate-global-python-argcomplete ; do
+		mv %i/bin/$i %i/bin/$i-py%type_raw[python]
+	done
+<<
+# We don't want to unversion the binaries, so skip P*InstScript and u-a
+Homepage: https://github.com/kislyuk/argcomplete
+DocFiles: LICENSE.rst README.rst
+DescDetail: <<
+Bash/zsh tab completion for argparse
+Argcomplete provides easy, extensible command line tab completion of
+arguments for your Python application.
+
+It makes two assumptions:
+* You're using bash or zsh as your shell
+* You're using argparse to manage your command line arguments/options
+
+Argcomplete is particularly useful if your program has lots of options
+or subparsers, and if your program can dynamically suggest completions
+for your argument/option values (for example, if the user is browsing
+resources over the network).
+<<
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pytest-cov-py-2.6.1.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pytest-cov-py-2.6.1.info
@@ -1,22 +1,51 @@
 Info2: <<
 Package: pytest-cov-py%type_pkg[python]
-Version: 4.1.0
+Version: 2.6.1
 Revision: 1
+Distribution: <<
+	(%type_pkg[python] = 34 ) 10.9,
+	(%type_pkg[python] = 34 ) 10.10,
+	(%type_pkg[python] = 34 ) 10.11,
+	(%type_pkg[python] = 34 ) 10.12,
+	(%type_pkg[python] = 34 ) 10.13,
+	(%type_pkg[python] = 34 ) 10.14,
+	(%type_pkg[python] = 34 ) 10.14.5,
+	(%type_pkg[python] = 34 ) 10.15,
+	(%type_pkg[python] = 35 ) 10.9,
+	(%type_pkg[python] = 35 ) 10.10,
+	(%type_pkg[python] = 35 ) 10.11,
+	(%type_pkg[python] = 35 ) 10.12,
+	(%type_pkg[python] = 35 ) 10.13,
+	(%type_pkg[python] = 35 ) 10.14,
+	(%type_pkg[python] = 35 ) 10.14.5,
+	(%type_pkg[python] = 35 ) 10.15,
+	(%type_pkg[python] = 36 ) 10.9,
+	(%type_pkg[python] = 36 ) 10.10,
+	(%type_pkg[python] = 36 ) 10.11,
+	(%type_pkg[python] = 36 ) 10.12,
+	(%type_pkg[python] = 36 ) 10.13,
+	(%type_pkg[python] = 36 ) 10.14,
+	(%type_pkg[python] = 36 ) 10.14.5,
+	(%type_pkg[python] = 36 ) 10.15
+<<
 Description: Coverage plugin for pytest
 License: BSD
 # Free to update and take over
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
-Type: python (3.7 3.8 3.9 3.10)
+Type: python (2.7 3.4 3.5 3.6)
 Depends: <<
 	python%type_pkg[python],
-	coverage-py%type_pkg[python] (>= 5.2.1),
-	pytest-py%type_pkg[python] (>= 4.6)
+	coverage-py%type_pkg[python] (>= 4.4),
+	pytest-py%type_pkg[python] (>= 2.9)
 <<
 BuildDepends: <<
 	setuptools-tng-py%type_pkg[python]
 <<
 Source: https://files.pythonhosted.org/packages/source/p/pytest-cov/pytest-cov-%v.tar.gz
-Source-Checksum: SHA256(3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6)
+Source-Checksum: SHA256(0ab664b25c6aa9716cbf203b17ddb301932383046082c081b9848a0edf5add33)
+PatchScript: <<
+	perl -pi -e 's|\[pytest|\[tool:pytest|g' setup.cfg
+<<
 CompileScript: <<
 	%p/bin/python%type_raw[python] setup.py build
 <<
@@ -25,10 +54,9 @@ CompileScript: <<
 # pytest-cov-2.8.1 needs pytest-xdist as well
 #InfoTest: <<
 #	TestDepends: <<
-#		coverage-py%type_pkg[python] (>= 5.2.1),
+#		coverage-py%type_pkg[python] (>= 4.4),
 #		fields-py%type_pkg[python],
-#		pytest-py%type_pkg[python] (>= 4.6),
-#		pytest-xdist-py%type_pkg[python],
+#		pytest-py%type_pkg[python] (>= 2.9),
 #		process-tests-py%type_pkg[python] (>= 2.0.2),
 #		six-py%type_pkg[python],
 #		virtualenv-py%type_pkg[python]

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pytest-cov-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pytest-cov-py.info
@@ -27,9 +27,10 @@ CompileScript: <<
 #	TestDepends: <<
 #		coverage-py%type_pkg[python] (>= 5.2.1),
 #		fields-py%type_pkg[python],
+#		hunter-py%type_pkg[python],
+#		process-tests-py%type_pkg[python] (>= 2.0.2),
 #		pytest-py%type_pkg[python] (>= 4.6),
 #		pytest-xdist-py%type_pkg[python],
-#		process-tests-py%type_pkg[python] (>= 2.0.2),
 #		six-py%type_pkg[python],
 #		virtualenv-py%type_pkg[python]
 #	<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pytest-py-6.2.5.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pytest-py-6.2.5.info
@@ -1,0 +1,120 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info4: <<
+Package: pytest-py%type_pkg[python]
+Version: 6.2.5
+Revision: 3
+Distribution: <<
+	(%type_pkg[python] = 36 ) 10.9,
+	(%type_pkg[python] = 36 ) 10.10,
+	(%type_pkg[python] = 36 ) 10.11,
+	(%type_pkg[python] = 36 ) 10.12,
+	(%type_pkg[python] = 36 ) 10.13,
+	(%type_pkg[python] = 36 ) 10.14,
+	(%type_pkg[python] = 36 ) 10.14.5,
+	(%type_pkg[python] = 36 ) 10.15
+<<
+Type: python (3.6)
+
+Description: Cross-project testing tool for Python
+DescDetail: <<
+	py.test is a command line tool to collect, run and report about
+	automated tests. It runs well on Linux, Windows and OSX and on many
+	versions of Python. It is used in many projects, ranging from
+	running 10 thousands of tests to a few inlined tests on a command line
+	script. You can also generate a no-dependency
+	py.test-equivalent standalone script that you can distribute along with
+	your application.
+<<
+Maintainer: Daniel Johnson <daniel@daniel-johnson.org>
+License: BSD
+Homepage: http://pytest.org/
+
+Source: https://files.pythonhosted.org/packages/source/p/pytest/pytest-%v.tar.gz
+Source-Checksum: SHA256(131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89)
+
+Depends: <<
+	attrs-py%type_pkg[python] (>= 19.2.0-1),
+	(%type_pkg[python] = 36) importlib-metadata-py%type_pkg[python],
+	(%type_pkg[python] = 37) importlib-metadata-py%type_pkg[python],
+	iniconfig-py%type_pkg[python],
+	packaging-py%type_pkg[python],
+	pluggy-py%type_pkg[python] (>= 0.12.0-1),
+	py-py%type_pkg[python] (>= 1.8.2-1),
+	python%type_pkg[python],
+	toml-py%type_pkg[python],
+	wcwidth-py%type_pkg[python]
+<<
+BuildDepends: <<
+	fink (>= 0.32),
+	setuptools-tng-py%type_pkg[python],
+	setuptools-scm-py%type_pkg[python]
+<<
+# need to avoid circular dep (pyexpect-pyXX:TestDepends:pytest-pyXX)
+Recommends: <<
+	pexpect-py%type_pkg[python]
+<<
+
+DescPackaging: <<
+	Needs tox to run tests and tox needs pytest. Unfortunately, tox tries
+	to download and install packages during tests which violates fink policy.
+<<
+
+PatchScript: <<
+	# Not hardcoding tox.ini to use the installed binary here - tox relies on using
+	# the sandboxed copy (in %b/.tox/py%type_pkg[python]/bin) from this build.
+	#perl -pi.bak -e 's|(pytest)( -[-nr][38adl])|%p/bin/${1}-%type_raw[python]${2}|g;' tox.ini
+	#perl -pi -e 's|(sphinx-build)( -)|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
+	#perl -pi -e 's|(coverage)( -r[eu])|%p/bin/${1}-%type_raw[python]${2}|g;' tox.ini
+<<	
+
+CompileScript: %p/bin/python%type_raw[python] setup.py build
+
+# tox will download and pip-install a gazillion of extra deps, even those already installed as packages.
+# I give up running tests. Requires net access to download multiple packages
+# which is against fink policy.
+#InfoTest: <<
+#	#TestDepends: yaml-py%type_pkg[python]
+#	TestDepends: coverage-py%type_pkg[python], hypothesis-py%type_pkg[python] (>= 3.56.0-1), nose-py%type_pkg[python], mock-py%type_pkg[python], requests-py%type_pkg[python]
+#	TestScript: <<
+#		#!/bin/bash -ev
+#		#mkdir -p build/bin
+#		#python%type_raw[python] setup.py install_scripts -d build/bin
+#		#python%type_raw[python] setup.py egg_info
+#		pushd bench
+#		PYTHONPATH=%b/build/lib python%type_raw[python] bench.py
+#		popd
+#		if [ -x %p/bin/tox-py%type_pkg[python] ]; then
+#			%p/bin/tox-py%type_pkg[python] -e py%type_pkg[python] || exit 2
+#		else
+#			echo "tox-py%type_pkg[python] is not installed. Skipping tests."
+#		fi
+#	<<
+#<<
+
+InstallScript: <<
+	# Clean up the droppings from tests
+	/usr/bin/find . -name '*.py[co]' -delete
+
+	%p/bin/python%type_raw[python] setup.py install --root=%d
+	mv %i/bin/py.test %i/bin/py.test-%type_raw[python]
+	mv %i/bin/pytest %i/bin/pytest-%type_raw[python]
+<<
+
+PostInstScript: <<
+	update-alternatives --install %p/bin/py.test py.test %p/bin/py.test-%type_raw[python] %type_pkg[python] --slave %p/bin/pytest pytest %p/bin/pytest-%type_raw[python]
+#	echo ''
+#	echo 'If you have just built and installed the pytest dependencies'
+#	echo 'atomicwrites-py%type_pkg[python], invoke-py%type_pkg[python], py-py%type_pkg[python], setuptools-scm-py%type_pkg[python]'
+#	echo 'for the first time, they will have been built with their tests disabled.'
+#	echo 'You may now test their builds using the `fink -m rebuild` command.'
+<<
+
+PreRmScript: <<
+	if [ $1 != "upgrade" ]; then
+		update-alternatives --remove py.test %p/bin/py.test-%type_raw[python]
+	fi
+<<
+
+DocFiles: AUTHORS CHANGELOG* CONTRIBUTING* LICENSE README* doc
+# Info4
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pytest-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pytest-py.info
@@ -1,19 +1,9 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info4: <<
 Package: pytest-py%type_pkg[python]
-Version: 6.2.5
-Revision: 3
-Distribution: <<
-	(%type_pkg[python] = 36 ) 10.9,
-	(%type_pkg[python] = 36 ) 10.10,
-	(%type_pkg[python] = 36 ) 10.11,
-	(%type_pkg[python] = 36 ) 10.12,
-	(%type_pkg[python] = 36 ) 10.13,
-	(%type_pkg[python] = 36 ) 10.14,
-	(%type_pkg[python] = 36 ) 10.14.5,
-	(%type_pkg[python] = 36 ) 10.15
-<<
-Type: python (3.6 3.7 3.8 3.9 3.10)
+Version: 7.4.4
+Revision: 1
+Type: python (3.7 3.8 3.9 3.10)
 
 Description: Cross-project testing tool for Python
 DescDetail: <<
@@ -30,21 +20,22 @@ License: BSD
 Homepage: http://pytest.org/
 
 Source: https://files.pythonhosted.org/packages/source/p/pytest/pytest-%v.tar.gz
-Source-Checksum: SHA256(131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89)
+Source-Checksum: SHA256(2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280)
 
 Depends: <<
 	attrs-py%type_pkg[python] (>= 19.2.0-1),
-	(%type_pkg[python] = 36) importlib-metadata-py%type_pkg[python],
+	exceptiongroup-py%type_pkg[python],
 	(%type_pkg[python] = 37) importlib-metadata-py%type_pkg[python],
 	iniconfig-py%type_pkg[python],
 	packaging-py%type_pkg[python],
 	pluggy-py%type_pkg[python] (>= 0.12.0-1),
 	py-py%type_pkg[python] (>= 1.8.2-1),
 	python%type_pkg[python],
-	toml-py%type_pkg[python],
+	tomli-py%type_pkg[python] (>= 1.0.0),
 	wcwidth-py%type_pkg[python]
 <<
 BuildDepends: <<
+	bootstrap-modules-py%type_pkg[python],
 	fink (>= 0.32),
 	setuptools-tng-py%type_pkg[python],
 	setuptools-scm-py%type_pkg[python]
@@ -67,35 +58,47 @@ PatchScript: <<
 	#perl -pi -e 's|(coverage)( -r[eu])|%p/bin/${1}-%type_raw[python]${2}|g;' tox.ini
 <<	
 
-CompileScript: %p/bin/python%type_raw[python] setup.py build
+CompileScript: <<
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m build --wheel --no-isolation --skip-dependency-check
+<<
 
-# tox will download and pip-install a gazillion of extra deps, even those already installed as packages.
-# I give up running tests. Requires net access to download multiple packages
-# which is against fink policy.
-#InfoTest: <<
-#	#TestDepends: yaml-py%type_pkg[python]
-#	TestDepends: coverage-py%type_pkg[python], hypothesis-py%type_pkg[python] (>= 3.56.0-1), nose-py%type_pkg[python], mock-py%type_pkg[python], requests-py%type_pkg[python]
-#	TestScript: <<
-#		#!/bin/bash -ev
-#		#mkdir -p build/bin
-#		#python%type_raw[python] setup.py install_scripts -d build/bin
-#		#python%type_raw[python] setup.py egg_info
-#		pushd bench
-#		PYTHONPATH=%b/build/lib python%type_raw[python] bench.py
-#		popd
-#		if [ -x %p/bin/tox-py%type_pkg[python] ]; then
-#			%p/bin/tox-py%type_pkg[python] -e py%type_pkg[python] || exit 2
-#		else
-#			echo "tox-py%type_pkg[python] is not installed. Skipping tests."
-#		fi
-#	<<
-#<<
+InfoTest: <<
+		#pytest-cov-py%type_pkg[python] (>= 4.1.0),
+	TestDepends: <<
+		argcomplete-py%type_pkg[python],
+		coverage-py%type_pkg[python],
+		hypothesis-py%type_pkg[python] (>= 3.56.0-1),
+		mock-py%type_pkg[python],
+		nose-py%type_pkg[python],
+		pygments-py%type_pkg[python] (>= 2.7.2),
+		xmlschema-py%type_pkg[python]
+	<<
+	TestScript: <<
+		#!/bin/bash -ev
+		# need pytest-cov for tests, but pytest-cov needs pytest. Avoid circular deps by only running if pytest-cov is already present (and correct version)
+		if [[ $(%p/bin/python%type_raw[python] -c "import pytest_cov; print(pytest_cov.__version__)" | cut -f 1 -d .) -ge "4" ]]; then 
+			echo "good pytest-cov present. Will run tests."
+		else
+			echo "pytest-cov missing or too old. Will not run tests" ||:
+			exit 0
+		fi
+		# install the wheel to a temp location, then use that to run tests
+		PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m installer --destdir %b/testdist dist/*.whl
+		# testing/test_debugging.py: test_pdb_* connection failures
+		# testing/io/test_terminalwriter.py::test_code_highlight: gh:pytest-dev/pytest/#10503
+		# testing/test_terminal.py: gh:pytest-dev/pytest/#10503
+		# testing/test_helpconfig.py::test_version_verbose: needs current pytest to be installed
+		# testing/test_junitxml.py::test_random_report_log_xdist: gh:pytest-dev/pytest/#10443
+		# testing/test_junitxml.py::test_runs_twice_xdist: gh:pytest-dev/pytest/#10443
+		PYTHONPATH=%b/testdist/%p/lib/python%type_raw[python]/site-packages:%p/lib/python%type_raw[python]/site-packages %b/testdist/%p/bin/pytest -vv -k "not (testing/test_debugging.py or test_code_highlight or testing/test_terminal.py or test_version_verbose or test_random_report_log_xdist or test_runs_twice_xdist)" || exit 2
+	<<
+<<
 
 InstallScript: <<
 	# Clean up the droppings from tests
 	/usr/bin/find . -name '*.py[co]' -delete
 
-	%p/bin/python%type_raw[python] setup.py install --root=%d
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m installer --destdir %d dist/*.whl
 	mv %i/bin/py.test %i/bin/py.test-%type_raw[python]
 	mv %i/bin/pytest %i/bin/pytest-%type_raw[python]
 <<


### PR DESCRIPTION
Some pymods are starting to need pytest >=7. Importantly, the update here activates it's own tests w/out needing to download tons of other pymods through tox/pip.
Tested py38/p310 on 10.14.5