### PR TITLE
poppler - update for c11++ compatibility

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/poppler5.1-qt5-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/poppler5.1-qt5-shlibs.info
@@ -38,7 +38,7 @@ GCC: 4.0
 Source: http://poppler.freedesktop.org/poppler-%v.tar.xz
 Source-Checksum: SHA256(b872e7228fc34a71ce4b47a5aea2a57ae67528818fa846e1e0eda089319bd242)
 PatchFile: poppler63-shlibs.patch
-PatchFile-MD5: 2c829d4be6275ac43e2a16008ef7cf7b
+PatchFile-Checksum: SHA256(a87e4abdb39589cbe40bd3659ab9cfde16b4a98984095710c260f2e452e6078f)
 PatchScript: <<
 	%{default_script}
 	# autoconf2.6ish patch for modern XQuartz paths

--- a/10.9-libcxx/stable/main/finkinfo/libs/poppler63-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/poppler63-shlibs.info
@@ -42,7 +42,7 @@ GCC: 4.0
 Source: http://poppler.freedesktop.org/poppler-%v.tar.xz
 Source-Checksum: SHA256(b872e7228fc34a71ce4b47a5aea2a57ae67528818fa846e1e0eda089319bd242)
 PatchFile: poppler63-shlibs.patch
-PatchFile-MD5: 2c829d4be6275ac43e2a16008ef7cf7b
+PatchFile-Checksum: SHA256(a87e4abdb39589cbe40bd3659ab9cfde16b4a98984095710c260f2e452e6078f)
 PatchScript: <<
 	%{default_script}
 	# autoconf2.6ish patch for modern XQuartz paths

--- a/10.9-libcxx/stable/main/finkinfo/libs/poppler63-shlibs.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/poppler63-shlibs.patch
@@ -1,6 +1,6 @@
-diff -Nurd poppler-0.47.0.orig/configure poppler-0.47.0/configure
---- poppler-0.47.0.orig/configure	2016-08-18 16:16:43.000000000 -0400
-+++ poppler-0.47.0/configure	2022-01-07 07:36:18.000000000 -0500
+diff -Nurd poppler-0.47.0-orig/configure poppler-0.47.0/configure
+--- poppler-0.47.0-orig/configure	2016-08-18 16:16:43
++++ poppler-0.47.0/configure	2025-10-04 17:56:26
 @@ -18531,6 +18531,7 @@
      CXXFLAGS="$CXXFLAGS -D__USE_MINGW_ANSI_STDIO=1"
    ;;
@@ -24,9 +24,9 @@ diff -Nurd poppler-0.47.0.orig/configure poppler-0.47.0/configure
  
  
  
-diff -Nurd poppler-0.47.0.orig/glib/Makefile.in poppler-0.47.0/glib/Makefile.in
---- poppler-0.47.0.orig/glib/Makefile.in	2016-08-18 16:16:50.000000000 -0400
-+++ poppler-0.47.0/glib/Makefile.in	2022-01-07 07:36:18.000000000 -0500
+diff -Nurd poppler-0.47.0-orig/glib/Makefile.in poppler-0.47.0/glib/Makefile.in
+--- poppler-0.47.0-orig/glib/Makefile.in	2016-08-18 16:16:50
++++ poppler-0.47.0/glib/Makefile.in	2025-10-04 17:56:26
 @@ -143,7 +143,6 @@
  LTLIBRARIES = $(lib_LTLIBRARIES)
  am__DEPENDENCIES_1 =
@@ -44,9 +44,9 @@ diff -Nurd poppler-0.47.0.orig/glib/Makefile.in poppler-0.47.0/glib/Makefile.in
  	$(top_builddir)/poppler/libpoppler-cairo.la	\
  	$(PTHREAD_LIBS)					\
  	$(POPPLER_GLIB_LIBS)				\
-diff -Nurd poppler-0.47.0.orig/glib/demo/Makefile.in poppler-0.47.0/glib/demo/Makefile.in
---- poppler-0.47.0.orig/glib/demo/Makefile.in	2016-08-18 16:16:50.000000000 -0400
-+++ poppler-0.47.0/glib/demo/Makefile.in	2022-01-07 07:36:18.000000000 -0500
+diff -Nurd poppler-0.47.0-orig/glib/demo/Makefile.in poppler-0.47.0/glib/demo/Makefile.in
+--- poppler-0.47.0-orig/glib/demo/Makefile.in	2016-08-18 16:16:50
++++ poppler-0.47.0/glib/demo/Makefile.in	2025-10-04 17:56:26
 @@ -131,7 +131,7 @@
  am__DEPENDENCIES_1 =
  poppler_glib_demo_DEPENDENCIES =  \
