### PR TITLE
libxaw3dxft: v1.6.4

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/x11/libxaw3dxft-api-tokens.patch
+++ b/10.9-libcxx/stable/main/finkinfo/x11/libxaw3dxft-api-tokens.patch
@@ -1,7 +1,24 @@
-diff -Nurd -x'*~' libXaw3dXft-1.6.2.orig/configure.ac libXaw3dXft-1.6.2/configure.ac
---- libXaw3dXft-1.6.2.orig/configure.ac	2012-02-25 08:11:37.000000000 -0500
-+++ libXaw3dXft-1.6.2/configure.ac	2012-08-08 19:20:56.000000000 -0400
-@@ -43,27 +43,55 @@
+diff -Nurd libxaw3dxft-1.6.4.intermediate/Makefile.am libxaw3dxft-1.6.4/Makefile.am
+--- libxaw3dxft-1.6.4.intermediate/Makefile.am	2025-08-01 13:01:20
++++ libxaw3dxft-1.6.4/Makefile.am	2025-08-01 13:20:34
+@@ -145,9 +145,11 @@
+ EXTRA_DIST = \
+   src/Template.c \
+   include/X11/Xaw3dxft/Template.h \
+-  include/X11/Xaw3dxft/TemplateP.h
++  include/X11/Xaw3dxft/TemplateP.h \
++  include/X11/Xaw3dxft/Xaw3dP.h.in
+ 
+-BUILT_SOURCES = src/laygram.h
++BUILT_SOURCES = src/laygram.h include/X11/Xaw3dxft/Xaw3dP.h
++include/X11/Xaw3dxft/Xaw3dP.h: include/X11/Xaw3dxft/Xaw3dP.h.in
+ dist_doc_DATA = README.md Xresources
+ readmepicsdir = $(docdir)/README_pics
+ dist_readmepics_DATA = \
+diff -Nurd libxaw3dxft-1.6.4.intermediate/configure.ac libxaw3dxft-1.6.4/configure.ac
+--- libxaw3dxft-1.6.4.intermediate/configure.ac	2025-08-01 13:01:20
++++ libxaw3dxft-1.6.4/configure.ac	2025-08-01 14:03:58
+@@ -37,34 +37,56 @@
      [XAW_I18N=$enableval], [XAW_I18N=yes])
  if test "x$XAW_I18N" = xyes; then
      XAW3D_CPPFLAGS="${XAW3D_CPPFLAGS} -DXAW_INTERNATIONALIZATION"
@@ -13,13 +30,17 @@ diff -Nurd -x'*~' libXaw3dXft-1.6.2.orig/configure.ac libXaw3dXft-1.6.2/configur
 +AC_SUBST(DEF_I18N_SUPPORT)
  
  AC_ARG_ENABLE([multiplane-bitmaps],
-     [AS_HELP_STRING([--enable-multiplane-bitmaps], dnl
--     [enable XPM support])],
+-    [AS_HELP_STRING([--enable-multiplane-bitmaps], [enable XPM support])],
+-    [],
++    [AS_HELP_STRING([--enable-multiplane-bitmaps], dnl
++    [enable XPM support (default: no)])],
++    [enable_multiplane_bitmaps=$enableval],
+     [enable_multiplane_bitmaps=no])
+ 
+-AS_IF([test "x$enable_multiplane_bitmaps" != xno],
 -     [XAW3D_CPPFLAGS="${XAW3D_CPPFLAGS} -DXAW_MULTIPLANE_PIXMAPS" dnl
 -      PKG_CHECK_MODULES(XPM, xpm)])
-+     [enable XPM support (default: no)])],
-+    [XAW_MULTIPLANE=$enableval], [XAW_MULTIPLANE=no])
-+if test "x$XAW_MULTIPLANE" = xyes; then
++if test "x$enable_multiplane_bitmaps" = xyes]; then
 +    PKG_CHECK_MODULES(XPM, xpm)
 +    XAW3D_CPPFLAGS="${XAW3D_CPPFLAGS} -DXAW_MULTIPLANE_PIXMAPS"
 +    DEF_XPM_SUPPORT="#define XAW_MULTIPLANE_PIXMAPS"
