### PR TITLE
lftp - update to version 4.9.3 and use of fink gnulib

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/net/lftp-gnulib-stream.patch
+++ b/10.9-libcxx/stable/main/finkinfo/net/lftp-gnulib-stream.patch
@@ -1,0 +1,50 @@
+From 353a3236d9328349c18ce2e4e984755cb4a76ea7 Mon Sep 17 00:00:00 2001
+From: Jan Palus <jpalus@fastmail.com>
+Date: Sun, 17 Nov 2024 18:58:42 +0100
+Subject: [PATCH] md5-stream, sha*-stream, sm3-stream: Avoid duplicate symbols.
+
+* lib/md5-stream.c (GL_OPENSSL_INLINE): Remove definition, that caused
+the symbols defined in md5.o to be defined in md5-stream.o as well.
+* lib/sha1-stream.c (GL_OPENSSL_INLINE): Likewise.
+* lib/sha256-stream.c (GL_OPENSSL_INLINE): Likewise.
+* lib/sha512-stream.c (GL_OPENSSL_INLINE): Likewise.
+* lib/sm3-stream.c (GL_OPENSSL_INLINE): Likewise.
+
+Copyright-paperwork-exempt: Yes
+---
+ ChangeLog           | 10 ++++++++++
+ lib/md5-stream.c    |  3 ---
+ lib/sha1-stream.c   |  3 ---
+ lib/sha256-stream.c |  3 ---
+ lib/sha512-stream.c |  3 ---
+ lib/sm3-stream.c    |  3 ---
+ 6 files changed, 10 insertions(+), 15 deletions(-)
+
+diff --git a/lib/md5-stream.c b/lib/md5-stream.c
+index fdd2bd8b4b..2cbdda6b0f 100644
+--- a/lib/md5-stream.c
++++ b/lib/md5-stream.c
+@@ -22,9 +22,6 @@
+ #include <config.h>
+ 
+ /* Specification.  */
+-#if HAVE_OPENSSL_MD5
+-# define GL_OPENSSL_INLINE _GL_EXTERN_INLINE
+-#endif
+ #include "md5.h"
+ 
+ #include <stdlib.h>
+diff --git a/lib/sha1-stream.c b/lib/sha1-stream.c
+index cbdf95ab76..b713e678a6 100644
+--- a/lib/sha1-stream.c
++++ b/lib/sha1-stream.c
+@@ -24,9 +24,6 @@
+ #include <config.h>
+ 
+ /* Specification.  */
+-#if HAVE_OPENSSL_SHA1
+-# define GL_OPENSSL_INLINE _GL_EXTERN_INLINE
+-#endif
+ #include "sha1.h"
+ 
+ #include <stdlib.h>

--- a/10.9-libcxx/stable/main/finkinfo/net/lftp.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/lftp.info
@@ -1,9 +1,28 @@
 Package: lftp
-Version: 4.9.2
-Revision: 2
+Version: 4.9.3
+Revision: 1
 ###
-Depends: %N-shlibs (>= %v-%r), expat1-shlibs, libgettext8-shlibs, libiconv, libidn2.0-shlibs, libncurses5-shlibs, openssl110-shlibs, readline8-shlibs
-BuildDepends: expat1, libgettext8-dev, libiconv-dev, libidn2.0-dev, libncurses5, openssl110-dev, readline8, fink (>= 0.28), fink-package-precedence
+Depends: <<
+	%N-shlibs (>= %v-%r),
+	expat1-shlibs,
+	libgettext8-shlibs,
+	libiconv,
+	libidn2.0-shlibs,
+	libncurses5-shlibs,
+	openssl110-shlibs,
+	readline8-shlibs
+<<
+BuildDepends: <<
+	expat1,
+	libgettext8-dev,
+	libiconv-dev,
+	libidn2.0-dev,
+	libncurses5,
+	openssl110-dev,
+	readline8,
+	fink (>= 0.32),
+	fink-package-precedence
+<<
 GCC: 4.0
 ###
 CustomMirror: <<
@@ -11,14 +30,21 @@ CustomMirror: <<
   Secondary: http://lftp.yar.ru/ftp/old/
 <<
 ###
