### PR TITLE
update libiconv and gettext to latest upstream for building on macOS15

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/base/dpkg.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/dpkg.info
@@ -1,11 +1,11 @@
 Package: dpkg
 Version: 1.10.21
-Revision: 1251
+Revision: 1252
 GCC: 4.0
 BuildDepends: fink (>= 0.30.0)
 Depends: <<
 	gzip,
-	libgettext8-shlibs (>= 0.20.2-1),
+	libgettext8-shlibs (>= 0.22.5-1),
 	libiconv (>= 1.14-6),
 	libncurses5-shlibs (>= 5.4-20041023-1006)
 <<
@@ -16,13 +16,13 @@ Maintainer: Fink Core Group <fink-core@lists.sourceforge.net>
 Source: mirror:sourceforge:fink/dpkg_%v.tar.gz
 SourceDirectory: dpkg-%v
 Source-MD5: a9f6c43891db74d727beab7dfc0ee663
-Source2: mirror:sourceforge:fink/gettext-0.20.2.tar.gz
-#Source2: mirror:gnu:gettext/gettext-0.20.2.tar.gz
-Source2-MD5: 30fec34a895fab4c02584449c500aac2
+Source2: mirror:sourceforge:fink/gettext-0.22.5.tar.gz
+#Source2: mirror:gnu:gettext/gettext-0.22.5.tar.gz
+Source2-MD5: 1245c87cfa0b123f55540681af396880
 PatchFile: %n.patch
 PatchFile-MD5: 4619ec40a935795c705fbd60b258cf5a
 PatchFile2: libgettext8-shlibs.patch
-PatchFile2-MD5: 8ebf1b7c276059b0d3a334f60a2f705e
+PatchFile2-MD5: 40c5bb69aea2d78ca50c7bf011653a01
 PatchFile3: %n-xcode12.patch
 PatchFile3-MD5: 04c17928d17ca1e2320258f142a4093a
 PatchScript: <<
@@ -42,11 +42,16 @@ CompileScript: <<
 	### match the new package parameters (except build static only here).
 	### Not necessary, but will avoid unforeseen consequences.
 	%p/bin/fink -y install gettext-bin libgettext8-dev libiconv-dev libncurses5
-	# gettext-tools >= 0.20.2 needs libtextstyle
-	cd %b/../gettext-0.20.2/libtextstyle
+	# gettext-tools >= 0.22.5 needs libtextstyle
+	cd %b/../gettext-0.22.5/libtextstyle
 	env EMACS=no JAVA=/usr/bin/java PATH=../bin:$PATH ./configure --prefix=%b/localtree --enable-shared=no ac_cv_prog_AWK=/usr/bin/awk ac_cv_path_GREP=/usr/bin/grep ac_cv_path_SED=/usr/bin/sed
 	/usr/bin/make -w
-	cd %b/../gettext-0.20.2/gettext-tools
+	#
+	cd %b/../gettext-0.22.5/gettext-runtime
+	env PATH=../bin:%b/localtree/bin:$PATH ./configure --prefix=%b/localtree --enable-shared=no 	--disable-java --disable-native-java ac_cv_prog_AWK=/usr/bin/awk ac_cv_path_GREP=/usr/bin/grep ac_cv_path_SED=/usr/bin/sed
+	/usr/bin/make -w
+	#
+	cd %b/../gettext-0.22.5/gettext-tools
 	env EMACS=no JAVA=/usr/bin/java GCJ=/usr/bin/javac ./configure \
 		--prefix="%b/../_inst%p" \
 		--infodir='${prefix}/share/info' \
@@ -116,6 +121,9 @@ DescPackaging: <<
  actual libs themselves.
 <<
 DescPort: <<
+1.10.21-1252
+- Bump to libgettext-0.22.5
+
 1.10.21-1251
 - Bump to libgettext-0.20.2
 

