### PR TITLE
Update tox-py to 4.24.1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py-3.14.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py-3.14.0.info
@@ -1,0 +1,125 @@
+Info4: <<
+
+Package: tox-py%type_pkg[python]
+Version: 3.14.0
+Revision: 1
+Distribution: <<
+	(%type_pkg[python] = 34 ) 10.9,
+	(%type_pkg[python] = 34 ) 10.10,
+	(%type_pkg[python] = 34 ) 10.11,
+	(%type_pkg[python] = 34 ) 10.12,
+	(%type_pkg[python] = 34 ) 10.13,
+	(%type_pkg[python] = 34 ) 10.14,
+	(%type_pkg[python] = 34 ) 10.14.5,
+	(%type_pkg[python] = 34 ) 10.15,
+	(%type_pkg[python] = 35 ) 10.9,
+	(%type_pkg[python] = 35 ) 10.10,
+	(%type_pkg[python] = 35 ) 10.11,
+	(%type_pkg[python] = 35 ) 10.12,
+	(%type_pkg[python] = 35 ) 10.13,
+	(%type_pkg[python] = 35 ) 10.14,
+	(%type_pkg[python] = 35 ) 10.14.5,
+	(%type_pkg[python] = 35 ) 10.15,
+	(%type_pkg[python] = 36 ) 10.9,
+	(%type_pkg[python] = 36 ) 10.10,
+	(%type_pkg[python] = 36 ) 10.11,
+	(%type_pkg[python] = 36 ) 10.12,
+	(%type_pkg[python] = 36 ) 10.13,
+	(%type_pkg[python] = 36 ) 10.14,
+	(%type_pkg[python] = 36 ) 10.14.5,
+	(%type_pkg[python] = 36 ) 10.15
+<<
+Maintainer: None <fink-devel@lists.sourceforge.net>
+License: BSD
+Type: python (2.7 3.4 3.5 3.6 3.7)
+Homepage: https://pypi.org/project/tox/
+Source: https://files.pythonhosted.org/packages/source/t/tox/tox-%v.tar.gz
+Source-Checksum: SHA256(c4f6b319c20ba4913dbfe71ebfd14ff95d1853c4231493608182f66e566ecfe1)
+PatchFile: %{ni}.patch
+PatchFile-Checksum: SHA256(d891cd72b1b1833121305c3584d5ca7195bc4e96091c8b8e6dfc40f47cea8ac0)
+
+Depends: python%type_pkg[python]-shlibs, pytest-py%type_pkg[python], virtualenv-py%type_pkg[python], pluggy-py%type_pkg[python]
+BuildDepends: python%type_pkg[python], setuptools-scm-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
+
+Description: Testing in virtualenvs
+
+DescDetail: <<
+Tox is a generic virtualenv management and test command line tool for:
+
+- checking the package installs correctly with different Python
+  versions and interpreters
+- running tests in each of the environments, configuring your test
+  tool of choice
+- acting as a frontend to Continuous Integration servers, greatly
+  reducing boilerplate and merging CI and shell-based testing.
+
+tox aims to automate and standardize testing in Python. It is part of a larger
+vision of easing the packaging, testing and release process of Python software.
+<<
+DescPackaging: <<
+Previous maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
+<<
+
+DocFiles: CODE_OF_CONDUCT.md README.md HOWTORELEASE.rst LICENSE CONTRIBUTING.rst CONTRIBUTORS PKG-INFO docs
+
+# Tests should not be run against the installed version and are not included in the package after installation,
+# but at least make sure they are running the correct script variants.
+PatchScript: <<
+    sed 's|PY_PKG|%type_pkg[python]|g;s|PY_RAW|%type_raw[python]|g;' %{PatchFile} | patch -p1
+    perl -pi -e 's|(basepython = python)(3.6)|${1}%type_raw[python]|g;' tox.ini
+    perl -pi -e 's|(python)(.-[cm])|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
+    perl -pi -e 's|(python)(3.6)(.-[cm])|%p/bin/${1}%type_raw[python]${3}|g;' tox.ini
+    perl -pi -e 's|(sphinx-build)(.-[d])|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
+<<
+
+CompileScript: <<
+    %p/bin/python%type_raw[python] setup.py build
+<<
+
+InfoTest: <<
+    TestDepends: pytest-mock-py%type_pkg[python]
+    TestScript: <<
+        #!/bin/bash -ev
+        # Create tox/tox-quickstart scripts locally and add pkg_resources info
+        mkdir -p build/bin
+        python%type_raw[python] setup.py install_scripts -d build/bin
+        python%type_raw[python] setup.py egg_info
+        mv build/bin/tox build/bin/tox-py%type_pkg[python]
+        mv build/bin/tox-quickstart build/bin/tox-quickstart-py%type_pkg[python]
+        chmod -R go+rX build tox*
+        PATH=%b/build/bin:$PATH
+        export PYTHONPATH=%b
+        # Locally installed scripts run correctly if tested separately, but when testing
+        # all at once, fail with a DistributionNotFound - go figure...
+        # Set DEB_SKIP_TOX_TESTS to disable them entirely [marked `skipif()`]
+        %p/bin/pytest-%type_raw[python] tests -k '_script' || exit 2
+        %p/bin/pytest-%type_raw[python] tests -k 'not _script' || exit 2
+    <<
+    TestSuiteSize: medium
+<<
+
+InstallScript: <<
+    #!/bin/bash -ev
+    find build/lib -name '*.pyc' -exec rm {} \;
+    python%type_raw[python] setup.py install --root=%d
+    mv %i/bin/tox %i/bin/tox-py%type_pkg[python]
+    mv %i/bin/tox-quickstart %i/bin/tox-quickstart-py%type_pkg[python]
+<<
+
+PostInstScript: <<
+    update-alternatives --verbose --install %p/bin/tox tox-py %p/bin/tox-py%type_pkg[python] %type_pkg[python] --slave %p/bin/tox-quickstart tox-quickstart %p/bin/tox-quickstart-py%type_pkg[python]
+    echo ''
+    echo 'If you have just built and installed the tox dependencies'
+    echo 'coverage-py%type_pkg[python], hypothesis-py%type_pkg[python], pytest-py%type_pkg[python], pytest-mock-py%type_pkg[python]'
+    echo 'for the first time, they will have been built with their tests disabled.'
+    echo 'You may now test their builds using the `fink -m rebuild` command.'
+<<
+
+PreRmScript: <<
+    if [ $1 != "upgrade" ]; then
+        update-alternatives --verbose --remove tox-py %p/bin/tox-py%type_pkg[python]
+    fi
+<<
+
+# Info4
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.info
@@ -1,47 +1,28 @@
-# -*- coding: ascii; tab-width: 4; x-counterpart: tox-py.patch -*-
 Info4: <<
 
 Package: tox-py%type_pkg[python]
