### PR TITLE
doxygen: patch for latest clang compiler

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/doxygen.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/doxygen.info
@@ -4,7 +4,7 @@ Package: doxygen
 # upgrading will require patching a few packages. See:
 # https://lists.debian.org/debian-devel/2019/10/msg00260.html
 Version: 1.9.8
-Revision: 1
+Revision: 2
 Source: mirror:sourceforge:%n/%n-%v.src.tar.gz
 SourceDirectory: %n-%v
 Source-Checksum: SHA256(05e3d228e8384b5f3af9c8fd6246d22804acb731a3a24ce285c8986ed7e14f62)
@@ -20,7 +20,7 @@ BuildDepends: <<
 	libiconv-dev
 <<
 PatchFile: %n.patch
-PatchFile-MD5: 4a5fc35ee6530b4b5b06fceae64f165f
+PatchFile-MD5: 22ae70a0d74499fea8d7296514d0c8ab
 GCC: 4.0
 CompileScript: <<
 	#!/bin/sh -ev

--- a/10.9-libcxx/stable/main/finkinfo/devel/doxygen.patch
+++ b/10.9-libcxx/stable/main/finkinfo/devel/doxygen.patch
@@ -1,6 +1,6 @@
-diff -ruN doxygen-1.9.8-orig/CMakeLists.txt doxygen-1.9.8/CMakeLists.txt
---- doxygen-1.9.8-orig/CMakeLists.txt	2023-08-16 09:54:32.000000000 -0500
-+++ doxygen-1.9.8/CMakeLists.txt	2023-10-01 06:11:49.000000000 -0500
+diff -Nurd doxygen-1.9.8.orig/CMakeLists.txt doxygen-1.9.8/CMakeLists.txt
+--- doxygen-1.9.8.orig/CMakeLists.txt	2023-08-16 15:54:32
++++ doxygen-1.9.8/CMakeLists.txt	2025-08-12 13:30:13
 @@ -203,11 +203,13 @@
  include(cmake/Coverage.cmake)
  include(cmake/WindowsEncoding.cmake)
@@ -34,3 +34,79 @@ diff -ruN doxygen-1.9.8-orig/CMakeLists.txt doxygen-1.9.8/CMakeLists.txt
  
  include(cmake/packaging.cmake) # set CPACK_xxxx properties
  include(CPack)
