### PR TITLE
gv: patch to use latest libxaw3dxft8

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/text/gv.info
+++ b/10.9-libcxx/stable/main/finkinfo/text/gv.info
@@ -1,6 +1,6 @@
 Package: gv
 Version: 3.7.4
-Revision: 4
+Revision: 5
 Source: gnu
 Source-Checksum: SHA256(2162b3b3a95481d3855b3c4e28f974617eef67824523e56e20b56f12fe201a61)
 BuildConflicts: libxt, libxt-flat
@@ -12,7 +12,7 @@ BuildDepends: <<
 	freetype219,
 	libgnugetopt (>= 1.2-3),
 	libiconv-dev,
-	libxaw3dxft (>= 1.6.2-7),
+	libxaw3dxft8-dev,
 	pkgconfig,
 	system-xfree86-dev (>= 3:2.7.112-3),
 	xft2-dev
@@ -25,24 +25,31 @@ PatchFile-MD5: 3e66fa49bc88296b36f74ee4d0621ee0
 PatchScript: <<
 	patch -p1 < %{PatchFile}
 	sed -i.bak 's|/usr/doc|%p/share/doc|' src/Makefile.in
+	sed -i 's|X11/Xaw3d/|X11/Xaw3dxft/|' src/paths.h
+#	sed -i 's|X11/Xaw3d/|X11/Xaw3dxft/|' configure.ac
+	sed -i 's|X11/Xaw3d/|X11/Xaw3dxft/|' configure
+#	sed -i 's|\[Xaw3d\]|\[Xaw3dxft\]|' configure.ac
+#	sed -i 's|\[xaw3d\]|\[libxaw3dxft\]|' configure.ac
+	sed -i 's|-lXaw3d|-lXaw3dxft|' configure
+	sed -i 's|\"xaw3d|\"libxaw3dxft|' configure
 <<
 Depends: <<
 	ghostscript | ghostscript-nox,
 	libgnugetopt-shlibs (>= 1.2-3),
 	libiconv,
-	libxaw3dxft-shlibs (>= 1.6.2-7),
+	libxaw3dxft8-shlibs,
+	fontconfig2-shlibs,
+	xft2-shlibs,
 	system-xfree86-shlibs (>= 3:2.7.112-3)
 <<
 ConfigureParams: <<
 	--mandir='${prefix}/share/man' \
 	--infodir='${prefix}/share/info' \
 	--enable-dependency-tracking \
-	--x-includes=/opt/X11/include \
-	--x-libraries=$X11_BASE_DIR/lib \
+	--x-includes=$X11_INCLUDE_DIR \
+	--x-libraries=$X11_LIBRARY_DIR \
 	--enable-setenv-code \
-	--enable-SIGCHLD-fallback \
-	CPPFLAGS="`pkg-config --cflags freetype2 xaw3d` $CPPFLAGS" \
-	LDFLAGS="`pkg-config --libs freetype2 xaw3d` $LDFLAGS"
+	--enable-SIGCHLD-fallback
 <<
 CompileScript: <<
 	#!/bin/sh -ev
@@ -57,10 +64,9 @@ Description: X11 interface for ghostscript interpreter
 DescPort: <<
 	o Patch GV to GV.addata to avoid potential case-sensitivity issues.
  
-	o scrollbar.c patched to provide proper number of arguments in function call
-	  https://savannah.gnu.org/bugs/index.php?35353
- 
 	o Added --enable-SIGCHLD-fallback required for Mac OS X
+
+	o Patch to use version 1.6.4+ of libxaw3dxft.
 	
 	o flag-sort used to put -I/usr/X11R6/include & -L/usr/X11R6/lib after all 
 	  Fink flags to prevent using X11's xft.h and fontconfig.h.  Could patch


### PR DESCRIPTION
A revision to gv, to compile against the latest version of libxaw3dxft. I've also cleaned up a few other bits in the info-file, removing a few unnecessary bits (e.g. the calls to pkg-config, which are now called by configure), and adding a dependency to the fontconfig2 and xft2 shlibs (which are linked in the executable).