--- a/10.9-libcxx/stable/main/finkinfo/base/dpkg.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/dpkg.info
@@ -56,12 +56,15 @@ CompileScript: <<
 		--disable-rpath \
 		--disable-libasprintf \
 		--disable-shared \
+		--disable-java \
+		--disable-native-java \
 		--with-included-glib \
 		--with-included-libcroco \
 		--with-included-libxml \
 		--with-included-libunistring \
 		--without-git \
 		--without-cvs \
+		--without-xz \
 		ac_cv_prog_AWK=/usr/bin/awk \
 		ac_cv_path_GREP=/usr/bin/grep \
 		ac_cv_path_SED=/usr/bin/sed

--- a/10.9-libcxx/stable/main/finkinfo/base/gettext-tools-tests.patch
+++ b/10.9-libcxx/stable/main/finkinfo/base/gettext-tools-tests.patch
@@ -1,20 +1,20 @@
-diff -ruNp gettext-0.19.3-orig/gettext-tools/tests/lang-bash gettext-0.19.3/gettext-tools/tests/lang-bash
---- gettext-0.19.3-orig/gettext-tools/tests/lang-bash	2014-04-14 20:52:10.000000000 -0500
-+++ gettext-0.19.3/gettext-tools/tests/lang-bash	2014-06-18 20:26:48.000000000 -0500
-@@ -10,6 +10,8 @@
- # output when accessing any .mo file not generated from a .po file in UTF-8
- # encoding.
+diff -ruN gettext-0.22.5-orig/gettext-tools/tests/lang-bash gettext-0.22.5/gettext-tools/tests/lang-bash
+--- gettext-0.22.5-orig/gettext-tools/tests/lang-bash	2019-05-11 06:29:32.000000000 -0500
++++ gettext-0.22.5/gettext-tools/tests/lang-bash	2024-12-02 03:50:42.000000000 -0600
+@@ -14,6 +14,8 @@
+ # because in this case the gettext-runtime/src/gettext program does not do
+ # any message catalog lookups.
  
 +echo "Skipping test: Darwin's bash lacks iconv support"; rm -fr $tmpfiles; exit 77;
 +
  cat <<\EOF > prog.bash
  #! /bin/bash
  
-diff -ruNp gettext-0.19.8.1-orig/gettext-tools/tests/lang-vala gettext-0.19.8.1/gettext-tools/tests/lang-vala
---- gettext-0.19.8.1-orig/gettext-tools/tests/lang-vala	2016-06-09 17:56:00.000000000 -0500
-+++ gettext-0.19.8.1/gettext-tools/tests/lang-vala	2016-06-12 15:35:03.000000000 -0500
-@@ -22,7 +22,7 @@ test $? -le 1 \
-   || { echo "Skipping test: valac not found"; Exit 77; }
+diff -ruN gettext-0.22.5-orig/gettext-tools/tests/lang-vala gettext-0.22.5/gettext-tools/tests/lang-vala
+--- gettext-0.22.5-orig/gettext-tools/tests/lang-vala	2022-10-09 02:30:42.000000000 -0500
++++ gettext-0.22.5/gettext-tools/tests/lang-vala	2024-12-02 03:50:42.000000000 -0600
+@@ -40,7 +40,7 @@
+ EOF
  
  : ${VALAC=valac}
 -${VALAC} --Xcc=-DGETTEXT_PACKAGE=\"prog\" prog.vala 2>prog.err \

--- a/10.9-libcxx/stable/main/finkinfo/base/gettext-tools.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/gettext-tools.info
@@ -63,12 +63,15 @@ CompileScript: <<
 	pushd libtextstyle
 	env EMACS=no JAVA=/usr/bin/java PATH=../bin:$PATH ./configure --prefix=%b/localtree --enable-shared=no ac_cv_prog_AWK=/usr/bin/awk ac_cv_path_GREP=/usr/bin/grep ac_cv_path_SED=/usr/bin/sed
 	/usr/bin/make -w
