### PR TITLE
duplicity upstream update to V3.0.7

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/utils/duplicity.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/duplicity.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: duplicity
-Version: 3.0.2
+Version: 3.0.6.3
 Revision: 1
 Description: Encrypted backup using rsync algorithm
 License: GPL
@@ -10,18 +10,17 @@ Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
 # Dependencies.
 BuildDepends: <<
 	fink (>= 0.24.12-1),
-	librsync (>= 0.9.7-1002),
+	librsync2,
 	sphinx-py310
 <<
 
 # boto3-py, ncftp, lft2, par2, pexepect, fastners-py, lxml-py310 needed for backends
 Depends: <<
 	python310,
-	librsync-shlibs (>= 0.9.7-1002),
+	librsync2-shlibs (>= 2.0),
 	gnupg2,
 	intltool40,
 	ncftp,
-	lftp,
 	par2,
 	setuptools-tng-py310,
 	boto3-py310,
@@ -31,10 +30,11 @@ Depends: <<
 	pexpect-py310,
 	requests-oauthlib-py310
 <<
+#	lftp,   Removed from dependencies since does not build
 
 # Unpack Phase.
 Source: https://gitlab.com/%n/%n/-/archive/rel.%v/%n-rel.%v.tar.gz
-Source-Checksum: SHA256(a3ae582e0eb3070e0147ad8d4115a590932bcb2d47fca79c9ae81c82dc9bb1a8)
+Source-Checksum: SHA256(57e2ff9f0e3296f26b3d86e6cac23c7b814f99352633fc3cc1775d0dd042bfad)
 
 # Patch Phase.
 PatchScript: <<
@@ -52,7 +52,9 @@ InfoTest: <<
 	pytest-cov-py310,
 	pytest-runner-py310,
 	coverage-py310,
-	pycodestyle-py310
+	black-py310 (>=24.8.0),
+	pycodestyle-py310,
+	pylint-py310
     <<
     TestScript: <<
     	#!/bin/sh -ev
@@ -95,13 +97,15 @@ Documentation not built and installed since
 exists on the web.
 The testing phase needs more than the default 256
 maximum files, it is set to 8192 in the test script.
-Testing Phase (on MacOS 14.6.1) has
-461 passed, 17 skipped in 659.93s (0:10:59)
+Testing Phase (on MacOS 15.3.1) has
+3 failed, 461 passed, 17 skipped, 1 xpassed (700.03s)
+1 failed test due to not installing rdiff
+1 failed test due to not installing black-py
+XPASS error is in GPGWriteFile
 supports
   ssh parmiko
   ssh pexpect
   rsync
-  lftp
   ncftp
   onedrive
   Amazon web services (multi-processing and Glacier)

--- a/10.9-libcxx/stable/main/finkinfo/utils/duplicity.info
+++ b/10.9-libcxx/stable/main/finkinfo/utils/duplicity.info
@@ -1,6 +1,6 @@
 Info2: <<
 Package: duplicity
-Version: 3.0.6.3
+Version: 3.0.7
 Revision: 1
 Description: Encrypted backup using rsync algorithm
 License: GPL
@@ -18,9 +18,11 @@ BuildDepends: <<
 Depends: <<
 	python310,
 	librsync2-shlibs (>= 2.0),
+	librsync-bin (>= 2.0),
 	gnupg2,
 	intltool40,
 	ncftp,
+	lftp,
 	par2,
 	setuptools-tng-py310,
 	boto3-py310,
@@ -30,14 +32,16 @@ Depends: <<
 	pexpect-py310,
 	requests-oauthlib-py310
 <<
-#	lftp,   Removed from dependencies since does not build
 
 # Unpack Phase.
 Source: https://gitlab.com/%n/%n/-/archive/rel.%v/%n-rel.%v.tar.gz
-Source-Checksum: SHA256(57e2ff9f0e3296f26b3d86e6cac23c7b814f99352633fc3cc1775d0dd042bfad)
+Source-Checksum: SHA256(39a7dab3e335f33510759b2f26f56a82e6c8c74a73119b3950b738c902ed7f46)
+PatchFile: %n.patch
+PatchFile-Checksum: SHA256(7ee4a5653a15282fbd301441b3472e07f2271187cd1d3f1188ea5e3841bf40b7)
 
 # Patch Phase.
 PatchScript: <<
+	patch -p1 < %{PatchFile}
 	grep -rl '^\#!.*python' 2> /dev/null | xargs -n1 perl -pi -e 's|/usr/bin/python3$|%p/bin/python3.10|g'
 	grep -rl '^\#!.*python' 2> /dev/null | xargs -n1 perl -pi -e 's|/usr/bin/env python3$|/usr/bin/env %p/bin/python3.10|g'
 	grep -rl 'python3[^\.]' 2> /dev/null | xargs -n1 perl -pi -e 's|\(\["python3"\]\)|\(\["python3.10"\]\)|g'
@@ -59,6 +63,10 @@ InfoTest: <<
     TestScript: <<
     	#!/bin/sh -ev
 	ulimit -n 8192
+	echo $PATH
+	trap "gpg-connect-agent KILLAGENT /bye ; exit" 0 1 2 3 15
+	mkdir "$HOME/.gnupg"
+	gpg-connect-agent /bye
 	%p/bin/pytest-3.10 -p no:xdist -p no:hypothesis -p no:randomly
     <<
 <<

--- a/10.9-libcxx/stable/main/finkinfo/utils/duplicity.patch
+++ b/10.9-libcxx/stable/main/finkinfo/utils/duplicity.patch
@@ -1,0 +1,19 @@
+diff -ruN duplicity-rel.3.0.7-orig/pyproject.toml duplicity-rel.3.0.7/pyproject.toml
+--- duplicity-rel.3.0.7-orig/pyproject.toml	2025-12-31 07:07:54
++++ duplicity-rel.3.0.7/pyproject.toml	2025-12-31 19:10:24
+@@ -26,7 +26,6 @@
+     "Programming Language :: Python :: 3.11",
+     "Programming Language :: Python :: 3.12",
+     "Programming Language :: Python :: 3.13",
+-    "Programming Language :: Python :: 3.14",
+     "Topic :: System :: Archiving :: Backup",
+ ]
+ 
+@@ -98,7 +97,6 @@
+     "py311",
+     "py312",
+     "py313",
+-    "py314",
+ ]
+ 
+ 


### PR DESCRIPTION
Updated to V3.0.7 in conjunction with gnupg2 update so passes all tests but pylint.  pylint is horribly out of date.

Tested on (macOS 15.7.3 / Xcode 26.2 / Intel)