### PR TITLE
xft2-dev patch to complie under macOS 15 / CLT 16.1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/x11/xft2-dev.info
+++ b/10.9-libcxx/stable/main/finkinfo/x11/xft2-dev.info
@@ -19,7 +19,7 @@ Depends: xft2-shlibs (= %v-%r)
 Source-Checksum: SHA256(c8685ae56da0c1dcc2bc1e34607e7d76ae98b86a1a71baba3a6b76dbcf5ff9b2)
 Source: http://xorg.freedesktop.org/releases/individual/lib/libXft-%v.tar.bz2
 PatchFile: %n.patch
-PatchFile-MD5: 95f1a8efbec3abec682e76e2df8b792a
+PatchFile-Checksum: SHA256(c36aeabbe147f49ec0ddd5003f67e710348d8a1255612dd94f75630251905c54)
 ConfigureParams: --prefix=%p/lib/xft2 --mandir=%p/share/man --disable-silent-rules --enable-dependency-tracking --disable-static
 
 # Moved from pkgconfig to ppkg-config for Apple Silicon

--- a/10.9-libcxx/stable/main/finkinfo/x11/xft2-dev.patch
+++ b/10.9-libcxx/stable/main/finkinfo/x11/xft2-dev.patch
@@ -1,6 +1,6 @@
-diff -Nurd -x'*~' libXft-2.2.0.orig/src/Makefile.in libXft-2.2.0/src/Makefile.in
---- libXft-2.2.0.orig/src/Makefile.in	2010-10-29 19:22:06.000000000 -0400
-+++ libXft-2.2.0/src/Makefile.in	2011-04-22 16:40:59.000000000 -0400
+diff -ruN libXft-2.2.0-orig/src/Makefile.in libXft-2.2.0/src/Makefile.in
+--- libXft-2.2.0-orig/src/Makefile.in	2010-10-29 19:22:06
++++ libXft-2.2.0/src/Makefile.in	2024-10-31 18:05:45
 @@ -254,8 +254,8 @@
  top_build_prefix = @top_build_prefix@
  top_builddir = @top_builddir@
@@ -12,9 +12,21 @@ diff -Nurd -x'*~' libXft-2.2.0.orig/src/Makefile.in libXft-2.2.0/src/Makefile.in
  
  lib_LTLIBRARIES = libXft.la
  libXft_la_SOURCES = xftint.h \
-diff -Nurd -x'*~' libXft-2.2.0.orig/src/xftglyphs.c libXft-2.2.0/src/xftglyphs.c
---- libXft-2.2.0.orig/src/xftglyphs.c	2009-10-16 17:27:08.000000000 -0400
-+++ libXft-2.2.0/src/xftglyphs.c	2015-01-25 01:07:12.000000000 -0500
+diff -ruN libXft-2.2.0-orig/src/xftdpy.c libXft-2.2.0/src/xftdpy.c
+--- libXft-2.2.0-orig/src/xftdpy.c	2009-10-16 17:27:08
++++ libXft-2.2.0/src/xftdpy.c	2024-10-31 18:10:10
+@@ -160,7 +160,7 @@
+     info->next = _XftDisplayInfo;
+     _XftDisplayInfo = info;
+ 
+-    info->glyph_memory = NULL;
++    info->glyph_memory = (unsigned long) NULL;
+     info->max_glyph_memory = XftDefaultGetInteger (dpy,
+ 						   XFT_MAX_GLYPH_MEMORY, 0,
+ 						   XFT_DPY_MAX_GLYPH_MEMORY);
+diff -ruN libXft-2.2.0-orig/src/xftglyphs.c libXft-2.2.0/src/xftglyphs.c
+--- libXft-2.2.0-orig/src/xftglyphs.c	2009-10-16 17:27:08
++++ libXft-2.2.0/src/xftglyphs.c	2024-10-31 18:05:45
 @@ -21,10 +21,11 @@
   */
  


### PR DESCRIPTION
Needed cast of NULL to (unsigned long) in xftdpy.c to comply with stricter compiler requirements.