### PR TITLE
Rustc update to 1.78.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/rustc.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/rustc.info
@@ -1,6 +1,7 @@
 Package: rustc
-Version: 1.30.0
+Version: 1.78.0
 Revision: 1
+Architecture: x86_64
 Description: Safe Fast System Programming Language
 Maintainer: None <fink-devel@lists.sourceforge.net>
 License: BSD
@@ -8,64 +9,135 @@ License: BSD
 Conflicts: rust (<< 1.11.0-2)
 Replaces: rust (<< 1.11.0-2)
 
-Source: https://static.rust-lang.org/dist/rustc-%v-src.tar.gz
-Source-Checksum: SHA256(cd0ba83fcca55b64c0c9f23130fe731dfc1882b73ae21bef96be8f2362c108ee)
+Source: https://static.rust-lang.org/dist/rustc-%v-src.tar.xz
+Source-Checksum: SHA256(8065824f0255faa3901db8206e6f9423f6f8c07cec28bc6f2797c6c948310ece)
 SourceDirectory: rustc-%v-src
 
-Source2: https://static.rust-lang.org/dist/2018-10-12/rust-std-1.29.2-x86_64-apple-darwin.tar.gz
-Source2-Checksum: SHA256(72cd953cb8ea05667f5d58f5c4ba615a564611a86303c0f8f9235e7a53852692)
+# derived from src/stage0.json
+Source2: https://static.rust-lang.org/dist/2024-03-21/rust-std-1.77.0-%m-apple-darwin.tar.xz
+Source2-Checksum: SHA256(95692e654b5ea16514b0d5558707b28c497b5c262c0d7c711d46e03033509f8c)
 # prevent automatic unpacking
-Source2Rename: rust-std-1.29.2-x86_64-apple-darwin.tar.gz.nounpack
+Source2Rename: rust-std-1.77.0-%m-apple-darwin.tar.xz.nounpack
 
-# derived from src/stage0.txt
-Source3: https://static.rust-lang.org/dist/2018-10-12/rustc-1.29.2-x86_64-apple-darwin.tar.gz
-Source3-Checksum: SHA256(d9c0dd8127ed632e27d751f051bca933578317ffe891e39155ae721bc1d3ec05)
-Source3Rename: rustc-1.29.2-x86_64-apple-darwin.tar.gz.nounpack
+Source3: https://static.rust-lang.org/dist/2024-03-21/rustc-1.77.0-%m-apple-darwin.tar.xz
+Source3-Checksum: SHA256(0bae384047cdb64200f4e87f8564238542504b45181870900f57745932c49d79)
+Source3Rename: rustc-1.77.0-%m-apple-darwin.tar.xz.nounpack
 
-Source4: https://static.rust-lang.org/dist/2018-10-12/cargo-0.30.0-x86_64-apple-darwin.tar.gz
-Source4-Checksum: SHA256(defc1ba047f09219a50ff39032b5d7aaf26563f6bed528b93055622eedfddabf)
-Source4Rename: cargo-bootstrap-0.30.0-x86_64-apple-darwin.tar.gz.nounpack
+Source4: https://static.rust-lang.org/dist/2024-03-21/cargo-1.77.0-%m-apple-darwin.tar.xz
+Source4-Checksum: SHA256(c95b98a306b26bf5f4f43d4d212c4535f3a09bbeda569ea0431bc54824a267b4)
+Source4Rename: cargo-bootstrap-1.77.0-%m-apple-darwin.tar.xz.nounpack
 
-BuildDepends: cmake, fink (>= 0.28)
+# uses liblzma5 at link time but then strips symbols?
+BuildDepends: <<
+	cmake,
+	fink (>= 0.32),
+	libcurl4,
+	liblzma5,
+	python310,
+	openssl300-dev,
+	pkgconfig
+<<
+Depends: <<
+	libcurl4-shlibs,
+	libgit2-1.7-shlibs,
+	openssl300-shlibs
+<<
+Suggests: <<
+	cargo,
+	python310
+<<
+# insists on using system-libiconv headers, but fink-libiconv.dylib
+# If find way to add %p/include to internal CPPFLAGS, promote this to Dep/BDep instead.
+BuildConflicts: <<
+	libiconv-dev
+<<
 
 PatchScript: <<
 #!/bin/sh -ev
 cat > config.toml <<EOF
