### PR TITLE
gnutls30-3.7 patch for updated compiler

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-3.7-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-3.7-shlibs.info
@@ -38,7 +38,7 @@ BuildDepends: <<
 	pkgconfig
 <<
 PatchFile: %n.patch
-PatchFile-MD5: a4ae29a2136df8a4e4f9f3f826c63c22
+PatchFile-Checksum: SHA256(c2fa4c3ae5ec2ac6e965e8f0b31571ceabc6aeecbab0ad4538e63710e4c6e41f)
 PatchScript: <<
 	%{default_script}
 	#strip unnecessary lines from .pc

--- a/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-3.7-shlibs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/gnutls30-3.7-shlibs.patch
@@ -1,34 +1,7 @@
-Description: Version filename of locale data (gnutls30.mo instead of
- gnutls.mo) This is necessary to make e.g. libgnutls26 and libgnutls28
- co-installable.
-Author: Andreas Metzler <ametzler@debian.org>
-Last-Update: 2020-09-06
-
---- a/po/Makevars
-+++ b/po/Makevars
-@@ -5,7 +5,7 @@
- # unlimited permission to use, copy, distribute, and modify it.
- 
- # Usually the message domain is the same as the package name.
--DOMAIN = $(PACKAGE)
-+DOMAIN = $(PACKAGE)30
- 
- # These two variables depend on the location of this directory.
- subdir = po
---- a/lib/global.c
-+++ b/lib/global.c
-@@ -262,7 +262,7 @@ static int _gnutls_global_init(unsigned
- 	}
- 
- #ifdef HAVE_DCGETTEXT
--	bindtextdomain(PACKAGE, LOCALEDIR);
-+	bindtextdomain(GNUTLSDOMAIN, LOCALEDIR);
- #endif
- 
- 	res = gnutls_crypto_init();
---- a/configure.ac
-+++ b/configure.ac
-@@ -320,6 +320,9 @@ dnl Try the hooks.m4
+diff -ruN gnutls-3.7.10-orig/configure.ac gnutls-3.7.10/configure.ac
+--- gnutls-3.7.10-orig/configure.ac	2023-08-03 10:42:37
++++ gnutls-3.7.10/configure.ac	2024-11-11 17:07:09
+@@ -339,6 +339,9 @@
  LIBGNUTLS_HOOKS
  LIBGNUTLS_EXTRA_HOOKS
  
@@ -38,8 +11,21 @@ Last-Update: 2020-09-06
  AC_ARG_ENABLE(tests,
    AS_HELP_STRING([--disable-tests], [don't compile or run any tests]),
      enable_tests=$enableval, enable_tests=$enable_tools)
---- a/lib/str.h
-+++ b/lib/str.h
+diff -ruN gnutls-3.7.10-orig/lib/global.c gnutls-3.7.10/lib/global.c
+--- gnutls-3.7.10-orig/lib/global.c	2023-08-03 10:42:26
++++ gnutls-3.7.10/lib/global.c	2024-11-11 17:07:09
+@@ -254,7 +254,7 @@
+ 	}
+ 
+ #ifdef HAVE_DCGETTEXT
+-	bindtextdomain(PACKAGE, LOCALEDIR);
++	bindtextdomain(GNUTLSDOMAIN, LOCALEDIR);
+ #endif
+ 
+ 	res = gnutls_crypto_init();
+diff -ruN gnutls-3.7.10-orig/lib/str.h gnutls-3.7.10/lib/str.h
+--- gnutls-3.7.10-orig/lib/str.h	2023-08-03 10:42:26
++++ gnutls-3.7.10/lib/str.h	2024-11-11 17:07:09
 @@ -33,7 +33,7 @@
  
  #ifdef HAVE_DCGETTEXT
@@ -49,8 +35,21 @@ Last-Update: 2020-09-06
  # define N_(String) gettext_noop (String)
  #else
  # define _(String) String
---- a/libdane/errors.c
-+++ b/libdane/errors.c
+diff -ruN gnutls-3.7.10-orig/lib/system/certs.c gnutls-3.7.10/lib/system/certs.c
+--- gnutls-3.7.10-orig/lib/system/certs.c	2023-08-03 10:42:26
++++ gnutls-3.7.10/lib/system/certs.c	2024-11-11 17:07:39
+@@ -278,7 +278,7 @@
+ }
+ #elif defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ static
+-int osstatus_error(status)
++int osstatus_error(int status)
+ {
+ 	CFStringRef err_str = SecCopyErrorMessageString(status, NULL);
+ 	_gnutls_debug_log("Error loading system root certificates: %s\n",
+diff -ruN gnutls-3.7.10-orig/libdane/errors.c gnutls-3.7.10/libdane/errors.c
+--- gnutls-3.7.10-orig/libdane/errors.c	2023-08-03 10:42:26
++++ gnutls-3.7.10/libdane/errors.c	2024-11-11 17:07:09
 @@ -25,7 +25,7 @@
  
  /* I18n of error codes. */
@@ -60,3 +59,15 @@ Last-Update: 2020-09-06
  #define N_(String) gettext_noop (String)
  
  #define ERROR_ENTRY(desc, name) \
+diff -ruN gnutls-3.7.10-orig/po/Makevars gnutls-3.7.10/po/Makevars
+--- gnutls-3.7.10-orig/po/Makevars	2023-08-03 10:47:44
++++ gnutls-3.7.10/po/Makevars	2024-11-11 17:07:09
+@@ -5,7 +5,7 @@
+ # unlimited permission to use, copy, distribute, and modify it.
+ 
+ # Usually the message domain is the same as the package name.
+-DOMAIN = $(PACKAGE)
++DOMAIN = $(PACKAGE)30
+ 
+ # These two variables depend on the location of this directory.
+ subdir = po


### PR DESCRIPTION
Function with undeclared type specified defaulted to int.  Now a specified declaration, int declaration in certs.c added,
Looked at newer upstream version (3.8.4) but not sure about Shlibs versioning.