### PR TITLE
Mock update to version 5.1.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/mock-py-3.0.5.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/mock-py-3.0.5.info
@@ -1,10 +1,29 @@
 Info2: <<
 Package: mock-py%type_pkg[python]
-Type: python ( 3.6 3.7 3.8 3.9 3.10 3.11 )
-Version: 5.1.0
+Type: python ( 2.7 3.4 3.5 )
+Version: 3.0.5
 Revision: 1
+Distribution: <<
+	(%type_pkg[python] = 34 ) 10.9,
+	(%type_pkg[python] = 34 ) 10.10,
+	(%type_pkg[python] = 34 ) 10.11,
+	(%type_pkg[python] = 34 ) 10.12,
+	(%type_pkg[python] = 34 ) 10.13,
+	(%type_pkg[python] = 34 ) 10.14,
+	(%type_pkg[python] = 34 ) 10.14.5,
+	(%type_pkg[python] = 34 ) 10.15,
+	(%type_pkg[python] = 35 ) 10.9,
+	(%type_pkg[python] = 35 ) 10.10,
+	(%type_pkg[python] = 35 ) 10.11,
+	(%type_pkg[python] = 35 ) 10.12,
+	(%type_pkg[python] = 35 ) 10.13,
+	(%type_pkg[python] = 35 ) 10.14,
+	(%type_pkg[python] = 35 ) 10.14.5,
+	(%type_pkg[python] = 35 ) 10.15
+<<
 
 Depends: <<
+	(%type_pkg[python] << 33) funcsigs-py%type_pkg[python],
 	pbr-py%type_pkg[python],
 	python%type_pkg[python],
 	six-py%type_pkg[python]
@@ -12,7 +31,7 @@ Depends: <<
 BuildDepends: setuptools-tng-py%type_pkg[python]
 
 Source: https://files.pythonhosted.org/packages/source/m/mock/mock-%v.tar.gz
-Source-Checksum: SHA256(5e96aad5ccda4718e0a229ed94b2024df75cc2d55575ba5762d31f5767b8767d)
+Source-Checksum: SHA256(83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3)
 
 # TODO: build docs
 DocFiles: CHANGELOG.rst LICENSE.txt README.rst
@@ -27,6 +46,7 @@ InfoTest: <<
 <<
 InstallScript: <<
    mkdir -p %i/share/doc/%n
+   #cp -pr %b/docs %bhtml %i/share/doc/%n
    %p/bin/python%type_raw[python] setup.py install --root=%d
 <<
 

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/mock-py-3.0.5.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/mock-py-3.0.5.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: mock-py%type_pkg[python]
-Type: python ( 2.7 3.4 3.5 )
+Type: python ( 2.7 3.4 3.5 3.6)
 Version: 3.0.5
 Revision: 1
 Distribution: <<
@@ -20,6 +20,14 @@ Distribution: <<
 	(%type_pkg[python] = 35 ) 10.14,
 	(%type_pkg[python] = 35 ) 10.14.5,
 	(%type_pkg[python] = 35 ) 10.15
+	(%type_pkg[python] = 36 ) 10.9,
+	(%type_pkg[python] = 36 ) 10.10,
+	(%type_pkg[python] = 36 ) 10.11,
+	(%type_pkg[python] = 36 ) 10.12,
+	(%type_pkg[python] = 36 ) 10.13,
+	(%type_pkg[python] = 36 ) 10.14,
+	(%type_pkg[python] = 36 ) 10.14.5,
+	(%type_pkg[python] = 36 ) 10.15
 <<
 
 Depends: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/mock-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/mock-py.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: mock-py%type_pkg[python]
-Type: python ( 3.6 3.7 3.8 3.9 3.10 3.11 )
+Type: python ( 3.7 3.8 3.9 3.10)
 Version: 5.1.0
 Revision: 1
 


### PR DESCRIPTION
Update mock to version 5.1.0, rename old version for python < 3.4 with mock current version 3.0.5
mock now supports python 3.10
passes fink -m tests on MacOS 14.5-Sonoma / Xcode 15.4 (command line tools 15.3)
Have emailed maintainer (Charles Lepple) who gave permission to update as I see fit.  Did original update to 3.0.5 to support python 3.10 in 2019.  Updated to 5.1.0 2024.