### PR TITLE
gdal3: fix for recent libxml2, bump dependencies

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/gdal3.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/gdal3.info
@@ -2,7 +2,7 @@ Info3: <<
 Package: gdal3
 # v3.4.3: libN=30
 Version: 3.2.3
-Revision: 2
+Revision: 3
 
 Depends: %n-shlibs (= %v-%r)
 
@@ -20,7 +20,7 @@ BuildDepends: <<
   hdf5.200.v1.12,
   ilmbase24-dev (>= 2.4.2-2),
   json-c5,
-  libcfitsio8-dev,
+  libcfitsio10-dev,
   libcryptopp5-dev,
   libcurl4,
   libdap11,
@@ -44,7 +44,7 @@ BuildDepends: <<
   libwebp7,
   libxml2 (>= 2.9.1-1),
   netcdf-bin,
-  netcdf-c18,
+  netcdf-c19,
   pkgconfig,
   postgresql12-dev,
   qhull8.0-dev (>= 2020.2-2),
@@ -58,6 +58,8 @@ GCC: 4.0
 Source: https://download.osgeo.org/gdal/%v/gdal-%v.tar.xz
 # SourceDirectory: gdal-%v
 Source-Checksum: SHA256(d9ec8458fe97fd02bf36379e7f63eaafce1005eeb60e329ed25bb2d2a17a796f)
+PatchFile: %n.patch
+PatchFile-MD5: afc65f1fa47ae8774c9e2069d6da8c1d
 
 # -MD for automatic header dependency tracking (not sure no standard
 # libtool --enable-dependency-tracking flag for this feature) --dmacks
@@ -66,6 +68,8 @@ SetCC: flag-sort gcc
 SetCXX: flag-sort g++
 
 PatchScript: <<
+  %{default_script}
+  
   # Address https://trac.osgeo.org/gdal/ticket/6607
   # (installation location of bash-completions)
   perl -pi -e 's|-rs \$\(DESTDIR\)\$\(INST_BASH_COMPLETION\)/gdalinfo|-s gdalinfo|' scripts/GNUmakefile
@@ -175,7 +179,7 @@ SplitOff: <<
     hdf5.200.v1.12-shlibs,
     ilmbase24-shlibs,
     json-c5-shlibs,
-    libcfitsio8-shlibs,
+    libcfitsio10-shlibs,
     libcryptopp5-shlibs,
     libcurl4-shlibs,
     libdap11-shlibs,
@@ -198,7 +202,7 @@ SplitOff: <<
     libtiff6-shlibs,
     libwebp7-shlibs,
     libxml2-shlibs (>= 2.9.1-1),
-    netcdf-c18-shlibs,
+    netcdf-c19-shlibs,
     postgresql12-shlibs,
     qhull8.0-shlibs (>= 2020.2-2),
     sqlite3-shlibs,

--- a/10.9-libcxx/stable/main/finkinfo/libs/gdal3.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/gdal3.patch
@@ -1,0 +1,30 @@
+diff -Nurd gdal-3.2.3.orig/gcore/gdaljp2metadatagenerator.cpp gdal-3.2.3/gcore/gdaljp2metadatagenerator.cpp
+--- gdal-3.2.3.orig/gcore/gdaljp2metadatagenerator.cpp	2021-04-27 10:11:16
++++ gdal-3.2.3/gcore/gdaljp2metadatagenerator.cpp	2025-08-19 21:35:20
+@@ -345,7 +345,11 @@
+ /************************************************************************/
+ 
+ static void GDALGMLJP2XPathErrorHandler( void * /* userData */,
++#if LIBXML_VERSION >= 21200
++                                         const xmlError *error)
++#else
+                                          xmlErrorPtr error)
++#endif
+ {
+     if( error->domain == XML_FROM_XPATH &&
+         error->str1 != nullptr &&
+diff -Nurd gdal-3.2.3.orig/port/cpl_xml_validate.cpp gdal-3.2.3/port/cpl_xml_validate.cpp
+--- gdal-3.2.3.orig/port/cpl_xml_validate.cpp	2021-04-27 10:13:57
++++ gdal-3.2.3/port/cpl_xml_validate.cpp	2025-08-19 21:34:30
+@@ -920,7 +920,11 @@
+ 
+     if( strstr(pszStr, "since this namespace was already imported") == nullptr )
+     {
++#if LIBXML_VERSION >= 21200
++        const xmlError *pErrorPtr = xmlGetLastError();
++#else
+         xmlErrorPtr pErrorPtr = xmlGetLastError();
++#endif
+         const char* pszFilename = static_cast<char *>(ctx);
+         char* pszStrDup = CPLStrdup(pszStr);
+         int nLen = static_cast<int>(strlen(pszStrDup));


### PR DESCRIPTION
A change in the `libxml2` headers cause an error with recent versions of clang (fixed in the patchfile).

And at the same time I have bumped dependencies from `libcfitsio8` to `libcfitsio10`, and from `netcdf-c18` to `netcdf-c19`.

Tested on MacOS 15.6, Apple Silicon, Xcode 16.4.