### PR TITLE
boto3-py new package to replace/update boto-py

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/boto3-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/boto3-py.info
@@ -1,0 +1,116 @@
+Info2: <<
+Package: boto3-py%type_pkg[python]
+Version: 1.34.139
+Revision: 1
+Type: python (3.8 3.9 3.10)
+
+Description: Python interface to Amazon Web Services
+License: BSD
+Homepage: https://pypi.org/project/boto3/
+Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
+
+# Dependencies.
+Depends: <<
+	python%type_pkg[python],
+	s3transfer-py%type_pkg[python],
+	botocore-py%type_pkg[python],
+	jmespath-py%type_pkg[python]
+<<
+
+Replaces: boto-py%type_pkg[python]
+
+BuildDepends: <<
+	setuptools-tng-py%type_pkg[python]
+<<
+
+# Unpack Phase.
+Source: https://files.pythonhosted.org/packages/source/b/boto3/boto3-%v.tar.gz
+Source-Checksum: SHA256(32b99f0d76ec81fdca287ace2c9744a2eb8b92cb62bf4d26d52a4f516b63a6bf)
+
+# Compile Phase.
+CompileScript: <<
+	%p/bin/python%type_raw[python] setup.py build
+<<
+
+# Install Phase.
+InstallScript: <<
+	%p/bin/python%type_raw[python] setup.py install --prefix=%p --root=%d
+<<
+
+DocFiles: CONTRIBUTING.rst LICENSE NOTICE README.rst
+
+# Documentation.
+DescDetail: <<
+Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK) for
+Python, which allows Python developers to write software that makes use
+of services like Amazon S3 and Amazon EC2.
+
+Boto3 is maintained and published by `Amazon Web Services`_.
+
+Boto (pronounced boh-toh) was named after the fresh water dolphin
+native to the Amazon river. The name was chosen by the author of the
+original Boto library, Mitch Garnaat, as a reference to the company.
+
+At the moment, boto supports:
+
+Compute
+  Amazon Elastic Compute Cloud (EC2)
+  Amazon Elastic Map Reduce (EMR)
+  AutoScaling
+  Amazon Kinesis
+Content Delivery
+  Amazon CloudFront
+Database
+  Amazon Relational Data Service (RDS)
+  Amazon DynamoDB
+  Amazon SimpleDB
+  Amazon ElastiCache
+  Amazon Redshift
+Deployment and Management
+  AWS Elastic Beanstalk
+  AWS CloudFormation
+  AWS Data Pipeline
+  AWS Opsworks
+  AWS CloudTrail
+Identity and Access
+  AWS Identity and Access Management (IAM)
+Application Services
+  Amazon CloudSearch
+  Amazon Elastic Transcoder
+  Amazon Simple Workflow Service (SWF)
+  Amazon Simple Queue Service (SQS)
+  Amazon Simple Notification Server (SNS)
+  Amazon Simple Email Service (SES)
+Monitoring
+  Amazon CloudWatch
+Networking
+  Amazon Route53
+  Amazon Virtual Private Cloud (VPC)
+  Elastic Load Balancing (ELB)
+  AWS Direct Connect
+Payments and Billing
+  Amazon Flexible Payment Service (FPS)
+Storage
+  Amazon Simple Storage Service (S3)
+  Amazon Glacier
+  Amazon Elastic Block Store (EBS)
+  Google Cloud Storage
+Workforce
+  Amazon Mechanical Turk
+Other
+  Marketplace Web Services
+  AWS Support
+
+The goal of boto is to support the full breadth and depth of Amazon Web 
+Services. In addition, boto provides support for other public services such 
+as Google Storage in addition to private cloud systems like Eucalyptus, 
+OpenStack and Open Nebula.
+<<
+DescPackaging: <<
+	Former maintainer: Murali Vadivelu <murali1080@users.sf.net>
+<<
+DescPort: <<
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
+<<
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/boto3-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/boto3-py.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: boto3-py%type_pkg[python]
 Version: 1.34.144
 Revision: 1
-Type: python (3.8 3.9 3.10 3.11)
+Type: python (3.8 3.9 3.10)
 
 Description: Python interface to Amazon Web Services
 License: BSD

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/boto3-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/boto3-py.info
@@ -107,7 +107,9 @@ as Google Storage in addition to private cloud systems like Eucalyptus,
 OpenStack and Open Nebula.
 <<
 DescPackaging: <<
-	Former maintainer: Murali Vadivelu <murali1080@users.sf.net>
+	Former maintainer of boto-py: Murali Vadivelu <murali1080@users.sf.net>
+	Boto3 package based on boto-py package by
+	Marc-Michael Blum <mmblum@users.sourceforge.net>
 <<
 DescPort: <<
 import ssl

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/boto3-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/boto3-py.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: boto3-py%type_pkg[python]
-Version: 1.34.139
+Version: 1.34.144
 Revision: 1
-Type: python (3.8 3.9 3.10)
+Type: python (3.8 3.9 3.10 3.11)
 
 Description: Python interface to Amazon Web Services
 License: BSD
@@ -25,7 +25,7 @@ BuildDepends: <<
 
 # Unpack Phase.
 Source: https://files.pythonhosted.org/packages/source/b/boto3/boto3-%v.tar.gz
-Source-Checksum: SHA256(32b99f0d76ec81fdca287ace2c9744a2eb8b92cb62bf4d26d52a4f516b63a6bf)
+Source-Checksum: SHA256(2f3e88b10b8fcc5f6100a9d74cd28230edc9d4fa226d99dd40a3ab38ac213673)
 
 # Compile Phase.
 CompileScript: <<


### PR DESCRIPTION
Older boto-py has been split into two utilities.  boto3-py depends on botocore-py ( PR #1151 ).  The boto3-py codes has no testing phase.