### PR TITLE
libogdi4: fix C99 errors

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libogdi4.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libogdi4.info
@@ -1,6 +1,6 @@
 Package: libogdi4
 Version: 4.1.0
-Revision: 2
+Revision: 3
 Description: OGDI - Open Geographic Datastore Interface
 License: BSD
 Homepage: http://ogdi.sourceforge.net
@@ -29,7 +29,7 @@ Source-Checksum: SHA256(e69ba86f32fa0c91564e128dd8352f8f4280fefd9b820c8e4db1a5b0
 
 # Patch Phase.
 PatchFile: %n.patch
-PatchFile-MD5: d57a7a71d01763a0e5cd4d3791b29ecb
+PatchFile-MD5: 67d048e13c34664a66d7d35ef90eb0bf
 # Compile Phase.
 SetLDFLAGS: -liconv
 ConfigureParams: <<

--- a/10.9-libcxx/stable/main/finkinfo/libs/libogdi4.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libogdi4.patch
@@ -1,6 +1,6 @@
 diff -Nurd ogdi-4.1.0.orig/config/common.mak.in ogdi-4.1.0/config/common.mak.in
---- ogdi-4.1.0.orig/config/common.mak.in	2019-04-20 13:00:51.000000000 +0100
-+++ ogdi-4.1.0/config/common.mak.in	2021-01-14 22:55:53.000000000 -0500
+--- ogdi-4.1.0.orig/config/common.mak.in	2019-04-20 13:00:51
++++ ogdi-4.1.0/config/common.mak.in	2025-08-19 20:27:41
 @@ -76,7 +76,7 @@
  #	Final OS installation location.
  #
@@ -94,8 +94,8 @@ diff -Nurd ogdi-4.1.0.orig/config/common.mak.in ogdi-4.1.0/config/common.mak.in
  install:	default-install $(EXTRA_INSTALL_TARGETS)
  
 diff -Nurd ogdi-4.1.0.orig/config/generic.mak.in ogdi-4.1.0/config/generic.mak.in
---- ogdi-4.1.0.orig/config/generic.mak.in	2019-04-20 13:00:51.000000000 +0100
-+++ ogdi-4.1.0/config/generic.mak.in	2020-12-27 15:20:53.000000000 +0000
+--- ogdi-4.1.0.orig/config/generic.mak.in	2019-04-20 13:00:51
++++ ogdi-4.1.0/config/generic.mak.in	2025-08-19 20:27:41
 @@ -37,9 +37,15 @@
  SHLIB_CFLAGS	= @C_PIC@
  COMMON_CFLAGS	= $(OPTIMIZATION) @CFLAGS@ @C_WFLAGS@ -DUNIX=1 @C_PIC@ @RPC_CFLAGS@
@@ -148,8 +148,8 @@ diff -Nurd ogdi-4.1.0.orig/config/generic.mak.in ogdi-4.1.0/config/generic.mak.i
 +	$(SHLIB_LD) -bundle $(COMMON_LDFLAGS) $(LDFLAGS) $(COMMON_CFLAGS) -o $(TOPDIR)/bin/$(TARGET)/$(LIB_PREFIX)$(TOBEGEN).$(SHLIB_EXT) $^ $(LINK_LIBS) 
 +	@echo $@ made successfully ...
 diff -Nurd ogdi-4.1.0.orig/config/unix.mak ogdi-4.1.0/config/unix.mak
---- ogdi-4.1.0.orig/config/unix.mak	2019-04-20 13:00:51.000000000 +0100
-+++ ogdi-4.1.0/config/unix.mak	2020-12-22 12:04:28.000000000 +0000
+--- ogdi-4.1.0.orig/config/unix.mak	2019-04-20 13:00:51
++++ ogdi-4.1.0/config/unix.mak	2025-08-19 20:27:41
 @@ -88,19 +88,19 @@
  
  $(PROGGEN): $(OBJECTS)
@@ -174,8 +174,8 @@ diff -Nurd ogdi-4.1.0.orig/config/unix.mak ogdi-4.1.0/config/unix.mak
  
  
 diff -Nurd ogdi-4.1.0.orig/configure ogdi-4.1.0/configure
---- ogdi-4.1.0.orig/configure	2019-04-20 13:00:51.000000000 +0100
-+++ ogdi-4.1.0/configure	2020-12-22 11:50:06.000000000 +0000
+--- ogdi-4.1.0.orig/configure	2019-04-20 13:00:51
++++ ogdi-4.1.0/configure	2025-08-19 20:27:41
 @@ -4044,8 +4044,8 @@
      as_fn_error $? "Unable to find $with_zlib/include/zlib.h" "$LINENO" 5
    fi
@@ -238,8 +238,8 @@ diff -Nurd ogdi-4.1.0.orig/configure ogdi-4.1.0/configure
  
    EXPAT_SETTING=external
 diff -Nurd ogdi-4.1.0.orig/include/Linux/ogdi_macro.h ogdi-4.1.0/include/Linux/ogdi_macro.h
---- ogdi-4.1.0.orig/include/Linux/ogdi_macro.h	2019-04-20 13:00:51.000000000 +0100
-+++ ogdi-4.1.0/include/Linux/ogdi_macro.h	2020-12-22 11:50:06.000000000 +0000
+--- ogdi-4.1.0.orig/include/Linux/ogdi_macro.h	2019-04-20 13:00:51
++++ ogdi-4.1.0/include/Linux/ogdi_macro.h	2025-08-19 20:27:41
 @@ -1,6 +1,6 @@
  #include <signal.h>
 -#include <wait.h>
@@ -250,8 +250,8 @@ diff -Nurd ogdi-4.1.0.orig/include/Linux/ogdi_macro.h ogdi-4.1.0/include/Linux/o
  
  #define ogdi_IXDR_PUT_LONG(buf, v) { \
 diff -Nurd ogdi-4.1.0.orig/ogdi/c-api/makefile ogdi-4.1.0/ogdi/c-api/makefile
---- ogdi-4.1.0.orig/ogdi/c-api/makefile	2019-04-20 13:00:51.000000000 +0100
-+++ ogdi-4.1.0/ogdi/c-api/makefile	2020-12-22 11:57:21.000000000 +0000
+--- ogdi-4.1.0.orig/ogdi/c-api/makefile	2019-04-20 13:00:51
++++ ogdi-4.1.0/ogdi/c-api/makefile	2025-08-19 20:27:41
 @@ -13,11 +13,7 @@
  
  TOBEGEN	= ogdi
@@ -265,8 +265,8 @@ diff -Nurd ogdi-4.1.0.orig/ogdi/c-api/makefile ogdi-4.1.0/ogdi/c-api/makefile
  SOURCES = ecs_dyna.c ecssplit.c \
            ecsassoc.c ecstile.c server.c ecsdist.c \
 diff -Nurd ogdi-4.1.0.orig/ogdi/c-api/server.c ogdi-4.1.0/ogdi/c-api/server.c
---- ogdi-4.1.0.orig/ogdi/c-api/server.c	2019-04-20 13:00:51.000000000 +0100
-+++ ogdi-4.1.0/ogdi/c-api/server.c	2020-12-22 12:07:17.000000000 +0000
+--- ogdi-4.1.0.orig/ogdi/c-api/server.c	2019-04-20 13:00:51
++++ ogdi-4.1.0/ogdi/c-api/server.c	2025-08-19 20:27:41
 @@ -292,7 +292,7 @@
    res = s->createserver(s,url); 
    if (res == NULL) {
@@ -277,8 +277,8 @@ diff -Nurd ogdi-4.1.0.orig/ogdi/c-api/server.c ogdi-4.1.0/ogdi/c-api/server.c
      return res;
      }
 diff -Nurd ogdi-4.1.0.orig/ogdi/driver/rpf/rpf.h ogdi-4.1.0/ogdi/driver/rpf/rpf.h
---- ogdi-4.1.0.orig/ogdi/driver/rpf/rpf.h	2019-04-20 13:00:51.000000000 +0100
-+++ ogdi-4.1.0/ogdi/driver/rpf/rpf.h	2020-12-22 11:50:06.000000000 +0000
+--- ogdi-4.1.0.orig/ogdi/driver/rpf/rpf.h	2019-04-20 13:00:51
++++ ogdi-4.1.0/ogdi/driver/rpf/rpf.h	2025-08-19 20:27:41
 @@ -74,7 +74,7 @@
  typedef unsigned short ushort;
  typedef unsigned long  uint;
@@ -318,8 +318,8 @@ diff -Nurd ogdi-4.1.0.orig/ogdi/driver/rpf/rpf.h ogdi-4.1.0/ogdi/driver/rpf/rpf.
  } Frame_file;
  
 diff -Nurd ogdi-4.1.0.orig/vpflib/reduce2.c ogdi-4.1.0/vpflib/reduce2.c
