### PR TITLE
Fix mac-fsevents-pm to build and run on macOS beyond X

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/mac-fsevents-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/mac-fsevents-pm.info
@@ -6,7 +6,7 @@ Revision: 1
 Description: Monitor a directory structure for changes
 License: Artistic
 Maintainer: Steve Huff <shuff@vecna.org>
-Type: perl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3)
+Type: perl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3 5.34.1)
 Distribution: <<
 	(%type_pkg[perl] = 5162) 10.9,
 	(%type_pkg[perl] = 5162) 10.10,
@@ -16,6 +16,8 @@ Distribution: <<
 <<
 Source: mirror:cpan:authors/id/R/RH/RHOELZ/Mac-FSEvents-%v.tar.gz
 Source-Checksum: SHA256(231b0533e2af1dd914a79265b8c4c95e0738ccca8159c69f742965ac8cec4018)
+PatchFile: %{ni}.patch
+PatchFile-MD5: 3c0a1c5030687d2a9e42b270f61cc7c6
 UpdatePOD: true
 DocFiles: README Changes
 InstallScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/mac-fsevents-pm.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/mac-fsevents-pm.patch
@@ -1,0 +1,54 @@
+diff -Nurd Mac-FSEvents-0.14/MacVersion.pm.orig Mac-FSEvents-0.14/MacVersion.pm
+--- Mac-FSEvents-0.14/MacVersion.pm.orig	2017-11-30 17:17:30
++++ Mac-FSEvents-0.14/MacVersion.pm	2024-11-08 19:22:04
+@@ -9,7 +9,7 @@
+ 
+ sub osx_version {
+     my $os_version = qx(system_profiler SPSoftwareDataType);
+-    if($os_version =~ /System Version:.+(?:(10)\.(\d+)(?:\.(\d+))?)/) {
++    if($os_version =~ /System Version:.+(?:(1[0-5])\.(\d+)(?:\.(\d+))?)/) {
+         return ($1, $2, $3 || 0);
+     } else {
+         $os_version =~ s/^/> /gm;
+diff -Nurd Mac-FSEvents-0.14/Makefile.PL.orig Mac-FSEvents-0.14/Makefile.PL
+--- Mac-FSEvents-0.14/Makefile.PL.orig	2017-11-30 17:17:30
++++ Mac-FSEvents-0.14/Makefile.PL	2024-11-08 19:54:40
+@@ -84,10 +84,10 @@
+ 
+ my ( $major, $minor, $release ) = osx_version();
+ 
+-if($minor >= 6) {
++if($major >= 11 or $minor >= 6) {
+     push @names, 'kFSEventStreamCreateFlagIgnoreSelf';
+ 
+-    if($minor >= 7) {
++    if($major >= 11 or $minor >= 7) {
+         push @names, 'kFSEventStreamCreateFlagFileEvents';
+     }
+ }
+
+diff -Nurd Mac-FSEvents-0.14/hints/darwin.pl.orig Mac-FSEvents-0.14/hints/darwin.pl
+--- Mac-FSEvents-0.14/hints/darwin.pl.orig	2017-11-30 17:17:30
++++ Mac-FSEvents-0.14/hints/darwin.pl	2024-11-08 19:17:49
+@@ -7,7 +7,7 @@
+     my ( $major, $minor, $release ) = osx_version();
+     my $os_version = join('.', $major, $minor);
+ 
+-    if($minor >= 5) { # Leopard and up
++    if($major > 10 or $minor >= 5) { # Leopard and up
+         my @directories = (
+             "/Developer/SDKs/MacOSX$os_version.sdk",
+             "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$os_version.sdk",
+@@ -27,7 +27,11 @@
+             die "No SDK found for your version of OS X.  Please install Xcode.\n";
+         }
+ 
+-        $arch = "-arch x86_64 -arch i386 -isysroot $sysroot -mmacosx-version-min=$os_version";
++        if($major > 10) { # Big Sur and up
++                $arch = "-arch x86_64 -arch arm64 -isysroot $sysroot -mmacosx-version-min=$os_version";
++        } else {
++                $arch = "-arch x86_64 -arch i386 -isysroot $sysroot -mmacosx-version-min=$os_version";
++        }
+     } else {
+         $arch = "-arch i386 -arch ppc";
+     }


### PR DESCRIPTION
Adding Perl 5.34.1 version; package did not even build to the Makefile creation step on 15.1 – it is unclear how it would ever have built on recent macOS since `MacVersion.pm` has been explicitly testing for `$major == 10`.
Not sure if the `@arch` combinations here will work for everything from 11.0-15.0, so should be checked on some other systems.

I tested for arm64 and x86_64 on Sequoia, both with one test failure, which probably points to a real issue:
```
/usr/bin/make test || exit 2
"/usr/bin/arch" -arm64 perl5.34 -MExtUtils::Command::MM -e 'cp_nonempty' -- FSEvents.bs /opt/sw2/src/fink.build/mac-fsevents-pm5341-0.14-1/Mac-FSEvents-0.14/blib/arch/auto/Mac/FSEvents/FSEvents.bs 644
PERL_DL_NONLAZY=1 "/usr/bin/arch" -arm64 perl5.34 "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', '/opt/sw2/src/fink.build/mac-fsevents-pm5341-0.14-1/Mac-FSEvents-0.14/blib/arch')" t/*.t
t/01use.t .................. ok   
t/02constructor.t .......... ok   
t/03event.t ................ ok   
t/04flags.t ................ 
    #   Failed test 'one event, because it's coalesced'
    #   at t/04flags.t line 66.
    #          got: '2'
    #     expected: '1'
    # Looks like you failed 1 test of 2.
t/04flags.t ................ 1/? 
#   Failed test 'none'
#   at t/04flags.t line 68.
t/04flags.t ................ 4/? # Looks like you failed 1 test of 4.
t/04flags.t ................ Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/4 subtests 
t/05fork.t ................. ok   
t/06receive-all-changes.t .. ok   

Test Summary Report
-------------------
t/04flags.t              (Wstat: 256 Tests: 4 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
Files=6, Tests=14, 16 wallclock secs ( 0.04 usr  0.05 sys +  1.16 cusr  1.39 csys =  2.64 CPU)
Result: FAIL
Failed 1/6 test programs. 1/14 subtests failed.
make: *** [test_dynamic] Error 255
```
i.e.
```perl
    my @events = fetch_events($fs, $fh);
    is scalar(@events), 1, "one event, because it's coalesced";
    like $events[0]->path, qr/^\Q$tmp_abs/;
```
is returning 2 events where only 1 should be found.
Out of my perl depth to investigate this further.

As a check I also built on 10.14, which is passing all tests both before and with this patch.