### PR TITLE
First release of s3transfer python module package version 0.10.2

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/s3transfer-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/s3transfer-py.info
@@ -13,9 +13,7 @@ Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
 Depends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
 
 # Unpack Phase.
-#Source: https://files.pythonhosted.org/packages/e1/eb/e57c93d5cd5edf8c1d124c831ef916601540db70acd96fa21fe60cef1365/s3transfer-%v.tar.gz
-Source: https://files.pythonhosted.org/packages/cb/67/94c6730ee4c34505b14d94040e2f31edf144c230b6b49e971b4f25ff8fab/s3transfer-%v.tar.gz
-#Source-Checksum: SHA256(2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947)
+Source: https://files.pythonhosted.org/packages/source/s/s3transfer/s3transfer-%v.tar.gz
 Source-Checksum: SHA256(0711534e9356d3cc692fdde846b4a1e4b0cb6519971860796e6bc4c7aea00ef6)
 
 # Compile Phase.

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/s3transfer-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/s3transfer-py.info
@@ -1,0 +1,48 @@
+Info2: <<
+Package: s3transfer-py%type_pkg[python]
+Version: 0.10.2
+Revision: 1
+Type: python (3.8 3.9 3.10)
+
+Description: Pythond library for s3 Transfers
+License: BSD
+Homepage: https://github.com/project/s3transfer
+Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
+
+# Dependencies.
+Depends: python%type_pkg[python], setuptools-tng-py%type_pkg[python]
+
+# Unpack Phase.
+#Source: https://files.pythonhosted.org/packages/e1/eb/e57c93d5cd5edf8c1d124c831ef916601540db70acd96fa21fe60cef1365/s3transfer-%v.tar.gz
+Source: https://files.pythonhosted.org/packages/cb/67/94c6730ee4c34505b14d94040e2f31edf144c230b6b49e971b4f25ff8fab/s3transfer-%v.tar.gz
+#Source-Checksum: SHA256(2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947)
+Source-Checksum: SHA256(0711534e9356d3cc692fdde846b4a1e4b0cb6519971860796e6bc4c7aea00ef6)
+
+# Compile Phase.
+CompileScript: <<
+%p/bin/python%type_raw[python] setup.py build
+<<
+
+# Install Phase.
+InstallScript: <<
+%p/bin/python%type_raw[python] setup.py install --prefix=%p --root=%d
+<<
+
+DocFiles: LICENSE.txt NOTICE.txt README.rst
+
+# Documentation.
+DescDetail: <<
+S3transfer is a Python library for managing
+Amazon S3 transfers. This project is
+maintained and published by Amazon Web
+Services.
+
+This project is not currently GA. If
+you are planning to use this code in
+production, make sure to lock to a minor
+version as interfaces may break from minor
+version to minor version. For a basic,
+stable interface of s3transfer, try the
+interfaces exposed in boto3
+<<
+<<


### PR DESCRIPTION
New package for the s3transfer python module for automated transfers to S3 repositories.  Builds on 14.5 and 13.6