-Source: mirror:custom:lftp-%v.tar.bz2
-Source-Checksum: SHA256(8a07cbf4df09b107fe3fc41d133ee2f6cea6ef4c33ccf06c8448ad058cd96b7e)
+Source: mirror:custom:lftp-%v.tar.xz
+Source-Checksum: SHA256(96e7199d7935be33cf6b1161e955b2aab40ab77ecdf2a19cea4fc1193f457edc)
 PatchFile: %n.patch
 PatchFile-MD5: 2b93a8f3a510286666a893a3c6070ea4
+PatchFile2: %n-gnulib-stream.patch
+PatchFile2-MD5:04624cc7357d06874a8d4a14056cff15
 PatchScript: <<
   %{default_script}
-	# Patch configure to see BigSur and beyond (Darwin20/21)
-	perl -pi.bak2 -e 's|darwin\[91|darwin[912|g; s|	10.\*\)|	1[0123].*)|g' configure
+	# Patch configure to see BigSur and beyond (Darwin20/21/...)
+	perl -pi.bak2 -e 's|^\t10\.(.*11\..*)$|\t*)|g' configure
+	# don't need super new autoconf
+	#perl -pi -e 's|2.71|2.69|' configure.ac
+	#autoreconf -vfi
+	#cp %p/share/gnulib/lib/dirent.in.h lib/dirent.in.h
+	#cp %p/share/gnulib/lib/wchar.in.h lib/wchar.in.h
 <<
 ###
 ###
@@ -27,7 +53,7 @@ SetCXX: g++
 DocFiles: ABOUT-NLS AUTHORS BUGS COPYING ChangeLog FAQ FEATURES NEWS README* THANKS TODO
 ConfFiles: %p/etc/lftp.conf
 ###
-ConfigureParams: --with-pic --with-modules --without-socksdante --with-openssl --with-readline=%p --localedir=%p/share/locale --mandir=%p/share/man --infodir=%p/share/info --libexecdir=%p/lib --enable-dependency-tracking
+ConfigureParams: --with-pic --with-modules --without-socksdante --with-openssl --with-readline=%p LDFLAGS="-L%p/lib" --localedir=%p/share/locale --mandir=%p/share/man --infodir=%p/share/info --libdir=/%p/lib --libexecdir=%p/lib --enable-dependency-tracking
 CompileScript: <<
   %{default_script}
   fink-package-precedence --prohibit-bdep=%n-dev .
@@ -35,9 +61,10 @@ CompileScript: <<
 ###
 InfoTest: <<
   TestScript: <<
+    #!/bin/sh -ev
     # many/all require net access (but passed for me when
     # it was available--dmacks)
-    #make check || exit 2
+    make check || exit 0
     #fink-package-precedence --prohibit-bdep=%n-dev .
   <<
 <<
@@ -46,7 +73,13 @@ InstallScript: make install DESTDIR=%d
 ###
 SplitOff: <<
   Package: %N-shlibs
-  Depends: libgettext8-shlibs, libiconv, libidn2.0-shlibs, libncurses5-shlibs, openssl110-shlibs
+  Depends: <<
+	libgettext8-shlibs,
+	libiconv,
+	libidn2.0-shlibs,
+	libncurses5-shlibs,
+	openssl110-shlibs
+  <<
   Files: lib/liblftp-jobs.*.dylib lib/liblftp-tasks.*.dylib
   Shlibs: <<
     %p/lib/liblftp-jobs.0.dylib 1.0.0 %n (>= 3.6.1-2)
@@ -81,6 +114,10 @@ DescDetail: <<
 DescPackaging: <<
   dmacks--updated to 4.8.3, with libidn and openssl dep upgrades, and
   then to 4.9.2
+  sth0--updated to 4.9.3
+  Fails check of lftp-https-get since ca-certificate is NOT in
+  "/etc/ssl/certs" for macOS = 15.x
+  Added LDFLAG to use fink gnulib instead of included version
 <<
 ###
 License: GPL

--- a/10.9-libcxx/stable/main/finkinfo/net/lftp.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/lftp.info
@@ -9,7 +9,7 @@ Depends: <<
 	libiconv,
 	libidn2.0-shlibs,
 	libncurses5-shlibs,
