### PR TITLE
ncftp fix for macOS 15 / Xcode 16.1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/net/ncftp.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/ncftp.info
@@ -1,6 +1,6 @@
 Package: ncftp
 Version: 3.2.6
-Revision: 1
+Revision: 2
 Source: mirror:custom:%n-%v-src.tar.gz
 Source-Checksum: SHA256(129e5954850290da98af012559e6743de193de0012e972ff939df9b604f81c23)
 SourceDirectory: %n-%v
@@ -14,7 +14,7 @@ Depends: <<
 	libncurses5-shlibs (>= 5.9-20110507-1)
 <<
 PatchFile: %n.patch
-PatchFile-MD5: 68c31ac77c2b85375eaf936449b6a3c3
+PatchFile-Checksum: SHA256(aa3c2a0198f4f475b3fd3f5b9204c54a84276460c23e929e1bff0a27b69cf52c)
 GCC: 4.0
 ConfigureParams: <<
 	--disable-precomp \

--- a/10.9-libcxx/stable/main/finkinfo/net/ncftp.patch
+++ b/10.9-libcxx/stable/main/finkinfo/net/ncftp.patch
@@ -1,6 +1,24 @@
 diff -ruN ncftp-3.2.6-orig/configure ncftp-3.2.6/configure
---- ncftp-3.2.6-orig/configure	2016-12-04 12:54:11.000000000 -0600
-+++ ncftp-3.2.6/configure	2020-10-14 20:08:34.000000000 -0500
+--- ncftp-3.2.6-orig/configure	2016-12-04 13:54:11
++++ ncftp-3.2.6/configure	2024-11-11 22:38:43
+@@ -841,7 +841,7 @@
+ #line 842 "configure"
+ #include "confdefs.h"
+ 
+-main(){return(0);}
++int main(){return(0);}
+ EOF
+ if { (eval echo configure:847: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext}; then
+   ac_cv_prog_cc_works=yes
+@@ -1111,7 +1111,7 @@
+ #include <stdio.h>
+ #include <gnu/libc-version.h>
+ 
+-main()
++int main()
+ {
+ 	const char *ver = gnu_get_libc_version();
+ 	const char *rel = gnu_get_libc_release();
 @@ -1232,7 +1232,7 @@
  	macos*|darwin|rhapsody)
  		OS="macosx"
@@ -10,6 +28,177 @@ diff -ruN ncftp-3.2.6-orig/configure ncftp-3.2.6/configure
  		if [ "$os_v" = "" ] && [ -x "$HOME/bin/macosver" ] ; then
  			os_v=`"$HOME/bin/macosver" 2>/dev/null`
  		fi
+@@ -1258,7 +1258,7 @@
+ #include <stdlib.h>
+ #include <ctype.h>
+ 
+-main()
++int main()
+ {
+ 	char line[256], *cp, *cp2; 
+ 	FILE *fp;
+@@ -2247,7 +2247,7 @@
+ 
+ #include <stdio.h>
+  
+-main()
++int main()
+ {
+ #ifdef __STDC_EXT__
+ 	if (__STDC_EXT__ == 0)
+@@ -2360,7 +2360,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	struct stat x;
+ 	FILE *fp;
+@@ -2441,7 +2441,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	off_t x = 0;
+ 	FILE *fp;
+@@ -2535,7 +2535,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	struct stat64 x;
+ 	FILE *fp;
+@@ -2618,7 +2618,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	off64_t x = 0;
+ 	FILE *fp;
+@@ -2701,7 +2701,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	struct stat x;
+ 	FILE *fp;
+@@ -2780,7 +2780,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	off_t x = 0;
+ 	FILE *fp;
+@@ -3411,7 +3411,7 @@
+ 
+ #include <stdio.h>
+  
+-main()
++int main()
+ {
+ #ifdef __STDC_EXT__
+ 	if (__STDC_EXT__ == 0)
+@@ -3524,7 +3524,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	struct stat x;
+ 	FILE *fp;
+@@ -3605,7 +3605,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	off_t x = 0;
+ 	FILE *fp;
+@@ -3686,7 +3686,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	size_t x = 0;
+ 	FILE *fp;
+@@ -3785,7 +3785,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	struct stat x;
+ 	FILE *fp;
+@@ -3864,7 +3864,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	off_t x = 0;
+ 	FILE *fp;
+@@ -3943,7 +3943,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	size_t x = 0;
+ 	FILE *fp;
+@@ -4032,7 +4032,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	struct stat64 x;
+ 	FILE *fp;
+@@ -4115,7 +4115,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	off64_t x = 0;
+ 	FILE *fp;
+@@ -4198,7 +4198,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	struct stat x;
+ 	FILE *fp;
+@@ -4277,7 +4277,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+  
+-main()
++int main()
+ {
+ 	off_t x = 0;
+ 	FILE *fp;
 @@ -4773,6 +4773,7 @@
  #line 4774 "configure"
  #include "confdefs.h"
@@ -18,14 +207,17 @@ diff -ruN ncftp-3.2.6-orig/configure ncftp-3.2.6/configure
  #define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
  #define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))
  #define XOR(e, f) (((e) && !(f)) || (!(e) && (f)))
-@@ -4954,6 +4955,7 @@
+@@ -4954,8 +4955,9 @@
  #ifdef HAVE_SYS_UN_H
  #include <sys/un.h>
  #endif
 +#include <stdlib.h>
   
- main()
+-main()
++int main()
  {
+ 	int sfd;
+ 
 @@ -5015,6 +5017,8 @@
  #include <sys/uio.h>
  #include <sys/socket.h>
@@ -35,14 +227,17 @@ diff -ruN ncftp-3.2.6-orig/configure ncftp-3.2.6/configure
  
  int main() {
  
-@@ -5588,6 +5592,7 @@
+@@ -5588,8 +5592,9 @@
  #include <sys/socket.h>
  #include <netinet/in.h>
  #include <netdb.h>
 +#include <stdlib.h>
   
- main()
+-main()
++int main()
  {
+ 	struct hostent *hp1, *hp2;
+ 
 @@ -6398,6 +6403,7 @@
  		/* includes */
  #include <stdio.h>
@@ -51,7 +246,16 @@ diff -ruN ncftp-3.2.6-orig/configure ncftp-3.2.6/configure
  
  #ifdef HAVE_NCURSES_H
  #	define NCURSES_OPAQUE 0
-@@ -7111,6 +7117,7 @@
+@@ -6454,7 +6460,7 @@
+ #endif
+ 
+  
+-main(int argc, char **argv)
++int main(int argc, char **argv)
+ {
+ 	/* Note:  don't actually call curses, since it may block;
+ 	 * We just want to see if it (dynamic) linked in okay.
+@@ -7111,10 +7117,11 @@
  #endif
  #include <sys/types.h>
  #include <stdio.h>
@@ -59,6 +263,56 @@ diff -ruN ncftp-3.2.6-orig/configure ncftp-3.2.6/configure
  
  long long hugeNumvar = 1;
  
+-main()
++int main()
+ {
+ 	long long hugeNumtoo = 2;
+ 
+@@ -7179,7 +7186,7 @@
+ #include <string.h>
+ #include <stdlib.h>
+ 
+-main()
++int main()
+ {
+ 	char s[80];
+ 	long long hugeNum;
+@@ -7238,7 +7245,7 @@
+ #include <string.h>
+ #include <stdlib.h>
+ 
+-main()
++int main()
+ {
+ 	char s[80];
+ 	long long hugeNum;
+@@ -7308,7 +7315,7 @@
+ #include <string.h>
+ #include <stdlib.h>
+ 
+-main()
++int main()
+ {
+ 	long long hugeNum, justAsHugeNum;
+ 
+@@ -7370,7 +7377,7 @@
+ #include <string.h>
+ #include <stdlib.h>
+ 
+-main()
++int main()
+ {
+ 	long long hugeNum, justAsHugeNum;
+ 
+@@ -7866,7 +7873,7 @@
+ #include <arpa/inet.h>
+ #include <netdb.h>
+ 
+-main()
++int main()
+ {
+ 	exit(0);
+ }
 @@ -8645,6 +8652,7 @@
  #ifdef HAVE_RESOLV_H
  #	include <resolv.h>
@@ -91,6 +345,42 @@ diff -ruN ncftp-3.2.6-orig/configure ncftp-3.2.6/configure
  
  int main() {
  
+@@ -9270,7 +9281,7 @@
+ #	include <snprintf.h>
+ #endif
+  
+-main()
++int main()
+ {
+ 	char s[16];
+ 	int i, result;
+@@ -9349,7 +9360,7 @@
+ #	include <snprintf.h>
+ #endif
+  
+-main()
++int main()
+ {
+ 	int result;
+ 	char s[8];
+@@ -9731,7 +9742,7 @@
+ #	include <snprintf.h>
+ #endif
+  
+-main()
++int main()
+ {
+ 	char s[16];
+ 	int i, result;
+@@ -9810,7 +9821,7 @@
+ #	include <snprintf.h>
+ #endif
+  
+-main()
++int main()
+ {
+ 	int result;
+ 	char s[8];
 @@ -9878,6 +9889,7 @@
  #include <stdio.h>
  #include <signal.h>
@@ -99,6 +389,15 @@ diff -ruN ncftp-3.2.6-orig/configure ncftp-3.2.6/configure
  
  int main() {
  
+@@ -10019,7 +10031,7 @@
+  * If this system has a BSD-style setpgrp, which takes arguments, exit
+  * successfully.
+  */
+-main()
++int main()
+ {
+     if (setpgrp(1,1) == -1)
+ 	exit(0);
 @@ -10072,6 +10084,7 @@
  #line 10073 "configure"
  #include "confdefs.h"
@@ -107,3 +406,21 @@ diff -ruN ncftp-3.2.6-orig/configure ncftp-3.2.6/configure
  	/* If setvbuf has the reversed format, exit 0. */
  	main () {
  	  /* This call has the arguments reversed.
+@@ -10315,7 +10328,7 @@
+   else
+     return (&dummy > addr) ? 1 : -1;
+ }
+-main ()
++int main ()
+ {
+   exit (find_stack_direction() < 0);
+ }
+@@ -10493,7 +10506,7 @@
+ #	include <curses.h>
+ #endif
+ 
+-main()
++int main()
+ {
+ 	exit(0);
+ }


### PR DESCRIPTION
 patched configure to explicitly define main() to return int, patched in lots of places.    Builds with -m option and package and deb file look good.  Should not change deb package on older systems.