### PR TITLE
Update to glib2-shlibs to compile under CLT 16.1 / macOS 15.X

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/gnome/glib2-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/gnome/glib2-shlibs.info
@@ -25,7 +25,7 @@ Replaces: glib2 (<< 2.12.0-1)
 Source: mirror:gnome:sources/glib/2.22/glib-%v.tar.bz2
 Source-Checksum: SHA256(0d1f6bf8aaeab772f2370229eefda45bef434e3f29a7d1d8e5dfafeaa1d8ad14)
 PatchFile: %n.patch
-PatchFile-MD5: 52b15fd8c1d1b57d7404370adbdcb8fd
+PatchFile-Checksum: SHA256(4d8136cd557884684ca81e6164f29966a8b2be79281373c37acec95d441582bf)
 PatchScript: <<
 	sed 's,@PREFIX@,%p,g' < %{PatchFile} | patch -p1
 

--- a/10.9-libcxx/stable/main/finkinfo/gnome/glib2-shlibs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/gnome/glib2-shlibs.patch
@@ -1,6 +1,6 @@
-diff -Nurd -x'*~' glib-2.22.4.orig/configure glib-2.22.4/configure
---- glib-2.22.4.orig/configure	2010-01-06 19:48:41.000000000 -0500
-+++ glib-2.22.4/configure	2023-02-24 00:46:35.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/configure glib-2.22.4/configure
+--- glib-2.22.4-orig/configure	2010-01-06 19:48:41
++++ glib-2.22.4/configure	2024-10-31 17:17:47
 @@ -4801,7 +4801,7 @@
  #define HAVE_CARBON 1
  _ACEOF
@@ -10,19 +10,19 @@ diff -Nurd -x'*~' glib-2.22.4.orig/configure glib-2.22.4/configure
  fi
  
  
-@@ -40056,6 +40056,9 @@
+@@ -40055,6 +40055,9 @@
+ 			# Guide".
  			G_THREAD_CFLAGS="-D_THREAD_SAFE"
  		fi
- 		;;
++		;;
 +	*-darwin*)
 +		# Nothing needed.
-+		;;
+ 		;;
  	*-dg-dgux*)  # DG/UX
  		G_THREAD_CFLAGS="-D_REENTRANT -D_POSIX4A_DRAFT10_SOURCE"
- 		;;
-diff -Nurd -x'*~' glib-2.22.4.orig/gio/Makefile.in glib-2.22.4/gio/Makefile.in
---- glib-2.22.4.orig/gio/Makefile.in	2010-01-06 19:48:36.000000000 -0500
-+++ glib-2.22.4/gio/Makefile.in	2010-01-13 09:57:06.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/gio/Makefile.in glib-2.22.4/gio/Makefile.in
+--- glib-2.22.4-orig/gio/Makefile.in	2010-01-06 19:48:36
++++ glib-2.22.4/gio/Makefile.in	2024-10-31 17:17:47
 @@ -677,6 +677,7 @@
  	$(SELINUX_LIBS) 				\
  	$(GLIB_LIBS) 					\
@@ -31,9 +31,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/gio/Makefile.in glib-2.22.4/gio/Makefile.in
  	$(NULL)
  
  @PLATFORM_WIN32_TRUE@no_undefined = -no-undefined
-diff -Nurd -x'*~' glib-2.22.4.orig/gio/gdesktopappinfo.c glib-2.22.4/gio/gdesktopappinfo.c
---- glib-2.22.4.orig/gio/gdesktopappinfo.c	2010-01-06 19:24:28.000000000 -0500
-+++ glib-2.22.4/gio/gdesktopappinfo.c	2010-01-13 08:35:24.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/gio/gdesktopappinfo.c glib-2.22.4/gio/gdesktopappinfo.c
+--- glib-2.22.4-orig/gio/gdesktopappinfo.c	2010-01-06 19:24:28
++++ glib-2.22.4/gio/gdesktopappinfo.c	2024-10-31 17:18:28
 @@ -1396,7 +1396,7 @@
        g_file_set_contents (filename, contents, -1, NULL);
        g_free (contents);
