### PR TITLE
xtide: v2.15.6

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide-harmonics-us.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide-harmonics-us.info
@@ -1,5 +1,5 @@
 Package: xtide-harmonics-us
-Version: 20230107
+Version: 20241229
 # must keep version in sync with 'xtide' package
 Revision: 1
 Description: US harmonic data for XTide
@@ -20,7 +20,7 @@ Maintainer: Alexander Hansen <alexkhansen@users.sourceforge.net>
 BuildDepends: fink (>= 0.32)
 
 Source: https://flaterco.com/files/xtide/harmonics-dwf-%v-free.tar.xz
-Source-Checksum: SHA256(1aed30ae78b01053494c05dede1af5f73ce9bf394f65995deb920b83828de18e)
+Source-Checksum: SHA256(70c0259848bee58e4e01942a46dc9d184167705ea83737252dd73285dfab1bc2)
 SourceDirectory: harmonics-dwf-%v
 
 CompileScript: printf "No compiling needed.\n" 

--- a/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/xtide.info
@@ -1,8 +1,8 @@
 Info2: <<
 Package: xtide
-Version: 2.15.5
+Version: 2.15.6
 Revision: 1
-Type: harm (20230107)
+Type: harm (20241229)
 # must keep type[harm] in sync with 'xtide-harmonics-us' package
 
 Description: Tide and current prediction software
@@ -20,8 +20,8 @@ BuildDepends: <<
 	fontconfig2-dev,
 	freetype219,
 	libpng16, 
-	libtcd (>= 2.2.7-r2),
-	libxaw3dxft (>= 1.6.2-7),
+	libtcd (>= 2.2.7-r3),
+	libxaw3dxft (>= 1.6.4-1),
 	xft2-dev,
 	system-xfree86-dev (>= 3:2.7.112-3)
 <<
@@ -29,8 +29,8 @@ Depends: <<
 	%N1-shlibs (= %v-%r),
 	daemonic (>= 20010902-12), 
 	libpng16-shlibs, 
-	libtcd-shlibs (>= 2.2.5-r3), 
-	libxaw3dxft-shlibs (>= 1.6.2-7),
+	libtcd-shlibs (>= 2.2.7-r3),
+	libxaw3dxft-shlibs (>= 1.6.4-1),
 	system-xfree86-shlibs (>= 3:2.7.112-3),
 	system-xfree86 (>= 3:2.7.112-3), 
 	xft2-shlibs,
@@ -41,7 +41,7 @@ GCC: 4.0
 Recommends: xtide-coastline (>= 20110414-2)
 
 Source: https://flaterco.com/files/xtide/%n-%v.tar.xz
-Source-Checksum: SHA256(b9460dcf167e8d9544dcb34a751516d14a97fc3f4aebc6a8bb5ca5f2710d7164)
+Source-Checksum: SHA256(91dfec1fa1a277d4f38e43d952c34765bb1b335a82299f094a995532c1d00ccf)
 
 PatchScript: <<
 	perl -pi -e 's,(/etc/xtide\.conf),%p\1,g' libxtide/Global.cc README tide.1 xtide.1 xttpd.8


### PR DESCRIPTION
The latest version of xtide. Requires #1256. Maintainer is @akhansen 