### PR TITLE
Updated help2man for perl 5.34.1 and macOS 15.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/help2man-perl.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/help2man-perl.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: help2man-perl%type_pkg[systemperl]
 Version: 1.49.2
-Revision: 1
+Revision: 2
 Distribution: <<
   (%type_pkg[systemperl] = 5162) 10.9,
   (%type_pkg[systemperl] = 5182) 10.10,
@@ -15,14 +15,15 @@ Distribution: <<
   (%type_pkg[systemperl] = 5302) 11.3,
   (%type_pkg[systemperl] = 5303) 12.0,
   (%type_pkg[systemperl] = 5303) 13.0,
-  (%type_pkg[systemperl] = 5303) 14.0
+  (%type_pkg[systemperl] = 5303) 14.0,
+  (%type_pkg[systemperl] = 5341) 15.0
 <<
 Source: mirror:gnu:help2man/help2man-%v.tar.xz
 Source-Checksum: SHA256(9e2e0e213a7e0a36244eed6204d902b6504602a578b6ecd15268b1454deadd36)
 ConfigureParams:  --infodir='%p/share/info' --mandir='%p/share/man'
 Depends: texinfo (>= 4.1-3), locale-gettext-pm%type_pkg[systemperl]
 BuildDepends: fink (>= 0.34), gettext-tools
-Type: systemperl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3)
+Type: systemperl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3 5.34.1)
 Provides: help2man
 Replaces: help2man
 Conflicts: help2man
@@ -48,6 +49,8 @@ CompileScript: <<
     PERL="/usr/bin/arch -%m perl5.30"
   elif [ "%type_pkg[systemperl]" = "5303" ] && [ -e "/usr/bin/perl5.30" ] ; then
     PERL="/usr/bin/arch -%m perl5.30"
+  elif [ "%type_pkg[systemperl]" = "5341" ] && [ -e "/usr/bin/perl5.34" ] ; then
+    PERL="/usr/bin/arch -%m perl5.34"
   else
     PERL="/usr/bin/env perl%type_raw[systemperl]"
   fi

--- a/10.9-libcxx/stable/main/finkinfo/devel/help2man-perl.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/help2man-perl.info
@@ -1,7 +1,7 @@
 Info2: <<
 Package: help2man-perl%type_pkg[systemperl]
 Version: 1.49.2
-Revision: 2
+Revision: 1
 Distribution: <<
   (%type_pkg[systemperl] = 5162) 10.9,
   (%type_pkg[systemperl] = 5182) 10.10,


### PR DESCRIPTION
Simple update of file, builds and installs on macOS 15.1, shouldn't change anything for other OS and perl versions.