### PR TITLE
llvm-15: new pkg at v15.0.7

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/languages/llvm-15-0044-soname.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/llvm-15-0044-soname.patch
@@ -1,0 +1,24 @@
+diff -ruN llvm-project-15.0.7.src-orig/clang/tools/libclang/CMakeLists.txt llvm-project-15.0.7.src/clang/tools/libclang/CMakeLists.txt
+--- llvm-project-15.0.7.src-orig/clang/tools/libclang/CMakeLists.txt	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/tools/libclang/CMakeLists.txt	2025-01-14 19:55:18.000000000 -0600
+@@ -133,7 +133,7 @@
+     remove_definitions("-D_XOPEN_SOURCE=700")
+ endif()
+ 
+-add_clang_library(libclang ${ENABLE_SHARED} ${ENABLE_STATIC} INSTALL_WITH_TOOLCHAIN
++add_clang_library(libclang ${ENABLE_SHARED} ${ENABLE_STATIC} INSTALL_WITH_TOOLCHAIN SONAME
+   OUTPUT_NAME ${output_name}
+   ${SOURCES}
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/tools/llvm-shlib/CMakeLists.txt llvm-project-15.0.7.src/llvm/tools/llvm-shlib/CMakeLists.txt
+--- llvm-project-15.0.7.src-orig/llvm/tools/llvm-shlib/CMakeLists.txt	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/tools/llvm-shlib/CMakeLists.txt	2025-01-14 19:55:18.000000000 -0600
+@@ -32,6 +32,8 @@
+   endif()
+   add_llvm_library(LLVM SHARED DISABLE_LLVM_LINK_LLVM_DYLIB SONAME ${INSTALL_WITH_TOOLCHAIN} ${SOURCES})
+ 
++  set_property(TARGET LLVM PROPERTY VERSION "1") # Append .1 to SONAME
++
+   list(REMOVE_DUPLICATES LIB_NAMES)
+   if(("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") OR (MINGW) OR (HAIKU)
+      OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")

--- a/10.9-libcxx/stable/main/finkinfo/languages/llvm-15-libclang-major-version-only.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/llvm-15-libclang-major-version-only.patch
@@ -1,0 +1,12 @@
+diff -ruN llvm-project-15.0.7.src-orig/clang/tools/libclang/CMakeLists.txt llvm-project-15.0.7.src/clang/tools/libclang/CMakeLists.txt
+--- llvm-project-15.0.7.src-orig/clang/tools/libclang/CMakeLists.txt	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/tools/libclang/CMakeLists.txt	2025-01-17 04:24:15.000000000 -0600
+@@ -194,7 +194,7 @@
+                  OBJECT_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libclang.map)
+ 
+     set_target_properties(libclang PROPERTIES
+-                          VERSION ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}${LLVM_VERSION_SUFFIX}
++                          VERSION ${LLVM_VERSION_MAJOR}
+                           SOVERSION ${LIBCLANG_SOVERSION})
+   endif()
+ endif()

--- a/10.9-libcxx/stable/main/finkinfo/languages/llvm-15-python3-shebang.patch
+++ b/10.9-libcxx/stable/main/finkinfo/languages/llvm-15-python3-shebang.patch
@@ -1,0 +1,2241 @@
+diff -ruN llvm-project-15.0.7.src-orig/bolt/test/link_fdata.py llvm-project-15.0.7.src/bolt/test/link_fdata.py
+--- llvm-project-15.0.7.src-orig/bolt/test/link_fdata.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/bolt/test/link_fdata.py	2025-01-26 05:33:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """
+ This script reads the input from stdin, extracts all lines starting with
+diff -ruN llvm-project-15.0.7.src-orig/bolt/utils/dot2html/dot2html.py llvm-project-15.0.7.src/bolt/utils/dot2html/dot2html.py
+--- llvm-project-15.0.7.src-orig/bolt/utils/dot2html/dot2html.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/bolt/utils/dot2html/dot2html.py	2025-01-26 05:33:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ import argparse
+ import os
+ import sys
+diff -ruN llvm-project-15.0.7.src-orig/bolt/utils/llvm-bolt-wrapper.py llvm-project-15.0.7.src/bolt/utils/llvm-bolt-wrapper.py
+--- llvm-project-15.0.7.src-orig/bolt/utils/llvm-bolt-wrapper.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/bolt/utils/llvm-bolt-wrapper.py	2025-01-26 05:33:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ import argparse
+ import subprocess
+ from typing import *
+diff -ruN llvm-project-15.0.7.src-orig/bolt/utils/nfc-check-setup.py llvm-project-15.0.7.src/bolt/utils/nfc-check-setup.py
+--- llvm-project-15.0.7.src-orig/bolt/utils/nfc-check-setup.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/bolt/utils/nfc-check-setup.py	2025-01-26 05:33:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ import argparse
+ import os
+ import re
+diff -ruN llvm-project-15.0.7.src-orig/clang/bindings/python/examples/cindex/cindex-dump.py llvm-project-15.0.7.src/clang/bindings/python/examples/cindex/cindex-dump.py
+--- llvm-project-15.0.7.src-orig/clang/bindings/python/examples/cindex/cindex-dump.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/bindings/python/examples/cindex/cindex-dump.py	2025-01-26 05:33:31.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #===- cindex-dump.py - cindex/Python Source Dump -------------*- python -*--===#
+ #
+diff -ruN llvm-project-15.0.7.src-orig/clang/bindings/python/examples/cindex/cindex-includes.py llvm-project-15.0.7.src/clang/bindings/python/examples/cindex/cindex-includes.py
+--- llvm-project-15.0.7.src-orig/clang/bindings/python/examples/cindex/cindex-includes.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/bindings/python/examples/cindex/cindex-includes.py	2025-01-26 05:33:31.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #===- cindex-includes.py - cindex/Python Inclusion Graph -----*- python -*--===#
+ #
+diff -ruN llvm-project-15.0.7.src-orig/clang/docs/tools/dump_ast_matchers.py llvm-project-15.0.7.src/clang/docs/tools/dump_ast_matchers.py
+--- llvm-project-15.0.7.src-orig/clang/docs/tools/dump_ast_matchers.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/docs/tools/dump_ast_matchers.py	2025-01-26 05:33:30.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ # A tool to parse ASTMatchers.h and update the documentation in
+ # ../LibASTMatchersReference.html automatically. Run from the
+ # directory in which this file is located to update the docs.
+diff -ruN llvm-project-15.0.7.src-orig/clang/docs/tools/dump_format_help.py llvm-project-15.0.7.src/clang/docs/tools/dump_format_help.py
+--- llvm-project-15.0.7.src-orig/clang/docs/tools/dump_format_help.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/docs/tools/dump_format_help.py	2025-01-26 05:33:30.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ # A tool to parse the output of `clang-format --help` and update the
+ # documentation in ../ClangFormat.rst automatically.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/clang/docs/tools/dump_format_style.py llvm-project-15.0.7.src/clang/docs/tools/dump_format_style.py
+--- llvm-project-15.0.7.src-orig/clang/docs/tools/dump_format_style.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/docs/tools/dump_format_style.py	2025-01-26 05:33:30.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ # A tool to parse the FormatStyle struct from Format.h and update the
+ # documentation in ../ClangFormatStyleOptions.rst automatically.
+ # Run from the directory in which this file is located to update the docs.
+diff -ruN llvm-project-15.0.7.src-orig/clang/docs/tools/generate_formatted_state.py llvm-project-15.0.7.src/clang/docs/tools/generate_formatted_state.py
+--- llvm-project-15.0.7.src-orig/clang/docs/tools/generate_formatted_state.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/docs/tools/generate_formatted_state.py	2025-01-26 05:33:30.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ # A tool to parse creates a document outlining how clang formatted the
+ # LLVM project is.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/clang/lib/Tooling/DumpTool/generate_cxx_src_locs.py llvm-project-15.0.7.src/clang/lib/Tooling/DumpTool/generate_cxx_src_locs.py
+--- llvm-project-15.0.7.src-orig/clang/lib/Tooling/DumpTool/generate_cxx_src_locs.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/lib/Tooling/DumpTool/generate_cxx_src_locs.py	2025-01-26 05:33:30.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ # -*- coding: utf-8 -*-
+ 
+ import os
+diff -ruN llvm-project-15.0.7.src-orig/clang/test/AST/gen_ast_dump_json_test.py llvm-project-15.0.7.src/clang/test/AST/gen_ast_dump_json_test.py
+--- llvm-project-15.0.7.src-orig/clang/test/AST/gen_ast_dump_json_test.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/test/AST/gen_ast_dump_json_test.py	2025-01-26 05:33:29.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ from collections import OrderedDict
+diff -ruN llvm-project-15.0.7.src-orig/clang/test/Analysis/check-analyzer-fixit.py llvm-project-15.0.7.src/clang/test/Analysis/check-analyzer-fixit.py
+--- llvm-project-15.0.7.src-orig/clang/test/Analysis/check-analyzer-fixit.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/test/Analysis/check-analyzer-fixit.py	2025-01-26 05:33:28.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ #===- check-analyzer-fixit.py - Static Analyzer test helper ---*- python -*-===#
+ #
+diff -ruN llvm-project-15.0.7.src-orig/clang/test/Driver/check-time-trace-sections.py llvm-project-15.0.7.src/clang/test/Driver/check-time-trace-sections.py
+--- llvm-project-15.0.7.src-orig/clang/test/Driver/check-time-trace-sections.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/test/Driver/check-time-trace-sections.py	2025-01-26 05:33:28.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import json, sys, time
+ 
+diff -ruN llvm-project-15.0.7.src-orig/clang/tools/clang-format/clang-format-diff.py llvm-project-15.0.7.src/clang/tools/clang-format/clang-format-diff.py
+--- llvm-project-15.0.7.src-orig/clang/tools/clang-format/clang-format-diff.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/tools/clang-format/clang-format-diff.py	2025-01-26 05:33:27.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ #===- clang-format-diff.py - ClangFormat Diff Reformatter ----*- python -*--===#
+ #
+diff -ruN llvm-project-15.0.7.src-orig/clang/tools/include-mapping/cppreference_parser.py llvm-project-15.0.7.src/clang/tools/include-mapping/cppreference_parser.py
+--- llvm-project-15.0.7.src-orig/clang/tools/include-mapping/cppreference_parser.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/tools/include-mapping/cppreference_parser.py	2025-01-26 05:33:27.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===- cppreference_parser.py -  ------------------------------*- python -*--===#
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/clang/tools/include-mapping/gen_std.py llvm-project-15.0.7.src/clang/tools/include-mapping/gen_std.py
+--- llvm-project-15.0.7.src-orig/clang/tools/include-mapping/gen_std.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/tools/include-mapping/gen_std.py	2025-01-26 05:33:27.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===- gen_std.py -  ------------------------------------------*- python -*--===#
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/clang/tools/include-mapping/test.py llvm-project-15.0.7.src/clang/tools/include-mapping/test.py
+--- llvm-project-15.0.7.src-orig/clang/tools/include-mapping/test.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/tools/include-mapping/test.py	2025-01-26 05:33:27.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===- test.py -  ---------------------------------------------*- python -*--===#
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/clang/tools/scan-view/share/Reporter.py llvm-project-15.0.7.src/clang/tools/scan-view/share/Reporter.py
+--- llvm-project-15.0.7.src-orig/clang/tools/scan-view/share/Reporter.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/tools/scan-view/share/Reporter.py	2025-01-26 05:33:27.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ # -*- coding: utf-8 -*-
+ 
+ """Methods for reporting bugs."""
+diff -ruN llvm-project-15.0.7.src-orig/clang/tools/scan-view/share/startfile.py llvm-project-15.0.7.src/clang/tools/scan-view/share/startfile.py
+--- llvm-project-15.0.7.src-orig/clang/tools/scan-view/share/startfile.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/tools/scan-view/share/startfile.py	2025-01-26 05:33:27.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ # -*- coding: utf-8 -*-
+ 
+ """Utility for opening a file using the default application in a cross-platform
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/ABITest/ABITestGen.py llvm-project-15.0.7.src/clang/utils/ABITest/ABITestGen.py
+--- llvm-project-15.0.7.src-orig/clang/utils/ABITest/ABITestGen.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/ABITest/ABITestGen.py	2025-01-26 05:33:29.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import absolute_import, division, print_function
+ from pprint import pprint
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/CIndex/completion_logger_server.py llvm-project-15.0.7.src/clang/utils/CIndex/completion_logger_server.py
+--- llvm-project-15.0.7.src-orig/clang/utils/CIndex/completion_logger_server.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/CIndex/completion_logger_server.py	2025-01-26 05:33:29.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ from __future__ import absolute_import, division, print_function
+ import sys
+ from socket import *
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/TestUtils/deep-stack.py llvm-project-15.0.7.src/clang/utils/TestUtils/deep-stack.py
+--- llvm-project-15.0.7.src-orig/clang/utils/TestUtils/deep-stack.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/TestUtils/deep-stack.py	2025-01-26 05:33:30.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import absolute_import, division, print_function
+ def pcall(f, N):
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/analyzer/CmpRuns.py llvm-project-15.0.7.src/clang/utils/analyzer/CmpRuns.py
+--- llvm-project-15.0.7.src-orig/clang/utils/analyzer/CmpRuns.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/analyzer/CmpRuns.py	2025-01-26 05:33:30.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """
+ CmpRuns - A simple tool for comparing two static analyzer runs to determine
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/analyzer/SATest.py llvm-project-15.0.7.src/clang/utils/analyzer/SATest.py
+--- llvm-project-15.0.7.src-orig/clang/utils/analyzer/SATest.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/analyzer/SATest.py	2025-01-26 05:33:30.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import argparse
+ import sys
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/analyzer/SATestAdd.py llvm-project-15.0.7.src/clang/utils/analyzer/SATestAdd.py
+--- llvm-project-15.0.7.src-orig/clang/utils/analyzer/SATestAdd.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/analyzer/SATestAdd.py	2025-01-26 05:33:30.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """
+ Static Analyzer qualification infrastructure: adding a new project to
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/analyzer/SATestBuild.py llvm-project-15.0.7.src/clang/utils/analyzer/SATestBuild.py
+--- llvm-project-15.0.7.src-orig/clang/utils/analyzer/SATestBuild.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/analyzer/SATestBuild.py	2025-01-26 05:33:29.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """
+ Static Analyzer qualification infrastructure.
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/analyzer/SATestUpdateDiffs.py llvm-project-15.0.7.src/clang/utils/analyzer/SATestUpdateDiffs.py
+--- llvm-project-15.0.7.src-orig/clang/utils/analyzer/SATestUpdateDiffs.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/analyzer/SATestUpdateDiffs.py	2025-01-26 05:33:29.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """
+ Update reference results for static analyzer.
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/analyzer/SumTimerInfo.py llvm-project-15.0.7.src/clang/utils/analyzer/SumTimerInfo.py
+--- llvm-project-15.0.7.src-orig/clang/utils/analyzer/SumTimerInfo.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/analyzer/SumTimerInfo.py	2025-01-26 05:33:29.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """
+ Script to Summarize statistics in the scan-build output.
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/analyzer/exploded-graph-rewriter.py llvm-project-15.0.7.src/clang/utils/analyzer/exploded-graph-rewriter.py
+--- llvm-project-15.0.7.src-orig/clang/utils/analyzer/exploded-graph-rewriter.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/analyzer/exploded-graph-rewriter.py	2025-01-26 05:33:30.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ #===- exploded-graph-rewriter.py - ExplodedGraph dump tool -----*- python -*--#
+ #
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/check_cfc/check_cfc.py llvm-project-15.0.7.src/clang/utils/check_cfc/check_cfc.py
+--- llvm-project-15.0.7.src-orig/clang/utils/check_cfc/check_cfc.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/check_cfc/check_cfc.py	2025-01-26 05:33:29.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Check CFC - Check Compile Flow Consistency
+ 
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/check_cfc/obj_diff.py llvm-project-15.0.7.src/clang/utils/check_cfc/obj_diff.py
+--- llvm-project-15.0.7.src-orig/clang/utils/check_cfc/obj_diff.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/check_cfc/obj_diff.py	2025-01-26 05:33:29.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import absolute_import, division, print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/check_cfc/test_check_cfc.py llvm-project-15.0.7.src/clang/utils/check_cfc/test_check_cfc.py
+--- llvm-project-15.0.7.src-orig/clang/utils/check_cfc/test_check_cfc.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/check_cfc/test_check_cfc.py	2025-01-26 05:33:29.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Test internal functions within check_cfc.py."""
+ 
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/clangdiag.py llvm-project-15.0.7.src/clang/utils/clangdiag.py
+--- llvm-project-15.0.7.src-orig/clang/utils/clangdiag.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/clangdiag.py	2025-01-26 05:33:29.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #----------------------------------------------------------------------
+ # Be sure to add the python path that points to the LLDB shared library.
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/convert_arm_neon.py llvm-project-15.0.7.src/clang/utils/convert_arm_neon.py
+--- llvm-project-15.0.7.src-orig/clang/utils/convert_arm_neon.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/convert_arm_neon.py	2025-01-26 05:33:29.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ # This script was committed on 20/11/2019 and it would probably make sense to remove
+ # it after the next release branches.
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/creduce-clang-crash.py llvm-project-15.0.7.src/clang/utils/creduce-clang-crash.py
+--- llvm-project-15.0.7.src-orig/clang/utils/creduce-clang-crash.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/creduce-clang-crash.py	2025-01-26 05:33:29.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ """Calls C-Reduce to create a minimal reproducer for clang crashes.
+ 
+ Output files:
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/modfuzz.py llvm-project-15.0.7.src/clang/utils/modfuzz.py
+--- llvm-project-15.0.7.src-orig/clang/utils/modfuzz.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/modfuzz.py	2025-01-26 05:33:29.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ # To use:
+ #  1) Update the 'decls' list below with your fuzzing configuration.
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/module-deps-to-rsp.py llvm-project-15.0.7.src/clang/utils/module-deps-to-rsp.py
+--- llvm-project-15.0.7.src-orig/clang/utils/module-deps-to-rsp.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/module-deps-to-rsp.py	2025-01-26 05:33:29.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ # Converts clang-scan-deps output into response files.
+ #
+diff -ruN llvm-project-15.0.7.src-orig/clang/utils/token-delta.py llvm-project-15.0.7.src/clang/utils/token-delta.py
+--- llvm-project-15.0.7.src-orig/clang/utils/token-delta.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/utils/token-delta.py	2025-01-26 05:33:29.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import absolute_import, division, print_function
+ import os
+diff -ruN llvm-project-15.0.7.src-orig/clang/www/builtins.py llvm-project-15.0.7.src/clang/www/builtins.py
+--- llvm-project-15.0.7.src-orig/clang/www/builtins.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang/www/builtins.py	2025-01-26 05:33:30.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import sys, fileinput
+ 
+diff -ruN llvm-project-15.0.7.src-orig/clang-tools-extra/clang-include-fixer/find-all-symbols/tool/run-find-all-symbols.py llvm-project-15.0.7.src/clang-tools-extra/clang-include-fixer/find-all-symbols/tool/run-find-all-symbols.py
+--- llvm-project-15.0.7.src-orig/clang-tools-extra/clang-include-fixer/find-all-symbols/tool/run-find-all-symbols.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang-tools-extra/clang-include-fixer/find-all-symbols/tool/run-find-all-symbols.py	2025-01-26 05:33:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ #=- run-find-all-symbols.py - Parallel find-all-symbols runner -*- python  -*-=#
+ #
+diff -ruN llvm-project-15.0.7.src-orig/clang-tools-extra/clang-tidy/add_new_check.py llvm-project-15.0.7.src/clang-tools-extra/clang-tidy/add_new_check.py
+--- llvm-project-15.0.7.src-orig/clang-tools-extra/clang-tidy/add_new_check.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang-tools-extra/clang-tidy/add_new_check.py	2025-01-26 05:33:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ #===- add_new_check.py - clang-tidy check generator ---------*- python -*--===#
+ #
+diff -ruN llvm-project-15.0.7.src-orig/clang-tools-extra/clang-tidy/rename_check.py llvm-project-15.0.7.src/clang-tools-extra/clang-tidy/rename_check.py
+--- llvm-project-15.0.7.src-orig/clang-tools-extra/clang-tidy/rename_check.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang-tools-extra/clang-tidy/rename_check.py	2025-01-26 05:33:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ #===- rename_check.py - clang-tidy check renamer ------------*- python -*--===#
+ #
+diff -ruN llvm-project-15.0.7.src-orig/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py llvm-project-15.0.7.src/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
+--- llvm-project-15.0.7.src-orig/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py	2025-01-26 05:33:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ #===- clang-tidy-diff.py - ClangTidy Diff Checker -----------*- python -*--===#
+ #
+diff -ruN llvm-project-15.0.7.src-orig/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py llvm-project-15.0.7.src/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+--- llvm-project-15.0.7.src-orig/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py	2025-01-26 05:33:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ #===- run-clang-tidy.py - Parallel clang-tidy runner --------*- python -*--===#
+ #
+diff -ruN llvm-project-15.0.7.src-orig/clang-tools-extra/clangd/test/remote-index/pipeline_helper.py llvm-project-15.0.7.src/clang-tools-extra/clangd/test/remote-index/pipeline_helper.py
+--- llvm-project-15.0.7.src-orig/clang-tools-extra/clangd/test/remote-index/pipeline_helper.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang-tools-extra/clangd/test/remote-index/pipeline_helper.py	2025-01-26 05:33:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ #===- pipeline_helper.py - Remote Index pipeline Helper *- python -------*--===#
+ #
+diff -ruN llvm-project-15.0.7.src-orig/clang-tools-extra/pseudo/tool/bundle_resources.py llvm-project-15.0.7.src/clang-tools-extra/pseudo/tool/bundle_resources.py
+--- llvm-project-15.0.7.src-orig/clang-tools-extra/pseudo/tool/bundle_resources.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang-tools-extra/pseudo/tool/bundle_resources.py	2025-01-26 05:33:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ # Simple bundler of files into string constants.
+ #
+ # Usage: bundle_resources.py foo.inc a.js path/b.css ...
+diff -ruN llvm-project-15.0.7.src-orig/clang-tools-extra/test/clang-tidy/check_clang_tidy.py llvm-project-15.0.7.src/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
+--- llvm-project-15.0.7.src-orig/clang-tools-extra/test/clang-tidy/check_clang_tidy.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/clang-tools-extra/test/clang-tidy/check_clang_tidy.py	2025-01-26 05:33:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ #===- check_clang_tidy.py - ClangTidy Test Helper ------------*- python -*--===#
+ #
+diff -ruN llvm-project-15.0.7.src-orig/compiler-rt/lib/asan/scripts/asan_symbolize.py llvm-project-15.0.7.src/compiler-rt/lib/asan/scripts/asan_symbolize.py
+--- llvm-project-15.0.7.src-orig/compiler-rt/lib/asan/scripts/asan_symbolize.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/compiler-rt/lib/asan/scripts/asan_symbolize.py	2025-01-26 05:33:25.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===- lib/asan/scripts/asan_symbolize.py -----------------------------------===#
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/compiler-rt/lib/dfsan/scripts/build-libc-list.py llvm-project-15.0.7.src/compiler-rt/lib/dfsan/scripts/build-libc-list.py
+--- llvm-project-15.0.7.src-orig/compiler-rt/lib/dfsan/scripts/build-libc-list.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/compiler-rt/lib/dfsan/scripts/build-libc-list.py	2025-01-26 05:33:25.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===- lib/dfsan/scripts/build-libc-list.py ---------------------------------===#
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/compiler-rt/lib/fuzzer/scripts/unbalanced_allocs.py llvm-project-15.0.7.src/compiler-rt/lib/fuzzer/scripts/unbalanced_allocs.py
+--- llvm-project-15.0.7.src-orig/compiler-rt/lib/fuzzer/scripts/unbalanced_allocs.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/compiler-rt/lib/fuzzer/scripts/unbalanced_allocs.py	2025-01-26 05:33:25.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===- lib/fuzzer/scripts/unbalanced_allocs.py ------------------------------===#
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/compiler-rt/lib/sanitizer_common/scripts/gen_dynamic_list.py llvm-project-15.0.7.src/compiler-rt/lib/sanitizer_common/scripts/gen_dynamic_list.py
+--- llvm-project-15.0.7.src-orig/compiler-rt/lib/sanitizer_common/scripts/gen_dynamic_list.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/compiler-rt/lib/sanitizer_common/scripts/gen_dynamic_list.py	2025-01-26 05:33:25.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===- lib/sanitizer_common/scripts/gen_dynamic_list.py ---------------------===#
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/compiler-rt/lib/sanitizer_common/scripts/sancov.py llvm-project-15.0.7.src/compiler-rt/lib/sanitizer_common/scripts/sancov.py
+--- llvm-project-15.0.7.src-orig/compiler-rt/lib/sanitizer_common/scripts/sancov.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/compiler-rt/lib/sanitizer_common/scripts/sancov.py	2025-01-26 05:33:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ # Merge or print the coverage data collected by asan's coverage.
+ # Input files are sequences of 4-byte integers.
+ # We need to merge these integers into a set and then
+diff -ruN llvm-project-15.0.7.src-orig/compiler-rt/test/sanitizer_common/android_commands/android_compile.py llvm-project-15.0.7.src/compiler-rt/test/sanitizer_common/android_commands/android_compile.py
+--- llvm-project-15.0.7.src-orig/compiler-rt/test/sanitizer_common/android_commands/android_compile.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/compiler-rt/test/sanitizer_common/android_commands/android_compile.py	2025-01-26 05:33:25.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import os, sys, subprocess
+ from android_common import *
+diff -ruN llvm-project-15.0.7.src-orig/compiler-rt/test/sanitizer_common/android_commands/android_run.py llvm-project-15.0.7.src/compiler-rt/test/sanitizer_common/android_commands/android_run.py
+--- llvm-project-15.0.7.src-orig/compiler-rt/test/sanitizer_common/android_commands/android_run.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/compiler-rt/test/sanitizer_common/android_commands/android_run.py	2025-01-26 05:33:25.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import os, signal, sys, subprocess, tempfile
+ from android_common import *
+diff -ruN llvm-project-15.0.7.src-orig/compiler-rt/test/sanitizer_common/ios_commands/iossim_compile.py llvm-project-15.0.7.src/compiler-rt/test/sanitizer_common/ios_commands/iossim_compile.py
+--- llvm-project-15.0.7.src-orig/compiler-rt/test/sanitizer_common/ios_commands/iossim_compile.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/compiler-rt/test/sanitizer_common/ios_commands/iossim_compile.py	2025-01-26 05:33:25.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import os, sys, subprocess
+ 
+diff -ruN llvm-project-15.0.7.src-orig/compiler-rt/test/sanitizer_common/ios_commands/iossim_env.py llvm-project-15.0.7.src/compiler-rt/test/sanitizer_common/ios_commands/iossim_env.py
+--- llvm-project-15.0.7.src-orig/compiler-rt/test/sanitizer_common/ios_commands/iossim_env.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/compiler-rt/test/sanitizer_common/ios_commands/iossim_env.py	2025-01-26 05:33:25.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import os, sys, subprocess
+ 
+diff -ruN llvm-project-15.0.7.src-orig/compiler-rt/test/sanitizer_common/ios_commands/iossim_prepare.py llvm-project-15.0.7.src/compiler-rt/test/sanitizer_common/ios_commands/iossim_prepare.py
+--- llvm-project-15.0.7.src-orig/compiler-rt/test/sanitizer_common/ios_commands/iossim_prepare.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/compiler-rt/test/sanitizer_common/ios_commands/iossim_prepare.py	2025-01-26 05:33:25.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import json
+ 
+diff -ruN llvm-project-15.0.7.src-orig/compiler-rt/test/sanitizer_common/ios_commands/iossim_run.py llvm-project-15.0.7.src/compiler-rt/test/sanitizer_common/ios_commands/iossim_run.py
+--- llvm-project-15.0.7.src-orig/compiler-rt/test/sanitizer_common/ios_commands/iossim_run.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/compiler-rt/test/sanitizer_common/ios_commands/iossim_run.py	2025-01-26 05:33:25.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import glob, os, pipes, sys, subprocess
+ 
+diff -ruN llvm-project-15.0.7.src-orig/cross-project-tests/debuginfo-tests/dexter/dexter.py llvm-project-15.0.7.src/cross-project-tests/debuginfo-tests/dexter/dexter.py
+--- llvm-project-15.0.7.src-orig/cross-project-tests/debuginfo-tests/dexter/dexter.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/cross-project-tests/debuginfo-tests/dexter/dexter.py	2025-01-26 05:31:43.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ # DExTer : Debugging Experience Tester
+ # ~~~~~~   ~         ~~         ~   ~~
+ #
+diff -ruN llvm-project-15.0.7.src-orig/cross-project-tests/debuginfo-tests/llgdb-tests/llgdb.py llvm-project-15.0.7.src/cross-project-tests/debuginfo-tests/llgdb-tests/llgdb.py
+--- llvm-project-15.0.7.src-orig/cross-project-tests/debuginfo-tests/llgdb-tests/llgdb.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/cross-project-tests/debuginfo-tests/llgdb-tests/llgdb.py	2025-01-26 05:31:47.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ """
+ A gdb-compatible frontend for lldb that implements just enough
+ commands to run the tests in the debuginfo-tests repository with lldb.
+diff -ruN llvm-project-15.0.7.src-orig/flang/test/Evaluate/test_folding.py llvm-project-15.0.7.src/flang/test/Evaluate/test_folding.py
+--- llvm-project-15.0.7.src-orig/flang/test/Evaluate/test_folding.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/flang/test/Evaluate/test_folding.py	2025-01-26 05:33:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """This script verifies expression folding.
+ It compiles a source file with '-fdebug-dump-symbols'
+diff -ruN llvm-project-15.0.7.src-orig/flang/test/Semantics/test_errors.py llvm-project-15.0.7.src/flang/test/Semantics/test_errors.py
+--- llvm-project-15.0.7.src-orig/flang/test/Semantics/test_errors.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/flang/test/Semantics/test_errors.py	2025-01-26 05:33:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Compiles a source file and checks errors against those listed in the file.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/flang/test/Semantics/test_modfile.py llvm-project-15.0.7.src/flang/test/Semantics/test_modfile.py
+--- llvm-project-15.0.7.src-orig/flang/test/Semantics/test_modfile.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/flang/test/Semantics/test_modfile.py	2025-01-26 05:33:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Compiles a source file and compares generated .mod files against expected.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/flang/test/Semantics/test_symbols.py llvm-project-15.0.7.src/flang/test/Semantics/test_symbols.py
+--- llvm-project-15.0.7.src-orig/flang/test/Semantics/test_symbols.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/flang/test/Semantics/test_symbols.py	2025-01-26 05:33:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Compiles a source file with "-fdebug-unparse-with-symbols' and verifies
+ we get the right symbols in the output, i.e. the output should be
+diff -ruN llvm-project-15.0.7.src-orig/libc/AOR_v20.02/math/tools/plot.py llvm-project-15.0.7.src/libc/AOR_v20.02/math/tools/plot.py
+--- llvm-project-15.0.7.src-orig/libc/AOR_v20.02/math/tools/plot.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/libc/AOR_v20.02/math/tools/plot.py	2025-01-26 05:33:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ # ULP error plot tool.
+ #
+diff -ruN llvm-project-15.0.7.src-orig/libcxx/test/libcxx/transitive_includes.sanitize.py llvm-project-15.0.7.src/libcxx/test/libcxx/transitive_includes.sanitize.py
+--- llvm-project-15.0.7.src-orig/libcxx/test/libcxx/transitive_includes.sanitize.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/libcxx/test/libcxx/transitive_includes.sanitize.py	2025-01-26 05:33:20.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===----------------------------------------------------------------------===##
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/libcxx/utils/cat_files.py llvm-project-15.0.7.src/libcxx/utils/cat_files.py
+--- llvm-project-15.0.7.src-orig/libcxx/utils/cat_files.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/libcxx/utils/cat_files.py	2025-01-26 05:33:21.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===----------------------------------------------------------------------===##
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/libcxx/utils/generate_abi_list.py llvm-project-15.0.7.src/libcxx/utils/generate_abi_list.py
+--- llvm-project-15.0.7.src-orig/libcxx/utils/generate_abi_list.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/libcxx/utils/generate_abi_list.py	2025-01-26 05:33:22.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===----------------------------------------------------------------------===##
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/libcxx/utils/generate_extended_grapheme_cluster_table.py llvm-project-15.0.7.src/libcxx/utils/generate_extended_grapheme_cluster_table.py
+--- llvm-project-15.0.7.src-orig/libcxx/utils/generate_extended_grapheme_cluster_table.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/libcxx/utils/generate_extended_grapheme_cluster_table.py	2025-01-26 05:33:22.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ # ===----------------------------------------------------------------------===##
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/libcxx/utils/generate_extended_grapheme_cluster_test.py llvm-project-15.0.7.src/libcxx/utils/generate_extended_grapheme_cluster_test.py
+--- llvm-project-15.0.7.src-orig/libcxx/utils/generate_extended_grapheme_cluster_test.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/libcxx/utils/generate_extended_grapheme_cluster_test.py	2025-01-26 05:33:22.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ # ===----------------------------------------------------------------------===##
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/libcxx/utils/generate_feature_test_macro_components.py llvm-project-15.0.7.src/libcxx/utils/generate_feature_test_macro_components.py
+--- llvm-project-15.0.7.src-orig/libcxx/utils/generate_feature_test_macro_components.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/libcxx/utils/generate_feature_test_macro_components.py	2025-01-26 05:33:22.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import os
+ from builtins import range
+diff -ruN llvm-project-15.0.7.src-orig/libcxx/utils/generate_header_inclusion_tests.py llvm-project-15.0.7.src/libcxx/utils/generate_header_inclusion_tests.py
+--- llvm-project-15.0.7.src-orig/libcxx/utils/generate_header_inclusion_tests.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/libcxx/utils/generate_header_inclusion_tests.py	2025-01-26 05:33:22.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import os
+ 
+diff -ruN llvm-project-15.0.7.src-orig/libcxx/utils/generate_header_tests.py llvm-project-15.0.7.src/libcxx/utils/generate_header_tests.py
+--- llvm-project-15.0.7.src-orig/libcxx/utils/generate_header_tests.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/libcxx/utils/generate_header_tests.py	2025-01-26 05:33:22.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import contextlib
+ import glob
+diff -ruN llvm-project-15.0.7.src-orig/libcxx/utils/graph_header_deps.py llvm-project-15.0.7.src/libcxx/utils/graph_header_deps.py
+--- llvm-project-15.0.7.src-orig/libcxx/utils/graph_header_deps.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/libcxx/utils/graph_header_deps.py	2025-01-26 05:33:22.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===----------------------------------------------------------------------===##
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/libcxx/utils/run.py llvm-project-15.0.7.src/libcxx/utils/run.py
+--- llvm-project-15.0.7.src-orig/libcxx/utils/run.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/libcxx/utils/run.py	2025-01-26 05:33:21.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===----------------------------------------------------------------------===##
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/libcxx/utils/ssh.py llvm-project-15.0.7.src/libcxx/utils/ssh.py
+--- llvm-project-15.0.7.src-orig/libcxx/utils/ssh.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/libcxx/utils/ssh.py	2025-01-26 05:33:22.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===----------------------------------------------------------------------===##
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/libcxx/utils/sym_diff.py llvm-project-15.0.7.src/libcxx/utils/sym_diff.py
+--- llvm-project-15.0.7.src-orig/libcxx/utils/sym_diff.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/libcxx/utils/sym_diff.py	2025-01-26 05:33:21.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===----------------------------------------------------------------------===##
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/lld/test/MachO/tools/generate-cfi-funcs.py llvm-project-15.0.7.src/lld/test/MachO/tools/generate-cfi-funcs.py
+--- llvm-project-15.0.7.src-orig/lld/test/MachO/tools/generate-cfi-funcs.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lld/test/MachO/tools/generate-cfi-funcs.py	2025-01-26 05:33:31.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Generate skeletal functions with a variety .cfi_ directives.
+ The purpose is to produce object-file test inputs to lld with a
+diff -ruN llvm-project-15.0.7.src-orig/lld/test/MachO/tools/generate-thunkable-program.py llvm-project-15.0.7.src/lld/test/MachO/tools/generate-thunkable-program.py
+--- llvm-project-15.0.7.src-orig/lld/test/MachO/tools/generate-thunkable-program.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lld/test/MachO/tools/generate-thunkable-program.py	2025-01-26 05:33:31.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Generate many skeletal functions with a thick call graph spanning a
+ large address space to induce lld to create branch-islands for arm64.
+diff -ruN llvm-project-15.0.7.src-orig/lld/test/MachO/tools/validate-unwind-info.py llvm-project-15.0.7.src/lld/test/MachO/tools/validate-unwind-info.py
+--- llvm-project-15.0.7.src-orig/lld/test/MachO/tools/validate-unwind-info.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lld/test/MachO/tools/validate-unwind-info.py	2025-01-26 05:33:31.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Validate compact unwind info by cross checking the llvm-objdump
+ reports of the input object file vs final linked output.
+diff -ruN llvm-project-15.0.7.src-orig/lld/utils/benchmark.py llvm-project-15.0.7.src/lld/utils/benchmark.py
+--- llvm-project-15.0.7.src-orig/lld/utils/benchmark.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lld/utils/benchmark.py	2025-01-26 05:33:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ # See https://llvm.org/LICENSE.txt for license information.
+diff -ruN llvm-project-15.0.7.src-orig/lldb/bindings/python/get-python-config.py llvm-project-15.0.7.src/lldb/bindings/python/get-python-config.py
+--- llvm-project-15.0.7.src-orig/lldb/bindings/python/get-python-config.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/bindings/python/get-python-config.py	2025-01-26 05:31:23.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import os
+ import sys
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/darwin/heap_find/heap.py llvm-project-15.0.7.src/lldb/examples/darwin/heap_find/heap.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/darwin/heap_find/heap.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/darwin/heap_find/heap.py	2025-01-26 05:31:21.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #----------------------------------------------------------------------
+ # This module is designed to live inside the "lldb" python package
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/armv7_cortex_m_target_defintion.py llvm-project-15.0.7.src/lldb/examples/python/armv7_cortex_m_target_defintion.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/armv7_cortex_m_target_defintion.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/armv7_cortex_m_target_defintion.py	2025-01-26 05:31:20.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===-- armv7_cortex_m_target_definition.py.py ------------------*- C++ -*-===//
+ #
+ #                     The LLVM Compiler Infrastructure
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/bsd.py llvm-project-15.0.7.src/lldb/examples/python/bsd.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/bsd.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/bsd.py	2025-01-26 05:31:20.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ from __future__ import print_function
+ 
+ import cmd
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/cmdtemplate.py llvm-project-15.0.7.src/lldb/examples/python/cmdtemplate.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/cmdtemplate.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/cmdtemplate.py	2025-01-26 05:31:19.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ # ---------------------------------------------------------------------
+ # Be sure to add the python path that points to the LLDB shared library.
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/crashlog.py llvm-project-15.0.7.src/lldb/examples/python/crashlog.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/crashlog.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/crashlog.py	2025-01-26 05:31:20.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #----------------------------------------------------------------------
+ # Be sure to add the python path that points to the LLDB shared library.
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/delta.py llvm-project-15.0.7.src/lldb/examples/python/delta.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/delta.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/delta.py	2025-01-26 05:31:19.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #----------------------------------------------------------------------
+ # This module will enable GDB remote packet logging when the
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/disasm-stress-test.py llvm-project-15.0.7.src/lldb/examples/python/disasm-stress-test.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/disasm-stress-test.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/disasm-stress-test.py	2025-01-26 05:31:18.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import argparse
+ import datetime
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/disasm.py llvm-project-15.0.7.src/lldb/examples/python/disasm.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/disasm.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/disasm.py	2025-01-26 05:31:18.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #----------------------------------------------------------------------
+ # Be sure to add the python path that points to the LLDB shared library.
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/file_extract.py llvm-project-15.0.7.src/lldb/examples/python/file_extract.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/file_extract.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/file_extract.py	2025-01-26 05:31:20.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import string
+ import struct
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/gdbremote.py llvm-project-15.0.7.src/lldb/examples/python/gdbremote.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/gdbremote.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/gdbremote.py	2025-01-26 05:31:19.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #----------------------------------------------------------------------
+ # This module will enable GDB remote packet logging when the
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/globals.py llvm-project-15.0.7.src/lldb/examples/python/globals.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/globals.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/globals.py	2025-01-26 05:31:18.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #----------------------------------------------------------------------
+ # For the shells csh, tcsh:
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/in_call_stack.py llvm-project-15.0.7.src/lldb/examples/python/in_call_stack.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/in_call_stack.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/in_call_stack.py	2025-01-26 05:31:19.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ 
+ def __lldb_init_module(debugger, internal_dict):
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/lldb_module_utils.py llvm-project-15.0.7.src/lldb/examples/python/lldb_module_utils.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/lldb_module_utils.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/lldb_module_utils.py	2025-01-26 05:31:18.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ from __future__ import print_function
+ 
+ import lldb
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/lldbtk.py llvm-project-15.0.7.src/lldb/examples/python/lldbtk.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/lldbtk.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/lldbtk.py	2025-01-26 05:31:18.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ from __future__ import print_function
+ 
+ import lldb
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/mach_o.py llvm-project-15.0.7.src/lldb/examples/python/mach_o.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/mach_o.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/mach_o.py	2025-01-26 05:31:18.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ from __future__ import print_function
+ 
+ import cmd
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/memory.py llvm-project-15.0.7.src/lldb/examples/python/memory.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/memory.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/memory.py	2025-01-26 05:31:18.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #----------------------------------------------------------------------
+ # Be sure to add the python path that points to the LLDB shared library.
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/operating_system.py llvm-project-15.0.7.src/lldb/examples/python/operating_system.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/operating_system.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/operating_system.py	2025-01-26 05:31:19.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import lldb
+ import struct
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/performance.py llvm-project-15.0.7.src/lldb/examples/python/performance.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/performance.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/performance.py	2025-01-26 05:31:19.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #----------------------------------------------------------------------
+ # Be sure to add the python path that points to the LLDB shared library.
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/process_events.py llvm-project-15.0.7.src/lldb/examples/python/process_events.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/process_events.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/process_events.py	2025-01-26 05:31:18.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #----------------------------------------------------------------------
+ # Be sure to add the python path that points to the LLDB shared library.
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/sbvalue.py llvm-project-15.0.7.src/lldb/examples/python/sbvalue.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/sbvalue.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/sbvalue.py	2025-01-26 05:31:19.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import lldb
+ 
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/shadow.py llvm-project-15.0.7.src/lldb/examples/python/shadow.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/shadow.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/shadow.py	2025-01-26 05:31:19.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ from __future__ import print_function
+ 
+ import lldb
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/sources.py llvm-project-15.0.7.src/lldb/examples/python/sources.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/sources.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/sources.py	2025-01-26 05:31:19.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ from __future__ import print_function
+ 
+ import lldb
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/stacks.py llvm-project-15.0.7.src/lldb/examples/python/stacks.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/stacks.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/stacks.py	2025-01-26 05:31:20.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ from __future__ import print_function
+ import lldb
+ import optparse
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/symbolication.py llvm-project-15.0.7.src/lldb/examples/python/symbolication.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/symbolication.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/symbolication.py	2025-01-26 05:31:19.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #----------------------------------------------------------------------
+ # Be sure to add the python path that points to the LLDB shared library.
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/types.py llvm-project-15.0.7.src/lldb/examples/python/types.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/types.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/types.py	2025-01-26 05:31:19.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #----------------------------------------------------------------------
+ # Be sure to add the python path that points to the LLDB shared library.
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/x86_64_linux_target_definition.py llvm-project-15.0.7.src/lldb/examples/python/x86_64_linux_target_definition.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/x86_64_linux_target_definition.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/x86_64_linux_target_definition.py	2025-01-26 05:31:18.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===-- x86_64_linux_target_definition.py -----------------------------*- C++ -*-===//
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/x86_64_qemu_target_definition.py llvm-project-15.0.7.src/lldb/examples/python/x86_64_qemu_target_definition.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/x86_64_qemu_target_definition.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/x86_64_qemu_target_definition.py	2025-01-26 05:31:19.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===-- x86_64_qemu_target_definition.py -----------------------------*- C++ -*-===//
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/lldb/examples/python/x86_64_target_definition.py llvm-project-15.0.7.src/lldb/examples/python/x86_64_target_definition.py
+--- llvm-project-15.0.7.src-orig/lldb/examples/python/x86_64_target_definition.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/examples/python/x86_64_target_definition.py	2025-01-26 05:31:19.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===-- x86_64_target_definition.py -----------------------------*- C++ -*-===//
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/lldb/packages/Python/lldbsuite/test/bench.py llvm-project-15.0.7.src/lldb/packages/Python/lldbsuite/test/bench.py
+--- llvm-project-15.0.7.src-orig/lldb/packages/Python/lldbsuite/test/bench.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/packages/Python/lldbsuite/test/bench.py	2025-01-26 05:31:22.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """
+ A simple bench runner which delegates to the ./dotest.py test driver to run the
+diff -ruN llvm-project-15.0.7.src-orig/lldb/packages/Python/lldbsuite/test/tools/lldb-vscode/vscode.py llvm-project-15.0.7.src/lldb/packages/Python/lldbsuite/test/tools/lldb-vscode/vscode.py
+--- llvm-project-15.0.7.src-orig/lldb/packages/Python/lldbsuite/test/tools/lldb-vscode/vscode.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/packages/Python/lldbsuite/test/tools/lldb-vscode/vscode.py	2025-01-26 05:31:22.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import binascii
+ import json
+diff -ruN llvm-project-15.0.7.src-orig/lldb/scripts/analyze-project-deps.py llvm-project-15.0.7.src/lldb/scripts/analyze-project-deps.py
+--- llvm-project-15.0.7.src-orig/lldb/scripts/analyze-project-deps.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/scripts/analyze-project-deps.py	2025-01-26 05:31:21.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import argparse
+ import itertools
+diff -ruN llvm-project-15.0.7.src-orig/lldb/scripts/reproducer-replay.py llvm-project-15.0.7.src/lldb/scripts/reproducer-replay.py
+--- llvm-project-15.0.7.src-orig/lldb/scripts/reproducer-replay.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/scripts/reproducer-replay.py	2025-01-26 05:31:21.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from multiprocessing import Pool
+ import multiprocessing
+diff -ruN llvm-project-15.0.7.src-orig/lldb/scripts/verify_api.py llvm-project-15.0.7.src/lldb/scripts/verify_api.py
+--- llvm-project-15.0.7.src-orig/lldb/scripts/verify_api.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/scripts/verify_api.py	2025-01-26 05:31:21.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import subprocess
+ import optparse
+diff -ruN llvm-project-15.0.7.src-orig/lldb/test/API/dotest.py llvm-project-15.0.7.src/lldb/test/API/dotest.py
+--- llvm-project-15.0.7.src-orig/lldb/test/API/dotest.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/test/API/dotest.py	2025-01-26 05:30:44.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ if __name__ == "__main__":
+     import use_lldb_suite
+diff -ruN llvm-project-15.0.7.src-orig/lldb/test/API/functionalities/plugins/python_os_plugin/operating_system.py llvm-project-15.0.7.src/lldb/test/API/functionalities/plugins/python_os_plugin/operating_system.py
+--- llvm-project-15.0.7.src-orig/lldb/test/API/functionalities/plugins/python_os_plugin/operating_system.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/test/API/functionalities/plugins/python_os_plugin/operating_system.py	2025-01-26 05:30:59.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import lldb
+ import struct
+diff -ruN llvm-project-15.0.7.src-orig/lldb/test/API/functionalities/plugins/python_os_plugin/operating_system2.py llvm-project-15.0.7.src/lldb/test/API/functionalities/plugins/python_os_plugin/operating_system2.py
+--- llvm-project-15.0.7.src-orig/lldb/test/API/functionalities/plugins/python_os_plugin/operating_system2.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/test/API/functionalities/plugins/python_os_plugin/operating_system2.py	2025-01-26 05:30:59.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import lldb
+ import struct
+diff -ruN llvm-project-15.0.7.src-orig/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/operating_system.py llvm-project-15.0.7.src/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/operating_system.py
+--- llvm-project-15.0.7.src-orig/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/operating_system.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/operating_system.py	2025-01-26 05:30:59.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import lldb
+ import struct
+diff -ruN llvm-project-15.0.7.src-orig/lldb/test/API/functionalities/postmortem/FreeBSDKernel/tools/copy-sparse.py llvm-project-15.0.7.src/lldb/test/API/functionalities/postmortem/FreeBSDKernel/tools/copy-sparse.py
+--- llvm-project-15.0.7.src-orig/lldb/test/API/functionalities/postmortem/FreeBSDKernel/tools/copy-sparse.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/test/API/functionalities/postmortem/FreeBSDKernel/tools/copy-sparse.py	2025-01-26 05:30:58.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import argparse
+ import re
+diff -ruN llvm-project-15.0.7.src-orig/lldb/test/API/test_runner/test/inferior.py llvm-project-15.0.7.src/lldb/test/API/test_runner/test/inferior.py
+--- llvm-project-15.0.7.src-orig/lldb/test/API/test_runner/test/inferior.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/test/API/test_runner/test/inferior.py	2025-01-26 05:33:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ """Inferior program used by process control tests."""
+ 
+ from __future__ import print_function
+diff -ruN llvm-project-15.0.7.src-orig/lldb/test/API/test_runner/test/test_process_control.py llvm-project-15.0.7.src/lldb/test/API/test_runner/test/test_process_control.py
+--- llvm-project-15.0.7.src-orig/lldb/test/API/test_runner/test/test_process_control.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/test/API/test_runner/test/test_process_control.py	2025-01-26 05:33:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ """
+ Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ See https://llvm.org/LICENSE.txt for license information.
+diff -ruN llvm-project-15.0.7.src-orig/lldb/test/Shell/Quit/expect_exit_code.py llvm-project-15.0.7.src/lldb/test/Shell/Quit/expect_exit_code.py
+--- llvm-project-15.0.7.src-orig/lldb/test/Shell/Quit/expect_exit_code.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/test/Shell/Quit/expect_exit_code.py	2025-01-26 05:33:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import subprocess
+ import sys
+diff -ruN llvm-project-15.0.7.src-orig/lldb/test/Shell/Register/Core/Inputs/strip-coredump.py llvm-project-15.0.7.src/lldb/test/Shell/Register/Core/Inputs/strip-coredump.py
+--- llvm-project-15.0.7.src-orig/lldb/test/Shell/Register/Core/Inputs/strip-coredump.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/test/Shell/Register/Core/Inputs/strip-coredump.py	2025-01-26 05:33:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ # Strip unnecessary data from a core dump to reduce its size.
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/patch-crashlog.py llvm-project-15.0.7.src/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/patch-crashlog.py
+--- llvm-project-15.0.7.src-orig/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/patch-crashlog.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/patch-crashlog.py	2025-01-26 05:33:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import json
+ import os
+diff -ruN llvm-project-15.0.7.src-orig/lldb/test/Shell/helper/build.py llvm-project-15.0.7.src/lldb/test/Shell/helper/build.py
+--- llvm-project-15.0.7.src-orig/lldb/test/Shell/helper/build.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/test/Shell/helper/build.py	2025-01-26 05:33:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/lldb/third_party/Python/module/pexpect-4.6/pexpect/FSM.py llvm-project-15.0.7.src/lldb/third_party/Python/module/pexpect-4.6/pexpect/FSM.py
+--- llvm-project-15.0.7.src-orig/lldb/third_party/Python/module/pexpect-4.6/pexpect/FSM.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/third_party/Python/module/pexpect-4.6/pexpect/FSM.py	2025-01-26 05:31:16.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ '''This module implements a Finite State Machine (FSM). In addition to state
+ this FSM also maintains a user defined "memory". So this FSM can be used as a
+diff -ruN llvm-project-15.0.7.src-orig/lldb/third_party/Python/module/progress/progress.py llvm-project-15.0.7.src/lldb/third_party/Python/module/progress/progress.py
+--- llvm-project-15.0.7.src-orig/lldb/third_party/Python/module/progress/progress.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/third_party/Python/module/progress/progress.py	2025-01-26 05:31:16.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/lldb/utils/lldb-repro/lldb-repro.py llvm-project-15.0.7.src/lldb/utils/lldb-repro/lldb-repro.py
+--- llvm-project-15.0.7.src-orig/lldb/utils/lldb-repro/lldb-repro.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/utils/lldb-repro/lldb-repro.py	2025-01-26 05:31:16.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ """lldb-repro
+ 
+ lldb-repro is a utility to transparently capture and replay debugger sessions
+diff -ruN llvm-project-15.0.7.src-orig/lldb/utils/lui/lui.py llvm-project-15.0.7.src/lldb/utils/lui/lui.py
+--- llvm-project-15.0.7.src-orig/lldb/utils/lui/lui.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/utils/lui/lui.py	2025-01-26 05:31:15.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ ##===-- lui.py -----------------------------------------------*- Python -*-===##
+ ##
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/lldb/utils/lui/sandbox.py llvm-project-15.0.7.src/lldb/utils/lui/sandbox.py
+--- llvm-project-15.0.7.src-orig/lldb/utils/lui/sandbox.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/lldb/utils/lui/sandbox.py	2025-01-26 05:31:15.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ ##===-- sandbox.py -------------------------------------------*- Python -*-===##
+ ##
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/llvm/examples/Kaleidoscope/MCJIT/cached/genk-timing.py llvm-project-15.0.7.src/llvm/examples/Kaleidoscope/MCJIT/cached/genk-timing.py
+--- llvm-project-15.0.7.src-orig/llvm/examples/Kaleidoscope/MCJIT/cached/genk-timing.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/examples/Kaleidoscope/MCJIT/cached/genk-timing.py	2025-01-26 05:31:35.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/examples/Kaleidoscope/MCJIT/cached/split-lib.py llvm-project-15.0.7.src/llvm/examples/Kaleidoscope/MCJIT/cached/split-lib.py
+--- llvm-project-15.0.7.src-orig/llvm/examples/Kaleidoscope/MCJIT/cached/split-lib.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/examples/Kaleidoscope/MCJIT/cached/split-lib.py	2025-01-26 05:31:35.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/examples/Kaleidoscope/MCJIT/complete/genk-timing.py llvm-project-15.0.7.src/llvm/examples/Kaleidoscope/MCJIT/complete/genk-timing.py
+--- llvm-project-15.0.7.src-orig/llvm/examples/Kaleidoscope/MCJIT/complete/genk-timing.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/examples/Kaleidoscope/MCJIT/complete/genk-timing.py	2025-01-26 05:31:35.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/examples/Kaleidoscope/MCJIT/complete/split-lib.py llvm-project-15.0.7.src/llvm/examples/Kaleidoscope/MCJIT/complete/split-lib.py
+--- llvm-project-15.0.7.src-orig/llvm/examples/Kaleidoscope/MCJIT/complete/split-lib.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/examples/Kaleidoscope/MCJIT/complete/split-lib.py	2025-01-26 05:31:35.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/examples/Kaleidoscope/MCJIT/lazy/genk-timing.py llvm-project-15.0.7.src/llvm/examples/Kaleidoscope/MCJIT/lazy/genk-timing.py
+--- llvm-project-15.0.7.src-orig/llvm/examples/Kaleidoscope/MCJIT/lazy/genk-timing.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/examples/Kaleidoscope/MCJIT/lazy/genk-timing.py	2025-01-26 05:31:35.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/test/BugPoint/compile-custom.ll.py llvm-project-15.0.7.src/llvm/test/BugPoint/compile-custom.ll.py
+--- llvm-project-15.0.7.src-orig/llvm/test/BugPoint/compile-custom.ll.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/test/BugPoint/compile-custom.ll.py	2025-01-26 05:31:25.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/test/CodeGen/WebAssembly/multivalue-stackify.py llvm-project-15.0.7.src/llvm/test/CodeGen/WebAssembly/multivalue-stackify.py
+--- llvm-project-15.0.7.src-orig/llvm/test/CodeGen/WebAssembly/multivalue-stackify.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/test/CodeGen/WebAssembly/multivalue-stackify.py	2025-01-26 05:31:25.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """A test case generator for register stackification.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/test/Other/opt-bisect-helper.py llvm-project-15.0.7.src/llvm/test/Other/opt-bisect-helper.py
+--- llvm-project-15.0.7.src-orig/llvm/test/Other/opt-bisect-helper.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/test/Other/opt-bisect-helper.py	2025-01-26 05:31:24.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/test/TableGen/JSON-check.py llvm-project-15.0.7.src/llvm/test/TableGen/JSON-check.py
+--- llvm-project-15.0.7.src-orig/llvm/test/TableGen/JSON-check.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/test/TableGen/JSON-check.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import sys
+ import subprocess
+diff -ruN llvm-project-15.0.7.src-orig/llvm/tools/opt-viewer/opt-diff.py llvm-project-15.0.7.src/llvm/tools/opt-viewer/opt-diff.py
+--- llvm-project-15.0.7.src-orig/llvm/tools/opt-viewer/opt-diff.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/tools/opt-viewer/opt-diff.py	2025-01-26 05:31:24.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/tools/opt-viewer/opt-stats.py llvm-project-15.0.7.src/llvm/tools/opt-viewer/opt-stats.py
+--- llvm-project-15.0.7.src-orig/llvm/tools/opt-viewer/opt-stats.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/tools/opt-viewer/opt-stats.py	2025-01-26 05:31:24.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/tools/opt-viewer/opt-viewer.py llvm-project-15.0.7.src/llvm/tools/opt-viewer/opt-viewer.py
+--- llvm-project-15.0.7.src-orig/llvm/tools/opt-viewer/opt-viewer.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/tools/opt-viewer/opt-viewer.py	2025-01-26 05:31:24.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/tools/opt-viewer/optrecord.py llvm-project-15.0.7.src/llvm/tools/opt-viewer/optrecord.py
+--- llvm-project-15.0.7.src-orig/llvm/tools/opt-viewer/optrecord.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/tools/opt-viewer/optrecord.py	2025-01-26 05:31:24.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/tools/sancov/coverage-report-server.py llvm-project-15.0.7.src/llvm/tools/sancov/coverage-report-server.py
+--- llvm-project-15.0.7.src-orig/llvm/tools/sancov/coverage-report-server.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/tools/sancov/coverage-report-server.py	2025-01-26 05:31:24.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ #===- symcov-report-server.py - Coverage Reports HTTP Serve --*- python -*--===#
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/DSAclean.py llvm-project-15.0.7.src/llvm/utils/DSAclean.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/DSAclean.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/DSAclean.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #changelog: 
+ #10/13/2005b: replaced the # in tmp(.#*)* with alphanumeric and _, this will then remove
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/DSAextract.py llvm-project-15.0.7.src/llvm/utils/DSAextract.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/DSAextract.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/DSAextract.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ #this is a script to extract given named nodes from a dot file, with
+ #the associated edges.  An edge is kept iff for edge x -> y
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/Reviewing/find_interesting_reviews.py llvm-project-15.0.7.src/llvm/utils/Reviewing/find_interesting_reviews.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/Reviewing/find_interesting_reviews.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/Reviewing/find_interesting_reviews.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/Target/ARM/analyze-match-table.py llvm-project-15.0.7.src/llvm/utils/Target/ARM/analyze-match-table.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/Target/ARM/analyze-match-table.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/Target/ARM/analyze-match-table.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/abtest.py llvm-project-15.0.7.src/llvm/utils/abtest.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/abtest.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/abtest.py	2025-01-26 05:31:35.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ # Given a previous good compile narrow down miscompiles.
+ # Expects two directories named "before" and "after" each containing a set of
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/add_argument_names.py llvm-project-15.0.7.src/llvm/utils/add_argument_names.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/add_argument_names.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/add_argument_names.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ import re, sys
+ 
+ def fix_string(s):
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/bugpoint_gisel_reducer.py llvm-project-15.0.7.src/llvm/utils/bugpoint_gisel_reducer.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/bugpoint_gisel_reducer.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/bugpoint_gisel_reducer.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Reduces GlobalISel failures.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/check_ninja_deps.py llvm-project-15.0.7.src/llvm/utils/check_ninja_deps.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/check_ninja_deps.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/check_ninja_deps.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ # ======- check-ninja-deps - build debugging script ----*- python -*--========#
+ #
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/chunk-print-before-all.py llvm-project-15.0.7.src/llvm/utils/chunk-print-before-all.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/chunk-print-before-all.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/chunk-print-before-all.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ # Given a -print-before-all -print-module-scope log from an opt invocation,
+ # chunk it into a series of individual IR files, one for each pass invocation.
+ # If the log ends with an obvious stack trace, try to split off a separate
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/collect_and_build_with_pgo.py llvm-project-15.0.7.src/llvm/utils/collect_and_build_with_pgo.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/collect_and_build_with_pgo.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/collect_and_build_with_pgo.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ """
+ This script:
+ - Builds clang with user-defined flags
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/convert-constraint-log-to-z3.py llvm-project-15.0.7.src/llvm/utils/convert-constraint-log-to-z3.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/convert-constraint-log-to-z3.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/convert-constraint-log-to-z3.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """
+ Helper script to convert the log generated by '-debug-only=constraint-system'
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/create_ladder_graph.py llvm-project-15.0.7.src/llvm/utils/create_ladder_graph.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/create_ladder_graph.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/create_ladder_graph.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ """A ladder graph creation program.
+ 
+ This is a python program that creates c source code that will generate
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/docker/scripts/llvm_checksum/llvm_checksum.py llvm-project-15.0.7.src/llvm/utils/docker/scripts/llvm_checksum/llvm_checksum.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/docker/scripts/llvm_checksum/llvm_checksum.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/docker/scripts/llvm_checksum/llvm_checksum.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ """ A small program to compute checksums of LLVM checkout.
+ """
+ from __future__ import absolute_import
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/extract-section.py llvm-project-15.0.7.src/llvm/utils/extract-section.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/extract-section.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/extract-section.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ from __future__ import print_function
+ '''
+ Helper script to print out the raw content of an ELF section.
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/extract_symbols.py llvm-project-15.0.7.src/llvm/utils/extract_symbols.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/extract_symbols.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/extract_symbols.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """A tool for extracting a list of symbols to export
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/extract_vplan.py llvm-project-15.0.7.src/llvm/utils/extract_vplan.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/extract_vplan.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/extract_vplan.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ # This script extracts the VPlan digraphs from the vectoriser debug messages
+ # and saves them in individual dot files (one for each plan). Optionally, and
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/git/github-automation.py llvm-project-15.0.7.src/llvm/utils/git/github-automation.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/git/github-automation.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/git/github-automation.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ # ======- github-automation - LLVM GitHub Automation Routines--*- python -*--==#
+ #
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/git/pre-push.py llvm-project-15.0.7.src/llvm/utils/git/pre-push.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/git/pre-push.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/git/pre-push.py	2025-01-26 05:31:35.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ # ======- pre-push - LLVM Git Help Integration ---------*- python -*--========#
+ #
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/gn/build/run_built_binary.py llvm-project-15.0.7.src/llvm/utils/gn/build/run_built_binary.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/gn/build/run_built_binary.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/gn/build/run_built_binary.py	2025-01-26 05:31:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ """Runs a built binary."""
+ 
+ import subprocess
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/gn/build/symbol_exports.py llvm-project-15.0.7.src/llvm/utils/gn/build/symbol_exports.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/gn/build/symbol_exports.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/gn/build/symbol_exports.py	2025-01-26 05:31:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Converts a .exports file to a format consumable by linkers.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/gn/build/symlink_or_copy.py llvm-project-15.0.7.src/llvm/utils/gn/build/symlink_or_copy.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/gn/build/symlink_or_copy.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/gn/build/symlink_or_copy.py	2025-01-26 05:31:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Symlinks, or on Windows copies, an existing file to a second location.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/gn/build/sync_source_lists_from_cmake.py llvm-project-15.0.7.src/llvm/utils/gn/build/sync_source_lists_from_cmake.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/gn/build/sync_source_lists_from_cmake.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/gn/build/sync_source_lists_from_cmake.py	2025-01-26 05:31:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Helps to keep BUILD.gn files in sync with the corresponding CMakeLists.txt.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/gn/build/write_cmake_config.py llvm-project-15.0.7.src/llvm/utils/gn/build/write_cmake_config.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/gn/build/write_cmake_config.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/gn/build/write_cmake_config.py	2025-01-26 05:31:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ r"""Emulates the bits of CMake's configure_file() function needed in LLVM.
+ 
+ The CMake build uses configure_file() for several things.  This emulates that
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/gn/build/write_library_dependencies.py llvm-project-15.0.7.src/llvm/utils/gn/build/write_library_dependencies.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/gn/build/write_library_dependencies.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/gn/build/write_library_dependencies.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import argparse
+ import os
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/gn/build/write_vcsrevision.py llvm-project-15.0.7.src/llvm/utils/gn/build/write_vcsrevision.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/gn/build/write_vcsrevision.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/gn/build/write_vcsrevision.py	2025-01-26 05:31:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Gets the current revision and writes it to VCSRevision.h."""
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/gn/get.py llvm-project-15.0.7.src/llvm/utils/gn/get.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/gn/get.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/gn/get.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ """Downloads a prebuilt gn binary to a place where gn.py can find it."""
+ 
+ import io
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/gn/gn.py llvm-project-15.0.7.src/llvm/utils/gn/gn.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/gn/gn.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/gn/gn.py	2025-01-26 05:31:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ """Calls `gn` with the right --dotfile= and --root= arguments for LLVM."""
+ 
+ # GN normally expects a file called '.gn' at the root of the repository.
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/gn/secondary/libcxx/utils/gen_link_script.py llvm-project-15.0.7.src/llvm/utils/gn/secondary/libcxx/utils/gen_link_script.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/gn/secondary/libcxx/utils/gen_link_script.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/gn/secondary/libcxx/utils/gen_link_script.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ #===----------------------------------------------------------------------===##
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/gn/secondary/llvm/include/llvm/Support/write_extension_def.py llvm-project-15.0.7.src/llvm/utils/gn/secondary/llvm/include/llvm/Support/write_extension_def.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/gn/secondary/llvm/include/llvm/Support/write_extension_def.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/gn/secondary/llvm/include/llvm/Support/write_extension_def.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import argparse
+ import os
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/gn/secondary/llvm/tools/llvm-config/write_extension_dependencies.py llvm-project-15.0.7.src/llvm/utils/gn/secondary/llvm/tools/llvm-config/write_extension_dependencies.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/gn/secondary/llvm/tools/llvm-config/write_extension_dependencies.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/gn/secondary/llvm/tools/llvm-config/write_extension_dependencies.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ r"""Writes ExtensionDepencencies.inc."""
+ 
+ import argparse
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/indirect_calls.py llvm-project-15.0.7.src/llvm/utils/indirect_calls.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/indirect_calls.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/indirect_calls.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """A tool for looking for indirect jumps and calls in x86 binaries.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lint/common_lint.py llvm-project-15.0.7.src/llvm/utils/lint/common_lint.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lint/common_lint.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lint/common_lint.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ # Common lint functions applicable to multiple types of files.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lint/cpp_lint.py llvm-project-15.0.7.src/llvm/utils/lint/cpp_lint.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lint/cpp_lint.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lint/cpp_lint.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ # Checks C++ files to make sure they conform to LLVM standards, as specified in
+ # http://llvm.org/docs/CodingStandards.html .
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lint/generic_lint.py llvm-project-15.0.7.src/llvm/utils/lint/generic_lint.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lint/generic_lint.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lint/generic_lint.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ # Checks files to make sure they conform to LLVM standards which can be applied
+ # to any programming language: at present, line length and trailing whitespace.
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/lit/ProgressBar.py llvm-project-15.0.7.src/llvm/utils/lit/lit/ProgressBar.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/lit/ProgressBar.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/lit/ProgressBar.py	2025-01-26 05:31:27.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ # Source: http://code.activestate.com/recipes/475116/, with
+ # modifications by Daniel Dunbar.
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/lit.py llvm-project-15.0.7.src/llvm/utils/lit/lit.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/lit.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/lit.py	2025-01-26 05:31:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from lit.main import main
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/googletest-crash/DummySubDir/OneTest.py llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/googletest-crash/DummySubDir/OneTest.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/googletest-crash/DummySubDir/OneTest.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/googletest-crash/DummySubDir/OneTest.py	2025-01-26 05:31:31.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import os
+ import sys
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/googletest-discovery-failed/subdir/OneTest.py llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/googletest-discovery-failed/subdir/OneTest.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/googletest-discovery-failed/subdir/OneTest.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/googletest-discovery-failed/subdir/OneTest.py	2025-01-26 05:31:32.000000000 -0600
+@@ -1,3 +1,3 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ raise SystemExit("We are not a valid gtest executable!")
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/googletest-format/DummySubDir/OneTest.py llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/googletest-format/DummySubDir/OneTest.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/googletest-format/DummySubDir/OneTest.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/googletest-format/DummySubDir/OneTest.py	2025-01-26 05:31:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import os
+ import sys
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/googletest-sanitizer-error/DummySubDir/OneTest.py llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/googletest-sanitizer-error/DummySubDir/OneTest.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/googletest-sanitizer-error/DummySubDir/OneTest.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/googletest-sanitizer-error/DummySubDir/OneTest.py	2025-01-26 05:31:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import os
+ import sys
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/googletest-timeout/DummySubDir/OneTest.py llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/googletest-timeout/DummySubDir/OneTest.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/googletest-timeout/DummySubDir/OneTest.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/googletest-timeout/DummySubDir/OneTest.py	2025-01-26 05:31:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import os
+ import sys
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-env/print_environment.py llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-env/print_environment.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-env/print_environment.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-env/print_environment.py	2025-01-26 05:31:31.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ import os
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-format/external_shell/write-bad-encoding.py llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-format/external_shell/write-bad-encoding.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-format/external_shell/write-bad-encoding.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-format/external_shell/write-bad-encoding.py	2025-01-26 05:31:31.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import sys
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-format/external_shell/write-control-chars.py llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-format/external_shell/write-control-chars.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-format/external_shell/write-control-chars.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-format/external_shell/write-control-chars.py	2025-01-26 05:31:31.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ import sys
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-not/fail.py llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-not/fail.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-not/fail.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-not/fail.py	2025-01-26 05:31:30.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import print_environment
+ import sys
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-not/fail2.py llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-not/fail2.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-not/fail2.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-not/fail2.py	2025-01-26 05:31:30.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import print_environment
+ import sys
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-not/pass.py llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-not/pass.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-not/pass.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-not/pass.py	2025-01-26 05:31:30.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import print_environment
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-shell/check_args.py llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-shell/check_args.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-shell/check_args.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-shell/check_args.py	2025-01-26 05:31:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import argparse
+ import platform
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-shell/check_path.py llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-shell/check_path.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-shell/check_path.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-shell/check_path.py	2025-01-26 05:31:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-shell/write-to-stderr.py llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-shell/write-to-stderr.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-shell/write-to-stderr.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-shell/write-to-stderr.py	2025-01-26 05:31:31.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import sys
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-shell/write-to-stdout-and-stderr.py llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-shell/write-to-stdout-and-stderr.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/lit/tests/Inputs/shtest-shell/write-to-stdout-and-stderr.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/lit/tests/Inputs/shtest-shell/write-to-stdout-and-stderr.py	2025-01-26 05:31:31.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import sys
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/llvm-gisel-cov.py llvm-project-15.0.7.src/llvm/utils/llvm-gisel-cov.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/llvm-gisel-cov.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/llvm-gisel-cov.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ """
+ Summarize the information in the given coverage files.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/llvm-locstats/llvm-locstats.py llvm-project-15.0.7.src/llvm/utils/llvm-locstats/llvm-locstats.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/llvm-locstats/llvm-locstats.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/llvm-locstats/llvm-locstats.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ # This is a tool that works like debug location coverage calculator.
+ # It parses the llvm-dwarfdump --statistics output by reporting it
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/llvm-mca-compare.py llvm-project-15.0.7.src/llvm/utils/llvm-mca-compare.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/llvm-mca-compare.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/llvm-mca-compare.py	2025-01-26 05:31:35.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import argparse
+ import sys
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/llvm-original-di-preservation.py llvm-project-15.0.7.src/llvm/utils/llvm-original-di-preservation.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/llvm-original-di-preservation.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/llvm-original-di-preservation.py	2025-01-26 05:31:32.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #
+ # Debugify summary for the original debug info testing.
+ #
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/merge-stats.py llvm-project-15.0.7.src/llvm/utils/merge-stats.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/merge-stats.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/merge-stats.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ '''
+ Merge .stats files generated by llvm tools
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/prepare-code-coverage-artifact.py llvm-project-15.0.7.src/llvm/utils/prepare-code-coverage-artifact.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/prepare-code-coverage-artifact.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/prepare-code-coverage-artifact.py	2025-01-26 05:31:35.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/reduce_pipeline.py llvm-project-15.0.7.src/llvm/utils/reduce_pipeline.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/reduce_pipeline.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/reduce_pipeline.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ # Automatically formatted with yapf (https://github.com/google/yapf)
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/reduce_pipeline_test/fake_opt.py llvm-project-15.0.7.src/llvm/utils/reduce_pipeline_test/fake_opt.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/reduce_pipeline_test/fake_opt.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/reduce_pipeline_test/fake_opt.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ # Automatically formatted with yapf (https://github.com/google/yapf)
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/reduce_pipeline_test/test.py llvm-project-15.0.7.src/llvm/utils/reduce_pipeline_test/test.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/reduce_pipeline_test/test.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/reduce_pipeline_test/test.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ # Automatically formatted with yapf (https://github.com/google/yapf)
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/release/findRegressions-nightly.py llvm-project-15.0.7.src/llvm/utils/release/findRegressions-nightly.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/release/findRegressions-nightly.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/release/findRegressions-nightly.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ from __future__ import print_function
+ 
+ import re, string, sys, os, time
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/release/findRegressions-simple.py llvm-project-15.0.7.src/llvm/utils/release/findRegressions-simple.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/release/findRegressions-simple.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/release/findRegressions-simple.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ import re, string, sys, os, time, math
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/release/github-upload-release.py llvm-project-15.0.7.src/llvm/utils/release/github-upload-release.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/release/github-upload-release.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/release/github-upload-release.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ # ===-- github-upload-release.py  ------------------------------------------===#
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/remote-exec.py llvm-project-15.0.7.src/llvm/utils/remote-exec.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/remote-exec.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/remote-exec.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ #===----------------------------------------------------------------------===##
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/revert_checker.py llvm-project-15.0.7.src/llvm/utils/revert_checker.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/revert_checker.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/revert_checker.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ # -*- coding: utf-8 -*-
+ #===----------------------------------------------------------------------===##
+ #
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/revert_checker_test.py llvm-project-15.0.7.src/llvm/utils/revert_checker_test.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/revert_checker_test.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/revert_checker_test.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ # -*- coding: utf-8 -*-
+ #===----------------------------------------------------------------------===##
+ #
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/rsp_bisect.py llvm-project-15.0.7.src/llvm/utils/rsp_bisect.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/rsp_bisect.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/rsp_bisect.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ #===----------------------------------------------------------------------===##
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/rsp_bisect_test/test.py llvm-project-15.0.7.src/llvm/utils/rsp_bisect_test/test.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/rsp_bisect_test/test.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/rsp_bisect_test/test.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ #===----------------------------------------------------------------------===##
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/rsp_bisect_test/test_script.py llvm-project-15.0.7.src/llvm/utils/rsp_bisect_test/test_script.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/rsp_bisect_test/test_script.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/rsp_bisect_test/test_script.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ #===----------------------------------------------------------------------===##
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/rsp_bisect_test/test_script_inv.py llvm-project-15.0.7.src/llvm/utils/rsp_bisect_test/test_script_inv.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/rsp_bisect_test/test_script_inv.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/rsp_bisect_test/test_script_inv.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ #===----------------------------------------------------------------------===##
+ #
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/schedcover.py llvm-project-15.0.7.src/llvm/utils/schedcover.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/schedcover.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/schedcover.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ # This creates a CSV file from the output of the debug output of subtarget:
+ #   llvm-tblgen --gen-subtarget --debug-only=subtarget-emitter
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/shuffle_fuzz.py llvm-project-15.0.7.src/llvm/utils/shuffle_fuzz.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/shuffle_fuzz.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/shuffle_fuzz.py	2025-01-26 05:31:35.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """A shuffle vector fuzz tester.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/shuffle_select_fuzz_tester.py llvm-project-15.0.7.src/llvm/utils/shuffle_select_fuzz_tester.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/shuffle_select_fuzz_tester.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/shuffle_select_fuzz_tester.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """A shuffle-select vector fuzz tester.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/sort_includes.py llvm-project-15.0.7.src/llvm/utils/sort_includes.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/sort_includes.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/sort_includes.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Script to sort the top-most block of #include lines.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/sysroot.py llvm-project-15.0.7.src/llvm/utils/sysroot.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/sysroot.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/sysroot.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Helps manage sysroots."""
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/testgen/mc-bundling-x86-gen.py llvm-project-15.0.7.src/llvm/utils/testgen/mc-bundling-x86-gen.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/testgen/mc-bundling-x86-gen.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/testgen/mc-bundling-x86-gen.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,5 +1,5 @@
+ 
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ # Auto-generates an exhaustive and repetitive test for correct bundle-locked
+ # alignment on x86.
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/unicode-case-fold.py llvm-project-15.0.7.src/llvm/utils/unicode-case-fold.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/unicode-case-fold.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/unicode-case-fold.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ """
+ Unicode case folding database conversion utility
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/update_analyze_test_checks.py llvm-project-15.0.7.src/llvm/utils/update_analyze_test_checks.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/update_analyze_test_checks.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/update_analyze_test_checks.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """A script to generate FileCheck statements for 'opt' analysis tests.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/update_cc_test_checks.py llvm-project-15.0.7.src/llvm/utils/update_cc_test_checks.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/update_cc_test_checks.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/update_cc_test_checks.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ '''A utility to update LLVM IR CHECK lines in C/C++ FileCheck test files.
+ 
+ Example RUN lines in .c/.cc test files:
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/update_llc_test_checks.py llvm-project-15.0.7.src/llvm/utils/update_llc_test_checks.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/update_llc_test_checks.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/update_llc_test_checks.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """A test case update script.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/update_mca_test_checks.py llvm-project-15.0.7.src/llvm/utils/update_mca_test_checks.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/update_mca_test_checks.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/update_mca_test_checks.py	2025-01-26 05:31:35.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """A test case update script.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/update_mir_test_checks.py llvm-project-15.0.7.src/llvm/utils/update_mir_test_checks.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/update_mir_test_checks.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/update_mir_test_checks.py	2025-01-26 05:31:34.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """Updates FileCheck checks in MIR tests.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/update_test_checks.py llvm-project-15.0.7.src/llvm/utils/update_test_checks.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/update_test_checks.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/update_test_checks.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """A script to generate FileCheck statements for 'opt' regression tests.
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/update_test_prefix.py llvm-project-15.0.7.src/llvm/utils/update_test_prefix.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/update_test_prefix.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/update_test_prefix.py	2025-01-26 05:31:33.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import os
+ import re
+diff -ruN llvm-project-15.0.7.src-orig/llvm/utils/wciia.py llvm-project-15.0.7.src/llvm/utils/wciia.py
+--- llvm-project-15.0.7.src-orig/llvm/utils/wciia.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm/utils/wciia.py	2025-01-26 05:31:26.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ """
+ wciia - Whose Code Is It Anyway
+ 
+diff -ruN llvm-project-15.0.7.src-orig/llvm-libgcc/generate_version_script.py llvm-project-15.0.7.src/llvm-libgcc/generate_version_script.py
+--- llvm-project-15.0.7.src-orig/llvm-libgcc/generate_version_script.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/llvm-libgcc/generate_version_script.py	2025-01-26 05:33:27.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ # Generates a version script for an architecture so that it can be incorporated
+ # into gcc_s.ver.
+diff -ruN llvm-project-15.0.7.src-orig/mlir/utils/generate-test-checks.py llvm-project-15.0.7.src/mlir/utils/generate-test-checks.py
+--- llvm-project-15.0.7.src-orig/mlir/utils/generate-test-checks.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/mlir/utils/generate-test-checks.py	2025-01-26 05:31:42.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ """A script to generate FileCheck statements for mlir unit tests.
+ 
+ This script is a utility to add FileCheck patterns to an mlir file.
+diff -ruN llvm-project-15.0.7.src-orig/mlir/utils/spirv/gen_spirv_dialect.py llvm-project-15.0.7.src/mlir/utils/spirv/gen_spirv_dialect.py
+--- llvm-project-15.0.7.src-orig/mlir/utils/spirv/gen_spirv_dialect.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/mlir/utils/spirv/gen_spirv_dialect.py	2025-01-26 05:31:42.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ # -*- coding: utf-8 -*-
+ 
+ # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+diff -ruN llvm-project-15.0.7.src-orig/openmp/libomptarget/utils/generate_microtask_cases.py llvm-project-15.0.7.src/openmp/libomptarget/utils/generate_microtask_cases.py
+--- llvm-project-15.0.7.src-orig/openmp/libomptarget/utils/generate_microtask_cases.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/openmp/libomptarget/utils/generate_microtask_cases.py	2025-01-26 05:31:48.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import argparse
+ 
+diff -ruN llvm-project-15.0.7.src-orig/openmp/runtime/tools/summarizeStats.py llvm-project-15.0.7.src/openmp/runtime/tools/summarizeStats.py
+--- llvm-project-15.0.7.src-orig/openmp/runtime/tools/summarizeStats.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/openmp/runtime/tools/summarizeStats.py	2025-01-26 05:31:48.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import pandas as pd
+ import numpy as np
+diff -ruN llvm-project-15.0.7.src-orig/openmp/tools/analyzer/analyzer.py llvm-project-15.0.7.src/openmp/tools/analyzer/analyzer.py
+--- llvm-project-15.0.7.src-orig/openmp/tools/analyzer/analyzer.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/openmp/tools/analyzer/analyzer.py	2025-01-26 05:31:48.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import subprocess
+ import os.path
+diff -ruN llvm-project-15.0.7.src-orig/polly/lib/External/isl/imath/tests/gmp-compat-test/genctest.py llvm-project-15.0.7.src/polly/lib/External/isl/imath/tests/gmp-compat-test/genctest.py
+--- llvm-project-15.0.7.src-orig/polly/lib/External/isl/imath/tests/gmp-compat-test/genctest.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/polly/lib/External/isl/imath/tests/gmp-compat-test/genctest.py	2025-01-26 05:31:48.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ import sys
+ import gmpapi
+ from gmpapi import void
+diff -ruN llvm-project-15.0.7.src-orig/polly/lib/External/isl/imath/tests/gmp-compat-test/gendata.py llvm-project-15.0.7.src/polly/lib/External/isl/imath/tests/gmp-compat-test/gendata.py
+--- llvm-project-15.0.7.src-orig/polly/lib/External/isl/imath/tests/gmp-compat-test/gendata.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/polly/lib/External/isl/imath/tests/gmp-compat-test/gendata.py	2025-01-26 05:31:48.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ import random
+ import gmpapi
+ 
+diff -ruN llvm-project-15.0.7.src-orig/polly/lib/External/isl/imath/tests/gmp-compat-test/genpytest.py llvm-project-15.0.7.src/polly/lib/External/isl/imath/tests/gmp-compat-test/genpytest.py
+--- llvm-project-15.0.7.src-orig/polly/lib/External/isl/imath/tests/gmp-compat-test/genpytest.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/polly/lib/External/isl/imath/tests/gmp-compat-test/genpytest.py	2025-01-26 05:31:48.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import gmpapi
+ import sys
+diff -ruN llvm-project-15.0.7.src-orig/polly/lib/External/isl/imath/tests/gmp-compat-test/gmpapi.py llvm-project-15.0.7.src/polly/lib/External/isl/imath/tests/gmp-compat-test/gmpapi.py
+--- llvm-project-15.0.7.src-orig/polly/lib/External/isl/imath/tests/gmp-compat-test/gmpapi.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/polly/lib/External/isl/imath/tests/gmp-compat-test/gmpapi.py	2025-01-26 05:31:48.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import sys
+ 
+diff -ruN llvm-project-15.0.7.src-orig/polly/lib/External/isl/imath/tests/gmp-compat-test/runtest.py llvm-project-15.0.7.src/polly/lib/External/isl/imath/tests/gmp-compat-test/runtest.py
+--- llvm-project-15.0.7.src-orig/polly/lib/External/isl/imath/tests/gmp-compat-test/runtest.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/polly/lib/External/isl/imath/tests/gmp-compat-test/runtest.py	2025-01-26 05:31:48.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ from __future__ import print_function
+ 
+diff -ruN llvm-project-15.0.7.src-orig/polly/lib/External/isl/imath/tools/findthreshold.py llvm-project-15.0.7.src/polly/lib/External/isl/imath/tools/findthreshold.py
+--- llvm-project-15.0.7.src-orig/polly/lib/External/isl/imath/tools/findthreshold.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/polly/lib/External/isl/imath/tools/findthreshold.py	2025-01-26 05:31:48.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ ##
+ ## Name:     findthreshold.py
+ ## Purpose:  Find a good threshold for recursive multiplication.
+diff -ruN llvm-project-15.0.7.src-orig/polly/lib/External/isl/imath/tools/mkdoc.py llvm-project-15.0.7.src/polly/lib/External/isl/imath/tools/mkdoc.py
+--- llvm-project-15.0.7.src-orig/polly/lib/External/isl/imath/tools/mkdoc.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/polly/lib/External/isl/imath/tools/mkdoc.py	2025-01-26 05:31:48.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ ##
+ ## Name:    mkdoc.py
+ ## Purpose: Extract documentation from header files.
+diff -ruN llvm-project-15.0.7.src-orig/polly/test/update_check.py llvm-project-15.0.7.src/polly/test/update_check.py
+--- llvm-project-15.0.7.src-orig/polly/test/update_check.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/polly/test/update_check.py	2025-01-26 05:31:47.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python3
++#!/usr/bin/env python@FINK_PYTHON@
+ # -*- coding: UTF-8 -*-
+ 
+ # Polly/LLVM update_check.py
+diff -ruN llvm-project-15.0.7.src-orig/polly/utils/jscop2cloog.py llvm-project-15.0.7.src/polly/utils/jscop2cloog.py
+--- llvm-project-15.0.7.src-orig/polly/utils/jscop2cloog.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/polly/utils/jscop2cloog.py	2025-01-26 05:31:47.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ import argparse, os
+ import json
+ 
+diff -ruN llvm-project-15.0.7.src-orig/polly/utils/pyscop/jscop2iscc.py llvm-project-15.0.7.src/polly/utils/pyscop/jscop2iscc.py
+--- llvm-project-15.0.7.src-orig/polly/utils/pyscop/jscop2iscc.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/polly/utils/pyscop/jscop2iscc.py	2025-01-26 05:31:48.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ import argparse, isl, os
+ import json
+ 
+diff -ruN llvm-project-15.0.7.src-orig/third-party/benchmark/tools/compare.py llvm-project-15.0.7.src/third-party/benchmark/tools/compare.py
+--- llvm-project-15.0.7.src-orig/third-party/benchmark/tools/compare.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/third-party/benchmark/tools/compare.py	2025-01-26 05:31:47.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ import unittest
+ """
+diff -ruN llvm-project-15.0.7.src-orig/third-party/benchmark/tools/strip_asm.py llvm-project-15.0.7.src/third-party/benchmark/tools/strip_asm.py
+--- llvm-project-15.0.7.src-orig/third-party/benchmark/tools/strip_asm.py	2023-01-12 01:12:30.000000000 -0600
++++ llvm-project-15.0.7.src/third-party/benchmark/tools/strip_asm.py	2025-01-26 05:31:47.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python@FINK_PYTHON@
+ 
+ """
+ strip_asm.py - Cleanup ASM output for the specified file

--- a/10.9-libcxx/stable/main/finkinfo/languages/llvm-15.info
+++ b/10.9-libcxx/stable/main/finkinfo/languages/llvm-15.info
@@ -1,0 +1,564 @@
+Info4: <<
+Package: llvm-15
+Version: 15.0.7
+Revision: 2
+Type: llvm_maj (15), python(3.10)
+
+Description: Modular and reusable compiler
+License: BSD
+Maintainer: None <fink-devel@lists.sourceforge.net>
+Depends: <<
+	libllvm%type_pkg[llvm_maj]-shlibs,
+	llvm-%type_pkg[llvm_maj]-linker-tools,
+	llvm-%type_pkg[llvm_maj]-runtime,
+	libncurses5-shlibs,
+	libxml2-shlibs,
+	libzstd1-shlibs
+<<
+BuildDepends: <<
+	fink (>= 0.32),
+	fink-buildenv-modules,
+	fink-package-precedence,
+	help2man,
+	libffi8,
+	libiconv-dev,
+	libncurses5,
+	libxml2,
+	libzstd1-dev,
+	pygments-py%type_pkg[python],
+	python%type_pkg[python],
+	yaml-py%type_pkg[python]
+<<
+Source: https://github.com/llvm/llvm-project/releases/download/llvmorg-%v/llvm-project-%v.src.tar.xz
+Source-Checksum: SHA256(8b5fcb24b4128cf04df1b0b9410ce8b1a729cb3c544e6da885d234280dedeac6)
+# from Debian
+PatchFile: %n-python3-shebang.patch
+PatchFile-MD5: dbe52ba786d804fc8251dd6af218ad55
+# from Debian
+PatchFile2: %n-0044-soname.patch
+PatchFile2-MD5: 782ae80b139d71cb0ddbe741e5f5322c
+# from Debian
+PatchFile3: %n-libclang-major-version-only.patch
+PatchFile3-MD5: 323bb73ee0696d5ae0382d13aa8d0287
+PatchScript: <<
+	sed -e 's,@FINK_PYTHON@,%type_raw[python],g' < %{PatchFile} | patch -p1
+	patch -p1 < %{PatchFile2}
+	patch -p1 < %{PatchFile3}
+<<
+UseMaxBuildJobs: false
+CompileScript: <<
+#!/bin/sh -ev
+	echo "Start:" `date` > /tmp/llvm-%type_pkg[llvm_maj]_build_times.txt
+	. %p/sbin/fink-buildenv-cmake.sh
+	
+	# original ENVVAR and locations
+	export ORIG_CPPFLAGS="$CPPFLAGS"
+	export ORIG_CXXFLAGS="$CXXFLAGS"
+	export ORIG_LDFLAGS="$LDFLAGS"
+	export ORIG_MAKEFLAGS="$MAKEFLAGS"
+	export ORIG_PATH="$PATH"
+
+	export TARGET_BUILD=%b/finkbuild
+	export TARGET_BUILD_STAGE2=${TARGET_BUILD}/tools/clang/stage2-bins
+	
+	# CLANG_BOOTSTRAP_PASSTHROUGH: pass variable to 2nd stage
+	# -DBOOTSTRAP* flags are used to build stage2
+	cmake \
+		-S "%b/llvm" \
+		-B "%b/finkbuild" \
+		-G "Unix Makefiles" \
+		$FINK_CMAKE_ARGS \
+		-DCLANG_BUILD_EXAMPLES=OFF \
+		-DCLANG_FORCE_MATCHING_LIBCLANG_SOVERSION=ON \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_NAME_DIR="%p/lib/llvm-%type_pkg[llvm_maj]" \
+		-DCMAKE_INSTALL_PREFIX="%p/lib/llvm-%type_pkg[llvm_maj]" \
+		-DFFI_INCLUDE_DIR="%p/include" \
+		-DFFI_LIBRARIES="%p/lib/libffi.dylib" \
+		-DFFI_LIBRARY_DIR="%p/lib" \
+		-DLIBCXXABI_USE_LLVM_UNWINDER=ON \
+		-DLIBXML2_INCLUDE_DIR="%p/include/libxml2" \
+		-DLIBXML2_LIBRARY:FILEPATH="%p/lib/libxml2.dylib" \
+		-DLIBXML2_XMLLINT_EXECUTABLE:FILEPATH="%p/bin/xmllint" \
+		-DLLVM_BUILD_DOCS=OFF \
+		-DLLVM_ENABLE_FFI=ON \
+		-DLLVM_ENABLE_OCAMLDOC=OFF \
+		-DLLVM_ENABLE_PROJECTS="clang;lld" \
+		-DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
+		-DLLVM_ENABLE_SPHINX=OFF \
+		-DLLVM_INCLUDE_EXAMPLES=OFF \
+		-DLLVM_INCLUDE_TESTS=ON \
+		-DLLVM_TARGETS_TO_BUILD=Native \
+		-DPACKAGE_VENDOR="Fink Project" \
+		-DPython3_EXECUTABLE="%p/bin/python3.10" \
+		-DTerminfo_LIBRARIES="%p/lib/libncurses.dylib" \
+		-DCLANG_ENABLE_BOOTSTRAP=ON \
+		-DCLANG_BOOTSTRAP_PASSTHROUGH="CMAKE_INSTALL_PREFIX;CMAKE_INSTALL_NAME_DIR;CMAKE_VERBOSE_MAKEFILE;CLANG_FORCE_MATCHING_LIBCLANG_SOVERSION;FFI_LIBRARIES;Python3_EXECUTABLE;Terminfo_LIBRARIES" \
+		-DBOOTSTRAP_CLANG_LINK_CLANG_DYLIB=ON \
+		-DBOOTSTRAP_CMAKE_INSTALL_NAME_DIR="%p/lib/llvm-%type_pkg[llvm_maj]" \
+		-DBOOTSTRAP_LIBCLANG_LIBRARY_VERSION=1 \
+		-DBOOTSTRAP_LIBCXXABI_USE_LLVM_UNWINDER=ON \
+		-DBOOTSTRAP_LLVM_ENABLE_FFI=ON \
+		-DBOOTSTRAP_LLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt;lld" \
+		-DBOOTSTRAP_LLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
+		-DBOOTSTRAP_LLVM_ENABLE_SPHINX=OFF \
+		-DBOOTSTRAP_LLVM_INSTALL_UTILS=ON \
+		-DBOOTSTRAP_LLVM_LINK_LLVM_DYLIB=ON \
+		-DBOOTSTRAP_LLVM_TARGETS_TO_BUILD="AArch64;ARM;X86" \
+		-DBOOTSTRAP_Python3_EXECUTABLE="%p/bin/python3.10" \
+		-DBOOTSTRAP_Terminfo_LIBRARIES="%p/lib/libncurses.dylib"
+
+	pushd finkbuild
+		make stage2 || echo "Failed:" `date` >> /tmp/llvm-%type_pkg[llvm_maj]_build_times.txt
+	popd
+	
+	# version libclang and libclang-cpp libraries.
+	# installing will re-link all things that use them and get the new name.
+	pushd ${TARGET_BUILD_STAGE2}/lib
+		mv libclang-cpp.dylib libclang-cpp.%type_pkg[llvm_maj].dylib
+		install_name_tool -id @rpath/libclang-cpp.%type_pkg[llvm_maj].dylib libclang-cpp.%type_pkg[llvm_maj].dylib
+		ln -s libclang-cpp.%type_pkg[llvm_maj].dylib libclang-cpp.dylib
+		
+		mv libclang.dylib libclang.1.dylib
+		install_name_tool -id @rpath/libclang.1.dylib libclang.1.dylib
+		ln -s libclang.1.dylib libclang.dylib
+		
+		# confirm fix
+		otool -L libclang-cpp.%type_pkg[llvm_maj].dylib libclang.1.dylib
+	popd
+	#fink-package-precedence --depfile-ext='\.d' ..
+	
+
+	echo "Finish:" `date` >> /tmp/llvm-%type_pkg[llvm_maj]_build_times.txt
+<<
+InstallScript: <<
+	#!/bin/sh -ev
+	export TARGET_BUILD=%b/finkbuild
+	export TARGET_BUILD_STAGE2=${TARGET_BUILD}/tools/clang/stage2-bins
+
+	pushd finkbuild
+		make stage2-install DESTDIR=%d
+	popd
+
+	pushd $TARGET_BUILD_STAGE2/lib
+		# make install only knows about the unversioned libclang-cpp.dylib and libclang.dylib
+		# install the versioned ones we created at the end of CompileScript
+		install -m 755 libclang-cpp.%type_pkg[llvm_maj].dylib %i/lib/llvm-%type_pkg[llvm_maj]/lib
+		install -m 755 libclang.1.dylib %i/lib/llvm-%type_pkg[llvm_maj]/lib
+	popd
+
+	# create some manpages. Do we want to ship them directly in %p/share/man ?
+	CMDS="clang clang++ clang-check clang-cpp clang-format clang-rename git-clang-format ld.lld ld64.lld lli"
+	for f in $CMDS; do
+		echo "Generating manpage of $f"
+		%p/bin/help2man --no-info --version-string=%type_pkg[llvm_maj] %i/lib/llvm-%type_pkg[llvm_maj]/bin/$f > %i/lib/llvm-%type_pkg[llvm_maj]/share/man/man1/$f-%type_pkg[llvm_maj].1 || true
+	done
+
+	# rename some files to be versioned
+	mv %i/lib/llvm-%type_pkg[llvm_maj]/share/man/man1/scan-build.1 %i/lib/llvm-%type_pkg[llvm_maj]/share/man/man1/scan-build-%type_pkg[llvm_maj].1
+	# also share/clang/clang-format-diff.py?
+
+<<
+SplitOff: <<
+	Package: clang-%type_pkg[llvm_maj]
+	Description: C, C++ and Objective-C compiler
+	Depends: <<
+		libclang-cpp%type_pkg[llvm_maj]-shlibs,
+		libclang1-%type_pkg[llvm_maj]-shlibs,
+		libllvm%type_pkg[llvm_maj]-shlibs
+	<<
+	Recommends: <<
+		python%type_pkg[python]
+	<<
+	# no man files?
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang++
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang-%type_pkg[llvm_maj]
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang-cpp
+		lib/llvm-%type_pkg[llvm_maj]/lib/cmake/clang
+		lib/llvm-%type_pkg[llvm_maj]/share/clang/bash-autocomplete.sh
+		lib/llvm-%type_pkg[llvm_maj]/share/man/man1/clang{,++,-cpp}-%type_pkg[llvm_maj].1
+	<<
+<<
+SplitOff2: <<
+	Package: libclang1-%type_pkg[llvm_maj]-shlibs
+	Description: C interface to the Clang library
+	Depends: <<
+		libllvm%type_pkg[llvm_maj]-shlibs
+	<<
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/lib/libclang.1.dylib
+	<<
+	Shlibs: <<
+		@rpath/libclang.1.dylib 1.0.0 %n (>= 15.0.7-1)
+	<<
+<<
+SplitOff3: <<
+	Package: libclang1-%type_pkg[llvm_maj]-dev
+	Description: Clang library - Development package
+	Depends: <<
+		libclang1-%type_pkg[llvm_maj]-shlibs
+	<<
+	Recommends: <<
+		libclang-common-%type_pkg[llvm_maj]-dev
+	<<
+	BuildDependsOnly: true
+#		lib/llvm-%type_pkg[llvm_maj]/include/clang-tidy
+#		lib/llvm-%type_pkg[llvm_maj]/lib/libclang.dylib
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/include/clang-c
+		lib/llvm-%type_pkg[llvm_maj]/include/clang
+		lib/llvm-%type_pkg[llvm_maj]/lib/libclang*.a
+		lib/llvm-%type_pkg[llvm_maj]/lib/libclang.dylib
+	<<
+<<
+SplitOff4: <<
+	Package: libclang-common-%type_pkg[llvm_maj]-dev
+	Description: Clang library - Common development package
+	Depends: <<
+		libllvm%type_pkg[llvm_maj]-shlibs
+	<<
+	BuildDependsOnly: true
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/lib/clang/%v
+	<<
+<<
+SplitOff5: <<
+	Package: libclang-cpp%type_pkg[llvm_maj]-shlibs
+	Description: C++ interface to the Clang library
+	Depends: <<
+		libllvm%type_pkg[llvm_maj]-shlibs
+	<<
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/lib/libclang-cpp.%type_pkg[llvm_maj].dylib
+	<<
+	Shlibs: <<
+		@rpath/libclang-cpp.%type_pkg[llvm_maj].dylib 0.0.0 %n (>= 15.0.7-1)
+	<<
+<<
+SplitOff6: <<
+	Package: libclang-cpp%type_pkg[llvm_maj]-dev
+	Description: C++ interface to the Clang library
+	Depends: <<
+		libclang-cpp%type_pkg[llvm_maj]-shlibs
+	<<
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/lib/libclang-cpp.dylib
+	<<
+<<
+SplitOff7: <<
+	Package: libllvm%type_pkg[llvm_maj]-shlibs
+	Description: Modular compiler and toolchain, runtime lib
+	Depends: <<
+		libffi8-shlibs,
+		libncurses5-shlibs,
+		libxml2-shlibs,
+		libzstd1-shlibs
+	<<
+#		lib/llvm-%type_pkg[llvm_maj]/lib/libLLVM-%type_pkg[llvm_maj].dylib
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/lib/libLLVM.1.dylib
+	<<
+	Shlibs: <<
+		@rpath/libLLVM.1.dylib 1.0.0 %n (>= 15.0.7-1)
+	<<
+<<
+SplitOff8: <<
+	Package: libllvm%type_pkg[llvm_maj]-dev
+	Description: Modular compiler and toolchain, runtime lib
+	Depends: <<
+		libllvm%type_pkg[llvm_maj]-shlibs,
+		libclang-cpp%type_pkg[llvm_maj]-shlibs,
+		llvm-%type_pkg[llvm_maj]-tools
+	<<
+	BuildDependsOnly: true
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/lib/libLLVM.dylib
+	<<
+<<
+SplitOff9: <<
+	Package: clang-tools-%type_pkg[llvm_maj]
+	Description: Clang-based tools
+	Depends: <<
+		clang-%type_pkg[llvm_maj],
+		libclang-cpp%type_pkg[llvm_maj]-shlibs,
+		libclang1-%type_pkg[llvm_maj]-shlibs,
+		llvm-%type_pkg[llvm_maj]-tools,
+		libxml2-shlibs,
+		python%type_pkg[python]
+	<<
+#		lib/llvm-%type_pkg[llvm_maj]/bin/amdgpu-arch
+#		lib/llvm-%type_pkg[llvm_maj]/bin/clang-apply-replacements
+#		lib/llvm-%type_pkg[llvm_maj]/bin/clang-change-namespace
+#		lib/llvm-%type_pkg[llvm_maj]/bin/clang-doc
+#		lib/llvm-%type_pkg[llvm_maj]/bin/clang-include-cleaner
+#		lib/llvm-%type_pkg[llvm_maj]/bin/clang-include-fixer
+#		lib/llvm-%type_pkg[llvm_maj]/bin/clang-move
+#		lib/llvm-%type_pkg[llvm_maj]/bin/clang-pseudo
+#		lib/llvm-%type_pkg[llvm_maj]/bin/clang-query
+#		lib/llvm-%type_pkg[llvm_maj]/bin/clang-reorder-fields
+#		lib/llvm-%type_pkg[llvm_maj]/bin/clang-tblgen
+#		lib/llvm-%type_pkg[llvm_maj]/bin/find-all-symbols
+#		lib/llvm-%type_pkg[llvm_maj]/bin/hwasan_symbolize
+#		lib/llvm-%type_pkg[llvm_maj]/bin/modularize
+#		lib/llvm-%type_pkg[llvm_maj]/bin/nvptx-arch
+#		lib/llvm-%type_pkg[llvm_maj]/bin/pp-trace
+#		lib/llvm-%type_pkg[llvm_maj]/share/clang/clang-include-fixer.el
+#		lib/llvm-%type_pkg[llvm_maj]/share/clang/clang-include-fixer.py
+#		lib/llvm-%type_pkg[llvm_maj]/share/clang/run-find-all-symbols.py
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/bin/analyze-build
+		lib/llvm-%type_pkg[llvm_maj]/bin/c-index-test
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang-check
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang-cl
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang-extdef-mapping
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang-linker-wrapper
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang-nvlink-wrapper
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang-offload-bundler
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang-offload-packager
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang-offload-wrapper
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang-refactor
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang-rename
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang-repl
+		lib/llvm-%type_pkg[llvm_maj]/bin/clang-scan-deps
+		lib/llvm-%type_pkg[llvm_maj]/bin/diagtool
+		lib/llvm-%type_pkg[llvm_maj]/bin/hmaptool
+		lib/llvm-%type_pkg[llvm_maj]/bin/intercept-build
+		lib/llvm-%type_pkg[llvm_maj]/bin/sancov
+		lib/llvm-%type_pkg[llvm_maj]/bin/scan-build
+		lib/llvm-%type_pkg[llvm_maj]/bin/scan-build-py
+		lib/llvm-%type_pkg[llvm_maj]/bin/scan-view
+		lib/llvm-%type_pkg[llvm_maj]/bin/set-xcode-analyzer
+		lib/llvm-%type_pkg[llvm_maj]/lib/libear
+		lib/llvm-%type_pkg[llvm_maj]/lib/libscanbuild
+		lib/llvm-%type_pkg[llvm_maj]/libexec
+		lib/llvm-%type_pkg[llvm_maj]/share/clang/clang-rename.el
+		lib/llvm-%type_pkg[llvm_maj]/share/clang/clang-rename.py
+		lib/llvm-%type_pkg[llvm_maj]/share/man/man1/scan-build-%type_pkg[llvm_maj].1
+		lib/llvm-%type_pkg[llvm_maj]/share/scan-build
+		lib/llvm-%type_pkg[llvm_maj]/share/scan-view
+		lib/llvm-%type_pkg[llvm_maj]/share/man/man1/clang-{check,rename}-%type_pkg[llvm_maj].1
+	<<
+<<
+SplitOff10: <<
+	Package: llvm-%type_raw[llvm_maj]-linker-tools
+	Description: Modular compiler and toolchain - plugins
+	Depends: <<
+		libllvm%type_pkg[llvm_maj]-shlibs
+	<<
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/lib/libLTO.dylib
+	<<
+	Shlibs: <<
+		!@rpath/libLTO.dylib
+	<<
+<<
+SplitOff11: <<
+	Package: llvm-%type_pkg[llvm_maj]-tools
+	Description: Modular compiler and toolchain - tools
+	Depends: <<
+		libllvm%type_pkg[llvm_maj]-shlibs,
+		libncurses5-shlibs,
+		libzstd1-shlibs,
+		python%type_pkg[python],
+		pygments-py%type_pkg[python],
+		python%type_pkg[python],
+		yaml-py%type_pkg[python]
+	<<
+#		lib/llvm-%type_pkg[llvm_maj]/build/utils/lit
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/bin/FileCheck
+		lib/llvm-%type_pkg[llvm_maj]/bin/UnicodeNameMappingGenerator
+		lib/llvm-%type_pkg[llvm_maj]/bin/count
+		lib/llvm-%type_pkg[llvm_maj]/bin/not
+		lib/llvm-%type_pkg[llvm_maj]/bin/split-file
+		lib/llvm-%type_pkg[llvm_maj]/bin/yaml-bench
+		lib/llvm-%type_pkg[llvm_maj]/share/opt-viewer
+	<<
+<<
+SplitOff12: <<
+	Package: llvm-%type_pkg[llvm_maj]-dev
+	Description: Modular compiler and toolchain - dev/headers
+	Depends: <<
+		libclang-cpp%type_pkg[llvm_maj]-shlibs,
+		libllvm%type_pkg[llvm_maj]-shlibs,
+#		llvm-%type_pkg[llvm_maj]-shlibs,
+		llvm-%type_pkg[llvm_maj]-tools
+	<<
+	BuildDependsOnly: true
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/include/llvm
+		lib/llvm-%type_pkg[llvm_maj]/include/llvm-c
+		lib/llvm-%type_pkg[llvm_maj]/lib/cmake/llvm
+		lib/llvm-%type_pkg[llvm_maj]/lib/libLLVM*.a
+		lib/llvm-%type_pkg[llvm_maj]/lib/libRemarks.dylib
+	<<
+	Shlibs: <<
+		!@rpath/libRemarks.dylib
+	<<
+<<
+SplitOff13: <<
+	Package: libunwind-%type_pkg[llvm_maj]-shlibs
+	Description: LLVM production quality unwinder
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/lib/libunwind.1*dylib
+	<<
+	Shlibs: <<
+		@rpath/libunwind.1.dylib 1.0.0 %n (>= 15.0.7-1)
+	<<
+<<
+SplitOff14: <<
+	Package: libunwind-%type_pkg[llvm_maj]-dev
+	Description: LLVM production quality unwinder (dev)
+	Depends: <<
+		libunwind-%type_pkg[llvm_maj]-shlibs
+	<<
+	BuildDependsOnly: true
+#		lib/llvm-%type_pkg[llvm_maj]/include/libunwind
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/lib/libunwind.a
+		lib/llvm-%type_pkg[llvm_maj]/lib/libunwind.dylib
+	<<
+<<
+SplitOff15: <<
+	Package: libc++abi1-%type_pkg[llvm_maj]-shlibs
+	Description: LLVM low level support for c++ library
+	Depends: <<
+		libunwind-%type_pkg[llvm_maj]-shlibs
+	<<
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/lib/libc++abi.1*.dylib
+	<<
+	Shlibs: <<
+		@rpath/libc++abi.1.dylib 1.0.0 %n (>= 15.0.7-1)
+	<<
+<<
+SplitOff16: <<
+	Package: libc++abi1-%type_pkg[llvm_maj]-dev
+	Description: 
+	Depends: <<
+		libc++abi1-%type_pkg[llvm_maj]-shlibs
+	<<
+	BuildDependsOnly: true
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/include/c++/v1/{__cxxabi_config,cxxabi}.h
+		lib/llvm-%type_pkg[llvm_maj]/lib/libc++abi.a
+		lib/llvm-%type_pkg[llvm_maj]/lib/libc++abi.dylib
+	<<
+<<
+SplitOff17: <<
+	Package: libc++1-%type_pkg[llvm_maj]-shlibs
+	Description: LLVM C++ Standard library
+	Depends: <<
+		libc++abi1-%type_pkg[llvm_maj]-shlibs,
+		libunwind-%type_pkg[llvm_maj]-shlibs
+	<<
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/lib/libc++.1*.dylib
+	<<
+	Shlibs: <<
+		@rpath/libc++.1.dylib 1.0.0 %n (>= 15.0.7-1)
+	<<
+<<
+SplitOff18: <<
+	Package: libc++-%type_pkg[llvm_maj]-dev
+	Description: LLVM C++ Standard library (development)
+	Depends: <<
+		libc++1-%type_pkg[llvm_maj]-shlibs,
+		libunwind-%type_pkg[llvm_maj]-shlibs
+	<<
+	Recommends: <<
+		libunwind-%type_pkg[llvm_maj]-dev
+	<<
+	BuildDependsOnly: true
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/include/c++
+		lib/llvm-%type_pkg[llvm_maj]/lib/libc++.a
+		lib/llvm-%type_pkg[llvm_maj]/lib/libc++.dylib
+		lib/llvm-%type_pkg[llvm_maj]/lib/libc++experimental.a
+	<<
+<<
+SplitOff19: <<
+	Package: liblld-%type_pkg[llvm_maj]
+	Description: LLVM-based linker, library
+	Depends: <<
+		libllvm%type_pkg[llvm_maj]-shlibs
+	<<
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/lib/liblld*.a
+	<<
+<<
+SplitOff20: <<
+	Package: liblld-%type_pkg[llvm_maj]-dev
+	Description: LLVM-based linker, library (headers)
+	Depends: <<
+		liblld-%type_pkg[llvm_maj],
+		lld-%type_pkg[llvm_maj]
+	<<
+	BuildDependsOnly: true
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/include/lld
+		lib/llvm-%type_pkg[llvm_maj]/lib/cmake/lld
+	<<
+<<
+SplitOff21: <<
+	Package: lld-%type_pkg[llvm_maj]
+	Description: LLVM-based linker
+	Depends: <<
+		libllvm%type_pkg[llvm_maj]-shlibs
+	<<
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/bin/ld*
+		lib/llvm-%type_pkg[llvm_maj]/bin/lld*
+		lib/llvm-%type_pkg[llvm_maj]/bin/wasm-ld
+		lib/llvm-%type_pkg[llvm_maj]/share/man/man1/{ld,ld64}.lld-%type_pkg[llvm_maj].1
+	<<
+<<
+SplitOff22: <<
+	Package: llvm-%type_pkg[llvm_maj]-runtime
+	Description: Modular compiler / toolchain, IR interpreter
+	Depends: <<
+		libllvm%type_pkg[llvm_maj]-shlibs,
+		libncurses5-shlibs,
+		libzstd1-shlibs
+	<<
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/bin/lli*
+		lib/llvm-%type_pkg[llvm_maj]/share/man/man1/lli-%type_pkg[llvm_maj].1
+	<<
+<<
+SplitOff23: <<
+	Package: clang-format-%type_pkg[llvm_maj]
+	Description: Tool to format C/C++/Obj-C code
+	Depends: <<
+		libclang-cpp%type_pkg[llvm_maj]-shlibs,
+		libllvm%type_pkg[llvm_maj]-shlibs,
+		python%type_pkg[python]
+	<<
+	Files: <<
+		lib/llvm-%type_pkg[llvm_maj]/bin/*clang-format
+		lib/llvm-%type_pkg[llvm_maj]/share/clang/clang-format*
+		lib/llvm-%type_pkg[llvm_maj]/share/man/man1/clang-format-%type_pkg[llvm_maj].1
+		lib/llvm-%type_pkg[llvm_maj]/share/man/man1/git-clang-format-%type_pkg[llvm_maj].1
+	<<
+<<
+DescPackaging: <<
+The basic build directions are here:
+https://llvm.org/docs/GettingStarted.html
+
+We follow the interal bootstrap process provided in the source. See
+https://llvm.org/docs/AdvancedBuilds.html for details.
+<<
+DescUsage: <<
+Add "%p/lib/llvm-%type_pkg[llvm_maj]/bin" to your PATH variable to find
+the clang compilers.
+<<
+DescPort: <<
+* no py files should use plain 'python3' or 'python'
+  find . -name "*.py" -exec %p/bin/sed -e "s|\!/usr/bin/env python3$|\!/usr/bin/env python%type_raw[python]|g" -e "s|\!/usr/bin/env python$|\!/usr/bin/env python%type_raw[python]|g" -i {} \;
+* version the install_name for libLLVM.dylib
+* Also version libclang-cpp.dylib, and libclang.dylib, but that has to be done manually for now.
+<<
+# Info2
+<<


### PR DESCRIPTION
Uses internal bootstrap process to build clang with system-compiler, then uses that to rebuild clang and everything else. Follows Debian's SplitOff.
To add maybe: flang, OpenMP