### PR TITLE
libnewt0-shlibs update to version 0.52.25

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libnewt0-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libnewt0-shlibs.info
@@ -1,63 +1,60 @@
 Package: libnewt0-shlibs
-Version: 0.52.19
-Revision: 1.3
+Version: 0.52.25
+Revision: 1
 ###
 BuildDepends: <<
-	fink (>= 0.32),
-	fink-package-precedence,
-	slang2,
-	popt,
-	gettext-tools,
-	fribidi-dev,
-	libgettext8-dev,
-	tcltk-dev,
-	python27,
-	python35,
 	autoconf2.6,
 	automake1.15-core,
-	docbook-utils
+	docbook-utils,
+	gettext-tools,
+	fink (>= 0.32),
+	fink-package-precedence,
+	fribidi-dev,
+	libgettext8-dev,
+	popt,
+	slang2 (>= 2.0.4-2),
+	tcltk-dev
 <<
 #	sgmltools-lite replaced with docbook-utils
 Depends: <<
-	slang2-shlibs,
-	libgettext8-shlibs
+	libgettext8-shlibs,
+	slang2-shlibs
 <<
 Recommends: <<
 	fribidi-shlibs
 <<
 ###
-Source: mirror:debian:pool/main/n/newt/newt_%v.orig.tar.xz
-Source-Checksum: SHA256(ca927dcb3b5ebe8ab291a1f5988b442267b2b0d0466b8c9fac01b46fe521eab0)
-SourceDirectory: newt-%v
-Source2: mirror:debian:pool/main/n/newt/newt_%v-1.debian.tar.xz
-Source2-Checksum: SHA256(74961cb745650e9d2099bf05ce0e78903dd649a6e8ae836de79edfcff2da3b91)
-Source2ExtractDir: newt-%v
+source: https://releases.pagure.org/newt/newt-%v.tar.gz
+Source-Checksum: SHA256(ef0ca9ee27850d1a5c863bb7ff9aa08096c9ed312ece9087b30f3a426828de82)
+#Source2: mirror:debian:pool/main/n/newt/newt_%v-1.debian.tar.xz
+#Source2-Checksum: SHA256(74961cb745650e9d2099bf05ce0e78903dd649a6e8ae836de79edfcff2da3b91)
+#Source2ExtractDir: newt-%v
 ###
 PatchScript: <<
 # Patch the Debian Patches before applying
-perl -pi -e 's,libfribidi\.so\.0,libfribidi\.0\.dylib,g' debian/patches/bidi.patch
-perl -pi -e 's,/usr,%p,g' debian/patches/bidi.patch
+#perl -pi -e 's,libfribidi\.so\.0,libfribidi\.0\.dylib,g' debian/patches/bidi.patch
+#perl -pi -e 's,/usr,%p,g' debian/patches/bidi.patch
 # fink doesn't use MARCH yet
-perl -pi -e 's,/" MARCH ",,g' debian/patches/bidi.patch
+#perl -pi -e 's,/" MARCH ",,g' debian/patches/bidi.patch
 
 # Debian Patches