-	pushd ../gettext-runtime
+	popd
+	pushd gettext-runtime
 	env PATH=../bin:%b/localtree/bin:$PATH ./configure %c
 	/usr/bin/make -w
-	pushd ../gettext-tools
+	popd
+	pushd gettext-tools
 	env EMACS=no JAVA=/usr/bin/java PATH=../bin:%b/localtree/bin:$PATH ./configure %c
 	/usr/bin/make -w
+	popd
 <<
 InfoTest: <<
 	### https://savannah.gnu.org/support/index.php?108122

--- a/10.9-libcxx/stable/main/finkinfo/base/gettext-tools.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/gettext-tools.info
@@ -83,7 +83,8 @@ InfoTest: <<
 		#!/bin/sh -ev
 		cd gettext-tools
 		LC_ALL=C /usr/bin/make -w -k check || echo "Checking for expected failures in test suites"
-		grep ^FAIL */test-suite.log | egrep -v 'lang-perl-1|lang-perl-2' && exit 2
+		# https://savannah.gnu.org/bugs/?66461
+		grep ^FAIL */test-suite.log | grep -E -v 'lang-perl-1|lang-perl-2|lang-python-1|lang-python-2' && exit 2
 	<<
 <<
 InstallScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/base/gettext-tools.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/gettext-tools.info
@@ -1,14 +1,14 @@
 Package: gettext-tools
-Version: 0.20.2
-Revision: 2
+Version: 0.22.5
+Revision: 1
 CustomMirror: <<
 	Primary: http://ftpmirror.gnu.org/gettext/
 	Secondary: http://downloads.sourceforge.net/fink/
 <<
 Source: mirror:custom:gettext-%v.tar.gz
-Source-MD5: 30fec34a895fab4c02584449c500aac2
+Source-MD5: 1245c87cfa0b123f55540681af396880
 PatchFile: libgettext8-shlibs.patch
-PatchFile-MD5: 8ebf1b7c276059b0d3a334f60a2f705e
+PatchFile-MD5: 97f499e17812d2c4841669a58303149e
 PatchFile2: gettext-tools-tests.patch
 PatchFile2-MD5: 6051a92acfc5ba9bf2274c258dbd6c7e
 PatchScript: <<
@@ -60,11 +60,13 @@ CompileScript: <<
 	#!/bin/sh -ev
 	mkdir bin
 	ln -s /usr/bin/javac bin/gcj
-	cd libtextstyle
+	pushd libtextstyle
 	env EMACS=no JAVA=/usr/bin/java PATH=../bin:$PATH ./configure --prefix=%b/localtree --enable-shared=no ac_cv_prog_AWK=/usr/bin/awk ac_cv_path_GREP=/usr/bin/grep ac_cv_path_SED=/usr/bin/sed
 	/usr/bin/make -w
-	cd ..
-	cd gettext-tools
+	pushd ../gettext-runtime
+	env PATH=../bin:%b/localtree/bin:$PATH ./configure %c
+	/usr/bin/make -w
+	pushd ../gettext-tools
 	env EMACS=no JAVA=/usr/bin/java PATH=../bin:%b/localtree/bin:$PATH ./configure %c
 	/usr/bin/make -w
 <<
@@ -73,8 +75,12 @@ InfoTest: <<
 	TestConflicts: <<
 		fpc
 	<<
+	# Possible failures in French locale tests
 	TestScript: <<
-		cd gettext-tools; LC_ALL=C /usr/bin/make -w -k check || exit 2
+		#!/bin/sh -ev
+		cd gettext-tools
+		LC_ALL=C /usr/bin/make -w -k check || echo "Checking for expected failures in test suites"
+		grep ^FAIL */test-suite.log | egrep -v 'lang-perl-1|lang-perl-2' && exit 2
 	<<
 <<
 InstallScript: <<
@@ -82,15 +88,15 @@ InstallScript: <<
 	cd gettext-tools; make install DESTDIR=%d
 	rm %i/lib/libgettextlib.*
 	rm %i/lib/libgettextsrc.*
