### PR TITLE
netpbm11-shlibs: fix for compiling on arm64

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/graphics/netpbm11-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/graphics/netpbm11-shlibs.info
@@ -1,6 +1,6 @@
 Package: netpbm11-shlibs
 Version: 11.07.01
-Revision: 1
+Revision: 2
 Description: Graphics manipulation programs and libraries
 License: OSI-Approved
 Maintainer: Hanspeter Niederstrasser <nieder@users.sourceforge.net>
@@ -26,6 +26,9 @@ PatchFile-MD5: 687e94819f96b785dc2a9dd96549386c
 PatchScript: <<
 	#!/bin/sh -ev
 	sed 's|@PREFIX@|%p|g' < %{PatchFile} | patch -p1
+	if [ "%m" = "arm64" ]; then
+		perl -pi -e 's|WANT_SSE	= Y|WANT_SSE	= N|' Makefile.config.fink
+	fi
 	cat config.mk.in Makefile.config.fink >config.mk
 	### don't convert libnetpbm filename to -lnetpbm when linking
 	### (avoids seeing an installed -lnetpbm)


### PR DESCRIPTION
I tried building netpbm11-shlibs on Apple Silicon running MacOS 15.6 with Xcode 16.4, and got an error because the compiler had been invoked with SSE options. I have amended the info-file to turn off the SSE options on the command line if we are running on Apple Silicon. I'm not 100% sure whether the revision needs to be bumped here, since it shouldn't actually be changing the underlying compilation.

Maintainer is @nieder 