-patch -p1 < debian/patches/endianness.patch
-patch -p1 < debian/patches/python.patch
-patch -p1 < debian/patches/tcl86.patch
-patch -p1 < debian/patches/icelandic.patch
-patch -p1 < debian/patches/python_memory_allocation.patch
-patch -p1 < debian/patches/belarussian.patch
-patch -p1 < debian/patches/kazakh.patch
-patch -p1 < debian/patches/escape_key.patch
-patch -p1 < debian/patches/uighir.patch
-patch -p1 < debian/patches/sinhala.patch
-patch -p1 < debian/patches/bidi.patch
-patch -p1 < debian/patches/lithuanian.patch
-patch -p1 < debian/patches/python_init_once.patch
-patch -p1 < debian/patches/messagebox_escape.patch
-patch -p1 < debian/patches/compiler-warnings.patch
-patch -p1 < debian/patches/snack.patch
-patch -p1 < debian/patches/whiptail-man.patch
+#patch -p1 < debian/patches/endianness.patch
+#patch -p1 < debian/patches/python.patch
+#patch -p1 < debian/patches/tcl86.patch
+#patch -p1 < debian/patches/icelandic.patch
+#patch -p1 < debian/patches/python_memory_allocation.patch
+#patch -p1 < debian/patches/belarussian.patch
+#patch -p1 < debian/patches/kazakh.patch
+#patch -p1 < debian/patches/escape_key.patch
+#patch -p1 < debian/patches/uighir.patch
+#patch -p1 < debian/patches/sinhala.patch
+#patch -p1 < debian/patches/bidi.patch
+#patch -p1 < debian/patches/lithuanian.patch
+#patch -p1 < debian/patches/python_init_once.patch
+#patch -p1 < debian/patches/messagebox_escape.patch
+#patch -p1 < debian/patches/compiler-warnings.patch
+#patch -p1 < debian/patches/snack.patch
+#patch -p1 < debian/patches/whiptail-man.patch
 
 # Patch maintainer scripts
 perl -pi -e 's,/etc,%p/etc,g' debian/*.pre*
@@ -77,7 +74,7 @@ perl -pi -e 's,\$\(WHIPTCLLIB\)\.\$\(SOEXT\),\$\(WHIPTCLLIB\)\.so,g' Makefile.in
 perl -pi -e 's,Tcl_setResult,Tcl_SetResult,g' whiptcl.c
 
 perl -pi -e 's,LIBTCL = .TCL_LIB_FLAG.,LIBTCL = -ltcl,g' Makefile.in
-perl -pi -e 's,PYTHONVERS = .*,PYTHONVERS = python2.7 python3.5,g' Makefile.in
+#perl -pi -e 's,PYTHONVERS = .*,PYTHONVERS = python2.7 python3.5,g' Makefile.in
 # fink doesn't have python-dbg packages
 perl -pi -e 's,PYTHONDBG := .*,PYTHONDBG :=,g' Makefile.in
 
@@ -104,6 +101,7 @@ perl -pi -e 's/^(automake)/#\1/' autogen.sh
 ConfigureParams: <<
 --without-gpm-support \
 --with-colorsfile=%p/etc/newt/palette \
+--without-python \
 ac_cv_c_tclconfig=%p/lib
 <<
 ###
@@ -122,17 +120,17 @@ fink-package-precedence --prohibit-bdep=libnewt-dev --depfile-ext='\.depend' .
 InstallScript: <<
 make install DESTDIR=%d
 
-find %i/python2.7 -name '*.o' | xargs rm -f
-find %i/python3.5 -name '*.o' | xargs rm -f
+#find %i/python2.7 -name '*.o' | xargs rm -f
+#find %i/python3.5 -name '*.o' | xargs rm -f
 
 install -d -m 755 %i/etc/newt
-install -m 644 %b/debian/palette.original %i/etc/newt/
+#install -m 644 %b/debian/palette.original %i/etc/newt/
 
 # Debian maintainer scripts
-install -d -m0755 "%d"/DEBIAN
-for i in `ls -1 debian/libnewt0.52.post* debian/libnewt0.52.pre* 2> /dev/null | grep -v "\.in$"`; do \
-	install -m755 $i "%d"/DEBIAN/${i##*.}; \
-done
+#install -d -m0755 "%d"/DEBIAN
+#for i in `ls -1 debian/libnewt0.52.post* debian/libnewt0.52.pre* 2> /dev/null | grep -v "\.in$"`; do \
+#	install -m755 $i "%d"/DEBIAN/${i##*.}; \
+#done
 
 # ConfFiles
 install -d -m0755 "%d"/DEBIAN
@@ -146,7 +144,7 @@ Shlibs: <<
 	%p/lib/libnewt.0.dylib 1.0.0 libnewt0-shlibs (>= 0.52.10-1.1)
 <<
 ###
-DocFiles: CHANGES debian/copyright
+DocFiles: AUTHORS CHANGES COPYING README
 Description: Not Erik's Windowing Toolkit
 DescDetail: <<
 Newt is a windowing toolkit for text mode built from the slang library.
@@ -184,7 +182,7 @@ fi
 		lib/libnewt.{a,dylib}
 		lib/pkgconfig
 	<<
-	DocFiles: CHANGES debian/copyright tutorial:tutorial.html
+	DocFiles: AUTHORS CHANGES COPYING README tutorial:tutorial.html
 	Description: Devel tools for newt windowing library
 	DescDetail: <<
 These are the header files and libraries for developing applications
@@ -206,53 +204,53 @@ SplitOff2: <<
 install -d -m0755 %i/lib/whiptcl
 mv %I/lib/whiptcl.so %i/lib/whiptcl/
 	<<
-	DocFiles: CHANGES debian/copyright
+	DocFiles: AUTHORS CHANGES COPYING README
 	Description: NEWT module for Tcl
 	DescDetail: <<
 This module allows you to build a text UI for your Tcl scripts
 using newt.
 	<<
 <<
-SplitOff3: <<
-	Package: newt-py27
-	Depends: <<
-		%N (= %v-%r),
-		slang2-shlibs,
-		python27
-	<<
-	InstallScript: << 
+#SplitOff3: <<
+#	Package: newt-py27
+#	Depends: <<
+#		%N (= %v-%r),
+#		slang2-shlibs,
+#		python27
+#	<<
+#	InstallScript: << 
 # examples
-install -d -m0755 %i/share/doc/%n/examples
-install -m0755 peanuts.py %i/share/doc/%n/examples/
-install -m0755 popcorn.py %i/share/doc/%n/examples/
-	<<
-	Files: <<
-		lib/python2.7
-	<<
-	DocFiles: CHANGES debian/copyright
-	Description: NEWT module for Python
-	DescDetail: <<
-This module allows you to built a text UI for your Python scripts
-using newt.
-	<<
-<<
-SplitOff4: <<
-	Package: newt-py35
-	Depends: <<
-		%N (= %v-%r),
-		slang2-shlibs,
-		python35
-	<<
-	Files: <<
-		lib/python3.5
-	<<
-	DocFiles: CHANGES debian/copyright
-	Description: NEWT module for Python3
-	DescDetail: <<
-This module allows you to built a text UI for your Python3 scripts
-using newt.
-	<<
-<<
+#install -d -m0755 %i/share/doc/%n/examples
+#install -m0755 peanuts.py %i/share/doc/%n/examples/
+#install -m0755 popcorn.py %i/share/doc/%n/examples/
+#	<<
+#	Files: <<
+#		lib/python2.7
+#	<<
+#	DocFiles: CHANGES debian/copyright
+#	Description: NEWT module for Python
+#	DescDetail: <<
+#This module allows you to built a text UI for your Python scripts
+#using newt.
+#	<<
+#<<
+#SplitOff4: <<
+#	Package: newt-py35
+#	Depends: <<
+#		%N (= %v-%r),
+#		slang2-shlibs,
+#		python35
+#	<<
+#	Files: <<
+#		lib/python3.5
+#	<<
+#	DocFiles: CHANGES debian/copyright
+#	Description: NEWT module for Python3
+#	DescDetail: <<
+#This module allows you to built a text UI for your Python3 scripts
+#using newt.
+#	<<
+#<<
 SplitOff5: <<
 	Package: whiptail
 	Depends: <<
@@ -266,7 +264,7 @@ SplitOff5: <<
 	<<
 	InstallScript: <<
 install -d -m0755 %i/share/bash-completion/completions
-install -m0644 debian/bash_completion.d/whiptail %i/share/bash-completion/completions/%n
+#install -m0644 debian/bash_completion.d/whiptail %i/share/bash-completion/completions/%n
 
 # Debian maintainer scripts
 install -d -m0755 "%d"/DEBIAN
@@ -275,16 +273,16 @@ for i in `ls -1 debian/%n.post* debian/%n.pre* 2> /dev/null | grep -v "\.in$"`; 
 done
 
 # README
-if [ -f debian/README.%n ]; then \
-	install -d -m0755 "%i"/share/doc/%n; \
-	install -m644 debian/README.%n "%i"/share/doc/%n/; \
-fi
+#if [ -f debian/README.%n ]; then \
+#	install -d -m0755 "%i"/share/doc/%n; \
+#	install -m644 debian/README.%n "%i"/share/doc/%n/; \
+#fi
 	<<
 	Files: <<
 		bin
 		share/man
 	<<
-	DocFiles: CHANGES debian/copyright
+	DocFiles: AUTHORS CHANGES COPYING README
 	Description: User-friendly dialog boxes from shell scripts
 	DescDetail: <<
 Whiptail is a "dialog" replacement using newt instead of ncurses. It
@@ -303,7 +301,7 @@ install -d -m0755 %i/lib
 cp newt*.ver %i/lib/libnewt_pic.map
 #install -m0644 libnewt_pic.a %i/lib/
 	<<
-	DocFiles: CHANGES debian/copyright
+	DocFiles: AUTHORS CHANGES COPYING README
 	Description: NEWT shared library subset kit
 	DescDetail: <<
 This is used to develop subsets of the newt shared libraries for use on custom
@@ -326,4 +324,6 @@ DescPackaging: <<
 	via default -I/-L, but 10.13 only has tclConfig.sh buried and
 	there is a bug in the detection of it in %p/lib. See:
 	https://pagure.io/newt/issue/5
+
+	sth0: package requires automake 1.16
 <<


### PR DESCRIPTION
removed python libs since did not want explicit python version dependency for various OS versions
       Now builds on macOS 15
set new source download
alphabetized depends
removed dependence on debian utilities and docs
There are a lot of commented lines that may be obsolete on this update.  Should remove those lines before merging
See [Issue #1243](https://github.com/fink/fink-distributions/issues/1243)

