### PR TITLE
fasteners-py updated for python 3.9 and 3.10

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/fasteners-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/fasteners-py.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: fasteners-py%type_pkg[python]
 Version: 0.15
-Revision: 6
+Revision: 7
 Distribution: <<
 	(%type_pkg[python] = 34 ) 10.9,
 	(%type_pkg[python] = 34 ) 10.10,
@@ -29,7 +29,7 @@ Distribution: <<
 	(%type_pkg[python] = 36 ) 10.15
 <<
 
-Type: python (2.7 3.4 3.5 3.6 3.7 3.8)
+Type: python (2.7 3.4 3.5 3.6 3.7 3.8 3.9 3.10)
 
 Description: Python package providing useful locks
 License: BSD


### PR DESCRIPTION
Again just added python 3.9 and 3.10 and bumped build version.  Cannot update to latest since uses different build system and there is no setup.py so I am lost on how to build it.  Depends on PR #1146