### PR TITLE
requests-oauthlib added support for python 3.9 and 3.10

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/requests-oauthlib-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/requests-oauthlib-py.info
@@ -28,7 +28,7 @@ Distribution: <<
 	(%type_pkg[python] = 36 ) 10.14.5,
 	(%type_pkg[python] = 36 ) 10.15
 <<
-Type: python (2.7 3.4 3.5 3.6 3.7 3.8)
+Type: python (2.7 3.4 3.5 3.6 3.7 3.8 3.9 3.10)
 Description: OAuthlib authentication support for Requests
 
 DescDetail: <<


### PR DESCRIPTION
Just added support for python 3.9 and 3.10, working through the dependencies slowly