### PR TITLE
ncview v 2.1.11

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/sci/ncview.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/ncview.info
@@ -44,7 +44,7 @@ PatchScript: <<
 # The next lines can be used to switch from "2D" Athena widgets to "3D" (with
 # appropriate dependencies). But really, this looks better in 2D.
 #	perl -pi -e 's|-lXaw|-lXaw3dxft|' configure
-#	perl -pi -e 's|-lXaw3d3d|-lXaw3dxft|' configure
+#	perl -pi -e 's|-lXaw3dxft3d|-lXaw3dxft|' configure
 #	perl -pi -e 's|X11/Xaw/|X11/Xaw3dxft/|' configure src/ncview.includes.h
 <<
 ConfigureParams: <<

--- a/10.9-libcxx/stable/main/finkinfo/sci/ncview.info
+++ b/10.9-libcxx/stable/main/finkinfo/sci/ncview.info
@@ -1,6 +1,6 @@
 Package: ncview
-Version: 2.1.9
-Revision: 2
+Version: 2.1.11
+Revision: 1
 Description: Graphical display of NetCDF files
 DescDetail: <<
 Ncview is a visual browser for netCDF format files. Typically you would use 
@@ -9,14 +9,14 @@ can view simple movies of the data, view along various dimensions, take a
 look at the actual data values, change color maps, invert the data, etc. 
 <<
 DescPort: <<
-Patchfile for implicitly declared functions no longer required. Still patch for Fink paths/libraries via PatchScript.
+Patchfile for implicitly declared functions no longer required. Still patch 
+for Fink paths/libraries via PatchScript.
 <<
 License: GPL/LGPL
 Maintainer: None <fink-devel@lists.sourceforge.net>
 Homepage: https://cirrus.ucsd.edu/ncview/
 Depends: <<
 	x11,
-	libxt-shlibs,
 	udunits2,
 	app-defaults,
 	netcdf-c19-shlibs,
@@ -26,23 +26,38 @@ Depends: <<
 BuildDepends: <<
 	netcdf-c19,
 	x11-dev,
-	libxt,
 	udunits2-dev,
 	libpng16,
 	expat1,
 	fink-buildenv-modules (>= 0.1.3-1)
 <<
+BuildConflicts: libxt, libxt-flat
 Source: https://cirrus.ucsd.edu/~pierce/%n/%n-%v.tar.gz
-Source-Checksum: SHA256(e2317ac094af62f0adcf68421d70658209436aae344640959ec8975a645891af)
+Source-Checksum: SHA256(597cfddf9c2d7993e9b0b86bca1b73839567ee9116ee33f6d750a449b5033d91)
 SourceDirectory: %n-%v
 PatchScript: <<
-perl -pi -e 's|/usr/lib/X11/app-defaults|%d%p/etc/app-defaults|' install-appdef
-perl -pi -e 's|UDUNITS2_LIBNAME=libudunits2.a|UDUNITS2_LIBNAME=libudunits2.dylib|' configure
-perl -pi -e 's|UDUNITS2_LIBS=-l\$UDUNITS2_LIBNAME|UDUNITS2_LIBS=-ludunits2|' configure
-perl -pi -e 's|PNG_LIBNAME=libpng.so|PNG_LIBNAME=libpng.dylib|' configure
-perl -pi -e 's|PNG_LIBS=-l\$PNG_LIBNAME|PNG_LIBS=-lpng|' configure
+	perl -pi -e 's|/usr/lib/X11/app-defaults|%d%p/etc/app-defaults|' install-appdef
+	perl -pi -e 's|UDUNITS2_LIBNAME=libudunits2.a|UDUNITS2_LIBNAME=libudunits2.dylib|' configure
+	perl -pi -e 's|UDUNITS2_LIBS=-l\$UDUNITS2_LIBNAME|UDUNITS2_LIBS=-ludunits2|' configure
+	perl -pi -e 's|PNG_LIBNAME=libpng.so|PNG_LIBNAME=libpng.dylib|' configure
+	perl -pi -e 's|PNG_LIBS=-l\$PNG_LIBNAME|PNG_LIBS=-lpng|' configure
+# The next lines can be used to switch from "2D" Athena widgets to "3D" (with
+# appropriate dependencies). But really, this looks better in 2D.
+#	perl -pi -e 's|-lXaw|-lXaw3dxft|' configure
+#	perl -pi -e 's|-lXaw3d3d|-lXaw3dxft|' configure
+#	perl -pi -e 's|X11/Xaw/|X11/Xaw3dxft/|' configure src/ncview.includes.h
 <<
-ConfigureParams: --prefix=%i --with-udunits2_incdir=%p/include --with-udunits2_libdir=%p/lib --with-nc-config=%p/bin/nc-config --with-png_incdir=%p/include --with-png_libdir=%p/lib --x-includes=$X11_BASE_DIR/include --x-libraries=$X11_BASE_DIR/lib --datadir=%p/share
+ConfigureParams: <<
+	--prefix=%i \
+	--with-udunits2_incdir=%p/include \
+	--with-udunits2_libdir=%p/lib \
+	--with-nc-config=%p/bin/nc-config \
+	--with-png_incdir=%p/include \
+	--with-png_libdir=%p/lib \
+	--x-includes=$X11_INCLUDE_DIR \
+	--x-libraries=$X11_LIBRARY_DIR \
+	--datadir=%p/share
+<<
 GCC: 4.0
 CompileScript: <<
 #!/bin/sh -ev


### PR DESCRIPTION
New upstream version of ncview. Switched from Fink's libxt to the built-in version. Briefly tested with libXaw3dxft, but haven't enabled it here (the extra lines are commented out in the patchscript).