@@ -65,9 +65,9 @@ diff -Nurd poppler-0.47.0.orig/glib/demo/Makefile.in poppler-0.47.0/glib/demo/Ma
  	$(GTK_TEST_LIBS)
  
  all: all-am
-diff -Nurd poppler-0.47.0.orig/glib/poppler-annot.cc poppler-0.47.0/glib/poppler-annot.cc
---- poppler-0.47.0.orig/glib/poppler-annot.cc	2016-05-01 18:08:03.000000000 -0400
-+++ poppler-0.47.0/glib/poppler-annot.cc	2022-01-07 07:36:18.000000000 -0500
+diff -Nurd poppler-0.47.0-orig/glib/poppler-annot.cc poppler-0.47.0/glib/poppler-annot.cc
+--- poppler-0.47.0-orig/glib/poppler-annot.cc	2016-05-01 18:08:03
++++ poppler-0.47.0/glib/poppler-annot.cc	2025-10-04 17:59:51
 @@ -264,6 +264,26 @@
    return _poppler_create_annot (POPPLER_TYPE_ANNOT_TEXT_MARKUP, annot);
  }
@@ -83,7 +83,7 @@ diff -Nurd poppler-0.47.0.orig/glib/poppler-annot.cc poppler-0.47.0/glib/poppler
 +{
 +  if (SIZE_OVERFLOWS (n_blocks, n_block_bytes))
 +    {
-+      g_error ("%s: overflow allocating %"G_GSIZE_FORMAT"*%"G_GSIZE_FORMAT" bytes",
++      g_error ("%s: overflow allocating %" G_GSIZE_FORMAT"*%" G_GSIZE_FORMAT" bytes",
 +               G_STRLOC, n_blocks, n_block_bytes);
 +    }
 +
@@ -104,9 +104,9 @@ diff -Nurd poppler-0.47.0.orig/glib/poppler-annot.cc poppler-0.47.0/glib/poppler
      sizeof (AnnotQuadrilaterals::AnnotQuadrilateral *),
      quads->len);
  
-diff -Nurd poppler-0.47.0.orig/glib/reference/Makefile.in poppler-0.47.0/glib/reference/Makefile.in
---- poppler-0.47.0.orig/glib/reference/Makefile.in	2016-08-18 16:16:50.000000000 -0400
-+++ poppler-0.47.0/glib/reference/Makefile.in	2022-01-07 07:36:18.000000000 -0500
+diff -Nurd poppler-0.47.0-orig/glib/reference/Makefile.in poppler-0.47.0/glib/reference/Makefile.in
+--- poppler-0.47.0-orig/glib/reference/Makefile.in	2016-08-18 16:16:50
++++ poppler-0.47.0/glib/reference/Makefile.in	2025-10-04 17:56:26
 @@ -425,7 +425,7 @@
  	$(POPPLER_GLIB_CFLAGS)				\
  	$(FREETYPE_CFLAGS)
@@ -116,18 +116,18 @@ diff -Nurd poppler-0.47.0.orig/glib/reference/Makefile.in poppler-0.47.0/glib/re
  	$(top_builddir)/glib/libpoppler-glib.la		\
  	$(POPPLER_GLIB_LIBS)				\
  	$(FREETYPE_LIBS)				\
-diff -Nurd poppler-0.47.0.orig/poppler-cairo.pc.in poppler-0.47.0/poppler-cairo.pc.in
---- poppler-0.47.0.orig/poppler-cairo.pc.in	2013-09-25 15:47:34.000000000 -0400
-+++ poppler-0.47.0/poppler-cairo.pc.in	2022-01-07 07:36:18.000000000 -0500
+diff -Nurd poppler-0.47.0-orig/poppler-cairo.pc.in poppler-0.47.0/poppler-cairo.pc.in
+--- poppler-0.47.0-orig/poppler-cairo.pc.in	2013-09-25 15:47:34
++++ poppler-0.47.0/poppler-cairo.pc.in	2025-10-04 17:56:26
 @@ -6,4 +6,4 @@
  Name: poppler-cairo
  Description: Cairo backend for Poppler PDF rendering library
  Version: @VERSION@
 -Requires: poppler = @VERSION@ cairo >= @CAIRO_VERSION@
 +Requires: poppler = @VERSION@
-diff -Nurd poppler-0.47.0.orig/qt4/demos/Makefile.in poppler-0.47.0/qt4/demos/Makefile.in
---- poppler-0.47.0.orig/qt4/demos/Makefile.in	2016-08-18 16:16:51.000000000 -0400
-+++ poppler-0.47.0/qt4/demos/Makefile.in	2022-01-07 07:36:18.000000000 -0500
+diff -Nurd poppler-0.47.0-orig/qt4/demos/Makefile.in poppler-0.47.0/qt4/demos/Makefile.in
+--- poppler-0.47.0-orig/qt4/demos/Makefile.in	2016-08-18 16:16:51
++++ poppler-0.47.0/qt4/demos/Makefile.in	2025-10-04 17:56:26
 @@ -125,7 +125,6 @@
  poppler_qt4viewer_OBJECTS = $(am_poppler_qt4viewer_OBJECTS)
  am__DEPENDENCIES_1 =
@@ -145,9 +145,9 @@ diff -Nurd poppler-0.47.0.orig/qt4/demos/Makefile.in poppler-0.47.0/qt4/demos/Ma
  	$(top_builddir)/qt4/src/libpoppler-qt4.la	\
  	$(POPPLER_QT4_LIBS)
  
-diff -Nurd poppler-0.47.0.orig/qt4/src/Makefile.in poppler-0.47.0/qt4/src/Makefile.in
---- poppler-0.47.0.orig/qt4/src/Makefile.in	2016-08-18 16:16:51.000000000 -0400
-+++ poppler-0.47.0/qt4/src/Makefile.in	2022-01-07 07:36:18.000000000 -0500
+diff -Nurd poppler-0.47.0-orig/qt4/src/Makefile.in poppler-0.47.0/qt4/src/Makefile.in
+--- poppler-0.47.0-orig/qt4/src/Makefile.in	2016-08-18 16:16:51
++++ poppler-0.47.0/qt4/src/Makefile.in	2025-10-04 17:56:26
 @@ -139,7 +139,7 @@
  LTLIBRARIES = $(lib_LTLIBRARIES)
  am__DEPENDENCIES_1 =
@@ -166,9 +166,9 @@ diff -Nurd poppler-0.47.0.orig/qt4/src/Makefile.in poppler-0.47.0/qt4/src/Makefi
  	$(POPPLER_QT4_LIBS)
  
  libpoppler_qt4_la_LDFLAGS = \
-diff -Nurd poppler-0.47.0.orig/qt4/tests/Makefile.in poppler-0.47.0/qt4/tests/Makefile.in
---- poppler-0.47.0.orig/qt4/tests/Makefile.in	2016-08-18 16:16:52.000000000 -0400
-+++ poppler-0.47.0/qt4/tests/Makefile.in	2022-01-07 07:36:18.000000000 -0500
+diff -Nurd poppler-0.47.0-orig/qt4/tests/Makefile.in poppler-0.47.0/qt4/tests/Makefile.in
+--- poppler-0.47.0-orig/qt4/tests/Makefile.in	2016-08-18 16:16:52
++++ poppler-0.47.0/qt4/tests/Makefile.in	2025-10-04 17:56:26
 @@ -150,7 +150,7 @@
  @BUILD_POPPLER_QT4_TRUE@	check_actualtext.$(OBJEXT)
  check_actualtext_OBJECTS = $(am_check_actualtext_OBJECTS)
@@ -258,9 +258,9 @@ diff -Nurd poppler-0.47.0.orig/qt4/tests/Makefile.in poppler-0.47.0/qt4/tests/Ma
  	$(top_builddir)/qt4/src/libpoppler-qt4.la	\
  	$(POPPLER_QT4_LIBS)
  
-diff -Nurd poppler-0.47.0.orig/qt5/demos/Makefile.in poppler-0.47.0/qt5/demos/Makefile.in
---- poppler-0.47.0.orig/qt5/demos/Makefile.in	2016-08-18 16:16:52.000000000 -0400
-+++ poppler-0.47.0/qt5/demos/Makefile.in	2022-01-07 07:36:18.000000000 -0500
+diff -Nurd poppler-0.47.0-orig/qt5/demos/Makefile.in poppler-0.47.0/qt5/demos/Makefile.in
+--- poppler-0.47.0-orig/qt5/demos/Makefile.in	2016-08-18 16:16:52
++++ poppler-0.47.0/qt5/demos/Makefile.in	2025-10-04 17:56:26
 @@ -125,7 +125,6 @@
  poppler_qt5viewer_OBJECTS = $(am_poppler_qt5viewer_OBJECTS)
  am__DEPENDENCIES_1 =
@@ -278,9 +278,9 @@ diff -Nurd poppler-0.47.0.orig/qt5/demos/Makefile.in poppler-0.47.0/qt5/demos/Ma
  	$(top_builddir)/qt5/src/libpoppler-qt5.la	\
  	$(POPPLER_QT5_LIBS)
  
-diff -Nurd poppler-0.47.0.orig/qt5/src/Makefile.in poppler-0.47.0/qt5/src/Makefile.in
---- poppler-0.47.0.orig/qt5/src/Makefile.in	2016-08-18 16:16:52.000000000 -0400
-+++ poppler-0.47.0/qt5/src/Makefile.in	2022-01-07 07:36:18.000000000 -0500
+diff -Nurd poppler-0.47.0-orig/qt5/src/Makefile.in poppler-0.47.0/qt5/src/Makefile.in
+--- poppler-0.47.0-orig/qt5/src/Makefile.in	2016-08-18 16:16:52
++++ poppler-0.47.0/qt5/src/Makefile.in	2025-10-04 17:56:26
 @@ -139,7 +139,7 @@
  LTLIBRARIES = $(lib_LTLIBRARIES)
  am__DEPENDENCIES_1 =
@@ -299,9 +299,9 @@ diff -Nurd poppler-0.47.0.orig/qt5/src/Makefile.in poppler-0.47.0/qt5/src/Makefi
  	$(POPPLER_QT5_LIBS)
  
  libpoppler_qt5_la_LDFLAGS = \
-diff -Nurd poppler-0.47.0.orig/qt5/tests/Makefile.in poppler-0.47.0/qt5/tests/Makefile.in
---- poppler-0.47.0.orig/qt5/tests/Makefile.in	2016-08-18 16:16:52.000000000 -0400
-+++ poppler-0.47.0/qt5/tests/Makefile.in	2022-01-07 07:36:18.000000000 -0500
+diff -Nurd poppler-0.47.0-orig/qt5/tests/Makefile.in poppler-0.47.0/qt5/tests/Makefile.in
+--- poppler-0.47.0-orig/qt5/tests/Makefile.in	2016-08-18 16:16:52
++++ poppler-0.47.0/qt5/tests/Makefile.in	2025-10-04 17:56:26
 @@ -150,7 +150,7 @@
  @BUILD_POPPLER_QT5_TRUE@	check_actualtext.$(OBJEXT)
  check_actualtext_OBJECTS = $(am_check_actualtext_OBJECTS)

--- a/10.9-libcxx/stable/main/finkinfo/libs/poppler8-glib-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/poppler8-glib-shlibs.info
@@ -2,7 +2,7 @@ Package: poppler8-glib-shlibs
 # NOTE: Must keep %v in sync among a bunch of poppler packages!
 # poppler8-glib and poppler4.4-qt4/poppler5.1-qt5 go with poppler63
 Version: 0.47.0
-Revision: 1
+Revision: 2
 Description: PDF rendering library (GLIB Interface)
 License: GPL
 Maintainer: Daniel Macks <dmacks@netspace.org>
@@ -36,7 +36,7 @@ GCC: 4.0
 Source: http://poppler.freedesktop.org/poppler-%v.tar.xz
 Source-Checksum: SHA256(b872e7228fc34a71ce4b47a5aea2a57ae67528818fa846e1e0eda089319bd242)
 PatchFile: poppler63-shlibs.patch
-PatchFile-MD5: 2c829d4be6275ac43e2a16008ef7cf7b
+PatchFile-Checksum: SHA256(a87e4abdb39589cbe40bd3659ab9cfde16b4a98984095710c260f2e452e6078f)
 PatchScript: <<
 	%{default_script}
 	# autoconf2.6ish patch for modern XQuartz paths
@@ -48,8 +48,6 @@ PatchScript: <<
 	perl -pi -e 's/G_PARAM_READWRITE/(GParamFlags)G_PARAM_READWRITE/g' glib/poppler-document.cc
 <<
 
-# new c++11 strictness doesn't like compiling libglib's pure-C code
-SetCPPFLAGS: -Wno-error=reserved-user-defined-literal
 ConfigureParams: <<
 	--mandir=%p/share/man \
 	--enable-dependency-tracking \


### PR DESCRIPTION
Added two spaces to c++ literals in patch file.  Builds all versions of poppler on intel and arm Xcode 16.4 and 26.0   qt4 and qt5 versions do not build since qt4 and qt5 do not build.
%" G_GSIZE_FORMAT" on lline ~248 of poppler-annot.cc