### PR TITLE
duplicity - Upstream update to V3.0.2

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/utils/duplicity.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/duplicity.info
@@ -57,8 +57,7 @@ InfoTest: <<
     TestScript: <<
     	#!/bin/sh -ev
 	ulimit -n 8192
-	PYTHONPATH='%b/build:%b/duplicity' %p/bin/python3.10 -Bm pytest -vv --capture=fd
-	# don't quit on test error || exit 2
+	%p/bin/pytest-3.10 -p no:xdist -p no:hypothesis -p no:randomly
     <<
 <<
 
@@ -73,7 +72,7 @@ InstallScript: <<
 
 # Documentation.
 DescDetail: <<
-Duplicity backs directories by producing encrypted
+Duplicity backsup directories by producing encrypted
 tar-format volumes and uploading them to a remote
 or local file server. Because duplicity uses
 librsync, the incremental archives are space
@@ -96,8 +95,8 @@ Documentation not built and installed since
 exists on the web.
 The testing phase needs more than the default 256
 maximum files, it is set to 8192 in the test script.
-Testing Phase (on MacOS 14.6) has
-459 passed, 17 skipped in 687.30s (0:11:27)
+Testing Phase (on MacOS 14.6.1) has
+461 passed, 17 skipped in 659.93s (0:10:59)
 supports
   ssh parmiko
   ssh pexpect

--- a/10.9-libcxx/stable/main/finkinfo/utils/duplicity.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/duplicity.info
@@ -1,5 +1,6 @@
+Info2: <<
 Package: duplicity
-Version: 3.0.0
+Version: 3.0.2
 Revision: 1
 Description: Encrypted backup using rsync algorithm
 License: GPL
@@ -33,7 +34,7 @@ Depends: <<
 
 # Unpack Phase.
 Source: https://gitlab.com/%n/%n/-/archive/rel.%v/%n-rel.%v.tar.gz
-Source-Checksum: SHA256(3100277e264778cf406513662efcc32059c03c3482da4b87cc206a2779374a7a)
+Source-Checksum: SHA256(a3ae582e0eb3070e0147ad8d4115a590932bcb2d47fca79c9ae81c82dc9bb1a8)
 
 # Patch Phase.
 PatchScript: <<
@@ -56,7 +57,8 @@ InfoTest: <<
     TestScript: <<
     	#!/bin/sh -ev
 	ulimit -n 8192
-	%p/bin/pytest-3.10 --capture=fd
+	PYTHONPATH='%b/build:%b/duplicity' %p/bin/python3.10 -Bm pytest -vv --capture=fd
+	# don't quit on test error || exit 2
     <<
 <<
 
@@ -90,13 +92,12 @@ GNU tar format.
 <<
 
 DescPackaging:  <<
+Documentation not built and installed since
+exists on the web.
 The testing phase needs more than the default 256
-maximum files, it is set to 8192 in the test script
-for older OS (<10.14).  Newer OS needs to be set
-manually since ulimit does not function the same.
-Testing phase (on MacOS 13.6) has:
-428 passed, 17 skipped, 1 warning in 469.83s (0:07:49)
-
+maximum files, it is set to 8192 in the test script.
+Testing Phase (on MacOS 14.6) has
+459 passed, 17 skipped in 687.30s (0:11:27)
 supports
   ssh parmiko
   ssh pexpect
@@ -109,13 +110,16 @@ supports
 
 Other backends
 Backend Requirements:
- * scp/sftp paramiko -- python-paramiko, python-pycryptopp
+ * scp/sftp paramiko -- python-paramiko
  * scp/sftp pexpect -- openssh, pexpect
  * lftp -- lftp version 3.7.15 or later
  * ncftp -- ncftp
  * OneDrive -- python-requests & python-requests-oauthlib
+(not Installed)
  * Azure -- python Azure SDK (not implemented)
  * Boto 2.7.0 or later for Glacier S3 access
 
 Previously maintained by Murali Vadivelu
+<<
+#Info2
 <<


### PR DESCRIPTION
Upstream bug fix update, also changed pytest to reliably and repeatedly pass all tests.