@@ -29,56 +50,48 @@ diff -Nurd -x'*~' libXaw3dXft-1.6.2.orig/configure.ac libXaw3dXft-1.6.2/configur
 +AC_SUBST(DEF_XPM_SUPPORT)
  
  AC_ARG_ENABLE([gray-stipples],
-     [AS_HELP_STRING([--enable-gray-stipples], dnl
--     [enable gray stipples])], [XAW3D_CPPFLAGS="${XAW3D_CPPFLAGS} -DXAW_GRAY_BLKWHT_STIPPLES"])
+-    [AS_HELP_STRING([--enable-gray-stipples], [enable gray stipples])],
+-    [],
++    [AS_HELP_STRING([--enable-gray-stipples], dnl
 +     [enable gray stipples (default: no)])],
-+    [XAW_STIPPLES=$enableval], [XAW_STIPPLES=no])
-+if test "x$XAW_SCROLLBARS" = xyes; then
-+      XAW3D_CPPFLAGS="${XAW3D_CPPFLAGS} -DXAW_GRAY_BLKWHT_STIPPLES"
-+      DEF_GRAY_STIPPLES="#define XAW_GRAY_BLKWHT_STIPPLES"
++    [enable_gray_stipples=$enableval],
+     [enable_gray_stipples=no])
+ 
+-AS_IF([test "x$enable_gray_stipples" != xno],
+-    [XAW3D_CPPFLAGS="${XAW3D_CPPFLAGS} -DXAW_GRAY_BLKWHT_STIPPLES"])
++if test "x$enable_gray_stipples" = xyes; then
++    XAW3D_CPPFLAGS="${XAW3D_CPPFLAGS} -DXAW_GRAY_BLKWHT_STIPPLES"
++    DEF_GRAY_STIPPLES="#define XAW_GRAY_BLKWHT_STIPPLES"
 +else
-+      DEF_GRAY_STIPPLES="/* #undef XAW_GRAY_BLKWHT_STIPPLES */"
++    DEF_GRAY_STIPPLES="/* #undef XAW_GRAY_BLKWHT_STIPPLES */"
 +fi
 +AC_SUBST(DEF_GRAY_STIPPLES)
  
  AC_ARG_ENABLE([arrow-scrollbars],
-     [AS_HELP_STRING([--enable-arrow-scrollbars], dnl
--     [enable arrow scrollbars])], [XAW3D_CPPFLAGS="${XAW3D_CPPFLAGS} -DXAW_ARROW_SCROLLBARS"])
+-    [AS_HELP_STRING([--enable-arrow-scrollbars], [enable arrow scrollbars])],
+-    [],
++    [AS_HELP_STRING([--enable-arrow-scrollbars], dnl
 +     [enable arrow scrollbars (default: no)])],
-+    [XAW_SCROLLBARS=$enableval], [XAW_SCROLLBARS=no])
-+if test "x$XAW_SCROLLBARS" = xyes; then
-+      XAW3D_CPPFLAGS="${XAW3D_CPPFLAGS} -DXAW_ARROW_SCROLLBARS"
-+      DEF_ARROW_SCROLLBARS="#define XAW_ARROW_SCROLLBARS"
++    [enable_arrow_scrollbars=$enableval],
+     [enable_arrow_scrollbars=no])
+ 
+-AS_IF([test "x$enable_arrow_scrollbars" != xno],
+-    [XAW3D_CPPFLAGS="${XAW3D_CPPFLAGS} -DXAW_ARROW_SCROLLBARS"])
++if test "x$enable_arrow_scrollbars" = xyes; then
++    XAW3D_CPPFLAGS="${XAW3D_CPPFLAGS} -DXAW_ARROW_SCROLLBARS"
++    DEF_ARROW_SCROLLBARS="#define XAW_ARROW_SCROLLBARS"
 +else
