### PR TITLE
Openssl350: new package

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/crypto/openssl100-dev.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/openssl100-dev.info
@@ -2,7 +2,7 @@
 Package: openssl100-dev
 # Final version of this package.
 Version: 1.0.2u
-Revision: 2
+Revision: 3
 Description: Secure Sockets Layer and Crypto Library
 License: OSI-Approved
 Homepage: https://www.openssl.org/
@@ -12,12 +12,14 @@ Conflicts: <<
 	openssl100-dev,
 	openssl110-dev,
 	openssl300-dev,
+	openssl350-dev,
 	system-openssl-dev
 <<
 Replaces: <<
 	openssl100-dev,
 	openssl110-dev,
 	openssl300-dev,
+	openssl350-dev,
 	system-openssl-dev
 <<
 BuildDependsOnly: True

--- a/10.9-libcxx/stable/main/finkinfo/crypto/openssl110-dev.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/openssl110-dev.info
@@ -2,7 +2,7 @@
 Package: openssl110-dev
 # 1.1 series goes out of support on 2023-09-11
 Version: 1.1.1w
-Revision: 1
+Revision: 2
 Description: Secure Sockets Layer and Crypto Library
 License: OSI-Approved
 Homepage: https://www.openssl.org/
@@ -12,14 +12,14 @@ Conflicts: <<
 	openssl100-dev,
 	openssl110-dev,
 	openssl300-dev,
-	openssl310-dev,
+	openssl350-dev,
 	system-openssl-dev
 <<
 Replaces: <<
 	openssl100-dev,
 	openssl110-dev,
 	openssl300-dev,
-	openssl310-dev,
+	openssl350-dev,
 	system-openssl-dev
 <<
 BuildDependsOnly: True

--- a/10.9-libcxx/stable/main/finkinfo/crypto/openssl350-dev.info
+++ b/10.9-libcxx/stable/main/finkinfo/crypto/openssl350-dev.info
@@ -1,0 +1,116 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Package: openssl350-dev
+Version: 3.5.0
+Revision: 2
+Description: Secure Sockets Layer and Crypto Library
+License: BSD
+Homepage: https://www.openssl.org/
+# Free to update, modify, and take over
+Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
+
+Conflicts: <<
+	openssl100-dev,
+	openssl110-dev,
+	openssl300-dev,
+	openssl350-dev,
+	system-openssl-dev
+<<
+Replaces: <<
+	openssl100-dev,
+	openssl110-dev,
+	openssl300-dev,
+	openssl350-dev,
+	system-openssl-dev
+<<
+BuildDependsOnly: True
+
+Source: https://github.com/openssl/openssl/releases/download/openssl-%v/openssl-%v.tar.gz
+Source-Checksum: SHA256(344d0a79f1a9b08029b0744e2cc401a43f9c90acd1044d09a530b4885a8e9fc0)
+
+Depends: openssl350-shlibs (= %v-%r)
+CompileScript: <<
+#!/bin/sh -ev
+        # disable Apple Crypto Random API for macOS 10.12 and lower
+        # because it will be detected but is broken on 10.12
+        # see: https://github.com/fink/fink-distributions/issues/888
+        OSX_MAJOR_VERSION=`sw_vers -productVersion | cut -d. -f1-2`
+        #if dpkg --compare-versions "$OSX_MAJOR_VERSION" le "10.12"; then
+        #   params="-DOPENSSL_NO_APPLE_CRYPTO_RANDOM"
+        #fi
+    # openssldir is absolute
+    # libdir is relative to prefix
+	PERL=/usr/bin/perl ./Configure -w --prefix=%p --openssldir=%p/etc/ssl --libdir=lib/openssl350/lib zlib-dynamic enable-ec_nistp_64_gcc_128 $params
+	make
+<<
+
+InfoTest: <<
+	TestScript: make test || exit 2
+<<
+
+InstallScript: <<
+#!/bin/sh -ev
+	make install DESTDIR=%d
+
+	## Should patch build to avoid even trying to create these so get
+	## same .deb on all build FS even without hacks.
+	## There remain symlinks BN_print.3 -> BN_bn2bin.3 and bn_print.3 -> bn_internal.3, we rename the latter.
+	rm -f %i/share/man/man3/BN_print.3ossl %i/share/man/man3/bn_print.3ossl || true
+	ln -fs BN_bn2bin.3ossl %i/share/man/man3/BN_print.3ossl
+	ln -fs bn_internal.3ossl %i/share/man/man3/_bn_print.3ossl
+
+	# Remove static libs.
+	rm %i/lib/openssl350/lib/*.a
+
+	# convenience symlinks so that packages don't have to search far
+	install -m 0755 -d %i/lib/cmake
+	install -m 0755 -d %i/lib/pkgconfig
+
+	ln -s %p/lib/openssl350/cmake/OpenSSL %i/lib/cmake/OpenSSL
+	for i in libcrypto libssl; do
+		ln -s %p/lib/openssl350/lib/${i}.dylib %i/lib/${i}.dylib
+	done
+	for i in libcrypto libssl openssl; do
+		ln -s %p/lib/openssl350/lib/pkgconfig/${i}.pc %i/lib/pkgconfig/${i}.pc
+	done
+<<
+
+DocFiles: AUTHORS.md README* LICENSE.txt CHANGES.md NEWS.md SUPPORT.md
+
+SplitOff: <<
+	Package: openssl350-shlibs
+	Files: <<
+		lib/openssl350/lib/libcrypto.3.dylib
+		lib/openssl350/lib/libssl.3.dylib
+		lib/openssl350/lib/engines-3
+		lib/openssl350/lib/ossl-modules
+	<<
+	Shlibs: <<
+		%p/lib/openssl350/lib/libcrypto.3.dylib 3.0.0 %n (>= 3.5.0-1)
+		%p/lib/openssl350/lib/libssl.3.dylib 3.0.0 %n (>= 3.5.0-1)
+	<<
+	DocFiles: AUTHORS.md README* LICENSE.txt CHANGES.md NEWS.md SUPPORT.md
+<<
+
+SplitOff2: <<
+	Package: openssl
+	Depends: openssl350-shlibs (>= %v-%r)
+	Files: <<
+		bin
+		etc
+		share/man/man1
+	<<
+	DocFiles: AUTHORS.md README* LICENSE.txt CHANGES.md NEWS.md SUPPORT.md
+	ConfFiles: %p/etc/ssl/openssl.cnf
+<<
+
+DescDetail: <<
+OpenSSL is a free implementation of the Secure Sockets Layer (SSL)
+and Transport Layer Security (TLS) protocols. It includes command line
+utilities to manage certificates and a separate library implementing common
+cryptograhic algorithms.
+<<
+
+DescPackaging: <<
+Libraries placed in %p/lib/openssl350 since it reuses the same
+install_name as the 3.0.x series but removed multiple symbols.
+<<


### PR DESCRIPTION
New package for openssl v3.5.0
Although this shares the same install_name as openssl300, some symbols were removed in v3.1.0, so I stashed the libraries in a private subdir (with symlinks in -dev to make them easy to find).

Tested to build against a few openssl300 packages and had no problem.

Please test with macOS 10.13 (@dmacks) or lower because I saw a post someplace that it didn't build with older Xcode.