### PR TITLE
Launch 1.2.5 update

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/utils/launch-1.2.5.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/launch-1.2.5.info
@@ -42,7 +42,7 @@ macosx/dpkg dependency should be added when that code is working.
 Former Maintainer: Ben Hines <bhines@alumni.ucsd.edu>
 <<
 DescPort: <<
-fink package broken into <=10.15 and >= 11
+fink package broken into < 10.13 and >= 10.13
 <<
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>

--- a/10.9-libcxx/stable/main/finkinfo/utils/launch-1.2.5.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/launch-1.2.5.info
@@ -1,13 +1,13 @@
 Package: launch
 Version: 1.2.5
 Revision: 3
-Distribution: 10.13, 10.14, 10.14.5, 10.15, 11.0, 11.3, 12.0, 13.0, 14.0, 15.0
 BuildDepends: xcode.app
+Distribution: 10.9, 10.10, 10.11, 10.12
 Source: https://sabi.net/nriley/software/%n-%v.tar.gz 
 Source-Checksum: SHA256(486632b11bee04d9f6bcb595fd2a68b5fde2f748ebdc182274778cc5cf97ff70)
 PatchScript: <<
 ls -la
-perl -pi -e 's#10.8#10.13#g' launch.xcodeproj/project.pbxproj 
+perl -pi -e 's#10.8#10.9#g' launch.xcodeproj/project.pbxproj 
 <<
 CompileScript: <<
 #!/bin/sh -ev

--- a/10.9-libcxx/stable/main/finkinfo/utils/launch.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/launch.info
@@ -1,7 +1,7 @@
 Package: launch
 Version: 1.2.5
 Revision: 3
-Distribution: 10.13, 10.14, 10.14.5, 10.15, 11.0, 11.3, 12.0, 13.0, 14.0, 15.0
+Distribution: 10.13, 10.14, 10.14.5, 10.15, 11.0, 11.3, 12.0, 13.0, 14.0, 14.4, 15.0
 BuildDepends: xcode.app
 Source: https://sabi.net/nriley/software/%n-%v.tar.gz 
 Source-Checksum: SHA256(486632b11bee04d9f6bcb595fd2a68b5fde2f748ebdc182274778cc5cf97ff70)
@@ -42,7 +42,7 @@ macosx/dpkg dependency should be added when that code is working.
 Former Maintainer: Ben Hines <bhines@alumni.ucsd.edu>
 <<
 DescPort: <<
-fink package broken into <=10.15 and >= 11
+fink package broken into < 10.13 and >= 10.13
 <<
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>


### PR DESCRIPTION
Launch will not build on newer Xcode that does not support minimum systems back to 10.9.  Updated 
Divided into 2 packages one for compilers with minimum system 10.9 and one for minimum systems 10.13

See Issue #1193

Tested on macOS 10.14.5, 15.2, 14.X