### PR TITLE
Update locale-gettext for MacOS 15 / perl 5.34.1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/locale-gettext-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/locale-gettext-pm.info
@@ -16,7 +16,7 @@ Replaces: %N-doc
 Source: mirror:cpan:authors/id/P/PV/PVANDRY/gettext-%v.tar.gz
 Source-Checksum: SHA256(909d47954697e7c04218f972915b787bd1244d75e3bd01620bc167d5bbc49c15)
 SourceRename: Locale-gettext-%v.tar.gz
-Type: perl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3)
+Type: perl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3 5.34.1)
 Distribution: <<
 	(%type_pkg[perl] = 5162) 10.9,
 	(%type_pkg[perl] = 5162) 10.10,


### PR DESCRIPTION
Added perl version 5.34.1 as possible version for system perl in macOS 15.X