### PR TITLE
Update python versions for logilab-common to include 3.9 and 3.10

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/logilab-common-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/logilab-common-py.info
@@ -1,7 +1,7 @@
 Info2: <<
 
 Package: logilab-common-py%type_pkg[python]
-Type: python (2.7 3.4 3.5 3.6 3.7 3.8)
+Type: python (2.7 3.4 3.5 3.6 3.7 3.8 3.9 3.10)
 Version: 0.63.2
 Revision: 2
 Distribution: <<


### PR DESCRIPTION
Simple change again just adding python 3.9 and 3.10 to package.