---- ogdi-4.1.0.orig/vpflib/reduce2.c	2019-04-20 13:00:51.000000000 +0100
-+++ ogdi-4.1.0/vpflib/reduce2.c	2020-12-22 11:50:06.000000000 +0000
+--- ogdi-4.1.0.orig/vpflib/reduce2.c	2019-04-20 13:00:51
++++ ogdi-4.1.0/vpflib/reduce2.c	2025-08-19 20:27:41
 @@ -11,8 +11,8 @@
  #include "reduce2.h"
  #endif
@@ -331,3 +331,25 @@ diff -Nurd ogdi-4.1.0.orig/vpflib/reduce2.c ogdi-4.1.0/vpflib/reduce2.c
  #define  DOCNT(i,t,n)   (_d_l=n, (_d_m=(t-(i)+_d_l)/_d_l) > 0 ? _d_m : 0L )
  
  /*    General purpose tools for polyline reduction:
+diff -Nurd ogdi-4.1.0.orig/vpflib/vpfprop.c ogdi-4.1.0/vpflib/vpfprop.c
+--- ogdi-4.1.0.orig/vpflib/vpfprop.c	2019-04-20 13:00:51
++++ ogdi-4.1.0/vpflib/vpfprop.c	2025-08-19 20:27:55
+@@ -840,7 +840,8 @@
+ #endif
+ 
+ {
+-  int32 ncov,i,j,k,n;
++  char ncov;
++  int32 i,j,k,n;
+   char path[255];
+   char **ptr, **coverages, **subset, **fcnames=(char **)NULL;
+ 
+@@ -1446,7 +1447,7 @@
+                  int32 *nfc )
+ #else
+    char **coverage_feature_class_names (library_path, coverage, nfc)
+-      char *library_path, coverage;
++      char *library_path, *coverage;
+       int32 *nfc;
+ #endif
+ 


### PR DESCRIPTION
Added libogdi/ogdi#28 to the patchfile to fix building with recent versions of Clang.

Maintainer is @babayoshihiko 