### PR TITLE
setuptools-tng: v68.0.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py-59.6.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/setuptools-tng-py-59.6.0.info
@@ -1,8 +1,10 @@
 Info2: << 
 Package: setuptools-tng-py%type_pkg[python]
-# 68.0.0 is last version to support py37
-Type: python (3.7 3.8 3.9 3.10)
-Version: 68.0.0
+# 59.6.0 is last version to support py36
+# >=60 will break numpy
+Type: python (3.6)
+# last version to support setup.py install in other pymods before pep517
+Version: 59.6.0
 Revision: 1
 Distribution: <<
 	(%type_pkg[python] = 36 ) 10.9,
@@ -15,48 +17,38 @@ Distribution: <<
 	(%type_pkg[python] = 36 ) 10.15
 <<
 Source: https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-%v.tar.gz
-Source-Checksum: SHA256(baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235)
+Source-Checksum: SHA256(22c7348c6d2976a52632c67f7ab0cdf40147db7789f9aed18734643fe9cf3373)
 
-BuildDepends: <<
-	fink (>=0.32),
-	bootstrap-modules-py%type_pkg[python]
-<<
+BuildDepends: fink (>=0.32)
 Depends: python%type_pkg[python]
 Replaces: distribute-py%type_pkg[python] (<< 0.7.2-3), setuptools-py%type_pkg[python] (<< 0.7.2-3)
 
 Description: EasyInstall and python eggs
-License: OSI-Approved
 Maintainer: None <fink-devel@lists.sourceforge.net>
-CompileScript: <<
-	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m build --wheel --no-isolation --skip-dependency-check
+DocFiles: docs
+CompileScript: echo Skipping compile stage
+InstallScript: <<
+  %p/bin/python%type_raw[python] setup.py install --root=%d --single-version-externally-managed
 <<
 
+LICENSE: OSI-Approved
+HomePage: https://pypi.org/project/setuptools
 
 #InfoTest: <<
 #Circular dependencies if testing is enabled
 #	TestDepends: <<
-#		ini2toml-py%type_pkg[python],
 #		jaraco.envs-py%type_pkg[python],
 #		jaraco.functools-py%type_pkg[python],
-#		jaraco.path-py%type_pkg[python] (>= 3.2.0),
-#		path-py%type_pkg[python],
-#		pytest-py%type_pkg[python] (>= 6),
-#		pytest-checkdocs-py%type_pkg[python] (>= 2.4),
-#		pytest-cov-py%type_pkg[python],
+#		mock-py%type_pkg[python],
+#		paver-py%type_pkg[python],
+#		pytest-py%type_pkg[python],
 #		pytest-fixture-config-py%type_pkg[python],
-#		pytest-virtualenv-py%type_pkg[python],
-#		tomli-w-py%type_pkg[python]
+#		pytest-virtualenv-py%type_pkg[python]
 #	<<
 #	TestScript: <<
-#		%p/bin/python%type_raw[python] -m pytest -p no:relaxed -vv || exit 2
+#		%p/bin/python%type_raw[python] -m pytest  || exit 2
 #	<<
 #<<
-InstallScript: <<
-  PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m installer --destdir %d dist/*.whl
-<<
-
-DocFiles: docs License README.rst
-HomePage: https://pypi.org/project/setuptools
 
 DescDetail: <<
 Easily download, build, install, upgrade, and uninstall Python


### PR DESCRIPTION
drop py36 support
Running tests would cause a lot of circular dependencies, so comment out. Still missing several as of this moment (primarily jaraco.path and indirectly pyobjc).

Tested to build with py37, py38, and py310 on 10.14.6.
Have not actually tried to build something with it.

Current 59.6.0 says that 60+ will break numpy, but have not tested that either.