### PR TITLE
Update pycrypto  info for python 3.9 and 3.10

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/pycrypto-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/pycrypto-py.info
@@ -2,7 +2,7 @@
 Info2: <<
 # upstream: PyCrypto 2.x is unmaintained, obsolete, and contains security vulnerabilities
 Package: pycrypto-py%type_pkg[python]
-Type: python (2.7 3.4 3.5 3.6 3.7 3.8)
+Type: python (2.7 3.4 3.5 3.6 3.7 3.8 3.9 3.10)
 
 Version: 2.6.1
 Revision: 1


### PR DESCRIPTION
Update info file to include python 3.9 and 3.10