### PR TITLE
Bleach py update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bleach-py-3.1.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bleach-py-3.1.0.info
@@ -1,0 +1,73 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+Package: bleach-py%type_pkg[python]
+Version: 3.1.0
+Revision: 1
+Distribution: <<
+	(%type_pkg[python] = 34 ) 10.9,
+	(%type_pkg[python] = 34 ) 10.10,
+	(%type_pkg[python] = 34 ) 10.11,
+	(%type_pkg[python] = 34 ) 10.12,
+	(%type_pkg[python] = 34 ) 10.13,
+	(%type_pkg[python] = 34 ) 10.14,
+	(%type_pkg[python] = 34 ) 10.14.5,
+	(%type_pkg[python] = 34 ) 10.15,
+	(%type_pkg[python] = 35 ) 10.9,
+	(%type_pkg[python] = 35 ) 10.10,
+	(%type_pkg[python] = 35 ) 10.11,
+	(%type_pkg[python] = 35 ) 10.12,
+	(%type_pkg[python] = 35 ) 10.13,
+	(%type_pkg[python] = 35 ) 10.14,
+	(%type_pkg[python] = 35 ) 10.14.5,
+	(%type_pkg[python] = 35 ) 10.15,
+	(%type_pkg[python] = 36 ) 10.9,
+	(%type_pkg[python] = 36 ) 10.10,
+	(%type_pkg[python] = 36 ) 10.11,
+	(%type_pkg[python] = 36 ) 10.12,
+	(%type_pkg[python] = 36 ) 10.13,
+	(%type_pkg[python] = 36 ) 10.14,
+	(%type_pkg[python] = 36 ) 10.14.5,
+	(%type_pkg[python] = 36 ) 10.15
+<<
+
+Maintainer: Derek Homeier <dhomeie@gwdg.de>
+Type: python (2.7 3.4 3.5 3.6)
+Depends: python%type_pkg[python], six-py%type_pkg[python], html5lib-py%type_pkg[python] (>= 0.999-1)
+#Source: https://github.com/mozilla/bleach/archive/v%v.tar.gz
+#Source-MD5: 16c3466551d3a5a369a563b5bca5ee44
+#SourceRename: bleach-%v.tar.gz
+Source: https://files.pythonhosted.org/packages/source/b/bleach/bleach-%v.tar.gz
+Source-Checksum: SHA256(3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa)
+CompileScript: <<
+ %p/bin/python%type_raw[python] setup.py build
+<<
+InstallScript: <<
+ %p/bin/python%type_raw[python] setup.py install --root %d
+<<
+InfoTest: <<
+  TestDepends: pytest-py%type_pkg[python], pytest-runner-py%type_pkg[python] 
+  TestScript: <<
+    %p/bin/python%type_raw[python] setup.py pytest --addopts tests
+  <<
+  TestSuiteSize: small
+<<
+
+DocFiles: README.rst LICENSE CHANGES docs/
+Description: Easy allowed-list-based HTML-sanitizing tool
+DescDetail: <<
+Bleach is an allowed-list-based HTML sanitizing library that escapes or strips
+markup and attributes. Bleach can also linkify text safely, applying filters
+that Django's urlize filter cannot, and optionally setting rel attributes,
+even on links already in the text.  
+Bleach is intended for sanitizing text from untrusted sources. If you find
+yourself jumping through hoops to allow your site administrators to do lots
+of things, you're probably outside the use cases. Either trust those users,
+or don't.
+Because it relies on html5lib, Bleach is as good as modern browsers at
+dealing with weird, quirky HTML fragments. And any of Bleach's methods
+will fix unbalanced or mis-nested tags.
+<<
+License: OSI-Approved
+Homepage: http://github.com/mozilla/bleach
+# Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bleach-py-6.0.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/bleach-py-6.0.0.info
@@ -1,11 +1,11 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: bleach-py%type_pkg[python]
-Version: 6.1.0
+Version: 6.0.0
 Revision: 1
 
 Maintainer: Derek Homeier <dhomeie@gwdg.de>
-Type: python (3.8 3.9 3.10)
+Type: python (3.7)
 Depends: <<
 	python%type_pkg[python],
 	html5lib-py%type_pkg[python] (>= 0.999-1),
@@ -16,7 +16,7 @@ Depends: <<
 #Source-MD5: 16c3466551d3a5a369a563b5bca5ee44
 #SourceRename: bleach-%v.tar.gz
 Source: https://files.pythonhosted.org/packages/source/b/bleach/bleach-%v.tar.gz
-Source-Checksum: SHA256(0a31f1837963c41d46bbf1331b8778e1308ea0791db03cc4e7357b97cf42a8fe)
+Source-Checksum: SHA256(1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414)
 CompileScript: <<
  %p/bin/python%type_raw[python] setup.py build
 <<
@@ -51,6 +51,6 @@ dealing with weird, quirky HTML fragments. And any of Bleach's methods
 will fix unbalanced or mis-nested tags.
 <<
 License: OSI-Approved
-Homepage: https://github.com/mozilla/bleach
+Homepage: http://github.com/mozilla/bleach
 # Info2
 <<


### PR DESCRIPTION
Updates bleach-py to the latest upstreams. The package itself has been loosely deprecated by upstream, but we might as well have the latest versions. There's a new similar binding called `nh3`, but it requires `ammonia`, which requires rust.