-	rm %i/lib/libintl*
-	rm %i/include/libintl.h
-	rm %i/share/locale/locale.alias
+	# libintl does not seem to be installed from under gettext-tools anymore
+	find %i/lib %i/include -name "libintl*" -delete
+	find %i/share/locale -name locale.alias -delete
 <<
 DocFiles: README* AUTHORS COPYING* NEWS THANKS ChangeLog* 
 InfoDocs: gettext.info
 Shlibs: <<
-  !%p/lib/libgettextlib-0.20.2.dylib
-  !%p/lib/libgettextsrc-0.20.2.dylib
+  !%p/lib/libgettextlib-0.22.5.dylib
+  !%p/lib/libgettextsrc-0.22.5.dylib
 <<
 Description: GNU Internationalization utils
 

--- a/10.9-libcxx/stable/main/finkinfo/base/gettext-tools.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/gettext-tools.info
@@ -8,9 +8,9 @@ CustomMirror: <<
 Source: mirror:custom:gettext-%v.tar.gz
 Source-MD5: 1245c87cfa0b123f55540681af396880
 PatchFile: libgettext8-shlibs.patch
-PatchFile-MD5: 97f499e17812d2c4841669a58303149e
+PatchFile-MD5: 40c5bb69aea2d78ca50c7bf011653a01
 PatchFile2: gettext-tools-tests.patch
-PatchFile2-MD5: 6051a92acfc5ba9bf2274c258dbd6c7e
+PatchFile2-MD5: f766ea0e37b9d2f68a49c51d7adea043
 PatchScript: <<
  patch -p1 < %{PatchFile}
  sed 's|@FINKPREFIX@|%p|g' < %{PatchFile2} | patch -p1

--- a/10.9-libcxx/stable/main/finkinfo/base/libgettext8-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/libgettext8-shlibs.info
@@ -10,7 +10,7 @@ Source-MD5: 1245c87cfa0b123f55540681af396880
 # libgettext8-shlibs.patch must be regenerated for every update since
 # dpkg uses it and needs the correct full file headers for patch -p0 
 PatchFile: %n.patch
-PatchFile-MD5: 97f499e17812d2c4841669a58303149e
+PatchFile-MD5: 40c5bb69aea2d78ca50c7bf011653a01
 PatchScript: <<
  patch -p1 < %{PatchFile}
 <<

--- a/10.9-libcxx/stable/main/finkinfo/base/libgettext8-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/libgettext8-shlibs.info
@@ -1,16 +1,16 @@
 Package: libgettext8-shlibs
-Version: 0.20.2
+Version: 0.22.5
 Revision: 1
 CustomMirror: <<
 	Primary: http://ftpmirror.gnu.org/gettext/
 	Secondary: http://downloads.sourceforge.net/fink/
 <<
 Source: mirror:custom:gettext-%v.tar.gz
-Source-MD5: 30fec34a895fab4c02584449c500aac2
+Source-MD5: 1245c87cfa0b123f55540681af396880
 # libgettext8-shlibs.patch must be regenerated for every update since
 # dpkg uses it and needs the correct full file headers for patch -p0 
 PatchFile: %n.patch
-PatchFile-MD5: 8ebf1b7c276059b0d3a334f60a2f705e
+PatchFile-MD5: 97f499e17812d2c4841669a58303149e
 PatchScript: <<
  patch -p1 < %{PatchFile}
 <<
@@ -55,7 +55,8 @@ InstallScript: <<
 	#!/bin/sh -ev
 	cd gettext-runtime
 	make install DESTDIR=%d
-	#No need for dependency_libs in .la files if not building static libs
+	# .la install sometimes fails after `test -n "$dependencies"`
+	[ -f %i/lib/libintl.la ] || /usr/bin/install -c -m 644 intl/.libs/libintl.lai %i/lib/libintl.la
 	perl -pi -e "s/dependency_libs=.*$/dependency_libs=''/" %i/lib/libintl.la
 <<
 DocFiles: README* AUTHORS gettext-runtime/BUGS COPYING* NEWS THANKS ChangeLog* 
