### PR TITLE
postgresql12: fix for recent libxml2, link to Fink's python

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql12.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql12.info
@@ -1,7 +1,7 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
-Version: 12.10
-Revision: 2
+Version: 12.22
+Revision: 1
 Type: postgresql 12
 Description: PostgreSQL open-source database
 License: BSD
@@ -33,7 +33,7 @@ Provides: postgresql-server
 GCC: 4.0
 
 Source: https://ftp.postgresql.org/pub/source/v%v/postgresql-%v.tar.bz2
-Source-Checksum: SHA256(83dd192e6034951192b9a86dc19cf3717a8b82120e2f11a0a36723c820d2b257)
+Source-Checksum: SHA256(8df3c0474782589d3c6f374b5133b1bd14d168086edbc13c6e72e67dd4527a3b)
 PatchScript: <<
 	#!/bin/sh -ex
 	sed -e 's|@BUILDDIR@|%b|g' -e 's|@INSTPREFIX@|%p|g' -e 's|@PGVERSION@|%type_raw[postgresql]|g' < %{PatchFile} | patch -p1
@@ -50,7 +50,7 @@ PatchScript: <<
 	fi
 <<
 PatchFile: %n.patch
-PatchFile-MD5: 2e6a0a64cb0aa25f26c72456e524ef2d
+PatchFile-MD5: ea668e2e2009b89b361c3f1e0a767b4a
 
 SetCPPFLAGS: -DHAVE_OPTRESET -fno-common
 SetLDFLAGS: -F/System/Library/Frameworks -headerpad_max_install_names

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql12.info
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql12.info
@@ -1,7 +1,7 @@
 Info4: <<
 Package: postgresql%type_pkg[postgresql]
 Version: 12.10
-Revision: 1
+Revision: 2
 Type: postgresql 12
 Description: PostgreSQL open-source database
 License: BSD
@@ -13,6 +13,7 @@ Depends: <<
 	libxslt-shlibs,
 	openssl300-shlibs (>= 3.0.1-2),
 	passwd-postgres,
+	python310-shlibs,
 	readline8-shlibs,
 	tcltk-shlibs,
 	%N-shlibs (>= %v-%r)
@@ -23,6 +24,7 @@ BuildDepends: <<
 	libxslt,
 	readline8,
 	openssl300-dev (>= 3.0.1-2),
+	python310,
 	system-perl,
 	tcltk,
 	tcltk-dev
@@ -48,7 +50,7 @@ PatchScript: <<
 	fi
 <<
 PatchFile: %n.patch
-PatchFile-MD5: ea668e2e2009b89b361c3f1e0a767b4a
+PatchFile-MD5: 2e6a0a64cb0aa25f26c72456e524ef2d
 
 SetCPPFLAGS: -DHAVE_OPTRESET -fno-common
 SetLDFLAGS: -F/System/Library/Frameworks -headerpad_max_install_names
@@ -56,11 +58,7 @@ CompileScript: <<
 	#!/bin/sh -xe
 	
 	export PERL=/usr/bin/perl
-	if [ -x /usr/bin/python ]; then
-		export PYTHON=/usr/bin/python
-	else
-		export PYTHON=/usr/bin/python3
-	fi
+	export PYTHON=%p/bin/python3.10
 	export FLEX=/usr/bin/flex	
 
         if [[ `uname -r | cut -d. -f1` -eq 15 ]] ; then

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql12.patch
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql12.patch
@@ -1,6 +1,6 @@
-diff -urN postgresql-12.10.orig/pgsql.sh postgresql-12.10/pgsql.sh
---- postgresql-12.10.orig/pgsql.sh	1970-01-01 01:00:00
-+++ postgresql-12.10/pgsql.sh	2025-08-19 20:54:36
+diff -x '*~' -urN postgresql-12.1_original/pgsql.sh postgresql-12.1_patched/pgsql.sh
+--- postgresql-12.1_original/pgsql.sh	1970-01-01 01:00:00.000000000 +0100
++++ postgresql-12.1_patched/pgsql.sh	2019-11-24 14:47:47.000000000 +0100
 @@ -0,0 +1,87 @@
 +#!/bin/sh
 +
@@ -89,9 +89,9 @@ diff -urN postgresql-12.10.orig/pgsql.sh postgresql-12.10/pgsql.sh
 +esac
 +
 +popd
-diff -urN postgresql-12.10.orig/src/Makefile.global.in postgresql-12.10/src/Makefile.global.in
---- postgresql-12.10.orig/src/Makefile.global.in	2022-02-07 21:19:04
-+++ postgresql-12.10/src/Makefile.global.in	2025-08-19 20:54:36
+diff -x '*~' -urN postgresql-12.1_original/src/Makefile.global.in postgresql-12.1_patched/src/Makefile.global.in
+--- postgresql-12.1_original/src/Makefile.global.in	2019-11-11 23:03:10.000000000 +0100
++++ postgresql-12.1_patched/src/Makefile.global.in	2019-11-24 14:47:47.000000000 +0100
 @@ -392,6 +392,12 @@
  	$(MKDIR_P) '$(abs_top_builddir)'/tmp_install/log
  	$(MAKE) -C '$(top_builddir)' DESTDIR='$(abs_top_builddir)'/tmp_install install >'$(abs_top_builddir)'/tmp_install/log/install.log 2>&1
@@ -105,31 +105,3 @@ diff -urN postgresql-12.10.orig/src/Makefile.global.in postgresql-12.10/src/Make
  endif
  endif
  endif
