### PR TITLE
Update coreutils to version 9.7

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/utils/coreutils.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/coreutils.info
@@ -1,5 +1,5 @@
 Package: coreutils
-Version: 8.32
+Version: 9.7
 Epoch: 1
 Revision: 2
 BuildDepends: <<
@@ -20,18 +20,13 @@ Depends: <<
 NoSetLDFLAGS: true
 SetLIBS: -L%p/lib
 Source: mirror:gnu:%n/%n-%v.tar.xz
-Source-Checksum: SHA256(4458d8de7849df44ccab15e16b1548b285224dbba5f08fac070c1c0e0bcc4cfa)
+Source-Checksum: SHA256(e8bb26ad0293f9b5a1fc43fb42ba970e312c66ce92c1b0b16713d7500db251bf)
+
 
 # Fink will cause test-getlogin to fail as getlogin will report the original
 # user that invoked su/sudo. The failure of test-getcwd.sh is residual breakage
 # from the fix for "bug#13516: tests/rm/unread3 fails on Mac OS X 10.8".
 # Buggy 64-bit posixtime implementation fails posixtm-tests on darwin10.
-
-PatchScript: <<
-	# Seems Clang doesn't treat the attribute as equivalent to the keyword.
-	# https://savannah.gnu.org/bugs/?63349 is upstream patch
-	perl -pi -e 's|static _Noreturn void|static __attribute_noreturn__ void|g' lib/obstack.c
-<<
 
 InfoTest: <<
 	TestScript: << 


### PR DESCRIPTION
Ok, you challenged me to checkout the versions update for coreutils.
This is simple update of version and hash.  Deleted patch script since fix incorporated in the update.
Validates correctly.
Fails 11 tests, looks like these are test of Chinese, French, and Japanese characters.
FAIL: test-c32isalnum.sh
FAIL: test-c32isalpha.sh
FAIL: test-c32isgraph.sh
FAIL: test-c32isprint.sh
FAIL: test-c32ispunct.sh
FAIL: test-c32islower.sh
FAIL: test-c32isspace.sh
FAIL: test-c32isupper.sh
FAIL: test-c32tolower.sh
FAIL: test-fnmatch-2.sh
FAIL: test-fnmatch-4.sh
FAIL: test-fnmatch-5.sh