### PR TITLE
libaudiofile: Fixes for newer gcc; +latest Debian CVE patches

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/libaudiofile1.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libaudiofile1.info
@@ -1,13 +1,14 @@
 Package: libaudiofile1
 Version: 0.3.6
-Revision: 1
+Revision: 2
 Epoch: 1
 ###
 Depends: %N-shlibs (= %e:%v-%r)
 BuildDepends: <<
   fink (>= 0.32.0),
   fink-package-precedence,
-  libflac8-dev
+  libflac12-dev,
+  pkgconfig
 <<
 BuildDependsOnly: true
 Replaces: audiofile
@@ -15,20 +16,20 @@ Conflicts: audiofile
 ###
 Source: https://audiofile.68k.org/audiofile-%v.tar.gz
 Source-Checksum: SHA256(cdc60df19ab08bfe55344395739bb08f50fc15c92da3962fac334d3bff116965)
-Source2: http://archive.ubuntu.com/ubuntu/pool/universe/a/audiofile/audiofile_%v-5build1.debian.tar.xz
-Source2-Checksum: SHA256(a4090f311416bd93c155e119c86f5eb285cc4b545ed907f9b736576958fe2410)
+Source2: mirror:debian:pool/main/a/audiofile/audiofile_%v-7.debian.tar.xz
+Source2-Checksum: SHA256(41f1cf70dd6f1ddf30ac452f94835d108bd585eef98586f4d40b0af69514baa2)
 ###
+# Equivalent to https://github.com/mpruett/audiofile/commit/b62c902dd258125cac86cd2df21fc898035a43d3
+# but applies on top of debian's 01_gcc6.patch
+# Also https://patchwork.yoctoproject.org/project/oe/patch/20251114013528.108047-1-raj.khem@gmail.com
+PatchFile: %n.patch
+PatchFile-MD5: 10b2adc418c80f6f62890b1c62838fe0
 PatchScript: <<
-	patch -p1 < ../debian/patches/03_CVE-2015-7747.patch
-	patch -p1 < ../debian/patches/04_clamp-index-values-to-fix-index-overflow-in-IMA.cpp.patch
-	patch -p1 < ../debian/patches/05_Always-check-the-number-of-coefficients.patch
-	patch -p1 < ../debian/patches/06_Check-for-multiplication-overflow-in-MSADPCM-decodeSam.patch
-	patch -p1 < ../debian/patches/07_Check-for-multiplication-overflow-in-sfconvert.patch
-	patch -p1 < ../debian/patches/08_Fix-signature-of-multiplyCheckOverflow.-It-returns-a-b.patch
-	patch -p1 < ../debian/patches/09_Actually-fail-when-error-occurs-in-parseFormat.patch
-	patch -p1 < ../debian/patches/10_Check-for-division-by-zero-in-BlockCodec-runPull.patch
-	patch -p1 < ../debian/patches/11_CVE-2018-13440.patch
-	patch -p1 < ../debian/patches/12_CVE-2018-17095.patch
+#!/bin/sh -ev
+	for f in `cat ../debian/patches/series`; do
+		patch -p1 < ../debian/patches/$f
+	done
+	%{default_script}
 <<
 GCC: 4.0
 ConfigureParams: <<
@@ -62,12 +63,12 @@ SplitOff: <<
   Shlibs: <<
     %p/lib/libaudiofile.1.dylib 2.0.0 libaudiofile1-shlibs (>= 0.3.4-1)
   <<
-  DocFiles: ACKNOWLEDGEMENTS AUTHORS COPYING* ChangeLog INSTALL NEWS NOTES README TODO
+  DocFiles: ACKNOWLEDGEMENTS AUTHORS COPYING* ChangeLog NEWS NOTES README TODO
   Description: Audio File Library *Shared Libraries*
 <<
 SplitOff2: <<
   Package: audiofile-bin
-  Depends: %N-shlibs (= %e:%v-%r), libflac8
+  Depends: %N-shlibs (= %e:%v-%r), libflac12
   Files: <<
     bin/sfconvert
     bin/sfinfo

--- a/10.9-libcxx/stable/main/finkinfo/libs/libaudiofile1.patch
+++ b/10.9-libcxx/stable/main/finkinfo/libs/libaudiofile1.patch
@@ -1,0 +1,25 @@
+diff -Nurd audiofile-0.3.6.orig/libaudiofile/modules/SimpleModule.h audiofile-0.3.6/libaudiofile/modules/SimpleModule.h
+--- audiofile-0.3.6.orig/libaudiofile/modules/SimpleModule.h	2025-11-25 00:40:26
++++ audiofile-0.3.6/libaudiofile/modules/SimpleModule.h	2025-11-25 00:39:41
+@@ -123,7 +123,8 @@
+ 	typedef typename IntTypes<Format>::UnsignedType UnsignedType;
+ 
+ 	static const int kScaleBits = (Format + 1) * CHAR_BIT - 1;
+-	static const int kMinSignedValue = 0-(1U<<kScaleBits);
++	static const int kMaxSignedValue = (((1 << (kScaleBits - 1)) - 1) << 1) + 1;
++	static const int kMinSignedValue = -kMaxSignedValue - 1;
+ 
+ 	struct signedToUnsigned : public std::unary_function<SignedType, UnsignedType>
+ 	{
+diff -Nurd audiofile-0.3.6.orig/test/Sign.cpp audiofile-0.3.6/test/Sign.cpp
+--- audiofile-0.3.6.orig/test/Sign.cpp	2025-11-25 00:40:26
++++ audiofile-0.3.6/test/Sign.cpp	2025-11-25 08:19:23
+@@ -157,7 +157,7 @@
+ 	AFframecount framesRead = afReadFrames(file, AF_DEFAULT_TRACK, readData, frameCount);
+ 	ASSERT_EQ(framesRead, frameCount);
+ 	afCloseFile(file);
+-	const uint32_t expectedData[] = { 0, -kMinInt32, kMaxUInt32 };
++	const uint32_t expectedData[] = { 0, static_cast<uint32_t>(-static_cast<int64_t>(kMinInt32)), kMaxUInt32 };
+ 	for (int i=0; i<frameCount; i++)
+ 		EXPECT_EQ(readData[i], expectedData[i]);
+ }


### PR DESCRIPTION
Fixes #1286