### PR TITLE
Update to compface face to patch implicit definition as int

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/compface.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/compface.info
@@ -3,16 +3,16 @@ Version: 1.5.2
 Revision: 3
 Source: http://ftp.xemacs.org/pub/xemacs/aux/%n-%v.tar.gz
 Source-Checksum: SHA256(a6998245f530217b800f33e01656be8d1f0445632295afa100e5c1611e4f6825)
-Source2: mirror:debian:pool/main/libc/libcompface/libcompface_1.5.2-5.diff.gz
+Source2: mirror:debian:pool/main/libc/libcompface/libcompface_%v-5.diff.gz
 Source2-Checksum: SHA256(0587f531d09aa229618e4f648ca085a816a8d35cb4d35e216446c7462ffef733)
 PatchFile: %n.patch
-PatchFile-Checksum: SHA256(32305e958a4ef1303369852eec1a5cab3eb7ed07e795dd9741ec4358abef933a)
+PatchFile-Checksum: SHA256(2c32e97dc4b8064083a35f3fd09391030310660b457ae850a4f41e1cf8b4ecd4)
 PatchFile2: %n-implicit-declarations.patch
-PatchFile2-MD5: 6ece31839e166a829152bbb1644e6a69
+PatchFile2-Checksum: SHA256(3e6621fad6f8a5041b3506e0cfbc21e6f396eed03862e68fa760c4fa37ea5262)
 BuildDepends: fink (>= 0.30.0-1)
 Depends: %N-shlibs (= %v-%r)
 PatchScript: <<
-	gzip -cd ../libcompface_1.5.2-5.diff.gz | patch -p1
+	gzip -cd ../libcompface_%v-5.diff.gz | patch -p1
 	%{default_script}
 <<
 ConfigureParams: --mandir='${prefix}/share/man'

--- a/10.9-libcxx/stable/main/finkinfo/graphics/compface.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/compface.info
@@ -1,12 +1,12 @@
 Package: compface
 Version: 1.5.2
-Revision: 3
+Revision: 4
 Source: http://ftp.xemacs.org/pub/xemacs/aux/%n-%v.tar.gz
 Source-Checksum: SHA256(a6998245f530217b800f33e01656be8d1f0445632295afa100e5c1611e4f6825)
 Source2: mirror:debian:pool/main/libc/libcompface/libcompface_1.5.2-5.diff.gz
 Source2-Checksum: SHA256(0587f531d09aa229618e4f648ca085a816a8d35cb4d35e216446c7462ffef733)
 PatchFile: %n.patch
-PatchFile-MD5: 742163684b5e05b8f8c017fd2bd6e0f1
+PatchFile-Checksum: SHA256(32305e958a4ef1303369852eec1a5cab3eb7ed07e795dd9741ec4358abef933a)
 PatchFile2: %n-implicit-declarations.patch
 PatchFile2-MD5: 6ece31839e166a829152bbb1644e6a69
 BuildDepends: fink (>= 0.30.0-1)

--- a/10.9-libcxx/stable/main/finkinfo/graphics/compface.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/compface.info
@@ -1,6 +1,6 @@
 Package: compface
 Version: 1.5.2
-Revision: 4
+Revision: 3
 Source: http://ftp.xemacs.org/pub/xemacs/aux/%n-%v.tar.gz
 Source-Checksum: SHA256(a6998245f530217b800f33e01656be8d1f0445632295afa100e5c1611e4f6825)
 Source2: mirror:debian:pool/main/libc/libcompface/libcompface_1.5.2-5.diff.gz

--- a/10.9-libcxx/stable/main/finkinfo/graphics/compface.patch
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/compface.patch
@@ -1,11 +1,12 @@
-diff -Nurd compface-1.5.2-orig/Makefile.in compface-1.5.2/Makefile.in
---- compface-1.5.2-orig/Makefile.in	2024-10-30 20:15:35
-+++ compface-1.5.2/Makefile.in	2024-10-30 21:17:49
-@@ -18,13 +18,15 @@
+diff -ruN compface-1.5.2-orig/Makefile.in compface-1.5.2/Makefile.in
+--- compface-1.5.2-orig/Makefile.in	2005-10-04 08:59:49
++++ compface-1.5.2/Makefile.in	2024-11-03 10:34:12
+@@ -17,14 +17,16 @@
+ SHELL           = /bin/sh
  
  NAME		= compface