-+      DEF_ARROW_SCROLLBARS="/* #undef XAW_ARROW_SCROLLBARS */"
++    DEF_ARROW_SCROLLBARS="/* #undef XAW_ARROW_SCROLLBARS */"
 +fi
 +AC_SUBST(DEF_ARROW_SCROLLBARS)
  
  AC_SUBST(XAW3D_CPPFLAGS)
- 
- AC_CONFIG_FILES([Makefile
- 		include/Makefile
-+		include/X11/Xaw3d/Xaw3dP.h
- 		src/Makefile
- 		xaw3d.pc])
- 
-diff -Nurd -x'*~' libXaw3dXft-1.6.2.orig/include/Makefile.am libXaw3dXft-1.6.2/include/Makefile.am
---- libXaw3dXft-1.6.2.orig/include/Makefile.am	2012-02-25 15:59:53.000000000 -0500
-+++ libXaw3dXft-1.6.2/include/Makefile.am	2012-08-08 16:21:33.000000000 -0400
-@@ -85,4 +85,8 @@
- 
- EXTRA_DIST = \
- 	X11/Xaw3d/Template.h \
--	X11/Xaw3d/TemplateP.h
-\ No newline at end of file
-+	X11/Xaw3d/TemplateP.h \
-+	X11/Xaw3d/Xaw3dP.h.in
-+
-+BUILT_SOURCES = X11/Xaw3d/Xaw3dP.h
-+X11/Xaw3d/Xaw3dP.h: X11/Xaw3d/Xaw3dP.h.in
-diff -Nurd -x'*~' libXaw3dXft-1.6.2.orig/include/X11/Xaw3d/Xaw3dP.h libXaw3dXft-1.6.2/include/X11/Xaw3d/Xaw3dP.h
---- libXaw3dXft-1.6.2.orig/include/X11/Xaw3d/Xaw3dP.h	2012-02-26 09:23:32.000000000 -0500
-+++ libXaw3dXft-1.6.2/include/X11/Xaw3d/Xaw3dP.h	1969-12-31 19:00:00.000000000 -0500
+-AC_CONFIG_FILES([Makefile libxaw3dxft.pc])
++AC_CONFIG_FILES([Makefile include/X11/Xaw3dxft/Xaw3dP.h libxaw3dxft.pc])
+ AC_OUTPUT
+diff -Nurd libxaw3dxft-1.6.4.intermediate/include/X11/Xaw3dxft/Xaw3dP.h libxaw3dxft-1.6.4/include/X11/Xaw3dxft/Xaw3dP.h
+--- libxaw3dxft-1.6.4.intermediate/include/X11/Xaw3dxft/Xaw3dP.h	2025-08-01 13:01:20
++++ libxaw3dxft-1.6.4/include/X11/Xaw3dxft/Xaw3dP.h	1970-01-01 01:00:00
 @@ -1,79 +0,0 @@
 -/*
 - * Xaw3dP.h
@@ -159,9 +172,9 @@ diff -Nurd -x'*~' libXaw3dXft-1.6.2.orig/include/X11/Xaw3d/Xaw3dP.h libXaw3dXft-
 -#endif
 -
 -#endif	/* _Xaw3dP_h */
