### PR TITLE
Cmake system libs

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/cmake.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/cmake.info
@@ -10,14 +10,16 @@ BuildDepends: <<
 	fink-package-precedence,
 	libcurl4,
 	liblzma5,
-	libncurses5
+	libncurses5,
+	libzstd1-dev (>= 1.5.7)
 <<
 Depends: <<
 	bzip2-shlibs,
 	expat1-shlibs,
 	libcurl4-shlibs,
 	liblzma5-shlibs,
-	libncurses5-shlibs
+	libncurses5-shlibs,
+	libzstd1-shlibs (>= 1.5.7)
 <<
 PatchScript: <<
 # Virtualize explicit '/sw' in sources
@@ -39,7 +41,6 @@ CompileScript: <<
 	export CMAKE_INCLUDE_PATH=%p/include
 	export CMAKE_LIBRARY_PATH=%p/lib
 	# ./bootstrap can use cmake style args after `--`
-	# libzstd uses cmake to build
 	./bootstrap --prefix=%p \
 		--docdir=/share/doc/%n \
 		--mandir=/share/man \
@@ -49,7 +50,6 @@ CompileScript: <<
 		--no-system-libarchive \
 		--no-system-librhash \
 		--no-system-libuv \
-		--no-system-zstd \
 		-- \
 		-DCMAKE_VERBOSE_MAKEFILE=ON \
 		-DCMAKE_USE_SYSTEM_LIBRARIES=ON

--- a/10.9-libcxx/stable/main/finkinfo/devel/cmake.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/cmake.info
@@ -1,16 +1,22 @@
 Package: cmake
 Version: 3.31.7
-Revision: 1
+Revision: 2
 Source: https://github.com/Kitware/CMake/releases/download/v%v/%n-%v.tar.gz
 Source-Checksum: SHA256(a6d2eb1ebeb99130dfe63ef5a340c3fdb11431cce3d7ca148524c125924cea68)
 License: BSD
 BuildDepends: <<
+	bzip2-dev,
+	expat1,
 	fink-package-precedence,
 	libcurl4,
+	liblzma5,
 	libncurses5
 <<
 Depends: <<
+	bzip2-shlibs,
+	expat1-shlibs,
 	libcurl4-shlibs,
+	liblzma5-shlibs,
 	libncurses5-shlibs
 <<
 PatchScript: <<
@@ -25,6 +31,7 @@ PatchScript: <<
   perl -pi -e 's,/opt/homebrew # Brew on Apple,# $&,g' Modules/Platform/Darwin.cmake
   perl -pi -e 's,/opt/homebrew,# $&,g' Modules/FindPython/Support.cmake
 <<
+GCC: 4.0
 CompileScript: <<
 #!/bin/sh -ev
 	export MACOSX_DEPLOYMENT_TARGET=""
@@ -36,8 +43,16 @@ CompileScript: <<
 	./bootstrap --prefix=%p \
 		--docdir=/share/doc/%n \
 		--mandir=/share/man \
+		--system-libs \
+		--no-system-cppdap \
+		--no-system-jsoncpp \
+		--no-system-libarchive \
+		--no-system-librhash \
+		--no-system-libuv \
+		--no-system-zstd \
 		-- \
-		-DCMAKE_VERBOSE_MAKEFILE=ON
+		-DCMAKE_VERBOSE_MAKEFILE=ON \
+		-DCMAKE_USE_SYSTEM_LIBRARIES=ON
 	make
 	fink-package-precedence --depfile-ext='\.d' .
 <<


### PR DESCRIPTION
Move cmake to use system-libs where appropriate instead of it's own internal ones.