-Version: 3.0.0
+Version: 4.24.1
 Revision: 1
-Distribution: <<
-	(%type_pkg[python] = 34 ) 10.9,
-	(%type_pkg[python] = 34 ) 10.10,
-	(%type_pkg[python] = 34 ) 10.11,
-	(%type_pkg[python] = 34 ) 10.12,
-	(%type_pkg[python] = 34 ) 10.13,
-	(%type_pkg[python] = 34 ) 10.14,
-	(%type_pkg[python] = 34 ) 10.14.5,
-	(%type_pkg[python] = 34 ) 10.15,
-	(%type_pkg[python] = 35 ) 10.9,
-	(%type_pkg[python] = 35 ) 10.10,
-	(%type_pkg[python] = 35 ) 10.11,
-	(%type_pkg[python] = 35 ) 10.12,
-	(%type_pkg[python] = 35 ) 10.13,
-	(%type_pkg[python] = 35 ) 10.14,
-	(%type_pkg[python] = 35 ) 10.14.5,
-	(%type_pkg[python] = 35 ) 10.15,
-	(%type_pkg[python] = 36 ) 10.9,
-	(%type_pkg[python] = 36 ) 10.10,
-	(%type_pkg[python] = 36 ) 10.11,
-	(%type_pkg[python] = 36 ) 10.12,
-	(%type_pkg[python] = 36 ) 10.13,
-	(%type_pkg[python] = 36 ) 10.14,
-	(%type_pkg[python] = 36 ) 10.14.5,
-	(%type_pkg[python] = 36 ) 10.15
-<<
 Maintainer: None <fink-devel@lists.sourceforge.net>
 License: BSD