@@ -111,7 +112,7 @@ DescPackaging: <<
 <<
 
 Shlibs: <<
-  %p/lib/libintl.8.dylib 10.0.0 %n (>= 0.18-1)
+  %p/lib/libintl.8.dylib 13.0.0 %n (>= 0.22.5-1)
 <<
 License: GPL/LGPL
 Maintainer: Fink Core Group <fink-core@lists.sourceforge.net>

--- a/10.9-libcxx/stable/main/finkinfo/base/libgettext8-shlibs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/base/libgettext8-shlibs.patch
@@ -1,18 +1,18 @@
-diff -ruN gettext-0.20.2-orig/gettext-runtime/libasprintf/Makefile.in gettext-0.20.2/gettext-runtime/libasprintf/Makefile.in
---- gettext-0.20.2-orig/gettext-runtime/libasprintf/Makefile.in	2020-04-13 23:45:32.000000000 -0500
-+++ gettext-0.20.2/gettext-runtime/libasprintf/Makefile.in	2021-01-01 06:21:30.000000000 -0600
-@@ -574,7 +574,7 @@
+diff -ruN gettext-0.22.5-orig/gettext-runtime/libasprintf/Makefile.in gettext-0.22.5/gettext-runtime/libasprintf/Makefile.in
+--- gettext-0.22.5-orig/gettext-runtime/libasprintf/Makefile.in	2024-02-21 17:35:57.000000000 +0200
++++ gettext-0.22.5/gettext-runtime/libasprintf/Makefile.in	2024-07-22 21:29:40.000000000 +0200
+@@ -1333,7 +1333,7 @@
  # How to build libasprintf.
  # With libtool 1.5.14, on some platforms, like BeOS, "libtool --tag=CXX" fails
  # to create a shared library, however "libtool --tag=CC" succeeds.