-	openssl110-shlibs,
+	openssl300-shlibs,
 	readline8-shlibs
 <<
 BuildDepends: <<
@@ -18,7 +18,7 @@ BuildDepends: <<
 	libiconv-dev,
 	libidn2.0-dev,
 	libncurses5,
-	openssl110-dev,
+	openssl300-dev,
 	readline8,
 	fink (>= 0.32),
 	fink-package-precedence
@@ -33,9 +33,9 @@ CustomMirror: <<
 Source: mirror:custom:lftp-%v.tar.xz
 Source-Checksum: SHA256(96e7199d7935be33cf6b1161e955b2aab40ab77ecdf2a19cea4fc1193f457edc)
 PatchFile: %n.patch
-PatchFile-MD5: 2b93a8f3a510286666a893a3c6070ea4
+PatchFile-Checksum: SHA256(65e8c6928bd8e2ca1aa94925fcc094e8d35a4fd2d0925625a77e214556afe26f)
 PatchFile2: %n-gnulib-stream.patch
-PatchFile2-MD5:04624cc7357d06874a8d4a14056cff15
+PatchFile2-Checksum: SHA256(70672d5427f327eeaee809435da245c8c15717de68e8ac7a4bc1a856977207a7)
 PatchScript: <<
   %{default_script}
 	# Patch configure to see BigSur and beyond (Darwin20/21/...)
@@ -47,7 +47,6 @@ PatchScript: <<
 	#cp %p/share/gnulib/lib/wchar.in.h lib/wchar.in.h
 <<
 ###
-###
 SetCXX: g++
 ###
 DocFiles: ABOUT-NLS AUTHORS BUGS COPYING ChangeLog FAQ FEATURES NEWS README* THANKS TODO
@@ -58,14 +57,16 @@ CompileScript: <<
   %{default_script}
   fink-package-precedence --prohibit-bdep=%n-dev .
 <<
-###
+### TESTS Disabled - need network access
 InfoTest: <<
   TestScript: <<
     #!/bin/sh -ev
     # many/all require net access (but passed for me when
     # it was available--dmacks)
-    make check || exit 0
-    #fink-package-precedence --prohibit-bdep=%n-dev .
+    # sth0 - Fails lftp-https-get Test, using localhost missing self certificate
+    # Fatal error: Certificate verification: unable to get local issuer certificate (AB:9D:02:63:24:4D:D0:32:6E:B6:70:15:70:5A:66:7E:79:CF:E9:98)
+#    make check
+#    fink-package-precedence --prohibit-bdep=%n-dev .
   <<
 <<
 ###
@@ -78,7 +79,7 @@ SplitOff: <<
 	libiconv,
 	libidn2.0-shlibs,
 	libncurses5-shlibs,
-	openssl110-shlibs
+	openssl300-shlibs
   <<
   Files: lib/liblftp-jobs.*.dylib lib/liblftp-tasks.*.dylib
   Shlibs: <<
@@ -115,8 +116,9 @@ DescPackaging: <<
   dmacks--updated to 4.8.3, with libidn and openssl dep upgrades, and
   then to 4.9.2
   sth0--updated to 4.9.3
+  testing disabled - needs network access to lftp.yar.ru
   Fails check of lftp-https-get since ca-certificate is NOT in
-  "/etc/ssl/certs" for macOS = 15.x
+  "/etc/ssl/certs" for macOS >= 15.x; do not terminate for this
   Added LDFLAG to use fink gnulib instead of included version
 <<
 ###


### PR DESCRIPTION
In trying to install lftp on macOS 15.X found that the included gnulib had several multiple defined errors.  Changed to link to the fink version of gnulib.  Updated to latest version of lftp.  Also see Issue #1200  and PR#1234.

Added gnulib patch from gnulib upstream, but probably unnecessary since now linking against fink gnulib which has (or soon will) that upstream patch.

The testing phase has 1 FAIL of retrieving an https file for failure to find root certificates on macOS.  Will see if that can be fixed later, see issue #1239

Package passes validation and all ftp tests
