### PR TITLE
pre-commit-py 4.1.0 new package

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pre-commit-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pre-commit-py.info
@@ -1,0 +1,62 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info2: <<
+Package: pre-commit-py%type_pkg[python]
+Version: 4.1.0
+Revision: 1
+Type: python (3.9 3.10)
+
+Description: Framework for multi-language pre-commit hooks
+Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
+License: BSD
+Homepage: https://pypi.org/project/pre-commit/
+
+Source: https://files.pythonhosted.org/packages/source/p/pre_commit/pre_commit-%v.tar.gz
+Source-Checksum: SHA256(ae3f018575a588e30dfddfab9a05448bfbd6b73d78709617b5a2b853549716d4)
+
+Depends: python%type_pkg[python]
+BuildDepends: <<
+	fink (>= 0.24.12),
+	setuptools-tng-py%type_pkg[python],
+	covdefaults-py%type_pkg[python] (>=2.2),
+	coverage-py%type_pkg[python],
+	distlib-py%type_pkg[python],
+	re-assert-py%type_pkg[python],
+	cfgv-py%type_pkg[python],
+	identify-py%type_pkg[python],
+	yaml-py%type_pkg[python]
+<<
+CompileScript: <<
+	%p/bin/python%type_raw[python] setup.py build
+<<
+
+# test_async_keywords fails on <3.5 because only 3.5+ supports async.
+#		pytest-env-py%type_pkg[python]
+InfoTest: <<
+	TestDepends: <<
+		pytest-py%type_pkg[python]
+	<<
+	TestScript: PYTHONPATH=. %p/bin/python%type_raw[python] test_mccabe.py || exit 1
+<<
+
+InstallScript: <<
+    #!/bin/bash -ev
+    export LC_ALL=en_US.UTF-8
+	%p/bin/python%type_raw[python] setup.py install --root=%d
+	for file in pre-commit; do
+       mv %i/bin/${file} %i/bin/${file}-py%type_pkg[python]
+    done
+<<
+
+PostInstScript: <<
+  update-alternatives --verbose --install "%p/bin/pre-commit" pre-commit "%p/bin/pre-commit-py%type_pkg[python]" %type_pkg[python]
+<<
+
+PreRmScript: <<
+  if [ $1 != "upgrade" ]; then
+    update-alternatives --verbose --remove pre-commit "%p/bin/pre-commit-py%type_pkg[python]"
+  fi
+<<
+
+DocFiles: LICENSE README.md
+#Info2
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pre-commit-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pre-commit-py.info
@@ -2,7 +2,7 @@
 Info2: <<
 Package: pre-commit-py%type_pkg[python]
 Version: 4.1.0
-Revision: 1
+Revision: 2
 Type: python (3.9 3.10)
 
 Description: Framework for multi-language pre-commit hooks
@@ -13,27 +13,23 @@ Homepage: https://pypi.org/project/pre-commit/
 Source: https://files.pythonhosted.org/packages/source/p/pre_commit/pre_commit-%v.tar.gz
 Source-Checksum: SHA256(ae3f018575a588e30dfddfab9a05448bfbd6b73d78709617b5a2b853549716d4)
 
-Depends: python%type_pkg[python]
-BuildDepends: <<
-	fink (>= 0.24.12),
-	setuptools-tng-py%type_pkg[python],
-	covdefaults-py%type_pkg[python] (>=2.2),
-	coverage-py%type_pkg[python],
-	distlib-py%type_pkg[python],
-	re-assert-py%type_pkg[python],
-	cfgv-py%type_pkg[python],
-	identify-py%type_pkg[python],
-	yaml-py%type_pkg[python]
-<<
-CompileScript: <<
-	%p/bin/python%type_raw[python] setup.py build
+Depends: <<
+    python%type_pkg[python],
+    cfgv-py%type_pkg[python] (>=2.0.0),
+    fink (>= 0.24.12),
+    identify-py%type_pkg[python] (>=1.0.0),
+    nodeenv-py%type_pkg[python] (>=0.11.1),
+    virtualenv-py%type_pkg[python] (>=20.10.0),
+    yaml-py%type_pkg[python] (>=5.1)
 <<
 
-InfoTest: <<
-	TestDepends: <<
-		pytest-py%type_pkg[python]
-	<<
-	TestScript: PYTHONPATH=. %p/bin/python%type_raw[python] test_mccabe.py || exit 1
+BuildDepends: <<
+    fink (>= 0.24.12),
+    setuptools-tng-py%type_pkg[python]
+<<
+
+CompileScript: <<
+	%p/bin/python%type_raw[python] setup.py build
 <<
 
 InstallScript: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pre-commit-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pre-commit-py.info
@@ -29,8 +29,6 @@ CompileScript: <<
 	%p/bin/python%type_raw[python] setup.py build
 <<
 
-# test_async_keywords fails on <3.5 because only 3.5+ supports async.
-#		pytest-env-py%type_pkg[python]
 InfoTest: <<
 	TestDepends: <<
 		pytest-py%type_pkg[python]

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pre-commit-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pre-commit-py.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info2: <<
 Package: pre-commit-py%type_pkg[python]
-Version: 4.1.0
+Version: 4.6.0
 Revision: 2
 Type: python (3.9 3.10)
 
@@ -11,7 +11,7 @@ License: BSD
 Homepage: https://pypi.org/project/pre-commit/
 
 Source: https://files.pythonhosted.org/packages/source/p/pre_commit/pre_commit-%v.tar.gz
-Source-Checksum: SHA256(ae3f018575a588e30dfddfab9a05448bfbd6b73d78709617b5a2b853549716d4)
+Source-Checksum: SHA256(718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9)
 
 Depends: <<
     python%type_pkg[python],


### PR DESCRIPTION
pre-commit-py 4.1.0 new package only for python 3.9+ needed for black which is also only 3.9+