### PR TITLE
texlive & texlive-texmf added variants of macOS 15, removing luajittex and luajithbtex

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/text/texlive-15.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/texlive-15.0.info
@@ -1,0 +1,446 @@
+Info2: <<
+Package: texlive%type_pkg[-nox]
+Type: -nox (boolean)
+Version: 20240312
+Revision: 100
+Distribution: 15.0
+Architecture: x86_64
+Description: Bundle package for TeX Live
+Depends: <<
+	%N-base (= %v-%r),
+	debianutils,
+	texinfo (>= 6.5)
+<<
+BuildDepends: <<
+ (%type_raw[-nox] = .) cairo (>= 1.12.14-1),
+ (%type_raw[-nox] = .) gd3 (>= 2.3.2-2),
+ (%type_raw[-nox] = .) libiconv-dev,
+ (%type_raw[-nox] = .) libxt,
+ (%type_raw[-nox] = .) openmotif4-2level,
+ (%type_raw[-nox] = .) x11, 
+ fink (>= 0.32.2),
+ fink-package-precedence,
+ flag-sort,
+ fontconfig2-dev (>= 2.10.0-1),
+ freetype219 (>= 2.10.2-1),
+ glib2-dev (>= 2.22.0-1),
+ gmp5,
+ libbrotli1,
+ libgraphite2-dev,
+ libharfbuzz0-dev,
+ libiconv-dev,
+ libicu72-dev,
+ libkpathsea6 (>= 6.4.0-1),
+ libmpfr6,
+ libpaper1-dev,
+ libpng16,
+ libpotrace0,
+ libwoff2-1.0.2-dev,
+ libxxhash0-dev,
+ pixman,
+ ppkg-config,
+ ptexenc1 (>= 1.4.6-1),
+ t1lib5-nox,
+ teckit-dev (>= 2.5.11-1),
+ xz,
+ zziplib13-dev
+<<
+BuildConflicts: <<
+ ccache-default,
+ gd2, gd2-nox,
+ (%type_raw[-nox] = -nox) gd3,
+ lua51-dev, lua52-dev, lua53-dev
+<<
+Conflicts: <<
+ system-tetex, tetex, tetex-nox, ptex (<= 3.1.10-1), ptex-nox (<= 3.1.10-1),
+ texlive, texlive-nox
+<<
+Replaces: <<
+ tetex, tetex-nox, ptex (<= 3.1.10-1), ptex-nox (<= 3.1.10-1),
+ texlive, texlive-nox
+<<
+Provides: bundle-tetex, bundle-texlive
+Recommends: psutils, tex4ht, t1utils, lcdf-typetools, lacheck, ps2eps
+Suggests: latex2html, foiltex
+Source: ftp://tug.org/texlive/historic/2024/texlive-%v-source.tar.xz
+Source-Checksum: SHA256(7b6d87cf01661670fac45c93126bed97b9843139ed510f975d047ea938b6fe96)
+TarFilesRename: texlive-20240312-source:texlive
+Source2: ftp://tug.org/texlive/historic/2024/texlive-%v-extra.tar.xz
+Source2-Checksum: SHA256(770f1946cdcd1b5ddada2ea328bb37294174f70a2be28b33f38ce14717bc5496)
+Source3: ftp://tug.org/texlive/historic/2024/install-tl-unx.tar.gz
+Source3-Checksum: SHA256(fa845fbbd8d5b78c93fb5e9f97e5d908b42fb50c1ae164f7d9aa31c8ad8c31c7)
+Source3Rename: install-tl-20240312.tar.gz
+# ptexlive is for Japanese formatting
+# but inactive since 2011
+#Source2: http://tutimura.ath.cx/~nob/tex/ptexlive/ptexlive-20100711.tar.gz
+#Source2-MD5: 2dbd0ab5290bf6dfb0b2b04a813df89f
+#Tar2FilesRename: ptexlive-20100711:ptexlive
+# tlptexlive is for Japanese formatting
+# but inactive since TeX-live 2015
+#Source3: http://www.preining.info/software/build-tlptexlive-20140507.zip
+#Source3-MD5: 2001631c7542f64867e952e5d4b113e2
+#Source4: http://hnd.jp.asi.finkmirrors.net/pkgdists/xdvik-20090903-texlive2009_2012.patch.gz
+#Source4: mirror:sourceforge:fink/xdvik-20090903-texlive2009_2012.patch.gz
+#Source4-MD5: 720aa3dfd0e8d42524f28cdf4bd7247c
+# 2012 texlive is used to have the xdvik and t1lib
+#Source5: ftp://tug.org/historic/systems/texlive/2012/texlive-20120701-source.tar.xz
+#Source5-MD5: 1d38be7dac26440fd022a4708f454a2b
+PatchFile: %{ni}-utftests.patch
+PatchFile-MD5: cc752b4767ba6fe5b03bc1dc196ca4cf
+PatchFile3: %{ni}-external-deps.patch
+PatchFile3-MD5: fd3a3cdedf51088c7d5c3f6bde074548
+NoSourceDirectory: true
+UseMaxBuildJobs: true
+# Tons of local -I before local upstream bugs (should be passed via
+# _CPPFLAGS instead of _CFLAGS/_CXXFLAGS, possibly extra complicated
+# due to internal-vs-external dependency options.
+SetCC: flag-sort -v -r gcc
+SetCXX: flag-sort -v -r g++
+SetLD: flag-sort -v -r ld
+#SetOBJCXX: flag-sort -v -r g++  # fink doesn't support this field
+PatchScript: <<
+#!/bin/bash -ev
+ # some tests generate same character but in different part of UTF space.
+ pushd texlive
+	# back up and diff to make sure the utftests patch applied as expected
+ 	cp -p texk/web2c/tests/enc-p.bbl texk/web2c/tests/enc-p.bbl.orig
+ 	cp -p texk/web2c/tests/enc-up.bbl texk/web2c/tests/enc-up.bbl.orig
+ 	cp -p texk/web2c/ptexdir/tests/nissya_bib.bbl texk/web2c/ptexdir/tests/nissya_bib.bbl.orig
+ 	cp -p texk/dviout-util/tests/jisx0208.txt texk/dviout-util/tests/jisx0208.txt.orig
+ 	patch -p1 < %{PatchFile}
+ 	# check that the patched files were truly changed according to 'diff'
+ 	diff -u texk/web2c/tests/enc-p.bbl.orig texk/web2c/tests/enc-p.bbl ||:
+ 	diff -u texk/web2c/tests/enc-up.bbl.orig texk/web2c/tests/enc-up.bbl ||:
+ 	diff -u texk/web2c/ptexdir/tests/nissya_bib.bbl.orig texk/web2c/ptexdir/tests/nissya_bib.bbl ||:
+ 	diff -u texk/dviout-util/tests/jisx0208.txt.orig texk/dviout-util/tests/jisx0208.txt ||:
+ popd
+
+ # externalize some libs: rotli, potrace, woff2, xxhash
+ # (configure loses the configure.ac segments that would give --enable
+ # flags and detection)
+ pushd texlive
+	patch -p1 < %{PatchFile3}
+ popd
+
+ # Install pxdvik
+ sed -i.bak -e 's|tex4htk|pxdvik|g' texlive/configure
+ sed -i.bak -e 's|tex4htk|pxdvik|g' texlive/texk/configure
+
+ #cp -R texlive-20120701-source/texk/xdvik texlive/texk/xdvik.2012
+ #cp -R texlive-20120701-source/libs/t1lib texlive/libs/
+ # part of ptexlive tarball, which is inactive
+ #xz -dc ptexlive/archive/xdvik-20090903-texlive2009.diff.xz \
+ #    | perl -pe 's/(\$\(common_includes\)) (\$\(FREETYPE2_INCLUDES\))/\2 \1/g' \
+ #    > xdvik-20090903-texlive2009.diff
+ #gzip -dc xdvik-20090903-texlive2009_2012.patch.gz | patch -p0
+ #xz -c xdvik-20090903-texlive2009.diff \
+ #    >  ptexlive/archive/xdvik-20090903-texlive2009.diff.xz
+
+ echo "TEXLIVE_VERSION=2009" >> ptexlive.cfg
+ echo "TEXMF=./texmf"        >> ptexlive.cfg
+ echo "SRC=`pwd`/texlive"    >> ptexlive.cfg
+ #head -n 290  ptexlive/common.sh > common.sh
+ #cp common.sh ptexlive/
+ echo '#!/bin/bash'         >> ptex-app.sh
+ echo '. ./common.sh'       >> ptex-app.sh
+ #sed -n '118,178p' ptexlive/2extract-src.sh | \
+ #sed -e 's|texk/xdvik|texk/xdvik.2012|' \
+ #    -e 's|2.3.9|2.5.3|g'   >> ptex-app.sh
+ chmod +x                      ptex-app.sh
+ #mv ptex-app.sh       ptexlive/ptex-app.sh
+ #pushd ptexlive
+ #  ./ptex-app.sh
+ #popd
+
+ # use Hiragino for pxdvi
+ #perl -pi -e "s/(Ryumin-Light\t\t)ipam.ttf/\1HiraMinPro-W3.otf/"    \
+ #                                    texlive/texk/pxdvik/texmf/pxdvi.cfg
+ #perl -pi -e "s/(GothicBBB-Medium\t)ipag.ttf/\1HiraKakuPro-W3.otf/" \
+ #                                    texlive/texk/pxdvik/texmf/pxdvi.cfg
+
+ # remove XFILESEARCHPATH
+ sed -i.bak -e 's|\(XFILESEARCHPATH=\)|#\1|' texlive/texk/xdvik/xdvi-sh.in
+
+ # apply pmpost patches
+ #patch -p1 -d texlive < build-tlptexlive-20140507/patches/ac-ctie
+ #patch -p1 -d texlive < build-tlptexlive-20140507/patches/pmpost-mp1.902
+ #patch -p1 -d texlive < build-tlptexlive-20140507/patches/upmpost-mp1.902
+ #patch -p1 -d texlive < build-tlptexlive-20140507/patches/reautoconf-stuff
+
+ # wrapper for jbibtex
+ echo '#!/bin/sh'    >> jbibtex
+ echo 'pbibtex "$@"' >> jbibtex
+
+ # wrapper for jmpost
+ echo '#!/bin/sh'    >> jmpost
+ echo 'pmpost "$@"'  >> jmpost
+
+ for autoconf_configure in `find . -name configure`; do
+   # autoconf2.6ish patch for modern XQuartz paths
+   perl -pi -e "s|/usr/lpp/Xamples|/opt/X11|" $autoconf_configure
+ done
+
+ # install missing file from 'install-tl' source (only config.guess) 
+ # into tlpkg dir from the 'extra' tarball.
+ install -m 755 -d texlive-%v-extra/tlpkg/installer
+ install -m 644 install-tl-2024*/tlpkg/installer/config.guess texlive-%v-extra/tlpkg/installer
+ # remove rest of install-tl-#### because it contains other files that annoy f-p-p
+ rm -r install-tl-2024*
+<<
+# system-poppler removed upstream on 2020-05-14
+# (%type_raw[-nox] = .) --with-system-poppler \
+# system-xpdf forgets to add -I flags for internal headers, and then confuses G*.h with Goo*.h
+# (%type_raw[-nox] = .) --with-system-xpdf \
+ConfigureParams: <<
+ (%type_raw[-nox] = .) --with-system-cairo \
+ (%type_raw[-nox] = .) --with-system-gd \
+ (%type_raw[-nox] = .) --with-xdvi-x-toolkit=motif \
+ (%type_raw[-nox] = .) --with-motif-libdir=%p/lib \
+ (%type_raw[-nox] = .) --with-motif-include=%p/include \
+ (%type_raw[-nox] = .) --with-x \
+ (%type_raw[-nox] = -nox) --without-x \
+ (%type_raw[-nox] = -nox) --disable-xdvik \
+ (%type_raw[-nox] = -nox) --disable-pxdvik \
+ (%type_raw[-nox] = -nox) --disable-xpdfopen \
+ --with-banner-add="/Fink %v-%r" \
+ --disable-native-texlive-build \
+ --disable-missing \
+ --disable-omfonts \
+ --disable-texi2html \
+ --disable-texinfo \
+ --disable-shared \
+ --datadir='${prefix}/share' \
+ --infodir='${prefix}/share/info' \
+ --mandir='${prefix}/share/man' \
+ --disable-multiplatform \
+ --with-system-harfbuzz \
+ --with-system-icu \
+ --with-system-teckit \
+ --with-system-graphite2 \
+ --with-system-zziplib \
+ --with-system-mpfr \
+ --with-system-gmp \
+ --with-system-pixman \
+ --with-system-potrace \
+ --with-system-freetype2 \
+ --with-system-libpng \
+ --with-system-libpaper \
+ --with-system-zlib \
+ --with-system-ptexenc \
+ --with-system-kpathsea \
+ --with-kpathsea-includes=%p/include \
+ --with-kpathsea-libdir=%p/lib \
+ --with-system-t1lib \
+ --disable-psutils \
+ --disable-dialog \
+ --disable-tex4htk \
+ --disable-t1utils \
+ --disable-xindy \
+ --disable-lcdf-typetools \
+ --disable-lacheck \
+ --disable-ps2eps \
+ --disable-luajittex \
+ --disable-luajithbtex \
+ PKG_CONFIG="%p/bin/ppkg-config"
+<<
+InfoTest: <<
+	TestScript: <<
+	#!/bin/bash -ev
+		rm texk/web2c/mfluajitdir/mfluajittraptest.test
+		pushd texlive/Work
+			unset LANG
+			# some 2024 tests expected kpathsea to be built in tree, so symlink to install in %p
+			mkdir -p texk/kpathsea
+			ln -s %p/bin/kpsewhich texk/kpathsea/kpsewhich
+			make -k check || exit 2
+		popd
+	<<
+<<
+CompileScript: <<
+#!/bin/bash -ev
+ # fink doesn't support SetOBJCXX field
+ export OBJCXX="flag-sort -v -r g++"
+ mkdir texlive/Work
+ pushd texlive/Work
+   ../configure %c
+   make
+ popd
+ fink-package-precedence .
+<<
+
+InstallScript: <<
+#!/bin/bash -ev
+ pushd texlive/Work
+   make install-strip DESTDIR=%d run_texlinks=/usr/bin/true
+ popd
+
+ # install jbibtex and jmpost
+ install -m 755 jbibtex %i/bin
+ install -m 755 jmpost  %i/bin
+
+ # install tlpkg dir
+ install -m 755 -d            %i/share/tlpkg
+ cp -R texlive-%v-extra/tlpkg %i/share
+ #install -m 644 texlive/texk/tests/TeXLive/*.pm  %i/share/tlpkg/TeXLive
+
+echo "Setting up symlinks ..."
+ export DYLD_LIBRARY_PATH="%b/texk/kpathsea/SHARED" PATH=%i/bin:$PATH TEXMFMAIN=%p/share/texmf-dist ; texlinks --cnffile %i/share/texmf-dist/web2c/fmtutil.cnf --verbose %i/bin
+
+echo "Creating a local texmf tree, and symlinking it into place ..."
+ mkdir -p %i/etc/texmf.local
+ %i/bin/mktexlsr %i/etc/texmf.local
+ mkdir -p %i/share
+ ln -s %p/etc/texmf.local %i/share/texmf-local
+
+echo "Creating a VARTEXMF tree, including a fonts directory ..."
+ mkdir -p %i/var/lib/texmf/fonts
+ %i/bin/mktexlsr %i/var/lib/texmf
+
+echo "Creating a TEXMFCONFIG tree ..."
+ mkdir -p %i/etc/texmf-config
+ %i/bin/mktexlsr %i/etc/texmf-config
+
+echo "Removing files that are supplied in the texlive-texmf package ..."
+ mv -f  %i/share/texmf-dist texmf-dist.conflict
+
+if [ "%type_raw[-nox]" == "." ]; then
+echo "Moving files from texmf to texmf-dist dir ..."
+ #mv -f %i/share/texmf texmf.obsolete
+ mkdir -p                                   %i/share/texmf-dist/xdvi
+ #mv -f texmf.obsolete/xdvi/pxdvi.cfg        %i/share/texmf-dist/xdvi
+ #mv -f texmf.obsolete/xdvi/xdvi-ptex.sample %i/share/texmf-dist/xdvi
+
+echo "Preparing xdvi for the alternatives system ..."
+ mv %i/bin/xdvi %i/bin/xdvik
+ mv %i/share/man/man1/xdvi.1 %i/share/man/man1/xdvik.1
+fi
+
+echo "Make font dirs and make links for apple's fonts ..."
+install -m 755 -d                %i/share/texmf-dist/fonts/{opentype,truetype}
+if [ "%type_raw[-nox]" == "." ]; then
+ ln -s %p/lib/X11/fonts/appleotf %i/share/texmf-dist/fonts/opentype
+ ln -s %p/lib/X11/fonts/applettf %i/share/texmf-dist/fonts/truetype
+fi
+<<
+DocFiles: texlive/README
+SplitOff: <<
+ Package: %N-base
+ Description: Base programs for a TeX Live installation
+ DescUsage: <<
+  It's been reported that there is a migration from texconfig to tlmgr
+  in recent versions of texlive: making available "tlmgr --usermode"
+  typically requires running "tlmgr init-usertree" first
+ <<
+ Depends: <<
+  (%type_raw[-nox] = -nox) ghostscript-nox | ghostscript, 
+  (%type_raw[-nox] = .) appleotffonts,
+  (%type_raw[-nox] = .) applesystemfonts,
+  (%type_raw[-nox] = .) cairo-shlibs (>= 1.12.14-1),
+  (%type_raw[-nox] = .) gd3-shlibs (>= 2.3.2-2),
+  (%type_raw[-nox] = .) ghostscript, 
+  (%type_raw[-nox] = .) libxt-shlibs,
+  (%type_raw[-nox] = .) openmotif4-2level-shlibs,
+  (%type_raw[-nox] = .) libiconv,
+  (%type_raw[-nox] = .) x11-shlibs,
+  (%type_raw[-nox] = .) x11, 
+  fontconfig2-shlibs (>= 2.10.0-1),
+  freetype219-shlibs (>= 2.10.2-1),
+  gmp5-shlibs,
+  libbrotli1-shlibs,
+  libgraphite2-shlibs,
+  libharfbuzz0-shlibs,
+  libicu72-shlibs,
+  libkpathsea6-shlibs (>= 6.4.0-1),
+  kpathsea (>= 6.4.0-1),
+  libmpfr6-shlibs,
+  libpaper1-shlibs,
+  libpng16-shlibs,
+  libpotrace0-shlibs,
+  libwoff2-1.0.2-shlibs,
+  libxxhash0-shlibs,
+  pixman-shlibs,
+  ptexenc1-shlibs (>= 1.4.6-1),
+  t1lib5-nox-shlibs,
+  teckit-shlibs (>= 2.5.11-1),
+  nkf,
+  texlive-texmf (>= %v),
+  zziplib13-shlibs
+ <<
+ Conflicts: <<
+  texlive-base (>= 0), texlive-nox-base,
+  tetex-base (>= 0), tetex-nox-base
+ <<
+ Replaces: <<
+  texlive-base (>= 0), texlive-nox-base,
+  tetex-base (>= 0), tetex-nox-base,
+  ptex-base (<= 3.1.11-1), ptex-nox-base (<= 3.1.11-1), ptex-texmf (<= 2.5-1),
+  context, dvipdfm, epstopdf, pdftex, tetex-macosx, tetex (<= 2.0-3),
+  (%type_raw[-nox] = .) xdvi (<=  22.70-1), 
+  libkpathsea4, detex, xetex, dvipdfmx, pdfjam, jadetex, latexdiff, eptex
+ <<
+ Provides: context, dvipdfm, epstopdf, pdftex, tetex-macosx, tetex-base, tetex3-base, texlive-base, detex, xetex, ptex3-base, dvipdfmx, pdfjam, jadetex, eptex
+ Files: bin etc share/info share/man share/texmf-dist share/texmf-local share/tlpkg var
+ InfoDocs: web2c.info dvips.info dvipng.info tlbuild.info
+ DocFiles: texlive/README
+ PreInstScript: <<
+  echo "Removing any leftover files from obsolete teTeX installations ..."
+  rm -f %p/etc/texmf.local/web2c/*
+  rm -f %p/etc/ls-R/texmf.macosx
+  rm -Rf %p/share/texmf.macosx
+  rm -Rf %p/etc/texmf-var
+  rm -Rf %p/var/lib/texmf
+
+  if [ -f %p/etc/texmf-config/web2c/fmtutil.cnf ]; then
+    time_date="`date +%%Y%%m%%d%%H%%M`"
+    mv -f %p/etc/texmf-config/web2c/fmtutil.cnf{,.finksave.${time_date}}
+  fi
+  if [ -f %p/etc/texmf-config/web2c/updmap.cfg ]; then
+   if [ ! "`grep @kanjiVariant@ %p/etc/texmf-config/web2c/updmap.cfg`" ]; then
+    # This updmap.cfg is not from texlive-texmf! Delete it!
+    time_date="`date +%%Y%%m%%d%%H%%M`"
+    mv -f %p/etc/texmf-config/web2c/updmap.cfg{,.finksave.${time_date}}
+   fi
+  fi
+  if [ -f %p/share/texmf/web2c/texmf.cnf ]; then
+    time_date="`date +%%Y%%m%%d%%H%%M`"
+    mkdir -p                             %p/etc/texmf-config/web2c
+    mv -f %p/share/texmf/web2c/texmf.cnf %p/etc/texmf-config/web2c/texmf.cnf.finksave.${time_date}
+  fi
+ <<
+ PostInstScript: <<
+if [ -e %p/bin/xdvik ] ; then
+  update-alternatives --install %p/bin/xdvi xdvi %p/bin/xdvik 30 --slave %p/share/man/man1/xdvi.1 xdvi.1 %p/share/man/man1/xdvik.1
+fi
+  mktexlsr %p/share/texmf-dist %p/etc/texmf-config %p/etc/texmf.local
+  # we don't use %p/share/texmf anymore!
+
+  updmap-sys --nomkmap --nohash --syncwithtrees
+  
+  PATH=%p/bin:${PATH} texconfig-sys init
+
+  echo "Adjusting permissions ..."
+  chmod -R a+rX %p/etc/texmf.local
+  chmod -R a+rwX %p/var/lib/texmf
+  chmod -R a+rwX %p/etc/texmf-config
+  if [ -f ~/Library/texmf/ls-R ]; then chmod a+rw ~/Library/texmf/ls-R; fi
+ <<
+ PreRmScript: <<
+  if [ "$1" != "upgrade" ]; then
+    if [ -e %p/bin/xdvik ]; then
+      update-alternatives --remove xdvi %p/bin/xdvik
+    fi
+  fi
+ <<
+<<
+DescPackaging: <<
+Allow ghostscript to satisfy Depends on -nox build.
+
+luajittex luajithbtex segfaults on >= 10.15
+disable it in %c, and make sure we have texlive-texmf
+that is also patched to not run it in
+our PostInstScript here when disabled
+<<
+License: Restrictive/Distributable
+Maintainer: Tomoaki Okayama <okayama@users.sourceforge.net>
+Homepage: https://www.tug.org/texlive/
+<<

--- a/10.9-libcxx/stable/main/finkinfo/text/texlive-texmf-15.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/texlive-texmf-15.0.info
@@ -1,6 +1,8 @@
 Package: texlive-texmf
 Version: 20240312
-Revision: 1
+Revision: 100
+Distribution: 15.0
+Architecture: x86_64
 BuildDepends: fink (>= 0.32)
 Conflicts:tetex-texmf
 Replaces: tetex-texmf, texlive-base (<= 0.20080816-3), texlive-nox-base (<= 0.20080816-3)
@@ -35,14 +37,17 @@ Provides: <<
 	xcolor,
 	xkeyval
 <<
-#Source: http://hnd.jp.asi.finkmirrors.net/pkgdists/texlive-%v-texmf-delpdf.tar.xz
 Source: mirror:sourceforge:fink/texlive-%v-texmf-delpdf.tar.xz
 Source-Checksum: SHA256(72dcbfb328242fe06f7f3f90bc21b48e98b7f914c357246760e6ce87819390de)
 PatchFile: %n.patch
 PatchFile-Checksum: SHA256(0d0a999cbef84d8925954c9030995bf29bfdc5dee273f5426a78a047168f4a05)
+PatchFile2: %n-luajittex.patch
+PatchFile2-Checksum: SHA256(8264a6732209965d116842c600c510d9b504050c9dbc8cf22af38ced64a25b33)
 PatchScript: <<
- sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
-
+ sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p 1
+# luajittex & luajithbtex segfault on macOS >= 15.0
+# remove from fmtutil.cnf
+ patch -d texmf-dist -p1 < %{PatchFile2}
 # Copying README into current dir ...
  cp    texmf-dist/README README.texmf-dist
 
@@ -132,6 +137,12 @@ used for this package:
 
  mv       texlive-20240312-texmf                 texlive-20240312-texmf-delpdf
  gtar cfJ texlive-20240312-texmf-delpdf.tar.xz texlive-20240312-texmf-delpdf/texmf-dist/*
+###############
+luajittex segfaults on macOS 15.x. Texlive's PostInstScript runs a command
+that parses %p/share/texmf-dist/web2c/fmtutil.cnf which eventually calls
+the luajittex command. So comment out this bit when we are going to be
+disabling luajittex.
+https://github.com/fink/fink-distributions/issues/1188
 <<
 DescPort: <<
 * tlmgr.pl: Default SELFAUTOPARENT basedir is two levels too high up. Set a correct depth.

--- a/10.9-libcxx/stable/main/finkinfo/text/texlive-texmf-luajittex.patch
+++ b/10.9-libcxx/stable/main/finkinfo/text/texlive-texmf-luajittex.patch
@@ -1,0 +1,15 @@
+diff -Naur texmf-dist-orig/web2c/fmtutil.cnf texmf-dist/web2c/fmtutil.cnf
+--- texmf-dist-orig/web2c/fmtutil.cnf	2024-02-12 19:43:44
++++ texmf-dist/web2c/fmtutil.cnf	2024-12-01 21:13:58
+@@ -92,8 +92,8 @@
+ luahbtex luahbtex language.def,language.dat.lua luatex.ini
+ #
+ # from luajittex:
+-luajithbtex luajithbtex language.def,language.dat.lua luatex.ini
+-luajittex luajittex language.def,language.dat.lua luatex.ini
++#luajithbtex luajithbtex language.def,language.dat.lua luatex.ini
++#luajittex luajittex language.def,language.dat.lua luatex.ini
+ #
+ # from luatex:
+ dviluatex luatex language.def,language.dat.lua dviluatex.ini
+


### PR DESCRIPTION
Removed from x86_64 systems where programs seg fault for both livetex and livetex-texmf.  Updated checksum type for livetex-texmf.info

Tested on macOS 15 arm64 which compiles correctly.  Tested on macOS 10.14 and works but no changes there.