### PR TITLE
nodeenv-py version 1.9.1 new package to satisfy pre-requisite

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/nodeenv-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/nodeenv-py.info
@@ -1,0 +1,55 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info4: <<
+Package: nodeenv-py%type_pkg[python]
+Version: 1.9.1
+Revision: 1
+Type: python (3.8 3.9 3.10)
+Description: Tool to create isolated node.js environments
+License: BSD
+Homepage: https://pypi.org/project/nodeenv
+Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
+
+Source: https://files.pythonhosted.org/packages/source/n/nodeenv/nodeenv-%v.tar.gz
+Source-Checksum: SHA256(6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f)
+
+Depends: <<
+	python%type_pkg[python]
+<<
+BuildDepends: <<
+	bootstrap-modules-py%type_pkg[python],
+	setuptools-tng-py%type_pkg[python]
+<<
+
+CompileScript: <<
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m build --wheel --no-isolation --skip-dependency-check
+<<
+
+#InfoTest: <<
+#	TestDepends: <<
+#		pytest-py%type_pkg[python] (>= 4.3.0)
+#	<<
+#	TestScript: <<
+#		PYTHONPATH=%b/src %p/bin/python%type_raw[python] -m pytest -k -vv || exit 2
+#	<<
+#<<
+
+InstallScript: <<
+    #!/bin/sh -ev
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m installer --destdir %d dist/*.whl
+    for i in nodeenv ; do
+        mv %i/bin/$i %i/bin/$i-py%type_pkg[python]
+    done
+<<
+DocFiles: AUTHORS CHANGES LICENSE README README.rst README.ru.rst
+
+DescDetail: <<
+nodeenv (node.js virtual environment) is a tool to create isolated node.js
+environments.  It creates an environment that has its own installation
+directories, that doesn't share libraries with other node.js virtual
+environments.
+Also the new environment can be integrated with the environment which
+was built by virtualenv (python).
+If you use nodeenv feel free to add your project on wiki: Who-Uses-Nodeenv.
+<<
+#Info4
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/nodeenv-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/nodeenv-py.info
@@ -1,7 +1,7 @@
 # -*- coding: ascii; tab-width: 4 -*-
 Info4: <<
 Package: nodeenv-py%type_pkg[python]
-Version: 1.9.1
+Version: 1.10.0
 Revision: 1
 Type: python (3.8 3.9 3.10)
 Description: Tool to create isolated node.js environments
@@ -10,12 +10,14 @@ Homepage: https://pypi.org/project/nodeenv
 Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
 
 Source: https://files.pythonhosted.org/packages/source/n/nodeenv/nodeenv-%v.tar.gz
-Source-Checksum: SHA256(6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f)
+Source-Checksum: SHA256(996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb)
 
 Depends: <<
 	python%type_pkg[python]
 <<
+RuntimeDepends: nodejs
 BuildDepends: <<
+	fink (>= 0.32),
 	bootstrap-modules-py%type_pkg[python],
 	setuptools-tng-py%type_pkg[python]
 <<
@@ -24,14 +26,16 @@ CompileScript: <<
 	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m build --wheel --no-isolation --skip-dependency-check
 <<
 
-#InfoTest: <<
-#	TestDepends: <<
-#		pytest-py%type_pkg[python] (>= 4.3.0)
-#	<<
-#	TestScript: <<
-#		PYTHONPATH=%b/src %p/bin/python%type_raw[python] -m pytest -k -vv || exit 2
-#	<<
-#<<
+InfoTest: <<
+	TestDepends: <<
+		pytest-py%type_pkg[python] (>= 4.3.0),
+		coverage-py%type_pkg[python],
+		nodejs
+	<<
+	TestScript: <<
+		PYTHONPATH=%b/src %p/bin/python%type_raw[python] -m pytest -k -vv || exit 2
+	<<
+<<
 
 InstallScript: <<
     #!/bin/sh -ev


### PR DESCRIPTION
nodeenv is a pre-req for pre-commit.  This version has the tests commented out since I *think* they need two more new packages and not sure how many more after that.  Builds and installs with the -mv options in fink.  See PR #1225
Uses modern bootstrap module so limited to python >= 3.8