### PR TITLE
perlmodule updates for macOS 15 / Perl 5.34.1

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/package-generator-pm-15.0.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/package-generator-pm-15.0.info
@@ -1,0 +1,21 @@
+Info2: <<
+Package: package-generator-pm
+Version: 1.106
+Revision: 1102
+Distribution: 15.0
+Source: mirror:cpan:authors/id/R/RJ/RJBS/Package-Generator-%v.tar.gz
+Source-Checksum: SHA256(2097ca273f8947bd62b1c19d40e1111eb106011338ae6be9f2f37cc88911d006)
+Type: perl, systemperl (5.34.1)
+InfoTest: <<
+	TestDepends: <<
+		system-perl%type_pkg[systemperl],
+		params-util-pm%type_pkg[systemperl]
+	<<
+<<
+DocFiles: Changes LICENSE README
+UpdatePOD: true
+Description: Create packages on-the-fly
+License: Artistic/GPL
+Maintainer: Daniel Macks <dmacks@netspace.org>
+Homepage: http://search.cpan.org/dist/Package-Generator
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/term-readkey-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/term-readkey-pm.info
@@ -3,7 +3,7 @@ Package: term-readkey-pm%type_pkg[perl]
 # PERL:XS
 Version: 2.38
 Revision: 1
-Type: perl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3)
+Type: perl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3 5.34.1)
 Distribution: <<
 	(%type_pkg[perl] = 5162) 10.9,
 	(%type_pkg[perl] = 5162) 10.10,

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/text-charwidth-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/text-charwidth-pm.info
@@ -2,8 +2,8 @@ Info2: <<
 Package: text-charwidth-pm%type_pkg[perl]
 # PERL:XS
 Version: 0.04
-Revision: 1
-Type: perl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3)
+Revision: 2
+Type: perl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3 5.34.1)
 Distribution: <<
 	(%type_pkg[perl] = 5162) 10.9,
 	(%type_pkg[perl] = 5162) 10.10,

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/text-iconv-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/text-iconv-pm.info
@@ -4,7 +4,7 @@ Package: text-iconv-pm%type_pkg[perl]
 Version: 1.7
 Revision: 3
 Description: The iconv() character set conversion function
-Type: perl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3)
+Type: perl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3 5.34.1)
 Distribution: <<
 	(%type_pkg[perl] = 5162) 10.9,
 	(%type_pkg[perl] = 5162) 10.10,

--- a/10.9-libcxx/stable/main/finkinfo/libs/perlmods/text-wrapi18n-pm.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/perlmods/text-wrapi18n-pm.info
@@ -2,7 +2,7 @@ Info2: <<
 Package: text-wrapi18n-pm%type_pkg[perl]
 Version: 0.06
 Revision: 1
-Type: perl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3)
+Type: perl (5.16.2 5.18.2 5.18.4 5.28.2 5.30.2 5.30.3 5.34.1)
 Distribution: <<
 	(%type_pkg[perl] = 5162) 10.9,
 	(%type_pkg[perl] = 5162) 10.10,


### PR DESCRIPTION
Simple updates so that dependencies are satisfied, one new file for distribution 15.0