-Type: python (2.7 3.4 3.5 3.6 3.7)
+Type: python (3.8 3.9 3.10)
 Homepage: https://pypi.org/project/tox/
 Source: https://files.pythonhosted.org/packages/source/t/tox/tox-%v.tar.gz
-Source-Checksum: SHA256(96efa09710a3daeeb845561ebbe1497641d9cef2ee0aea30db6969058b2bda2f)
+Source-Checksum: SHA256(083a720adbc6166fff0b7d1df9d154f9d00bfccb9403b8abf6bc0ee435d6a62e)
 PatchFile: %{ni}.patch
-PatchFile-MD5: a3372c83f50d93b2f00a2de60697d419
+PatchFile-Checksum: SHA256(d891cd72b1b1833121305c3584d5ca7195bc4e96091c8b8e6dfc40f47cea8ac0)
 
-Depends: python%type_pkg[python]-shlibs, pytest-py%type_pkg[python], virtualenv-py%type_pkg[python], pluggy-py%type_pkg[python]
-BuildDepends: python%type_pkg[python], setuptools-scm-py%type_pkg[python], setuptools-tng-py%type_pkg[python]
-
+Depends: <<
+	python%type_pkg[python]-shlibs,
+	pytest-py%type_pkg[python],
+	virtualenv-py%type_pkg[python],
+	pluggy-py%type_pkg[python],
+	colorama-py%type_pkg[python]
+<<
+BuildDepends: <<
+	bootstrap-modules-py%type_pkg[python],
+	setuptools-tng-py%type_pkg[python]
+<<
 Description: Testing in virtualenvs
 
 DescDetail: <<
@@ -61,54 +42,37 @@ DescPackaging: <<
 Previous maintainer: Kurt Schwehr <goatbar@users.sourceforge.net>
 <<
 
-DocFiles: README.rst CHANGELOG.rst HOWTORELEASE.rst CONTRIBUTING.rst CONTRIBUTORS PKG-INFO doc
+DocFiles: LICENSE PKG-INFO README.md
 
 # Tests should not be run against the installed version and are not included in the package after installation,
 # but at least make sure they are running the correct script variants.
 PatchScript: <<
-    sed 's|PY_PKG|%type_pkg[python]|g;s|PY_RAW|%type_raw[python]|g;' %{PatchFile} | patch -p1
-    perl -pi -e 's|(basepython = python)(3.6)|${1}%type_raw[python]|g;' tox.ini
-    perl -pi -e 's|(python)(.-[cm])|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
-    perl -pi -e 's|(python)(3.6)(.-[cm])|%p/bin/${1}%type_raw[python]${3}|g;' tox.ini
-    perl -pi -e 's|(sphinx-build)(.-[d])|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
+#    sed 's|PY_PKG|%type_pkg[python]|g;s|PY_RAW|%type_raw[python]|g;' %{PatchFile} | patch -p1
+#    perl -pi -e 's|(basepython = python)(3.6)|${1}%type_raw[python]|g;' tox.ini
+#    perl -pi -e 's|(python)(.-[cm])|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
+#    perl -pi -e 's|(python)(3.6)(.-[cm])|%p/bin/${1}%type_raw[python]${3}|g;' tox.ini
+#    perl -pi -e 's|(sphinx-build)(.-[d])|%p/bin/${1}%type_raw[python]${2}|g;' tox.ini
 <<
 
 CompileScript: <<
