### PR TITLE
Update lazy-object-proxy for python 3.9 and 3.10

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/lazy-object-proxy-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/lazy-object-proxy-py.info
@@ -1,7 +1,7 @@
 Info3: <<
 
 Package: lazy-object-proxy-py%type_pkg[python]
-Type: python (2.7 3.4 3.5 3.6 3.7 3.8)
+Type: python (2.7 3.4 3.5 3.6 3.7 3.8 3.9 3.10)
 
 Version: 1.3.1
 Revision: 2


### PR DESCRIPTION
Simple update to lazy-object-proxy to allow astroid-py310 to build.  Hopefully this is the last dependancy for pylint update.
Have added this PR as a depends for pull request #1139
Did not update version of lazy-object-proxy since was pointed out that needs updated setuptools which will take extensive testing.