-diff -urN postgresql-12.10.orig/src/backend/utils/adt/xml.c postgresql-12.10/src/backend/utils/adt/xml.c
---- postgresql-12.10.orig/src/backend/utils/adt/xml.c	2022-02-07 21:19:04
-+++ postgresql-12.10/src/backend/utils/adt/xml.c	2025-08-19 20:57:39
-@@ -119,7 +119,11 @@
- 
- static xmlParserInputPtr xmlPgEntityLoader(const char *URL, const char *ID,
- 										   xmlParserCtxtPtr ctxt);
-+#if LIBXML_VERSION >= 21200
-+static void xml_errorHandler(void *data, const xmlError *error);
-+#else
- static void xml_errorHandler(void *data, xmlErrorPtr error);
-+#endif
- static void xml_ereport_by_code(int level, int sqlcode,
- 								const char *msg, int errcode);
- static void chopStringInfoNewlines(StringInfo str);
-@@ -1751,8 +1755,12 @@
- /*
-  * Error handler for libxml errors and warnings
-  */
-+#if LIBXML_VERSION >= 21200
-+static void xml_errorHandler(void *data, const xmlError *error)
-+#else
- static void
- xml_errorHandler(void *data, xmlErrorPtr error)
-+#endif
- {
- 	PgXmlErrorContext *xmlerrcxt = (PgXmlErrorContext *) data;
- 	xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) error->ctxt;

--- a/10.9-libcxx/stable/main/finkinfo/database/postgresql12.patch
+++ b/10.9-libcxx/stable/main/finkinfo/database/postgresql12.patch
@@ -1,6 +1,6 @@
-diff -x '*~' -urN postgresql-12.1_original/pgsql.sh postgresql-12.1_patched/pgsql.sh
---- postgresql-12.1_original/pgsql.sh	1970-01-01 01:00:00.000000000 +0100
-+++ postgresql-12.1_patched/pgsql.sh	2019-11-24 14:47:47.000000000 +0100
+diff -urN postgresql-12.10.orig/pgsql.sh postgresql-12.10/pgsql.sh
+--- postgresql-12.10.orig/pgsql.sh	1970-01-01 01:00:00
++++ postgresql-12.10/pgsql.sh	2025-08-19 20:54:36
 @@ -0,0 +1,87 @@
 +#!/bin/sh
 +
@@ -89,9 +89,9 @@ diff -x '*~' -urN postgresql-12.1_original/pgsql.sh postgresql-12.1_patched/pgsq
 +esac
 +
 +popd
-diff -x '*~' -urN postgresql-12.1_original/src/Makefile.global.in postgresql-12.1_patched/src/Makefile.global.in
---- postgresql-12.1_original/src/Makefile.global.in	2019-11-11 23:03:10.000000000 +0100
-+++ postgresql-12.1_patched/src/Makefile.global.in	2019-11-24 14:47:47.000000000 +0100
+diff -urN postgresql-12.10.orig/src/Makefile.global.in postgresql-12.10/src/Makefile.global.in
+--- postgresql-12.10.orig/src/Makefile.global.in	2022-02-07 21:19:04
++++ postgresql-12.10/src/Makefile.global.in	2025-08-19 20:54:36
 @@ -392,6 +392,12 @@
  	$(MKDIR_P) '$(abs_top_builddir)'/tmp_install/log
  	$(MAKE) -C '$(top_builddir)' DESTDIR='$(abs_top_builddir)'/tmp_install install >'$(abs_top_builddir)'/tmp_install/log/install.log 2>&1
@@ -105,3 +105,31 @@ diff -x '*~' -urN postgresql-12.1_original/src/Makefile.global.in postgresql-12.
  endif
  endif
  endif
+diff -urN postgresql-12.10.orig/src/backend/utils/adt/xml.c postgresql-12.10/src/backend/utils/adt/xml.c
+--- postgresql-12.10.orig/src/backend/utils/adt/xml.c	2022-02-07 21:19:04
++++ postgresql-12.10/src/backend/utils/adt/xml.c	2025-08-19 20:57:39
+@@ -119,7 +119,11 @@
+ 
+ static xmlParserInputPtr xmlPgEntityLoader(const char *URL, const char *ID,
+ 										   xmlParserCtxtPtr ctxt);
++#if LIBXML_VERSION >= 21200
++static void xml_errorHandler(void *data, const xmlError *error);
++#else
+ static void xml_errorHandler(void *data, xmlErrorPtr error);
++#endif
+ static void xml_ereport_by_code(int level, int sqlcode,
+ 								const char *msg, int errcode);
+ static void chopStringInfoNewlines(StringInfo str);
+@@ -1751,8 +1755,12 @@
+ /*
+  * Error handler for libxml errors and warnings
+  */
++#if LIBXML_VERSION >= 21200
++static void xml_errorHandler(void *data, const xmlError *error)
++#else
+ static void
+ xml_errorHandler(void *data, xmlErrorPtr error)
++#endif
+ {
+ 	PgXmlErrorContext *xmlerrcxt = (PgXmlErrorContext *) data;
+ 	xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) error->ctxt;


### PR DESCRIPTION
There are two fixes here:

- A change in the `libxml2` headers cause an error with recent versions of clang (in `src/backend/utils/adt/xml.c`).
- And in recent versions of MacOS, we don't have the required Python headers unless the full Xcode app is installed. So one fix would be to add a build dependency on `xcode.app`. But I've opted to link to Fink's `python310`/`python310-shlibs` instead.

Tested on MacOS 15.6, Apple Silicon, Xcode 16.4. Maintainer is @wodev 