+diff -Nurd doxygen-1.9.8.orig/deps/TinyDeflate/gunzip.hh doxygen-1.9.8/deps/TinyDeflate/gunzip.hh
+--- doxygen-1.9.8.orig/deps/TinyDeflate/gunzip.hh	2023-01-05 09:20:06
++++ doxygen-1.9.8/deps/TinyDeflate/gunzip.hh	2025-08-12 13:25:33
+@@ -702,7 +702,7 @@
+                     // Note: Throws away progress already made traversing the tree
+                     return ~std::uint_least32_t(0); // error flag
+                 }
+-                cur = (unsigned(cur) << 1) | unsigned(bool(p));
++                cur = (unsigned(cur) << 1) | bool(p);
+             #ifdef DEFL_DO_HUFF_STATS
+                 if(len > maxlen)
+                 {
+@@ -944,27 +944,23 @@
+ 
+         // The following routines are macros rather than e.g. lambda functions,
+         // in order to make them inlined in the function structure, and breakable/resumable.
+-	#define CONCAT(a, b) a##b
+ 
+         // Bit-by-bit input routine
+-        #define DummyGetBits_(line,numbits) do { \
+-            auto CONCAT(pd,line) = state.template GetBits<bool(Abortable&Flag_InputAbortable)>(std::forward<InputFunctor>(input), numbits); \
+-            if((Abortable & Flag_InputAbortable) && !~CONCAT(pd,line)) return -2; \
++        #define DummyGetBits(numbits) do { \
++            auto p = state.template GetBits<bool(Abortable&Flag_InputAbortable)>(std::forward<InputFunctor>(input), numbits); \
++            if((Abortable & Flag_InputAbortable) && !~p) return -2; \
+         } while(0)
+-        #define DummyGetBits(numbits) DummyGetBits_(__LINE__, numbits)
+ 
+-        #define GetBits_(line,numbits, target) \
+-            auto CONCAT(pb,line) = state.template GetBits<bool(Abortable&Flag_InputAbortable)>(std::forward<InputFunctor>(input), numbits); \
+-            if((Abortable & Flag_InputAbortable) && !~CONCAT(pb,line)) return -2; \
+-            target = CONCAT(pb,line)
+-        #define GetBits(numbits, target) GetBits_(__LINE__, numbits, target)
++        #define GetBits(numbits, target) \
++            auto p = state.template GetBits<bool(Abortable&Flag_InputAbortable)>(std::forward<InputFunctor>(input), numbits); \
++            if((Abortable & Flag_InputAbortable) && !~p) return -2; \
++            target = p
+ 
+         // Huffman tree read routine.
+-        #define HuffRead_(line, tree, target) \
+-            auto CONCAT(ph,line) = state.template HuffRead<bool(Abortable&Flag_InputAbortable)>(std::forward<InputFunctor>(input), tree); \
+-            if((Abortable & Flag_InputAbortable) && !~CONCAT(ph,line)) return -2; \
+-            target = CONCAT(ph,line)
+-        #define HuffRead(tree, target) HuffRead_(__LINE__, tree, target)
++        #define HuffRead(tree, target) \
++            auto p = state.template HuffRead<bool(Abortable&Flag_InputAbortable)>(std::forward<InputFunctor>(input), tree); \
++            if((Abortable & Flag_InputAbortable) && !~p) return -2; \
++            target = p
+ 
+         #define Fail_If(condition) do { \
+             /*assert(!(condition));*/ \
+@@ -1141,21 +1137,21 @@
+             //fprintf(stderr, "both track flag\n");
+             SizeTracker<DeflateTrackBothSize> tracker;
+             return tracker(Gunzip<code & Flag_NoTrackFlagMask>
+-                (tracker.template ForwardInput(i), tracker.template ForwardOutput(o), tracker.template ForwardWindow(c), std::forward<B>(b)));
++                (tracker.template ForwardInput<I>(i), tracker.template ForwardOutput<O>(o), tracker.template ForwardWindow<C>(c), std::forward<B>(b)));
+         }
+         else if constexpr(code & Flag_TrackIn)
+         {
+             //fprintf(stderr, "in track flag\n");
+             SizeTracker<DeflateTrackInSize> tracker;
+             return tracker(Gunzip<code & Flag_NoTrackFlagMask>
+-                (tracker.template ForwardInput(i),std::forward<O>(o),std::forward<C>(c),std::forward<B>(b)));
++                (tracker.template ForwardInput<I>(i),std::forward<O>(o),std::forward<C>(c),std::forward<B>(b)));
+         }
+         else if constexpr(code & Flag_TrackOut)
+         {
+             //fprintf(stderr, "out track flag\n");
+             SizeTracker<DeflateTrackOutSize> tracker;
+             return tracker(Gunzip<code & Flag_NoTrackFlagMask>
+-                (std::forward<I>(i), tracker.template ForwardOutput(o), tracker.template ForwardWindow(c), std::forward<B>(b)));
++                (std::forward<I>(i), tracker.template ForwardOutput<O>(o), tracker.template ForwardWindow<C>(c), std::forward<B>(b)));
+         }
+         else
+         {


### PR DESCRIPTION
Building doxygen failed with MacOS 15.6 and Xcode 16.4, because of missing template argument lists after the template keyword. I have modified the patch to update deps/TinyDeflate/gunzip.hh to the latest version from https://github.com/bisqwit/TinyDeflate - including the fix from #bisqwit/TinyDeflate#9