@@ -52,9 +52,18 @@ diff -Nurd -x'*~' glib-2.22.4.orig/gio/gdesktopappinfo.c glib-2.22.4/gio/gdeskto
    
    return TRUE;
  }
-diff -Nurd -x'*~' glib-2.22.4.orig/gio/gdrive.h glib-2.22.4/gio/gdrive.h
---- glib-2.22.4.orig/gio/gdrive.h	2009-08-28 22:52:22.000000000 -0400
-+++ glib-2.22.4/gio/gdrive.h	2010-01-13 09:13:20.000000000 -0500
+@@ -2358,7 +2358,7 @@
+   
+   for (i = 0; new_desktop_file_ids[i] != NULL; i++)
+     {
+-      if (!g_list_find_custom (desktop_file_ids, new_desktop_file_ids[i], strcmp))
++      if (!g_list_find_custom (desktop_file_ids, new_desktop_file_ids[i], (int (*)(const void *, const void *)) strcmp))
+ 	desktop_file_ids = g_list_append (desktop_file_ids,
+ 					  g_strdup (new_desktop_file_ids[i]));
+     }
+diff -Nurd -x*~ glib-2.22.4-orig/gio/gdrive.h glib-2.22.4/gio/gdrive.h
+--- glib-2.22.4-orig/gio/gdrive.h	2009-08-28 22:52:22
++++ glib-2.22.4/gio/gdrive.h	2024-10-31 17:17:47
 @@ -164,7 +164,7 @@
  gboolean g_drive_is_media_check_automatic (GDrive               *drive);
  gboolean g_drive_can_poll_for_media       (GDrive               *drive);
