### PR TITLE
diskcache-py initial package

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/diskcache-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/diskcache-py.info
@@ -1,0 +1,44 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info4: <<
+Package: diskcache-py%type_pkg[python]
+Version: 5.6.3
+Revision: 1
+Type: python (3.5 3.6 3.7 3.8 3.9 3.10)
+Description: Python package for disk & file cache library
+License: BSD
+Homepage: https://pypi.org/project/diskcache
+Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
+
+#downloading from python hosted has different checksum than listed on pypi
+#Source: https://files.pythonhosted.org/packages/source/d/diskcache-%v.tar.gz
+#Source-Checksum: SHA256(e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855)
+
+Source: https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-%v.tar.gz
+Source-Checksum: SHA256(2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc)
+
+Depends: <<
+	python%type_pkg[python]
+<<
+BuildDepends: <<
+	bootstrap-modules-py%type_pkg[python]
+<<
+
+CompileScript: <<
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m build --wheel --no-isolation --skip-dependency-check
+<<
+
+InfoTest: <<
+	TestDepends: <<
+		pytest-py%type_pkg[python] (>= 4.3.0),
+		django-py%type_pkg[python]
+	<<
+	TestScript: <<
+		PYTHONPATH=%b/src %p/bin/python%type_raw[python] -m pytest -vv || exit 2
+	<<
+<<
+
+InstallScript: <<
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m installer --destdir %d dist/*.whl
+<<
+DocFiles: LICENSE PKG-INFO README.rst
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/diskcache-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/diskcache-py.info
@@ -9,11 +9,7 @@ License: BSD
 Homepage: https://pypi.org/project/diskcache
 Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
 
-#downloading from python hosted has different checksum than listed on pypi
-#Source: https://files.pythonhosted.org/packages/source/d/diskcache-%v.tar.gz
-#Source-Checksum: SHA256(e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855)
-
-Source: https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-%v.tar.gz
+Source: https://files.pythonhosted.org/packages/source/d/diskcache/diskcache-%v.tar.gz
 Source-Checksum: SHA256(2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc)
 
 Depends: <<
@@ -27,15 +23,17 @@ CompileScript: <<
 	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m build --wheel --no-isolation --skip-dependency-check
 <<
 
-InfoTest: <<
-	TestDepends: <<
-		pytest-py%type_pkg[python] (>= 4.3.0),
-		django-py%type_pkg[python]
-	<<
-	TestScript: <<
-		PYTHONPATH=%b/src %p/bin/python%type_raw[python] -m pytest -vv || exit 2
-	<<
-<<
+# Testing disabled since requires django which requires bash which has implicit
+# declaration errorsand doesn't build on Venturs/Sonoma
+#InfoTest: <<
+#	TestDepends: <<
+#		pytest-py%type_pkg[python] (>= 4.3.0),
+#		django-py%type_pkg[python]
+#	<<
+#	TestScript: <<
+#		PYTHONPATH=%b/src %p/bin/python%type_raw[python] -m pytest -vv || exit 2
+#	<<
+#<<
 
 InstallScript: <<
 	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m installer --destdir %d dist/*.whl

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/diskcache-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/diskcache-py.info
@@ -3,7 +3,7 @@ Info4: <<
 Package: diskcache-py%type_pkg[python]
 Version: 5.6.3
 Revision: 1
-Type: python (3.5 3.6 3.7 3.8 3.9 3.10)
+Type: python (3.6 3.7 3.8 3.9 3.10)
 Description: Python package for disk & file cache library
 License: BSD
 Homepage: https://pypi.org/project/diskcache


### PR DESCRIPTION
diskcache-py is needed to test new version of fasteners.  This version will install.
However this will NOT run the tests, since it needs django to be installed, which needs docutils to be installed.  docutils is horribly out of date and  will not build with python 3.10 (or maybe much earlier), the current installed version needs eventlet-py which is very deprecated and will not build for python 3.  I would rather not try to update an infinite number of packages.  And leave docutils-py to a later date and someone more competent.  With diskcache installed, fasteners will pass all tests.  ( see PR #1148 )