### PR TITLE
Package update for Sequoia, packages build on MacOS15/Xcode 16.2

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libopenmpt0-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libopenmpt0-shlibs.info
@@ -3,7 +3,7 @@ Package: libopenmpt0-shlibs
 Version: 0.5.24
 Revision: 1
 # Dist restricted by needing c++17
-Distribution: 10.13, 10.14, 10.14.5, 10.15, 11.0, 11.3, 12.0, 13.0, 14.0
+Distribution: 10.13, 10.14, 10.14.5, 10.15, 11.0, 11.3, 12.0, 13.0, 14.0, 14.4, 15.0
 Description: Library to decode tracked music files
 License: BSD
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>

--- a/10.9-libcxx/stable/main/finkinfo/text/asciidoc.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/asciidoc.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: asciidoc
 Version: 9.1.1
 Revision: 1
-Distribution: 11.0, 11.3, 12.0, 13.0, 14.0
+Distribution: 11.0, 11.3, 12.0, 13.0, 14.0, 14.4, 15.0
 Source: https://github.com/%n/%n/archive/%v.tar.gz
 Source-Checksum: SHA256(914dfc1542c30bd47faa0aaaae0985cb57d0ca584015729ccd1b94d90da3a616)
 SourceRename: %n-%v.tar.gz


### PR DESCRIPTION
Simply added 14.4, 15.0 to distribution list.  Packages build and install.
Tested on Sequoia