@@ -64,9 +73,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/gio/gdrive.h glib-2.22.4/gio/gdrive.h
  void     g_drive_eject                    (GDrive               *drive,
  					   GMountUnmountFlags    flags,
                                             GCancellable         *cancellable,
-diff -Nurd -x'*~' glib-2.22.4.orig/gio/gfile.h glib-2.22.4/gio/gfile.h
---- glib-2.22.4.orig/gio/gfile.h	2010-01-06 19:19:12.000000000 -0500
-+++ glib-2.22.4/gio/gfile.h	2010-01-13 09:13:13.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/gio/gfile.h glib-2.22.4/gio/gfile.h
+--- glib-2.22.4-orig/gio/gfile.h	2010-01-06 19:19:12
++++ glib-2.22.4/gio/gfile.h	2024-10-31 17:17:47
 @@ -867,7 +867,7 @@
  GFile *                 g_file_mount_mountable_finish     (GFile                      *file,
  							   GAsyncResult               *result,
@@ -85,9 +94,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/gio/gfile.h glib-2.22.4/gio/gfile.h
  void                    g_file_eject_mountable            (GFile                      *file,
  							   GMountUnmountFlags          flags,
  							   GCancellable               *cancellable,
-diff -Nurd -x'*~' glib-2.22.4.orig/gio/gmount.h glib-2.22.4/gio/gmount.h
---- glib-2.22.4.orig/gio/gmount.h	2010-01-06 19:19:12.000000000 -0500
-+++ glib-2.22.4/gio/gmount.h	2010-01-13 09:12:58.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/gio/gmount.h glib-2.22.4/gio/gmount.h
+--- glib-2.22.4-orig/gio/gmount.h	2010-01-06 19:19:12
++++ glib-2.22.4/gio/gmount.h	2024-10-31 17:17:47
 @@ -167,7 +167,7 @@
  gboolean    g_mount_can_unmount               (GMount              *mount);
  gboolean    g_mount_can_eject                 (GMount              *mount);
@@ -97,9 +106,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/gio/gmount.h glib-2.22.4/gio/gmount.h
  void        g_mount_unmount                   (GMount              *mount,
                                                 GMountUnmountFlags   flags,
                                                 GCancellable        *cancellable,
-diff -Nurd -x'*~' glib-2.22.4.orig/gio/gunixmounts.c glib-2.22.4/gio/gunixmounts.c
---- glib-2.22.4.orig/gio/gunixmounts.c	2009-03-31 19:04:20.000000000 -0400
-+++ glib-2.22.4/gio/gunixmounts.c	2010-01-13 08:39:56.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/gio/gunixmounts.c glib-2.22.4/gio/gunixmounts.c
+--- glib-2.22.4-orig/gio/gunixmounts.c	2009-03-31 19:04:20
++++ glib-2.22.4/gio/gunixmounts.c	2024-10-31 17:17:47
 @@ -243,6 +243,7 @@
      "/proc",
      "/sbin",
@@ -108,9 +117,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/gio/gunixmounts.c glib-2.22.4/gio/gunixmounts
      NULL
    };
  
-diff -Nurd -x'*~' glib-2.22.4.orig/gio/gvolume.h glib-2.22.4/gio/gvolume.h
---- glib-2.22.4.orig/gio/gvolume.h	2009-08-28 22:52:23.000000000 -0400
-+++ glib-2.22.4/gio/gvolume.h	2010-01-13 09:12:51.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/gio/gvolume.h glib-2.22.4/gio/gvolume.h
+--- glib-2.22.4-orig/gio/gvolume.h	2009-08-28 22:52:23
++++ glib-2.22.4/gio/gvolume.h	2024-10-31 17:17:47
 @@ -180,7 +180,7 @@
  gboolean g_volume_mount_finish          (GVolume              *volume,
  					 GAsyncResult         *result,
@@ -120,9 +129,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/gio/gvolume.h glib-2.22.4/gio/gvolume.h
  void     g_volume_eject                 (GVolume              *volume,
  					 GMountUnmountFlags    flags,
  					 GCancellable         *cancellable,
-diff -Nurd -x'*~' glib-2.22.4.orig/gio/gvolumemonitor.h glib-2.22.4/gio/gvolumemonitor.h
---- glib-2.22.4.orig/gio/gvolumemonitor.h	2009-08-28 22:52:23.000000000 -0400
-+++ glib-2.22.4/gio/gvolumemonitor.h	2010-01-13 09:11:16.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/gio/gvolumemonitor.h glib-2.22.4/gio/gvolumemonitor.h
+--- glib-2.22.4-orig/gio/gvolumemonitor.h	2009-08-28 22:52:23
++++ glib-2.22.4/gio/gvolumemonitor.h	2024-10-31 17:17:47
 @@ -142,7 +142,7 @@
  GMount *        g_volume_monitor_get_mount_for_uuid   (GVolumeMonitor *volume_monitor,
                                                         const char     *uuid);
@@ -132,9 +141,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/gio/gvolumemonitor.h glib-2.22.4/gio/gvolumem
  GVolume *       g_volume_monitor_adopt_orphan_mount   (GMount         *mount);
  #endif
  
-diff -Nurd -x'*~' glib-2.22.4.orig/gio/xdgmime/xdgmime.c glib-2.22.4/gio/xdgmime/xdgmime.c
---- glib-2.22.4.orig/gio/xdgmime/xdgmime.c	2009-10-06 16:07:59.000000000 -0400
-+++ glib-2.22.4/gio/xdgmime/xdgmime.c	2010-01-13 08:35:09.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/gio/xdgmime/xdgmime.c glib-2.22.4/gio/xdgmime/xdgmime.c
+--- glib-2.22.4-orig/gio/xdgmime/xdgmime.c	2009-10-06 16:07:59
++++ glib-2.22.4/gio/xdgmime/xdgmime.c	2024-10-31 17:17:47
 @@ -257,7 +257,7 @@
  
    xdg_data_dirs = getenv ("XDG_DATA_DIRS");
@@ -144,9 +153,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/gio/xdgmime/xdgmime.c glib-2.22.4/gio/xdgmime
  
    ptr = xdg_data_dirs;
  
-diff -Nurd -x'*~' glib-2.22.4.orig/glib/gconvert.c glib-2.22.4/glib/gconvert.c
---- glib-2.22.4.orig/glib/gconvert.c	2009-11-01 15:01:21.000000000 -0500
-+++ glib-2.22.4/glib/gconvert.c	2014-02-21 12:28:25.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/glib/gconvert.c glib-2.22.4/glib/gconvert.c
+--- glib-2.22.4-orig/glib/gconvert.c	2009-11-01 15:01:21
++++ glib-2.22.4/glib/gconvert.c	2024-10-31 17:17:47
 @@ -539,7 +539,9 @@
   * g_convert_with_iconv:
   * @str:           the string to convert
@@ -284,9 +293,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/glib/gconvert.c glib-2.22.4/glib/gconvert.c
   * @bytes_read:    location to store the number of bytes in the
   *                 input string that were successfully converted, or %NULL.
   *                 Even if the conversion was successful, this may be 
-diff -Nurd -x'*~' glib-2.22.4.orig/glib/gmacros.h glib-2.22.4/glib/gmacros.h
---- glib-2.22.4.orig/glib/gmacros.h	2009-03-31 19:04:20.000000000 -0400
-+++ glib-2.22.4/glib/gmacros.h	2010-01-13 09:11:26.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/glib/gmacros.h glib-2.22.4/glib/gmacros.h
+--- glib-2.22.4-orig/glib/gmacros.h	2009-03-31 19:04:20
++++ glib-2.22.4/glib/gmacros.h	2024-10-31 17:17:47
 @@ -120,7 +120,8 @@
  #define G_GNUC_WARN_UNUSED_RESULT
  #endif /* __GNUC__ */
@@ -297,9 +306,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/glib/gmacros.h glib-2.22.4/glib/gmacros.h
  /* Wrap the gcc __PRETTY_FUNCTION__ and __FUNCTION__ variables with
   * macros, so we can refer to them as strings unconditionally.
   * usage not-recommended since gcc-3.0
-diff -Nurd -x'*~' glib-2.22.4.orig/glib/gmessages.h glib-2.22.4/glib/gmessages.h
---- glib-2.22.4.orig/glib/gmessages.h	2009-08-28 22:52:23.000000000 -0400
-+++ glib-2.22.4/glib/gmessages.h	2010-01-13 09:11:36.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/glib/gmessages.h glib-2.22.4/glib/gmessages.h
+--- glib-2.22.4-orig/glib/gmessages.h	2009-08-28 22:52:23
++++ glib-2.22.4/glib/gmessages.h	2024-10-31 17:17:47
 @@ -121,7 +121,8 @@
                                 int             line,
                                 const char     *func,
@@ -310,9 +319,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/glib/gmessages.h glib-2.22.4/glib/gmessages.h
  void g_assert_warning         (const char *log_domain,
  			       const char *file,
  			       const int   line,
-diff -Nurd -x'*~' glib-2.22.4.orig/glib/gslice.c glib-2.22.4/glib/gslice.c
---- glib-2.22.4.orig/glib/gslice.c	2009-03-31 19:04:20.000000000 -0400
-+++ glib-2.22.4/glib/gslice.c	2010-01-13 09:06:27.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/glib/gslice.c glib-2.22.4/glib/gslice.c
+--- glib-2.22.4-orig/glib/gslice.c	2009-03-31 19:04:20
++++ glib-2.22.4/glib/gslice.c	2024-10-31 17:17:47
 @@ -1131,19 +1131,18 @@
                      gsize memsize)
  {
@@ -348,29 +357,21 @@ diff -Nurd -x'*~' glib-2.22.4.orig/glib/gslice.c glib-2.22.4/glib/gslice.c
    return aligned_memory;
  }
  
-diff -Nurd glib-2.22.4.orig/glib/gunicollate.c glib-2.22.4/glib/gunicollate.c
---- glib-2.22.4.orig/glib/gunicollate.c	2009-03-31 19:04:20.000000000 -0400
-+++ glib-2.22.4/glib/gunicollate.c	2023-02-24 00:50:06.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/glib/gunicollate.c glib-2.22.4/glib/gunicollate.c
+--- glib-2.22.4-orig/glib/gunicollate.c	2009-03-31 19:04:20
++++ glib-2.22.4/glib/gunicollate.c	2024-10-31 17:17:47
 @@ -210,28 +210,31 @@
  {
    gchar *result;
    gsize result_len;
 -  gsize i;
--
++  long *lkey = (long *) key;
+ 
 -  /* Pretty smart algorithm here: ignore first eight bytes of the
 -   * collation key. It doesn't produce results equivalent to
 -   * UCCompareCollationKeys's, but the difference seems to be only
 -   * that UCCompareCollationKeys in some cases produces 0 where our
 -   * comparison gets -1 or 1. */
--
--  if (key_len * sizeof (UCCollationValue) <= 8)
--    return g_strdup ("");
-+  long *lkey = (long *) key;
- 
--  result_len = 0;
--  for (i = 8; i < key_len * sizeof (UCCollationValue); i++)
--    /* there may be nul bytes, encode byteval+1 */
--    result_len += utf8_encode (NULL, *((guchar*)key + i) + 1);
 +  /* UCCollationValue format:
 +   *
 +   * UCCollateOptions (32/64 bits)
@@ -389,6 +390,14 @@ diff -Nurd glib-2.22.4.orig/glib/gunicollate.c glib-2.22.4/glib/gunicollate.c
 +   * chars. Also, experience shows this is directly strcmp-able.
 +   */
  
+-  if (key_len * sizeof (UCCollationValue) <= 8)
+-    return g_strdup ("");
+-
+-  result_len = 0;
+-  for (i = 8; i < key_len * sizeof (UCCollationValue); i++)
+-    /* there may be nul bytes, encode byteval+1 */
+-    result_len += utf8_encode (NULL, *((guchar*)key + i) + 1);
+-
 +  result_len = lkey[1];
    result = g_malloc (result_len + 1);
 -  result_len = 0;
@@ -401,9 +410,9 @@ diff -Nurd glib-2.22.4.orig/glib/gunicollate.c glib-2.22.4/glib/gunicollate.c
    return result;
  }
  
-diff -Nurd -x'*~' glib-2.22.4.orig/glib/gutils.c glib-2.22.4/glib/gutils.c
---- glib-2.22.4.orig/glib/gutils.c	2009-12-21 09:20:17.000000000 -0500
-+++ glib-2.22.4/glib/gutils.c	2010-01-13 08:34:24.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/glib/gutils.c glib-2.22.4/glib/gutils.c
+--- glib-2.22.4-orig/glib/gutils.c	2009-12-21 09:20:17
++++ glib-2.22.4/glib/gutils.c	2024-10-31 17:17:47
 @@ -2779,7 +2779,7 @@
        gchar *data_dirs = (gchar *) g_getenv ("XDG_DATA_DIRS");
  
@@ -422,9 +431,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/glib/gutils.c glib-2.22.4/glib/gutils.c
  
        conf_dir_vector = g_strsplit (conf_dirs, G_SEARCHPATH_SEPARATOR_S, 0);
  #endif
-diff -Nurd -x'*~' glib-2.22.4.orig/glib/gutils.h glib-2.22.4/glib/gutils.h
---- glib-2.22.4.orig/glib/gutils.h	2010-01-06 19:19:20.000000000 -0500
-+++ glib-2.22.4/glib/gutils.h	2010-01-13 08:33:50.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/glib/gutils.h glib-2.22.4/glib/gutils.h
+--- glib-2.22.4-orig/glib/gutils.h	2010-01-06 19:19:20
++++ glib-2.22.4/glib/gutils.h	2024-10-31 17:17:47
 @@ -101,7 +101,11 @@
  #  define G_INLINE_FUNC
  #  undef  G_CAN_INLINE
@@ -437,9 +446,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/glib/gutils.h glib-2.22.4/glib/gutils.h
  #elif defined (G_CAN_INLINE) 
  #  define G_INLINE_FUNC static inline
  #else /* can't inline */
-diff -Nurd -x'*~' glib-2.22.4.orig/glib/libcharset/Makefile.in glib-2.22.4/glib/libcharset/Makefile.in
---- glib-2.22.4.orig/glib/libcharset/Makefile.in	2010-01-06 19:48:38.000000000 -0500
-+++ glib-2.22.4/glib/libcharset/Makefile.in	2010-01-13 08:33:32.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/glib/libcharset/Makefile.in glib-2.22.4/glib/libcharset/Makefile.in
+--- glib-2.22.4-orig/glib/libcharset/Makefile.in	2010-01-06 19:48:38
++++ glib-2.22.4/glib/libcharset/Makefile.in	2024-10-31 17:17:47
 @@ -310,7 +310,7 @@
  	codeset.m4 update.sh make-patch.sh libcharset-glib.patch
  TEST_PROGS = 
@@ -469,9 +478,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/glib/libcharset/Makefile.in glib-2.22.4/glib/
  	if test -f $(charset_alias); then \
  	  sed -f ref-add.sed $(charset_alias) > $(charset_tmp) ; \
  	  $(INSTALL_DATA) $(charset_tmp) $(charset_alias) ; \
-diff -Nurd -x'*~' glib-2.22.4.orig/glib/libcharset/charset.alias glib-2.22.4/glib/libcharset/charset.alias
---- glib-2.22.4.orig/glib/libcharset/charset.alias	1969-12-31 19:00:00.000000000 -0500
-+++ glib-2.22.4/glib/libcharset/charset.alias	2010-01-13 08:32:49.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/glib/libcharset/charset.alias glib-2.22.4/glib/libcharset/charset.alias
+--- glib-2.22.4-orig/glib/libcharset/charset.alias	1969-12-31 19:00:00
++++ glib-2.22.4/glib/libcharset/charset.alias	2024-10-31 17:17:47
 @@ -0,0 +1,111 @@
 +# This file contains a table of character encoding aliases,
 +# suitable for operating system 'darwin'.
@@ -584,9 +593,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/glib/libcharset/charset.alias glib-2.22.4/gli
 +zh_CN.EUC		GB2312
 +zh_TW			UTF-8
 +zh_TW.Big5		BIG5
-diff -Nurd -x'*~' glib-2.22.4.orig/glib-gettextize.in glib-2.22.4/glib-gettextize.in
---- glib-2.22.4.orig/glib-gettextize.in	2009-03-31 19:04:20.000000000 -0400
-+++ glib-2.22.4/glib-gettextize.in	2010-01-13 08:31:30.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/glib-gettextize.in glib-2.22.4/glib-gettextize.in
+--- glib-2.22.4-orig/glib-gettextize.in	2009-03-31 19:04:20
++++ glib-2.22.4/glib-gettextize.in	2024-10-31 17:17:47
 @@ -49,8 +49,8 @@
      ;;
  esac
@@ -597,9 +606,9 @@ diff -Nurd -x'*~' glib-2.22.4.orig/glib-gettextize.in glib-2.22.4/glib-gettextiz
  
  gettext_dir=$prefix/share/glib-2.0/gettext
  
-diff -Nurd -x'*~' glib-2.22.4.orig/tests/child-test.c glib-2.22.4/tests/child-test.c
---- glib-2.22.4.orig/tests/child-test.c	2009-03-31 19:04:20.000000000 -0400
-+++ glib-2.22.4/tests/child-test.c	2010-01-13 08:30:21.000000000 -0500
+diff -Nurd -x*~ glib-2.22.4-orig/tests/child-test.c glib-2.22.4/tests/child-test.c
+--- glib-2.22.4-orig/tests/child-test.c	2009-03-31 19:04:20
++++ glib-2.22.4/tests/child-test.c	2024-10-31 17:17:47
 @@ -175,7 +175,7 @@
  #ifdef G_OS_WIN32
    system ("ipconfig /all");


### PR DESCRIPTION
Added cast to strcmp function, line 2361 of gdesktopappinfo.c needed (int (*)(const void *, const void *)) before strcmp for consistency.

I applied existing patch file to source, edited gdesktopappinfo.c and created new patch file, but there seem to be more differences between the patch files than the one edit.
(getting closer to building ghostscript)