+profile = "dist"
+change-id = 121754 # does this need to be changed every %v bump?
+
+[llvm]
+cflags = "-I%p/include"
+cxxflags = "-I%p/include"
+ldflags = "-L%p/lib"
+# generate a dylib for internal LLVM (smaller downstream binaries)
+link-shared = true
+
 [build]
 vendor = true
+python = "%p/bin/python3.10"
 #extended = true
+verbose = 1
 
 [install]
-prefix = "%i"
+prefix = "%p"
+sysconfdir = "etc"
 
 [rust]
 codegen-units = 0
 channel = "stable"
+description = "Fink/%v-%r"
 rpath = false
 EOF
-<<
 
+# these are from Debian
+# don't care about lock changes
+#rm -f Cargo.lock src/bootstrap/Cargo.lock src/tools/rust-analyzer/Cargo.lock src/tools/cargo/Cargo.lock
+# Link against system liblzma,
+# see https://github.com/alexcrichton/xz2-rs/issues/16
+# https://doc.rust-lang.org/cargo/reference/build-scripts.html
+# and update the checksum
+cat > vendor/lzma-sys/build.rs <<EOF
+fn main() {
+    println!("cargo:rustc-link-search=%p/lib");
+    println!("cargo:rustc-link-lib=lzma");
+}
+EOF
+# final SHASUM is variable because %p gets resolved
+SHASUM=`shasum -a 256 vendor/lzma-sys/build.rs | cut -f 1 -d ' '`
+perl -pi -e "s|052d600babd2f95d9549f2b846e6dcf1e39b1c15d4fa6a293797ce1c85199e24|$SHASUM|g" vendor/lzma-sys/.cargo-checksum.json
+
+<<
+GCC: 4.0
 CompileScript: <<
 #!/bin/sh -ev
-CACHEDIR=build/cache/2018-10-12
+export TARGET_CFLAGS=$CFLAGS
+export TARGET_CXXFLAGS=$CPPFLAGS
+export TARGET_CPPFLAGS=$CPPFLAGS
+export TARGET_LDFLAGS=$LDFLAGS
+#unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
+
+export LIBSSH2_SYS_USE_PKG_CONFIG=1
+
+export PYTHON=%p/bin/python3.10
+
+CACHEDIR=build/cache/2024-03-21
 
 mkdir -p $CACHEDIR
-mv ../rust-std-1.29.2-x86_64-apple-darwin.tar.gz.nounpack $CACHEDIR/rust-std-1.29.2-x86_64-apple-darwin.tar.gz
-mv ../rustc-1.29.2-x86_64-apple-darwin.tar.gz.nounpack $CACHEDIR/rustc-1.29.2-x86_64-apple-darwin.tar.gz
-mv ../cargo-bootstrap-0.30.0-x86_64-apple-darwin.tar.gz.nounpack $CACHEDIR/cargo-0.30.0-x86_64-apple-darwin.tar.gz
+mv ../rust-std-1.77.0-%m-apple-darwin.tar.xz.nounpack $CACHEDIR/rust-std-1.77.0-%m-apple-darwin.tar.xz
+mv ../rustc-1.77.0-%m-apple-darwin.tar.xz.nounpack $CACHEDIR/rustc-1.77.0-%m-apple-darwin.tar.xz
+mv ../cargo-bootstrap-1.77.0-%m-apple-darwin.tar.xz.nounpack $CACHEDIR/cargo-1.77.0-%m-apple-darwin.tar.xz
 
-./x.py dist
+$PYTHON ./x.py dist
 <<
 InstallScript: <<
 #!/bin/sh -ev
-  ./x.py install
+  export PYTHON=%p/bin/python3.10
+  DESTDIR=%d $PYTHON ./x.py install
 
-  mv %i/share/doc/rust %i/share/doc/%n
+  mv %i/share/doc/docs %i/share/doc/rust-doc
   
