### PR TITLE
cpan-meta-pm updated for perl 5.34.1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/cpan-meta-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/cpan-meta-pm.info
@@ -11,7 +11,7 @@ Homepage: https://metacpan.org/dist/CPAN-Meta/
 Source: mirror:cpan:authors/id/D/DA/DAGOLDEN/CPAN-Meta-%v.tar.gz
 Source-Checksum: SHA256(e4f80f2ec73e0741455f957bbfc992b167ecbfa1c9e23ba358df3b37b86ba3d6)
 
-Type: perl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3)
+Type: perl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3 5.34.1)
 Distribution: <<
 	(%type_pkg[perl] = 5162) 10.9,
 	(%type_pkg[perl] = 5162) 10.10,


### PR DESCRIPTION
added 5.34.1 to Type: perl
And with the other two PRs will now build and load.