--libasprintf_la_LDFLAGS = @LTNOUNDEF@
-+libasprintf_la_LDFLAGS = @LTNOUNDEF@ -static
- libgnu_la_SOURCES = size_max.h xsize.h xsize.c
- libgnu_la_LIBADD = $(gl_LTLIBOBJS) @LTALLOCA@
- libgnu_la_DEPENDENCIES = $(gl_LTLIBOBJS) @LTALLOCA@
-diff -ruN gettext-0.20.2-orig/gettext-tools/src/Makefile.in gettext-0.20.2/gettext-tools/src/Makefile.in
---- gettext-0.20.2-orig/gettext-tools/src/Makefile.in	2020-04-13 23:46:32.000000000 -0500
-+++ gettext-0.20.2/gettext-tools/src/Makefile.in	2021-01-01 06:21:30.000000000 -0600
+-libasprintf_la_LDFLAGS = @LTNOUNDEF@ -export-symbols-regex $(LIBASPRINTF_EXPORTED_SYMBOLS_REGEX)
++libasprintf_la_LDFLAGS = @LTNOUNDEF@ -static -export-symbols-regex $(LIBASPRINTF_EXPORTED_SYMBOLS_REGEX)
+ 
+ # Documentation.
+
+diff -ruN gettext-0.22.5-orig/gettext-tools/src/Makefile.in gettext-0.22.5/gettext-tools/src/Makefile.in
+--- gettext-0.22.5-orig/gettext-tools/src/Makefile.in	2024-02-21 17:35:57.000000000 +0200
++++ gettext-0.22.5/gettext-tools/src/Makefile.in	2024-07-22 21:29:40.000000000 +0200
 @@ -3633,10 +3633,10 @@
  	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(urlget_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o urlget-urlget.obj `if test -f 'urlget.c'; then $(CYGPATH_W) 'urlget.c'; else $(CYGPATH_W) '$(srcdir)/urlget.c'; fi`
  

--- a/10.9-libcxx/stable/main/finkinfo/base/libgettext8-shlibs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/base/libgettext8-shlibs.patch
@@ -1,6 +1,6 @@
 diff -ruN gettext-0.22.5-orig/gettext-runtime/libasprintf/Makefile.in gettext-0.22.5/gettext-runtime/libasprintf/Makefile.in
---- gettext-0.22.5-orig/gettext-runtime/libasprintf/Makefile.in	2024-02-21 17:35:57.000000000 +0200
-+++ gettext-0.22.5/gettext-runtime/libasprintf/Makefile.in	2024-07-22 21:29:40.000000000 +0200
+--- gettext-0.22.5-orig/gettext-runtime/libasprintf/Makefile.in	2024-02-21 10:35:57.000000000 -0600
++++ gettext-0.22.5/gettext-runtime/libasprintf/Makefile.in	2024-12-02 03:18:37.000000000 -0600
 @@ -1333,7 +1333,7 @@
  # How to build libasprintf.
  # With libtool 1.5.14, on some platforms, like BeOS, "libtool --tag=CXX" fails
@@ -9,11 +9,11 @@ diff -ruN gettext-0.22.5-orig/gettext-runtime/libasprintf/Makefile.in gettext-0.
 +libasprintf_la_LDFLAGS = @LTNOUNDEF@ -static -export-symbols-regex $(LIBASPRINTF_EXPORTED_SYMBOLS_REGEX)
  
  # Documentation.
-
+ 
 diff -ruN gettext-0.22.5-orig/gettext-tools/src/Makefile.in gettext-0.22.5/gettext-tools/src/Makefile.in
---- gettext-0.22.5-orig/gettext-tools/src/Makefile.in	2024-02-21 17:35:57.000000000 +0200
-+++ gettext-0.22.5/gettext-tools/src/Makefile.in	2024-07-22 21:29:40.000000000 +0200
-@@ -3633,10 +3633,10 @@
+--- gettext-0.22.5-orig/gettext-tools/src/Makefile.in	2024-02-21 10:36:32.000000000 -0600
++++ gettext-0.22.5/gettext-tools/src/Makefile.in	2024-12-02 03:18:37.000000000 -0600
+@@ -4940,10 +4940,10 @@
  	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(urlget_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o urlget-urlget.obj `if test -f 'urlget.c'; then $(CYGPATH_W) 'urlget.c'; else $(CYGPATH_W) '$(srcdir)/urlget.c'; fi`
  
  xgettext-xgettext.o: xgettext.c

--- a/10.9-libcxx/stable/main/finkinfo/base/libiconv.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/libiconv.info
@@ -1,6 +1,6 @@
 Package: libiconv
-Version: 1.16
-Revision: 3
+Version: 1.17
+Revision: 1
 Description: Character set conversion library
 License: LGPL
 Maintainer: Fink Core Group <fink-core@lists.sourceforge.net>
@@ -15,15 +15,12 @@ CustomMirror: <<
 	Secondary: http://downloads.sourceforge.net/fink/
 <<
 Source: mirror:custom:libiconv-%v.tar.gz
-Source-MD5: 7d2a800b952942bb2880efb00cfd524c
-Source2: mirror:sourceforge:fink/gettext-0.20.2.tar.gz
-#Source2: mirror:gnu:gettext/gettext-0.20.2.tar.gz
-Source2-MD5: 30fec34a895fab4c02584449c500aac2
+Source-MD5: d718cd5a59438be666d1575855be72c3
+Source2: mirror:sourceforge:fink/gettext-0.22.5.tar.gz
+#Source2: mirror:gnu:gettext/gettext-0.22.5.tar.gz
+Source2-MD5: 1245c87cfa0b123f55540681af396880
 PatchFile: %n.patch
-PatchFile-MD5: 5e7d6a1b9c563b71d1ac08a6ad2106cf
-PatchScript: <<
-	cd %b/..; patch -p0 < %{PatchFile}
-<<
+PatchFile-MD5: b4e5dfc26337f538e35c645128d5e30b
 NoSetLDFLAGS: true
 NoSetCPPFLAGS: true
 CompileScript: <<
@@ -32,7 +29,7 @@ CompileScript: <<
 ### If gettext gets updated, make sure these ./configure parameters 
 ### match the new package parameters (except build static only here).
 ### Not necessary, but will avoid unforeseen consequences.
-cd %b/../gettext-0.20.2/gettext-runtime
+cd %b/../gettext-0.22.5/gettext-runtime
 EMACS=no CPPFLAGS="-I%b/../_inst%p/include" LDFLAGS="-L%b/../_inst%p/lib" am_cv_func_iconv=no ./configure \
 	--prefix=%p \
 	--infodir='${prefix}/share/info' \
@@ -167,5 +164,10 @@ our build system.
  /usr/bin/groff and fink's groff is heavy and gives circular dep.
 
  Externalize gperf
+
+2024-07-22 Derek Homeier
+* Update to 1.17
+* Patch utf8mac.h to fix incompatible pointer errors on macOS 15 / Xcode 16.
+* Bump internal gettext to latest 0.22.5
 <<
 Homepage: http://www.gnu.org/software/libiconv/

--- a/10.9-libcxx/stable/main/finkinfo/base/libiconv.info
+++ b/10.9-libcxx/stable/main/finkinfo/base/libiconv.info
@@ -39,6 +39,8 @@ EMACS=no CPPFLAGS="-I%b/../_inst%p/include" LDFLAGS="-L%b/../_inst%p/lib" am_cv_
 	--disable-rpath \
 	--disable-libasprintf \
 	--disable-shared \
+	--disable-java \
+	--disable-native-java \
 	--with-included-glib \
 	--with-included-libcroco \
 	--with-included-libxml \

--- a/10.9-libcxx/stable/main/finkinfo/base/libiconv.patch
+++ b/10.9-libcxx/stable/main/finkinfo/base/libiconv.patch
@@ -1660,7 +1660,7 @@ diff -ruN libiconv-1.16-orig/lib/utf8mac.h libiconv-1.16/lib/utf8mac.h
 +}
 +
 +static int
-+utf8mac_mbtowc (conv_t conv, ucs4_t *pwc, const unsigned char *s, int n)
++utf8mac_mbtowc (conv_t conv, ucs4_t *pwc, const unsigned char *s, size_t n)
 +{
 +    u_int16_t ucsp[13];
 +    size_t ucslen = 0, consumed = 0;
@@ -1675,7 +1675,7 @@ diff -ruN libiconv-1.16-orig/lib/utf8mac.h libiconv-1.16/lib/utf8mac.h
 +    flags |= UTF_REVERSE_ENDIAN;
 +#endif
 +
-+    ret = utf8_decodestr(s, n, ucsp, &ucslen, sizeof(ucsp), NULL, flags, &consumed);
++    ret = utf8_decodestr(s, n, ucsp, &ucslen, sizeof(ucsp), '/', flags, &consumed);
 +
 +    if (ret == ENAMETOOLONG)	/* Name didn't fit; only ucslen chars were decoded */
 +	return RET_TOOFEW(0);
@@ -1690,7 +1690,7 @@ diff -ruN libiconv-1.16-orig/lib/utf8mac.h libiconv-1.16/lib/utf8mac.h
 +}
 +
 +static int
-+utf8mac_wctomb (conv_t conv, unsigned char *r, ucs4_t wc, int n) /* n == 0 is acceptable */
++utf8mac_wctomb (conv_t conv, unsigned char *r, ucs4_t wc, size_t n) /* n == 0 is acceptable */
 +{
 +    int ret;
 +    size_t len;


### PR DESCRIPTION
Updates libiconv and libgettext/gettext-tools to their latest upstreams. Includes some fixes that are needed for soon to be released macOS15.

Taken from fink/fink#267, which is for bootstrapping, and this is for the installed tree.