### PR TITLE
Coreutils patch for newer Clang

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/utils/coreutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/coreutils.info
@@ -1,7 +1,7 @@
 Package: coreutils
 Version: 8.32
 Epoch: 1
-Revision: 1
+Revision: 2
 BuildDepends: <<
 	expat1,
 	fink (>= 0.32),
@@ -26,6 +26,12 @@ Source-Checksum: SHA256(4458d8de7849df44ccab15e16b1548b285224dbba5f08fac070c1c0e
 # user that invoked su/sudo. The failure of test-getcwd.sh is residual breakage
 # from the fix for "bug#13516: tests/rm/unread3 fails on Mac OS X 10.8".
 # Buggy 64-bit posixtime implementation fails posixtm-tests on darwin10.
+
+PatchScript: <<
+	# Seems Clang doesn't treat the attribute as equivalent to the keyword.
+	# https://savannah.gnu.org/bugs/?63349 is upstream patch
+	perl -pi -e 's|static _Noreturn void|static __attribute_noreturn__ void|g' lib/obstack.c
+<<
 
 InfoTest: <<
 	TestScript: << 


### PR DESCRIPTION
 Seems Clang doesn't treat the attribute as equivalent to the keyword.  Simple one line patch.  This is an upstream patch reference in the info file.  https://savannah.gnu.org/bugs/?63349

Passes maintainer mode referencing that InfoDocs: section is deprecated did not update anything else in the package. Revision bumped to force recompile.  Should be compatible with earlier versions of Clang that do not flag this inconsistency.
(answered own question in Issue #1235)