### PR TITLE
Creation of librsync2 as update to librsync.

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/librsync2.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/librsync2.info
@@ -1,0 +1,82 @@
+Package: librsync2
+Version: 2.3.4
+Revision: 2
+Description: Algorithm for remote file synchronization
+License: GPL
+Homepage: https://github.com/librsync/librsync
+Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
+
+# Dependencies.
+Depends: %n-shlibs (= %v-%r)
+BuildDepends: <<
+	cmake,
+	bzip2-dev (>= 1.0.2-12),
+	popt (>= 1.7-1),
+	fink-buildenv-modules,
+	fink-package-precedence
+<<
+BuildDependsOnly: true
+Conflicts: librsync
+Replaces: librsync
+# Unpack Phase.
+Source: https://github.com/librsync/librsync/releases/download/v%v/librsync-%v.tar.gz
+Source-Checksum: SHA256(a0dedf9fff66d8e29e7c25d23c1f42beda2089fb4eac1b36e6acd8a29edfbd1f)
+
+# Compile Phase.
+CompileScript: <<
+        #!/bin/sh -ev
+        . %p/sbin/fink-buildenv-cmake.sh
+        mkdir finkbuild
+        pushd finkbuild
+                cmake $FINK_CMAKE_ARGS ..
+                make
+        popd
+        fink-package-precedence --depfile-ext='\.d' .
+<<
+InfoTest: <<
+        TestScript: <<
+                #!/bin/sh -ev
+                pushd finkbuild
+                        make test || exit 2
+                popd
+        <<
+<<
+
+# Install Phase.
+InstallScript: <<
+        #!/bin/sh -ev
+        pushd finkbuild
+                make install DESTDIR=%d
+        popd
+<<
+DocFiles: AUTHORS CONTRIBUTING.md COPYING NEWS.md README.RPM README.md THANKS TODO.md doc
+SplitOff: <<
+  Package: %N-shlibs
+  Depends: bzip2-shlibs (>= 1.0.2-12), popt-shlibs (>= 1.7-1)
+  Shlibs: %p/lib/librsync.2.dylib 2.0.0 %n (>= 2.3.4-1)
+  Files: lib/librsync.*.dylib
+  DocFiles: AUTHORS CONTRIBUTING.md COPYING NEWS.md README.RPM README.md THANKS TODO.md doc
+<<
+SplitOff2: <<
+  Package: %N-bin
+  Depends: %N-shlibs (= %v-%r)
+  Files: bin share/man/man1
+  DocFiles: AUTHORS CONTRIBUTING.md COPYING NEWS.md README.RPM README.md THANKS TODO.md doc
+<<
+# Documentation.
+DescDetail: <<
+librsync implements the rolling-checksum algorithm of remote file
+synchronization that was popularized by the rsync utility and is used in
+rproxy. This algorithm transfers the differences between 2 files without
+needing both files on the same system.
+
+It was originaly developed as part of rproxy, but is now used by other
+applications and has its own project on github.
+
+  https://github.com/librsync/librsync
+
+This library was previously known as libhsync up to version 0.9.0.
+<<
+DescPackaging: <<
+Previous Maintainer: Evi Vanoost <vanooste@rcbi.rochester.edu>
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/librsync2.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/librsync2.info
@@ -11,9 +11,10 @@ Depends: %n-shlibs (= %v-%r)
 BuildDepends: <<
 	cmake,
 	bzip2-dev (>= 1.0.2-12),
-	popt (>= 1.7-1),
 	fink-buildenv-modules,
-	fink-package-precedence
+	fink-package-precedence,
+	pkgconfig,
+	popt (>= 1.7-1)
 <<
 BuildDependsOnly: true
 Conflicts: librsync
@@ -58,7 +59,7 @@ SplitOff: <<
   DocFiles: AUTHORS CONTRIBUTING.md COPYING NEWS.md README.RPM README.md THANKS TODO.md doc
 <<
 SplitOff2: <<
-  Package: %N-bin
+  Package: librsync-bin
   Depends: %N-shlibs (= %v-%r)
   Files: bin share/man/man1
   DocFiles: AUTHORS CONTRIBUTING.md COPYING NEWS.md README.RPM README.md THANKS TODO.md doc


### PR DESCRIPTION
Continuation from PR #1222 (librsync) now with clean PR and hopefully fully conformant.
This is version 2.3.4 and installs versioned and unversioned libraries as needed by duplicity and rdiff-backup the only users of librsync.  The original librsync could technically be EOL or discarded.

Not sure what I fixed.  I had this setup already done but did not pass tests.  Now passes maintainer mode tests.