### PR TITLE
Updated Monotonic to include Python 3.9 and 3.10

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/monotonic-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/monotonic-py.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: monotonic-py%type_pkg[python]
-Version: 1.5
-Revision: 7
+Version: 1.6
+Revision: 1
 Distribution: <<
 	(%type_pkg[python] = 34 ) 10.9,
 	(%type_pkg[python] = 34 ) 10.10,
@@ -32,14 +32,14 @@ Type: python (2.7 3.4 3.5 3.6 3.7 3.8 3.9 3.10)
 
 Description: Function time.monotonic() for Python 2&<3.3
 License: BSD
-Homepage: https://pypi.org/project/fasteners
+Homepage: https://pypi.org/project/monotonic/
 Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
 
 Depends: python%type_pkg[python]
 BuildDepends: setuptools-tng-py%type_pkg[python]
 
 Source: https://files.pythonhosted.org/packages/source/m/monotonic/monotonic-%v.tar.gz
-Source-Checksum: SHA256(23953d55076df038541e648a53676fb24980f7a1be290cdda21300b3bc21dfb0)
+Source-Checksum: SHA256(3a55207bcfed53ddd5c5bae174524062935efed17792e9de2ad0205ce9ad63f7)
 
 CompileScript: <<
   %p/bin/python%type_raw[python] setup.py build

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/monotonic-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/monotonic-py.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: monotonic-py%type_pkg[python]
 Version: 1.5
-Revision: 5
+Revision: 7
 Distribution: <<
 	(%type_pkg[python] = 34 ) 10.9,
 	(%type_pkg[python] = 34 ) 10.10,
@@ -28,7 +28,7 @@ Distribution: <<
 	(%type_pkg[python] = 36 ) 10.14.5,
 	(%type_pkg[python] = 36 ) 10.15
 <<
-Type: python (2.7 3.4 3.5 3.6 3.7 3.8)
+Type: python (2.7 3.4 3.5 3.6 3.7 3.8 3.9 3.10)
 
 Description: Function time.monotonic() for Python 2&<3.3
 License: BSD


### PR DESCRIPTION
Added python 3.9 and 3.10 to the available python versions for monotonic