### PR TITLE
Support arm processor in libtidyp-shlibs

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/web/libtidyp-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/web/libtidyp-shlibs.info
@@ -11,7 +11,11 @@ Source: http://homepage.mac.com/danielj7/tidyp-%v.tar.gz
 Source-Checksum: SHA256(20b0fad32c63575bd4685ed09b8c5ca222bbc7b15284210d4b576d0223f0b338)
 
 # Using -version-info AND -release is bad.
-PatchScript: perl -pi -e 's/-release \$\(LT_RELEASE\) //' src/Makefile.in
+# Allow detection of arm cpu.
+PatchScript: <<
+  perl -pi -e 's/-release \$\(LT_RELEASE\) //' src/Makefile.in
+  perl -pi -e 's/(powerpc)(. UNAME_PROCESSOR)(=powerpc)/*${2}=`uname -p`/' config.guess
+<<
 
 UseMaxBuildJobs: true
 


### PR DESCRIPTION
Only a small patch to config.guess required, should even continue to support powerpc ;-)
the rest of the build proceeds without further changes.
I was able to build html-tidy-pm in #1181 with this (15.1/Xcode 16.1 arm64).