++VERSION		= 1.4
  UNNAME		= uncompface
-+VERSION		= 1.5
  EXEEXT		= @EXEEXT@
  NAMEEXE		= $(NAME)$(EXEEXT)
  UNNAMEEXE	= $(UNNAME)$(EXEEXT)
@@ -45,9 +46,9 @@ diff -Nurd compface-1.5.2-orig/Makefile.in compface-1.5.2/Makefile.in
  
  shar :
  		shar.script $(OTHERS) $(HDRS) $(SOURCES) > $(NAME).sh
-diff -Nurd compface-1.5.2-orig/file.c compface-1.5.2/file.c
---- compface-1.5.2-orig/file.c	2024-10-30 20:42:42
-+++ compface-1.5.2/file.c	2024-10-30 20:48:21
+diff -ruN compface-1.5.2-orig/file.c compface-1.5.2/file.c
+--- compface-1.5.2-orig/file.c	2024-11-03 10:37:08
++++ compface-1.5.2/file.c	2024-11-03 10:35:48
 @@ -80,7 +80,7 @@
  	static char table_inv[] = { 0,8,4,12,2,10,6,14,1,9, 5,13, 3,11, 7,15 };
  	static char table_nop[] = { 0,1,2, 3,4, 5,6, 7,8,9,10,11,12,13,14,15 };
@@ -56,3 +57,4 @@ diff -Nurd compface-1.5.2-orig/file.c compface-1.5.2/file.c
 +	register int inc = 0;		/* optionally swap nimmles */
  	int bits;
  	int len;
+ 

--- a/10.9-libcxx/stable/main/finkinfo/graphics/compface.patch
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/compface.patch
@@ -1,12 +1,11 @@
-diff -Nurd -x'*~' compface-1.5.2.orig/Makefile.in compface-1.5.2/Makefile.in
---- compface-1.5.2.orig/Makefile.in	2005-10-04 08:59:49.000000000 -0400
-+++ compface-1.5.2/Makefile.in	2016-10-06 03:52:46.000000000 -0400
-@@ -17,14 +17,16 @@
- SHELL           = /bin/sh
+diff -Nurd compface-1.5.2-orig/Makefile.in compface-1.5.2/Makefile.in
+--- compface-1.5.2-orig/Makefile.in	2024-10-30 20:15:35
++++ compface-1.5.2/Makefile.in	2024-10-30 21:17:49
+@@ -18,13 +18,15 @@
  
  NAME		= compface
-+VERSION		= 1.4
  UNNAME		= uncompface
++VERSION		= 1.5
  EXEEXT		= @EXEEXT@
  NAMEEXE		= $(NAME)$(EXEEXT)
  UNNAMEEXE	= $(UNNAME)$(EXEEXT)
@@ -46,3 +45,14 @@ diff -Nurd -x'*~' compface-1.5.2.orig/Makefile.in compface-1.5.2/Makefile.in
  
  shar :
  		shar.script $(OTHERS) $(HDRS) $(SOURCES) > $(NAME).sh
+diff -Nurd compface-1.5.2-orig/file.c compface-1.5.2/file.c
+--- compface-1.5.2-orig/file.c	2024-10-30 20:42:42
++++ compface-1.5.2/file.c	2024-10-30 20:48:21
+@@ -80,7 +80,7 @@
+ 	static char table_inv[] = { 0,8,4,12,2,10,6,14,1,9, 5,13, 3,11, 7,15 };
+ 	static char table_nop[] = { 0,1,2, 3,4, 5,6, 7,8,9,10,11,12,13,14,15 };
+ 	char *table = table_nop;	/* optionally invert bits in nibble */
+-	register inc = 0;		/* optionally swap nimmles */
++	register int inc = 0;		/* optionally swap nimmles */
+ 	int bits;
+ 	int len;


### PR DESCRIPTION
Newer compiler choked on implicit definition.  Now is explicitly "int".  Builds under OS 15.1 and installs.