-  # lib path is in build tree
-  for tgt in %i/bin/* %i/lib/*.dylib %i/lib/rustlib/x86_64-apple-darwin/codegen-backends/*.dylib
+  for tgt in %i/bin/* %i/lib/*.dylib %i/lib/rustlib/%m-apple-darwin/lib/*.dylib %i/libexec/* 
   do
+    # lib path is in build tree
     for lib in $(otool -L $tgt | grep %b | awk '{print $1}')
+    do
+      install_name_tool -change $lib %p/lib/$(basename $lib) $tgt
+    done
+    # @rpath -> full path
+    for lib in $(otool -L $tgt | grep rpath | awk '{print $1}')
     do
       install_name_tool -change $lib %p/lib/$(basename $lib) $tgt
     done
@@ -81,7 +153,7 @@ InstallScript: <<
   # the same shared lib as in the root, and bad things happen if
   # a binary ends up linking to both copies. So just replace the
   # rustlib version with a symlink to the parent.
-  for tgt in %i/lib/rustlib/x86_64-apple-darwin/lib/*.dylib
+  for tgt in %i/lib/rustlib/%m-apple-darwin/lib/*.dylib
   do
     lib=$(basename $tgt)
     if [ -f %i/lib/$lib ]
@@ -90,52 +162,24 @@ InstallScript: <<
     fi
   done
 
-  install_name_tool -id %p/lib/rustlib/x86_64-apple-darwin/lib/libLLVM.dylib %i/lib/rustlib/x86_64-apple-darwin/lib/libLLVM.dylib
-  install_name_tool -id %p/lib/rustlib/x86_64-apple-darwin/codegen-backends/librustc_codegen_llvm-llvm.dylib %i/lib/rustlib/x86_64-apple-darwin/codegen-backends/librustc_codegen_llvm-llvm.dylib
+  #install_name_tool -id %p/lib/rustlib/%m-apple-darwin/lib/libLLVM.dylib %i/lib/rustlib/%m-apple-darwin/lib/libLLVM.dylib
+  #install_name_tool -id %p/lib/rustlib/%m-apple-darwin/codegen-backends/librustc_codegen_llvm-llvm.dylib %i/lib/rustlib/%m-apple-darwin/codegen-backends/librustc_codegen_llvm-llvm.dylib
+  
+  mv %i/libexec/rust-analyzer-proc-macro-srv %i/bin
+  rm -rf %i/libexec
+  
+  rm %i/lib/rustlib/install.log %i/lib/rustlib/uninstall.sh
 <<
 Shlibs: <<
-  !%p/lib/libsyntax_ext-0610082927f13b68.dylib
-  !%p/lib/librustc_privacy-3d33ff72e4be01b5.dylib
-  !%p/lib/librustc_cratesio_shim-89f003a3cf6a0f50.dylib
-  !%p/lib/libproc_macro-3c3310d56327c751.dylib
-  !%p/lib/librustc_passes-5ac07255fd417c7c.dylib
-  !%p/lib/libgraphviz-c745ad126f555404.dylib
-  !%p/lib/librustc_resolve-0d9c524c490cd9a3.dylib
-  !%p/lib/librustc_mir-edaccdabe5628117.dylib
-  !%p/lib/librustc_driver-458544d1543584e9.dylib
-  !%p/lib/librustc_codegen_utils-c51aa952698007b6.dylib
-  !%p/lib/librustc_traits-cc86a672bc385867.dylib
-  !%p/lib/librustc_metadata_utils-11a27c37b38fb414.dylib
-  !%p/lib/librustc_fs_util-195ee3fb273b97b8.dylib
-  !%p/lib/libsyntax_pos-af163bbd2a3b6cd4.dylib
-  !%p/lib/librustc_target-9b72dc107559762c.dylib
-  !%p/lib/librustc_data_structures-2444c86d41a6f566.dylib
-  !%p/lib/librustc_lint-ef0c6b45c55e1240.dylib
-  !%p/lib/librustc_save_analysis-1f003a00ca6206d5.dylib
-  !%p/lib/librustc_metadata-d63be93a557a9597.dylib
-  !%p/lib/librustc-a140d9ea5f6f61ed.dylib
-  !%p/lib/libarena-640d3352917efd05.dylib
-  !%p/lib/libserialize-48f4ceb2315fb290.dylib
-  !%p/lib/librustc_borrowck-82a0023f67ed38e8.dylib
-  !%p/lib/librustc_typeck-d938956a2378df20.dylib
-  !%p/lib/libtest-3d08e1a1fd6ab8b9.dylib
-  !%p/lib/libfmt_macros-cd8f1f3ba30325c9.dylib
-  !%p/lib/libsyntax-5804bc44f6aa386c.dylib
-  !%p/lib/librustc_platform_intrinsics-7e34762bb9904c06.dylib
-  !%p/lib/librustc_incremental-d61b642a5aa7f559.dylib
-  !%p/lib/libterm-99cc253bfe0ceff1.dylib
-  !%p/lib/librustc_plugin-68a342b785413fe8.dylib
-  !%p/lib/libstd-8b3bb8561e753cc3.dylib
-  !%p/lib/librustc_allocator-23cb74b7a7975376.dylib
-  !%p/lib/librustc_errors-4eab085f8d21579c.dylib
-  !%p/lib/rustlib/x86_64-apple-darwin/lib/libLLVM.dylib
-  !%p/lib/rustlib/x86_64-apple-darwin/codegen-backends/librustc_codegen_llvm-llvm.dylib
+	!%p/lib/librustc_driver-4f3eee8274de91bd.dylib
+	!%p/lib/libstd-d50560e9e437b847.dylib
+	!%p/lib/rustlib/x86_64-apple-darwin/lib/libstd-d50560e9e437b847.dylib
+	!%p/lib/libLLVM.dylib
 <<
 DocFiles: <<
   CONTRIBUTING.md COPYRIGHT LICENSE-APACHE LICENSE-MIT README.md RELEASES.md
 <<
-
-Homepage: http://www.rust-lang.org/
+Homepage: https://www.rust-lang.org/
 DescDetail: <<
 Rust is a curly-brace, block-structured expression language. It visually
 resembles the C language family, but differs significantly in syntactic

--- a/10.9-libcxx/stable/main/finkinfo/languages/rustc.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/rustc.info
@@ -1,6 +1,6 @@
 Package: rustc
 Version: 1.78.0
-Revision: 1
+Revision: 2
 Architecture: x86_64
 Description: Safe Fast System Programming Language
 Maintainer: None <fink-devel@lists.sourceforge.net>
@@ -37,14 +37,8 @@ BuildDepends: <<
 	openssl300-dev,
 	pkgconfig
 <<
-Depends: <<
-	libcurl4-shlibs,
-	libgit2-1.7-shlibs,
-	openssl300-shlibs
-<<
 Suggests: <<
-	cargo,
-	python310
+	cargo
 <<
 # insists on using system-libiconv headers, but fink-libiconv.dylib
 # If find way to add %p/include to internal CPPFLAGS, promote this to Dep/BDep instead.
@@ -178,6 +172,52 @@ Shlibs: <<
 <<
 DocFiles: <<
   CONTRIBUTING.md COPYRIGHT LICENSE-APACHE LICENSE-MIT README.md RELEASES.md
+<<
+SplitOff: <<
+	Package: cargo
+	Description: Rust package manager
+	# add libiconv once we can correctly link to fink-libiconv
+	Depends: <<
+		libcurl4-shlibs,
+		libgit2-1.7-shlibs,
+		openssl300-shlibs,
+		rustc
+	<<
+	Suggests: <<
+		python310
+	<<
+	Files: <<
+		bin/cargo
+		etc/bash_completion.d/cargo
+		share/doc/cargo
+		share/man/man1/cargo*
+		share/zsh/site-functions
+	<<
+<<
+SplitOff2: <<
+	Package: libstd-rust-dev
+	Description: Rust standard libraries - development files
+	BuildDependsOnly: true
+	Depends: <<
+		rustc (= %v-%r)
+	<<
+	Files: <<
+		lib/rustlib/%m-apple-darwin/lib
+	<<
+<<
+SplitOff3: <<
+	Package: rust-doc
+	Description: Rust  programming language - Documentation
+	Files: <<
+		share/doc/rust-doc
+	<<
+<<
+SplitOff4: <<
+	Package: rust-src
+	Description: Rust programming language - source code
+	Files: <<
+		lib/rustlib/src
+	<<
 <<
 Homepage: https://www.rust-lang.org/
 DescDetail: <<


### PR DESCRIPTION
bump to 1.78.0
Package includes cargo, which used to be a separate package, but cargo 0.79.0 is included as part of 1.78.0 dist
I was able to build a couple sample .rs files with this, and cargo was able to download some crates and use them to compile another thing.