### PR TITLE
Update pylint for python 3.9 and 3.10

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/pylint-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/pylint-py.info
@@ -1,7 +1,7 @@
 Info3: <<
 
 Package: pylint-py%type_pkg[python]
-Type: python (3.5 3.6 3.7 3.8)
+Type: python (3.7 3.8 3.9 3.10)
 Version: 2.3.1
 Revision: 1
 Distribution: <<


### PR DESCRIPTION
Added python 3.9 and 3.10 to the info file as options