-    %p/bin/python%type_raw[python] setup.py build
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m build --wheel --no-isolation --skip-dependency-check
 <<
 
 InfoTest: <<
-    TestDepends: pytest-mock-py%type_pkg[python]
-    TestScript: <<
-        #!/bin/bash -ev
-        # Create tox/tox-quickstart scripts locally and add pkg_resources info
-        mkdir -p build/bin
-        python%type_raw[python] setup.py install_scripts -d build/bin
-        python%type_raw[python] setup.py egg_info
-        mv build/bin/tox build/bin/tox-py%type_pkg[python]
-        mv build/bin/tox-quickstart build/bin/tox-quickstart-py%type_pkg[python]
-        chmod -R go+rX build tox*
-        PATH=%b/build/bin:$PATH
-        export PYTHONPATH=%b
-        # Locally installed scripts run correctly if tested separately, but when testing
-        # all at once, fail with a DistributionNotFound - go figure...
-        # Set DEB_SKIP_TOX_TESTS to disable them entirely [marked `skipif()`]
-        %p/bin/pytest-%type_raw[python] tests -k '_script' || exit 2
-        %p/bin/pytest-%type_raw[python] tests -k 'not _script' || exit 2
-    <<
-    TestSuiteSize: medium
+	TestScript: <<
+		PYTHONPATH=%b/build/lib %p/bin/python%type_raw[python] pytest -e %type_raw[python] || exit 2
+	<<
 <<
-
 InstallScript: <<
