### PR TITLE
duplicity - new upstream update to 3.0.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/utils/duplicity.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/duplicity.info
@@ -1,68 +1,77 @@
 Package: duplicity
-Version: 0.7.18.1
-Revision: 3
+Version: 3.0.0
+Revision: 1
 Description: Encrypted backup using rsync algorithm
 License: GPL
 Homepage: http://duplicity.nongnu.org/
-Maintainer:  Scott Hannahs <shannahs@users.sourceforge.net>
+Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
 
 # Dependencies.
 BuildDepends: <<
 	fink (>= 0.24.12-1),
-	librsync (>= 0.9.7-1002)
+	librsync (>= 0.9.7-1002),
+	sphinx-py310,
+	gcc12
 <<
 
+# boto3-py, ncftp, lft2, par2, pexepect, fastners-py, lxml-py310 needed for backends
 Depends: <<
-	python27,
+	python310,
 	librsync-shlibs (>= 0.9.7-1002),
 	gnupg2,
-	fasteners-py27,
 	intltool40,
-	paramiko-py27,
-	pycrypto-py27,
-	pycryptopp-py27,
-	pexpect-py27,
-	lftp,
 	ncftp,
+	lftp,
 	par2,
-	boto-py27 (>= 2.7.0),
-	requests-oauthlib-py27
+	setuptools-tng-py310,
+	boto3-py310,
+	fasteners-py310,
+	lxml-py310,
+	paramiko-py310,
+	pexpect-py310,
+	requests-oauthlib-py310
 <<
 
+SetCC: gcc-12
+
 # Unpack Phase.
-Source: https://code.launchpad.net/%n/0.7-series/%v/+download/%n-%v.tar.gz
-Source-Checksum: SHA256(c935019ed953e4767df8d39765c4dd41198709a14668e823e2e9e3e20710809d)
+Source: https://gitlab.com/%n/%n/-/archive/rel.%v/%n-rel.%v.tar.gz
+Source-Checksum: SHA256(3100277e264778cf406513662efcc32059c03c3482da4b87cc206a2779374a7a)
 
 # Patch Phase.
-PatchFile: %n.patch
-PatchFile-MD5: 6c3d2a0d7abf7b3c27001ef53429fdd1
 PatchScript: <<
-    sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
+	grep -rl '^\#!.*python' 2> /dev/null | xargs -n1 perl -pi -e 's|/usr/bin/python3$|%p/bin/python3.10|g'
+	grep -rl '^\#!.*python' 2> /dev/null | xargs -n1 perl -pi -e 's|/usr/bin/env python3$|/usr/bin/env %p/bin/python3.10|g'
+	grep -rl 'python3[^\.]' 2> /dev/null | xargs -n1 perl -pi -e 's|\(\["python3"\]\)|\(\["python3.10"\]\)|g'
 <<
 
 # Compile Phase.
-CompileScript: %p/bin/python2.7 setup.py build  --librsync-dir=%p
+CompileScript: %p/bin/python3.10 setup.py build  --librsync-dir=%p --build-base=%i
 
 InfoTest: <<
     TestDepends: <<
-        pylint-py27,
-        librsync-bin,
-	mock-py27,
-	pluggy-py27,
-	py-py27,
-	tox-py27
-<<
+	tox-py310,
+	pytest-py310,
+	pytest-cov-py310,
+	pytest-runner-py310,
+	coverage-py310,
+	pycodestyle-py310
+    <<
     TestScript: <<
     	#!/bin/sh -ev
-    	ulimit -n 5120
-		chmod 0700 `pwd`/testing/gnupg
-        %p/bin/python2.7 setup.py test
-<<
+	ulimit -n 8192
+	%p/bin/pytest-3.10 --capture=fd
+    <<
 <<
 
 # Install Phase.
-InstallScript: %p/bin/python2.7 setup.py install --prefix=%p --root=%d  --librsync-dir=%p
-DocFiles: CHANGELOG COPYING Changelog.GNU README README-LOG README-REPO
+DocFiles: CHANGELOG.md AUTHORS.md COPYING README-LOG.md README-REPO.md README-TESTING.md README.md
+InstallScript: <<
+	%p/bin/python3.10 setup.py install --prefix=%p --root=%d  --librsync-dir=%p
+	mkdir -p %i/bin
+	cp %b/debian/duplicity.sh %i/bin/duplicity
+	chmod a+x %i/bin/duplicity
+<<
 
 # Documentation.
 DescDetail: <<
@@ -86,10 +95,11 @@ GNU tar format.
 
 DescPackaging:  <<
 The testing phase needs more than the default 256
-maximum files, it is set to 5120 in the test script.
-Testing phase has 418 tests, 0 failures and 9
-errors when built as nobody.  Upstream is working on
-the testing issue.
+maximum files, it is set to 8192 in the test script
+for older OS (<10.14).  Newer OS needs to be set
+manually since ulimit does not function the same.
+Testing phase (on MacOS 13.6) has:
+428 passed, 17 skipped, 1 warning in 469.83s (0:07:49)
 
 supports
   ssh parmiko


### PR DESCRIPTION
Update of duplicity encrypted backup software from version 0.7.18.1 to version 3.0.0.  Passes all tests.  Builds with python 3.10 only.  Working on updating newest release 3.0.2 but that fails several tests and is recommended to update python 3.10 and pytest to version 8.3.2 which will delay getting this update out and working.

The documentation is on the web and so not built by the package.  This would also require several new and updated modules and is not necessary.