### PR TITLE
New package botocore for AWS services

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/botocore-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/botocore-py.info
@@ -1,0 +1,63 @@
+Info2: <<
+Package: botocore-py%type_pkg[python]
+Version: 1.34.140
+Revision: 2
+Type: python (3.8 3.9 3.10)
+
+Description: The low-level, core functionality of boto 3
+License: BSD
+Homepage: https://pypi.org/project/botocore/
+Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
+
+# Dependencies.
+Depends: <<
+	python%type_pkg[python],
+	jsonschema-py%type_pkg[python],
+	coverage-py%type_pkg[python]
+<<
+
+BuildDepends: <<
+	setuptools-tng-py%type_pkg[python]
+<<
+
+# Unpack Phase.
+Source: https://files.pythonhosted.org/packages/source/b/botocore/botocore-%v.tar.gz
+Source-Checksum: SHA256(86302b2226c743b9eec7915a4c6cfaffd338ae03989cd9ee181078ef39d1ab39)
+
+# Compile Phase.
+CompileScript: <<
+%p/bin/python%type_raw[python] setup.py build
+<<
+
+# Test phase commented out since fails unless you have
+# aws credentials in ~/.aws/credentials and
+# default region in ~/.aws/config
+# Test Phase.
+#InfoTest: <<
+#	TestDepends: <<
+#		pytest-py%type_pkg[python] (>= 4.3.0),
+#		pytest-cov-py%type_pkg[python],
+#		pytest-xdist-py%type_pkg[python]
+#	<<
+#	TestScript: <<
+#		PYTHONPATH=%b/src %p/bin/python%type_raw[python] -m pytest -vv || exit 2
+#	<<
+#<<
+
+# Install Phase.
+InstallScript: <<
+%p/bin/python%type_raw[python] setup.py install --prefix=%p --root=%d
+<<
+
+DocFiles: LICENSE.txt NOTICE README.rst
+
+# Documentation.
+DescDetail: <<
+A low-level interface to a growing number of Amazon Web Services.
+The botocore package is the foundation for the AWS CLI as well as boto3.
+Botocore is maintained and published by Amazon Web Services.
+Botocore is the Amazon Web Services (AWS) Software Development Kit (SDK) for
+Python, which allows Python developers to write software that makes use
+of services like Amazon S3 and Amazon EC2.
+<<
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/botocore-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/botocore-py.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: botocore-py%type_pkg[python]
-Version: 1.34.140
-Revision: 2
-Type: python (3.8 3.9 3.10)
+Version: 1.34.144
+Revision: 1
+Type: python (3.8 3.9 3.10 3.11)
 
 Description: The low-level, core functionality of boto 3
 License: BSD
@@ -22,7 +22,7 @@ BuildDepends: <<
 
 # Unpack Phase.
 Source: https://files.pythonhosted.org/packages/source/b/botocore/botocore-%v.tar.gz
-Source-Checksum: SHA256(86302b2226c743b9eec7915a4c6cfaffd338ae03989cd9ee181078ef39d1ab39)
+Source-Checksum: SHA256(4215db28d25309d59c99507f1f77df9089e5bebbad35f6e19c7c44ec5383a3e8)
 
 # Compile Phase.
 CompileScript: <<


### PR DESCRIPTION
New package botocore for AWS services.  Replacing old boto-py with upstream botocore and boto3.  Test phase commented out due to need for AWS credentials to be installed for testing.  And I think I got the source file correct for once.... :-)