### PR TITLE
Update astroid info for python versions 3.9 and 3.10

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/astroid-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/astroid-py.info
@@ -1,7 +1,7 @@
 Info3: <<
 
 Package: astroid-py%type_pkg[python]
-Type: python (3.4 3.5 3.6 3.7 3.8)
+Type: python (3.4 3.5 3.6 3.7 3.8 3.9 3.10)
 Version: 2.2.5
 Revision: 3
 Distribution: <<


### PR DESCRIPTION
Simple addition of 3.9 and 3.10 to python versions for astroid.  I have a package that I haven't pushed an update for years but have a bunch of these updates in my local tree.