-diff -Nurd -x'*~' libXaw3dXft-1.6.2.orig/include/X11/Xaw3d/Xaw3dP.h.in libXaw3dXft-1.6.2/include/X11/Xaw3d/Xaw3dP.h.in
---- libXaw3dXft-1.6.2.orig/include/X11/Xaw3d/Xaw3dP.h.in	1969-12-31 19:00:00.000000000 -0500
-+++ libXaw3dXft-1.6.2/include/X11/Xaw3d/Xaw3dP.h.in	2012-08-08 16:23:06.000000000 -0400
+diff -Nurd libxaw3dxft-1.6.4.intermediate/include/X11/Xaw3dxft/Xaw3dP.h.in libxaw3dxft-1.6.4/include/X11/Xaw3dxft/Xaw3dP.h.in
+--- libxaw3dxft-1.6.4.intermediate/include/X11/Xaw3dxft/Xaw3dP.h.in	1970-01-01 01:00:00
++++ libxaw3dxft-1.6.4/include/X11/Xaw3dxft/Xaw3dP.h.in	2025-08-01 13:23:22
 @@ -0,0 +1,79 @@
 +/*
 + * Xaw3dP.h

--- a/10.9-libcxx/stable/main/finkinfo/x11/libxaw3dxft.info
+++ b/10.9-libcxx/stable/main/finkinfo/x11/libxaw3dxft.info
@@ -1,11 +1,10 @@
 Package: libxaw3dxft
-Version: 1.6.2
-Revision: 7
+Version: 1.6.4
+Revision: 1
 BuildDependsOnly: true
 
-Source: mirror:sourceforge:sf-xpaint/libXaw3dXft-%v.tar.bz2
-Source-Checksum: SHA256(0a1af64590cab7a4e4a5cf42dafa1a94984c6453c56377f40b5d1682f6c4ecfd)
-SourceDirectory: libXaw3dXft-%v
+Source: https://github.com/DaveFlater/libXaw3dXft/releases/download/v%v/%n-%v.tar.xz
+Source-Checksum: SHA256(283d2d1c9332ae2c51b54228eb82b89737b1c94d9cf5d0bd15cc26863a5feff6)
 
 BuildDepends: <<
 	x11-dev, 
@@ -14,7 +13,7 @@ BuildDepends: <<
 	freetype219, 
 	xft2-dev, 
 	pkgconfig,
-	fink ( >= 0.30.0 ),
+	fink ( >= 0.32 ),
 	automake1.15,
 	autoconf2.6 (>= 2.69-5),
 	libtool2,
@@ -27,17 +26,12 @@ Conflicts: xaw3d-static, xaw3d
 Replaces: xaw3d-static, xaw3d
 
 PatchFile: %n.patch
-PatchFile-MD5: f30ad12fdb084be5259233a6a5476155
+PatchFile-MD5: 228ab3546410a0b1617236b66f60b9ed
 PatchFile2: %n-api-tokens.patch
-PatchFile2-MD5: 98c58f496ee110dc7cc08ed645aedca1
+PatchFile2-MD5: d6ba3f30c048e3f1b4f9157a5103801c
 PatchScript: <<
 	%{default_script}
-	perl -pi -e 's/-lXft\s+-lfontconfig//' xaw3d.pc.in
-
-	# dmacks, makin' automake happy
-	mkdir m4
-	echo 'AC_CONFIG_MACRO_DIR([m4])' >> configure.ac
-	echo 'ACLOCAL_AMFLAGS = -I m4' >> Makefile.am
+	perl -pi -e 's/-lXft\s+-lfontconfig//' libxaw3dxft.pc.in
 <<
 
 ConfigureParams: --enable-arrow-scrollbars --disable-static --disable-silent-rules
@@ -49,8 +43,11 @@ Compilescript: <<
 
 InstallScript: <<
 	make install DESTDIR=%D
+	cp %i/lib/libXaw3dxft.8.dylib %i/lib/libXaw3d.8.dylib
+	install_name_tool -change %p/lib/libXaw3dxft.8.dylib %p/lib/libXaw3d.8.dylib -id %p/lib/libXaw3d.8.dylib %i/lib/libXaw3d.8.dylib
+	ln -s libXaw3d.8.dylib %i/lib/libXaw3d.dylib
 <<
-DocFiles: src/README.XAW3D COPYING README
+DocFiles: COPYING README
 SplitOff: <<
   Package: %N-shlibs
   Depends: <<
@@ -59,13 +56,16 @@ SplitOff: <<
   	system-xfree86-shlibs (>= 3:2.7.112-3),
   	xft2-shlibs
   <<
-  Files: lib/libXaw3d.*.dylib
-  Shlibs: %p/lib/libXaw3d.8.dylib 9.0.0 %n (>= 1.6.2-1)
-  DocFiles: src/README.XAW3D COPYING README
+  Files: lib/libXaw3dxft.*.dylib lib/libXaw3d.*.dylib
+  Shlibs: <<
+  	%p/lib/libXaw3d.8.dylib 9.0.0 %n (>= 1.6.2-1)
+  	%p/lib/libXaw3dxft.8.dylib 9.0.0 %n (>= 1.6.4-1)
+  <<
+  DocFiles: COPYING README
 <<
 Description: Athena widget set with 3D look
 License: OSI-Approved
-Homepage: https://sourceforge.net/projects/sf-xpaint/files/libxaw3dxft/
+Homepage: https://github.com/DaveFlater/libXaw3dXft
 Maintainer: Alexander Hansen <alexkhansen@users.sf.net>
 DescPackaging: <<
 Tries to redefine Pixel, so we patch that out.
@@ -80,7 +80,8 @@ TODO:  Use fink-package-precedence (>=0.32-1) to avoid the new otool on Xcode 8 
 that we aren't somehow using fink's libxt any more.
 <<
 DescDetail: <<
-Updated Xaw3D from the xpaint project at Sourceforge.
+Updated Xaw3D from GitHub (previously part of the xpaint project at
+Sourceforge).
 
 This is a newer version which should be entirely source compatible with the
 current development versions of libXaw3d-1.6.2 and provides additionally

--- a/10.9-libcxx/stable/main/finkinfo/x11/libxaw3dxft.patch
+++ b/10.9-libcxx/stable/main/finkinfo/x11/libxaw3dxft.patch
@@ -1,13 +1,14 @@
-diff -Nurd libXaw3dXft-1.6.2/src/Xaw3dXft.c libXaw3dXft-1.6.2.patched/src/Xaw3dXft.c
---- libXaw3dXft-1.6.2/src/Xaw3dXft.c	2012-03-04 08:43:44.000000000 -0700
-+++ libXaw3dXft-1.6.2.patched/src/Xaw3dXft.c	2012-06-08 15:42:18.000000000 -0700
-@@ -46,9 +46,6 @@
- #include <X11/Xaw3d/Xaw3dXft.h>
+diff -Nurd libxaw3dxft-1.6.4.orig/src/Xaw3dXft.c libxaw3dxft-1.6.4/src/Xaw3dXft.c
+--- libxaw3dxft-1.6.4.orig/src/Xaw3dXft.c	2025-03-02 00:17:40
++++ libxaw3dxft-1.6.4/src/Xaw3dXft.c	2025-08-01 12:09:47
+@@ -47,10 +47,6 @@
  
- #define XAW3DXFTDEFAULTFONT "Liberation-9"
+ #define XAW3DXFT_DEFAULTFONT "Liberation-9"
+ 
 -#ifndef Pixel
 -typedef unsigned long Pixel;
 -#endif
+-
+ Xaw3dXftData * _Xaw3dXft;
  
- char Xaw3dXftEncoding = 0;
- char Xaw3dXftStringHilight = 0;
+ void Xaw3dXftSetDefaultHilitColor(void)


### PR DESCRIPTION
This is a new version of libxaw3dxft, now moved from Sourceforge to https://github.com/DaveFlater/libXaw3dXft. The major change here is that the library has been renamed from libXaw3d.8.dylib to libXaw3dxft.8.dylib. I have created a copy with the old name (and then update the install name). Hopefully this should work for future updates, while maintaining backward compatibility. Tested on MacOS 15.6 Intel and Apple Silicon. Maintainer is @akhansen 