-    #!/bin/bash -ev
-    find build/lib -name '*.pyc' -exec rm {} \;
-    python%type_raw[python] setup.py install --root=%d
-    mv %i/bin/tox %i/bin/tox-py%type_pkg[python]
-    mv %i/bin/tox-quickstart %i/bin/tox-quickstart-py%type_pkg[python]
+	#!/bin/sh -ev
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m installer --destdir %d dist/*.whl
+	for i in tox ; do
+		mv %i/bin/$i %i/bin/$i-py%type_pkg[python]
+	done
 <<
 
 PostInstScript: <<
-    update-alternatives --verbose --install %p/bin/tox tox-py %p/bin/tox-py%type_pkg[python] %type_pkg[python] --slave %p/bin/tox-quickstart tox-quickstart %p/bin/tox-quickstart-py%type_pkg[python]
+    update-alternatives --verbose --install %p/bin/tox tox-py %p/bin/tox-py%type_pkg[python] %type_pkg[python]
     echo ''
     echo 'If you have just built and installed the tox dependencies'
     echo 'coverage-py%type_pkg[python], hypothesis-py%type_pkg[python], pytest-py%type_pkg[python], pytest-mock-py%type_pkg[python]'

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/tox-py.patch
@@ -1,52 +1,59 @@
-diff --git a/tox.ini b/tox.ini
---- a/tox.ini	2018-02-22 12:08:28.000000000 +0100
-+++ b/tox.ini	2018-05-16 22:15:56.000000000 +0200
-@@ -15,7 +15,8 @@
- setenv = COVERAGE_FILE={toxworkdir}/.coverage.{envname}
- passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE TOXENV CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_* CODECOV_*
- extras = testing
--commands = pytest {posargs:--cov-config="{toxinidir}/tox.ini" --cov="{envsitepackagesdir}/tox" --timeout=180 tests}
-+commands = pytest-PY_RAW {posargs:--cov-config="{toxinidir}/tox.ini" --cov="{envsitepackagesdir}/tox" --timeout=180 tests}
-+whitelist_externals: pytest-PY_RAW
- 
- [testenv:docs]
- description = invoke sphinx-build to build the HTML docs, check that URIs are valid
-diff --git a/tests/test_z_cmdline.py b/tests/test_z_cmdline.py
---- a/tests/test_z_cmdline.py	2018-03-24 11:05:06.000000000 +0100
-+++ b/tests/test_z_cmdline.py	2018-05-16 22:07:44.000000000 +0200
-@@ -492,7 +492,7 @@
+diff -ruN tox-3.14.0-orig/tests/unit/test_z_cmdline.py tox-3.14.0/tests/unit/test_z_cmdline.py
+--- tox-3.14.0-orig/tests/unit/test_z_cmdline.py	2019-09-08 16:57:05.000000000 -0400
++++ tox-3.14.0/tests/unit/test_z_cmdline.py	2019-09-08 17:13:44.000000000 -0400
+@@ -456,7 +456,7 @@
              changedir=tests
              commands= pytest --basetemp={envtmpdir} \
                                --junitxml=junit-{envname}.xml
 -            deps=pytest
 +            sitepackages=True
-         '''
-     })
- 
-@@ -586,7 +586,7 @@
+         """,
+         },
+     )
+@@ -606,7 +606,7 @@
              changedir=tests
              commands=
                  pytest --basetemp={envtmpdir} --junitxml=junit-{envname}.xml []
--            deps=pytest
-+            sitepackages=True
-         '''
-     })
-     result = cmd("-v")
-@@ -892,13 +892,15 @@
-                                " Environment variables are missing or defined recursively.\n")
+-            deps=pytest"""
++            sitepackages=True"""
+             + """
+             skipsdist={}
+         """.format(
+@@ -1017,15 +1017,17 @@
+     )
  
  
 +@pytest.mark.skipif(os.environ.get('DEB_SKIP_TOX_TESTS'), reason='Use DEP-8')
- def test_tox_console_script():
--    result = subprocess.check_call(['tox', '--help'])
-+    result = subprocess.check_call(['tox-pyPY_PKG', '--help'])
+ def test_tox_console_script(initproj):
+     initproj("help", filedefs={"tox.ini": ""})
+-    result = subprocess.check_call(["tox", "--help"])
++    result = subprocess.check_call(["tox-pyPY_PKG", "--help"])
      assert result == 0
  
  
 +@pytest.mark.skipif(os.environ.get('DEB_SKIP_TOX_TESTS'), reason='Use DEP-8')
- def test_tox_quickstart_script():
--    result = subprocess.check_call(['tox-quickstart', '--help'])
-+    result = subprocess.check_call(['tox-quickstart-pyPY_PKG', '--help'])
+ def test_tox_quickstart_script(initproj):
+     initproj("help", filedefs={"tox.ini": ""})
+-    result = subprocess.check_call(["tox-quickstart", "--help"])
++    result = subprocess.check_call(["tox-quickstart-pyPY_PKG", "--help"])
      assert result == 0
  
  
+diff -ruN tox-3.14.0-orig/tox.ini tox-3.14.0/tox.ini
+--- tox-3.14.0-orig/tox.ini	2019-09-08 16:57:05.000000000 -0400
++++ tox-3.14.0/tox.ini	2019-09-08 17:04:42.000000000 -0400
+@@ -22,12 +22,13 @@
+ passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE PYTEST_*
+ deps = pip == 19.1.1
+ extras = testing
+-commands = pytest \
++commands = pytest-PY_RAW \
+            --cov "{envsitepackagesdir}/tox" \
+            --cov-config "{toxinidir}/tox.ini" \
+            --junitxml {toxworkdir}/junit.{envname}.xml \
+            -n={env:PYTEST_XDIST_PROC_NR:auto} \
+            {posargs:.}
++whitelist_externals = pytest-PY_RAW
+ 
+ [testenv:docs]
+ description = invoke sphinx-build to build the HTML docs


### PR DESCRIPTION
New build system for tox-py requires python version 3.8 or later.
Keep old tox-py 3.14.0 for python version <= 3.7, added newer tox-py 4.24.1 for python version >=3.8
Patch file only for version 3.14