### PR TITLE
pyproject-api-py new package version 1.9.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pyproject-api-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/pyproject-api-py.info
@@ -1,0 +1,40 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info4: <<
+Package: pyproject-api-py%type_pkg[python]
+Version: 1.9.0
+Revision: 1
+Type: python (3.9 3.10)
+Description: Python providing api to pyproject for tox
+License: BSD
+Homepage: https://pypi.org/project/pyproject-api
+Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
+
+Source: https://files.pythonhosted.org/packages/source/p/pyproject_api/pyproject_api-%v.tar.gz
+Source-Checksum: SHA256(7e8a9854b2dfb49454fae421cb86af43efbb2b2454e5646ffb7623540321ae6e)
+
+Depends: <<
+	python%type_pkg[python]
+<<
+BuildDepends: <<
+	bootstrap-modules-py%type_pkg[python],
+	setuptools-tng-py%type_pkg[python]
+<<
+
+CompileScript: <<
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m build --wheel --no-isolation --skip-dependency-check
+<<
+
+InfoTest: <<
+	TestDepends: <<
+		pytest-py%type_pkg[python] (>= 4.3.0)
+	<<
+	TestScript: <<
+		PYTHONPATH=%b/src %p/bin/python%type_raw[python] -m pytest -k "not(test_eventlet_spawn_n_bug)" -vv || exit 2
+	<<
+<<
+
+InstallScript: <<
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m installer --destdir %d dist/*.whl
+<<
+DocFiles: CODE_OF_CONDUCT.md LICENSE PKG-INFO README.md
+<<


### PR DESCRIPTION
Necessary for tox-py to run tests.  See PR#1223
WIP, does not pass 2 tests.  Not sure if this is fault of the code or if the asserts have a wrong format?
Does this require the "wheel" package to be installed?  I don't think so but I might be misinterpreting the error message of "requirement(wheel).
Error1:
```
_________________ test_setuptools_get_requires_for_build_wheel _________________

frontend_setuptools = <pyproject_api._via_fresh_subprocess.SubprocessFrontend object at 0x10bfd9c00>

    def test_setuptools_get_requires_for_build_wheel(frontend_setuptools: SubprocessFrontend) -> None:
        result = frontend_setuptools.get_requires_for_build_wheel()
>       assert not result.requires
E       assert not (<Requirement('wheel')>,)
E        +  where (<Requirement('wheel')>,) = RequiresBuildWheelResult(requires=(<Requirement('wheel')>,), out="started backend BackendProxy(backend=<module 'setuptools.build_meta' from '/opt/sw/lib/python3.10/site-packages/setuptools/build_meta.py'>)\nBackend: run command get_requires_for_build_wheel with args {'config_settings': None}\nrunning egg_info\nwriting demo.egg-info/PKG-INFO\nwriting dependency_links to demo.egg-info/dependency_links.txt\nwriting entry points to demo.egg-info/entry_points.txt\nwriting requirements to demo.egg-info/requires.txt\nwriting top-level names to demo.egg-info/top_level.txt\nreading manifest file 'demo.egg-info/SOURCES.txt'\nwriting manifest file 'demo.egg-info/SOURCES.txt'\nBackend: Wrote response {'return': ['wheel']} to /private/tmp/pep517_get_requires_for_build_wheel-bput5dqs.json\n", err="listing git files failed - pretending there aren't any\n").requires

tests/test_frontend_setuptools.py:62: AssertionError
```
And error 2, which looks like it should pass except the conditions have parenthesis around them
```
_______________ test_setuptools_prepare_metadata_for_build_wheel _______________

frontend_setuptools = <pyproject_api._via_fresh_subprocess.SubprocessFrontend object at 0x10bfd9c00>
tmp_path = PosixPath('/private/tmp/pytest-of-fink-bld/pytest-0/test_setuptools_prepare_metada0')

    def test_setuptools_prepare_metadata_for_build_wheel(frontend_setuptools: SubprocessFrontend, tmp_path: Path) -> None:
        meta = tmp_path / "meta"
        result = frontend_setuptools.prepare_metadata_for_build_wheel(metadata_directory=meta)
        assert result is not None
        dist = Distribution.at(str(result.metadata))
        assert list(dist.entry_points) == [EntryPoint(name="demo_exe", value="demo:a", group="console_scripts")]
        assert dist.version == "1.0"
        assert dist.metadata["Name"] == "demo"
        values = [v for k, v in dist.metadata.items() if k == "Requires-Dist"]  # type: ignore[attr-defined]
        # ignore because "PackageMetadata" has no attribute "items"
        expected = ["magic>3", "requests>2"] if sys.version_info[0:2] > (3, 8) else ["magic >3", "requests >2"]
>       assert sorted(values) == expected
E       AssertionError: assert ['magic (>3)', 'requests (>2)'] == ['magic>3', 'requests>2']
E         At index 0 diff: 'magic (>3)' != 'magic>3'
E         Full diff:
E         - ['magic>3', 'requests>2']
E         + ['magic (>3)', 'requests (>2)']
E         ?        ++  +            ++  +

tests/test_frontend_setuptools.py:78: AssertionError
```