### PR TITLE
Doxygen update to 1.14.0

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/doxygen-1.9.2.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/doxygen-1.9.2.info
@@ -1,0 +1,96 @@
+Info3: <<
+Package: doxygen
+# Don't forget to keep doxygen-doc synced at the same version.
+# upgrading will require patching a few packages. See:
+# https://lists.debian.org/debian-devel/2019/10/msg00260.html
+Version: 1.9.2
+Revision: 1
+# Dist restricted due to C++17
+Distribution: 10.9, 10.10, 10.11, 10.12, 10.13
+Source: mirror:sourceforge:%n/%n-%v.src.tar.gz
+SourceDirectory: %n-%v
+Source-Checksum: SHA256(060f254bcef48673cc7ccf542736b7455b67c110b30fdaa33512a5b09bbecee5)
+Depends: <<
+	libiconv
+<<
+BuildDepends: <<
+	bison (>= 2.7),
+	cmake,
+	fink-buildenv-modules,
+	fink-package-precedence,
+	flex (>= 2.5.37),
+	libiconv-dev
+<<
+PatchFile: %n-%v.patch
+PatchFile-MD5: 0c123481be840e69c30deda23cc794f8
+GCC: 4.0
+CompileScript: <<
+	#!/bin/sh -ev
+	if [ -x /usr/bin/python ]; then
+		export PYTHON=/usr/bin/python
+	else
+		export PYTHON=/usr/bin/python3
+	fi
+	. %p/sbin/fink-buildenv-cmake.sh
+	mkdir finkbuild
+	pushd finkbuild
+		cmake $FINK_CMAKE_ARGS \
+			-DBISON_EXECUTABLE:FILEPATH=%p/bin/bison \
+			-DDOT:FILEPATH=%p/bin/dot \
+			-DFLEX_EXECUTABLE:FILEPATH=%p/bin/flex \
+			-DICONV_INCLUDE_DIR:PATH=%p/include \
+			-DICONV_LIBRARY:FILEPATH=%p/lib/libiconv.dylib \
+			-DPYTHON_EXECUTABLE:FILEPATH=${PYTHON} \
+			-DCMAKE_CXX_FLAGS:STRING=-MD \
+			-Dbuild_doc=OFF \
+			-LAH ..
+		make -w
+	popd
+	fink-package-precedence --depfile-ext='\.d' .
+<<
+InstallScript: <<
+	#!/bin/sh -ev
+	pushd finkbuild
+		make install DESTDIR=%d MAN1DIR=share/man/man1
+	popd
+	install -d -m 755 %i/share/man/man1
+	install -m 644 doc/doxygen.1 %i/share/man/man1
+<<
+DocFiles: LANGUAGE.HOWTO LICENSE README.md VERSION
+Description: Documentation system for C++, Java, IDL and C
+DescDetail: <<
+	Doxygen is a documentation system for C++, Java, IDL and C
+
+	1.  It can generate an on-line documentation browser (in HTML) and/or 
+	an off-line reference manual (in  ) from a set of documented source 
+	files. There is also support for generating output in RTF (MS-Word), 
+	PostScript, hyperlinked PDF, compressed HTML, and Unix man pages. The 
+	documentation is extracted directly from the sources, which makes it 
+	much easier to keep the documentation consistent with the source code.
+
+	2. Doxygen can be configured to extract the code structure from 
+	undocumented source files. This can be very useful to quickly find 
+	your way in large source distributions. The relations between the 
+	various elements are be visualized by means of include dependency 
+	graphs, inheritance diagrams, and collaboration diagrams, which are 
+	all generated automatically.
+
+	Docs are now built and installed by the package doxygen-doc
+<<
+License: GPL
+DescPort: <<
+* Special version 1.9.2 for 10.13 and earlier that doesn't use c++17 (#1180)
+* Bumped to 1.9.8 by Hanspeter to deal with texlive-2021 and ghostscript-10 in docs.
+	* Main build needs bison >= 2.7 (system is 2.3) and flex >= 2.5.37.
+* Bumped to 1.8.14 by Hanspeter to deal with newer macOS (13+).
+* Bumped to 1.8.9.1 by Hanspeter for 10.9-libcxx tree.
+* Bumped by Matthias Neeracher <neeracher@mac.com>, upgraded for 10.7 tree.
+* Modified by Michele Garoche <michele.garoche@easyconnect.fr>
+<<
+DescPackaging: <<
+* doxygen.1 normally installed as part of docs, but we want it in the main package.
+<<
+Maintainer: None <fink-devel@lists.sourceforge.net>
+Homepage: http://www.doxygen.org
+
+<<

--- a/10.9-libcxx/stable/main/finkinfo/devel/doxygen-1.9.2.patch
+++ b/10.9-libcxx/stable/main/finkinfo/devel/doxygen-1.9.2.patch
@@ -1,0 +1,39 @@
+diff -ruN doxygen-1.9.2-orig/CMakeLists.txt doxygen-1.9.2/CMakeLists.txt
+--- doxygen-1.9.2-orig/CMakeLists.txt	2021-05-12 13:44:30
++++ doxygen-1.9.2/CMakeLists.txt	2026-02-13 05:20:25
+@@ -169,13 +169,15 @@
+ include(cmake/CompilerWarnings.cmake)
+ include(cmake/Coverage.cmake)
+ 
+-add_subdirectory(libmd5)
+-add_subdirectory(liblodepng)
+-add_subdirectory(libmscgen)
+-add_subdirectory(libversion)
+-add_subdirectory(libxml)
+-add_subdirectory(vhdlparser)
+-add_subdirectory(src)
++if (NOT build_doc)
++    add_subdirectory(libmd5)
++    add_subdirectory(liblodepng)
++    add_subdirectory(libmscgen)
++    add_subdirectory(libversion)
++    add_subdirectory(libxml)
++    add_subdirectory(vhdlparser)
++    add_subdirectory(src)
++endif ()
+ 
+ if (build_doc_chm)
+     if (WIN32)
+@@ -192,10 +194,12 @@
+     add_subdirectory(doc)
+ endif ()
+ 
++if (NOT build_doc)
+ add_subdirectory(addon)
+ 
+ enable_testing()
+ add_subdirectory(testing)
++endif ()
+ 
+ include(cmake/packaging.cmake) # set CPACK_xxxx properties
+ include(CPack)

--- a/10.9-libcxx/stable/main/finkinfo/devel/doxygen-doc-1.9.2.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/doxygen-doc-1.9.2.info
@@ -1,0 +1,72 @@
+Info3: <<
+Package: doxygen-doc
+# Don't forget to keep doxygen synced at the same version.
+Version: 1.9.2
+Revision: 1
+# Dist restricted due to C++17
+Distribution: 10.9, 10.10, 10.11, 10.12, 10.13
+Source: mirror:sourceforge:doxygen/doxygen-%v.src.tar.gz
+SourceDirectory: doxygen-%v
+Source-Checksum: SHA256(060f254bcef48673cc7ccf542736b7455b67c110b30fdaa33512a5b09bbecee5)
+BuildDepends: <<
+	bison (>= 2.7),
+	cmake,
+	doxygen (>= %v),
+	fink-buildenv-modules,
+	flex (>= 2.5.37),
+	ghostscript (>= 10.02.0-1) | ghostscript-nox (>= 10.02.0-1),
+	graphviz,
+	libiconv-dev,
+	tetex3-base
+<<
+PatchFile: doxygen-%v.patch
+PatchFile-MD5: 0c123481be840e69c30deda23cc794f8
+CompileScript: <<
+	#!/bin/sh -ev
+	. %p/sbin/fink-buildenv-cmake.sh
+	# the binary needs to be in tree during the doc build
+	install -m 0755 -d finkbuild/bin
+	ln -s %p/bin/doxygen ./finkbuild/bin/doxygen
+	# These 2 are needed to avoid "no rule to make target ..."
+	ln -s %p/bin/doxygen ./doc/doxygen
+	ln -s %p/bin/doxygen ./examples/doxygen
+	export PATH=%b/finkbuild/bin:$PATH
+	if [ -x /usr/bin/python ]; then
+		export PYTHON=/usr/bin/python
+	else
+		export PYTHON=/usr/bin/python3
+	fi
+	pushd finkbuild
+	cmake $FINK_CMAKE_ARGS \
+		-DBISON_EXECUTABLE:FILEPATH=%p/bin/bison \
+		-DDOT:FILEPATH=%p/bin/dot \
+		-DFLEX_EXECUTABLE:FILEPATH=%p/bin/flex \
+		-DICONV_INCLUDE_DIR:PATH=%p/include \
+		-DICONV_LIBRARY:FILEPATH=%p/lib/libiconv.dylib \
+		-DPYTHON_EXECUTABLE:FILEPATH=${PYTHON} \
+		-Dbuild_doc=ON \
+		-DDOC_INSTALL_DIR:STRING=share/doc/doxygen \
+		-Ddoxygen_BINARY_DIR=%b/finkbuild \
+		-LAH ..
+	make -w -j1 docs
+	popd
+<<
+InstallScript: <<
+	#!/bin/sh -ev
+	pushd finkbuild/doc
+		make install DESTDIR=%d
+	popd
+	# doxygen.1 already exists in the main doxygen package
+	rm %i/share/man/man1/doxygen.1
+<<
+DocFiles: LANGUAGE.HOWTO LICENSE README.md VERSION
+Description: Doxygen documentation
+DescDetail: <<
+	This package contains the documentation for the Doxygen software. It was
+	split up to reduce the build dependencies of the main doxygen package.
+<<
+License: GPL
+Maintainer: None <fink-devel@lists.sourceforge.net>
+Homepage: http://www.doxygen.org
+
+<<

--- a/10.9-libcxx/stable/main/finkinfo/devel/doxygen-doc.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/doxygen-doc.info
@@ -1,11 +1,12 @@
 Info3: <<
 Package: doxygen-doc
 # Don't forget to keep doxygen synced at the same version.
-Version: 1.9.8
+Version: 1.14.0
 Revision: 1
-Source: ftp://ftp.stack.nl/pub/users/dimitri/doxygen-%v.src.tar.gz
+Distribution: 10.14, 10.14.5, 10.15, 11.0, 11.3, 12.0, 13.0, 14.0, 14.4, 15.0, 26.0
+Source: mirror:sourceforge:doxygen/doxygen-%v.src.tar.gz
 SourceDirectory: doxygen-%v
-Source-Checksum: SHA256(05e3d228e8384b5f3af9c8fd6246d22804acb731a3a24ce285c8986ed7e14f62)
+Source-Checksum: SHA256(d4536d11ab13037327d8d026b75f5a86b7ccb2093e2f546235faf61fd86e6b5d)
 BuildDepends: <<
 	bison (>= 2.7),
 	cmake,
@@ -17,8 +18,9 @@ BuildDepends: <<
 	libiconv-dev,
 	tetex3-base
 <<
+# changes to the patchfile need to be mirrored in doxygen
 PatchFile: doxygen.patch
-PatchFile-MD5: 4a5fc35ee6530b4b5b06fceae64f165f
+PatchFile-MD5: b05a7940276209cbc441f9184b75aa36
 CompileScript: <<
 	#!/bin/sh -ev
 	. %p/sbin/fink-buildenv-cmake.sh
@@ -45,6 +47,12 @@ CompileScript: <<
 		-Dbuild_doc=ON \
 		-DDOC_INSTALL_DIR:STRING=share/doc/doxygen \
 		-Ddoxygen_BINARY_DIR=%b/finkbuild \
+		-DJAVACC_EXECUTABLE=NOT_FOUND \
+		-Dbuild_search=OFF \
+		-Dbuild_parse=OFF \
+		-Duse_sys_spdlog=OFF \
+		-Duse_sys_fmt=OFF \
+		-Duse_sys_sqlite3=OFF \
 		-LAH ..
 	make -w -j1 docs
 	popd

--- a/10.9-libcxx/stable/main/finkinfo/devel/doxygen.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/doxygen.info
@@ -3,11 +3,12 @@ Package: doxygen
 # Don't forget to keep doxygen-doc synced at the same version.
 # upgrading will require patching a few packages. See:
 # https://lists.debian.org/debian-devel/2019/10/msg00260.html
-Version: 1.9.8
-Revision: 2
+Version: 1.14.0
+Revision: 1
+Distribution: 10.14, 10.14.5, 10.15, 11.0, 11.3, 12.0, 13.0, 14.0, 14.4, 15.0, 26.0
 Source: mirror:sourceforge:%n/%n-%v.src.tar.gz
 SourceDirectory: %n-%v
-Source-Checksum: SHA256(05e3d228e8384b5f3af9c8fd6246d22804acb731a3a24ce285c8986ed7e14f62)
+Source-Checksum: SHA256(d4536d11ab13037327d8d026b75f5a86b7ccb2093e2f546235faf61fd86e6b5d)
 Depends: <<
 	libiconv
 <<
@@ -19,8 +20,20 @@ BuildDepends: <<
 	flex (>= 2.5.37),
 	libiconv-dev
 <<
+# too hard to patch to avoid pulling in sys-fmt headers
+BuildConflicts: <<
+	libfmt9-dev,
+	libfmt10-dev,
+	libfmt12-dev
+<<
+# changes to the patchfile need to be mirrored in doxygen-doc
 PatchFile: %n.patch
-PatchFile-MD5: 22ae70a0d74499fea8d7296514d0c8ab
+PatchFile-MD5: b05a7940276209cbc441f9184b75aa36
+PatchScript: <<
+	%{default_script}
+	# don't try to grab our sqlite3 headers. The iconv -I flag is put at the very front during configure
+	perl -pi -e 's|\<sqlite3.h\>|\"../deps/sqlite3/sqlite3.h\"|g' src/doxygen.cpp src/sqlite3gen.cpp
+<<
 GCC: 4.0
 CompileScript: <<
 	#!/bin/sh -ev
@@ -36,10 +49,16 @@ CompileScript: <<
 			-DBISON_EXECUTABLE:FILEPATH=%p/bin/bison \
 			-DDOT:FILEPATH=%p/bin/dot \
 			-DFLEX_EXECUTABLE:FILEPATH=%p/bin/flex \
-			-DICONV_INCLUDE_DIR:PATH=%p/include \
-			-DICONV_LIBRARY:FILEPATH=%p/lib/libiconv.dylib \
+			-DIconv_INCLUDE_DIR:PATH=%p/include \
+			-DIconv_LIBRARY:FILEPATH=%p/lib/libiconv.dylib \
 			-DPYTHON_EXECUTABLE:FILEPATH=${PYTHON} \
 			-DCMAKE_CXX_FLAGS:STRING=-MD \
+			-DJAVACC_EXECUTABLE=NOT_FOUND \
+			-Dbuild_search=OFF \
+			-Dbuild_parse=OFF \
+			-Duse_sys_spdlog=OFF \
+			-Duse_sys_fmt=OFF \
+			-Duse_sys_sqlite3=OFF \
 			-Dbuild_doc=OFF \
 			-LAH ..
 		make -w
@@ -77,6 +96,9 @@ DescDetail: <<
 <<
 License: GPL
 DescPort: <<
+* Bumped to 1.14.1 by Hanspeter
+	* Making cmake find iconv.h pushes -I%p/include to the front of the
+	compile command, which can mask headers from bundled deps.
 * Bumped to 1.9.8 by Hanspeter to deal with texlive-2021 and ghostscript-10 in docs.
 	* Main build needs bison >= 2.7 (system is 2.3) and flex >= 2.5.37.
 * Bumped to 1.8.14 by Hanspeter to deal with newer macOS (13+).

--- a/10.9-libcxx/stable/main/finkinfo/devel/doxygen.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/doxygen.info
@@ -51,7 +51,7 @@ CompileScript: <<
 			-DFLEX_EXECUTABLE:FILEPATH=%p/bin/flex \
 			-DIconv_INCLUDE_DIR:PATH=%p/include \
 			-DIconv_LIBRARY:FILEPATH=%p/lib/libiconv.dylib \
-			-DPYTHON_EXECUTABLE:FILEPATH=${PYTHON} \
+			-DPython_EXECUTABLE:FILEPATH=${PYTHON} \
 			-DCMAKE_CXX_FLAGS:STRING=-MD \
 			-DJAVACC_EXECUTABLE=NOT_FOUND \
 			-Dbuild_search=OFF \

--- a/10.9-libcxx/stable/main/finkinfo/devel/doxygen.patch
+++ b/10.9-libcxx/stable/main/finkinfo/devel/doxygen.patch
@@ -1,7 +1,7 @@
-diff -Nurd doxygen-1.9.8.orig/CMakeLists.txt doxygen-1.9.8/CMakeLists.txt
---- doxygen-1.9.8.orig/CMakeLists.txt	2023-08-16 15:54:32
-+++ doxygen-1.9.8/CMakeLists.txt	2025-08-12 13:30:13
-@@ -203,11 +203,13 @@
+diff -ruN doxygen-1.14.0-orig/CMakeLists.txt doxygen-1.14.0/CMakeLists.txt
+--- doxygen-1.14.0-orig/CMakeLists.txt	2025-05-15 14:16:04
++++ doxygen-1.14.0/CMakeLists.txt	2026-02-11 06:58:52
+@@ -298,11 +298,13 @@
  include(cmake/Coverage.cmake)
  include(cmake/WindowsEncoding.cmake)
  
@@ -11,22 +11,22 @@ diff -Nurd doxygen-1.9.8.orig/CMakeLists.txt doxygen-1.9.8/CMakeLists.txt
 -add_subdirectory(vhdlparser)
 -add_subdirectory(src)
 +if (NOT build_doc)
-+	add_subdirectory(deps)
-+	add_subdirectory(libversion)
-+	add_subdirectory(libxml)
-+	add_subdirectory(vhdlparser)
-+	add_subdirectory(src)
++    add_subdirectory(deps)
++    add_subdirectory(libversion)
++    add_subdirectory(libxml)
++    add_subdirectory(vhdlparser)
++    add_subdirectory(src)
 +endif ()
  
  if (build_doc_chm)
      if (WIN32)
-@@ -225,10 +227,13 @@
- endif ()
- 
- add_subdirectory(doc_internal)
-+
+@@ -327,10 +329,12 @@
+ if (GENERATEDS_FOUND)
+   set(update_doxmlparser_dependency "update_doxmlparser_files")
+ endif()
+-add_subdirectory(addon)
 +if (NOT build_doc)
- add_subdirectory(addon)
++    add_subdirectory(addon)
  
  enable_testing()
  add_subdirectory(testing)
@@ -34,79 +34,23 @@ diff -Nurd doxygen-1.9.8.orig/CMakeLists.txt doxygen-1.9.8/CMakeLists.txt
  
  include(cmake/packaging.cmake) # set CPACK_xxxx properties
  include(CPack)
-diff -Nurd doxygen-1.9.8.orig/deps/TinyDeflate/gunzip.hh doxygen-1.9.8/deps/TinyDeflate/gunzip.hh
---- doxygen-1.9.8.orig/deps/TinyDeflate/gunzip.hh	2023-01-05 09:20:06
-+++ doxygen-1.9.8/deps/TinyDeflate/gunzip.hh	2025-08-12 13:25:33
-@@ -702,7 +702,7 @@
-                     // Note: Throws away progress already made traversing the tree
-                     return ~std::uint_least32_t(0); // error flag
-                 }
--                cur = (unsigned(cur) << 1) | unsigned(bool(p));
-+                cur = (unsigned(cur) << 1) | bool(p);
-             #ifdef DEFL_DO_HUFF_STATS
-                 if(len > maxlen)
-                 {
-@@ -944,27 +944,23 @@
+diff -ruN doxygen-1.14.0-orig/src/portable_c.c doxygen-1.14.0/src/portable_c.c
+--- doxygen-1.14.0-orig/src/portable_c.c	2022-08-11 15:14:32
++++ doxygen-1.14.0/src/portable_c.c	2026-02-11 06:56:19
+@@ -1,13 +1,13 @@
+-#if (defined(__APPLE__) || defined(macintosh)) && !defined(DMG_BUILD)
++//#if (defined(__APPLE__) || defined(macintosh)) && !defined(DMG_BUILD)
+ #include <AvailabilityMacros.h>
+ // this hack doesn't seem to be needed on El Captain (10.11)
+ #if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_11
+ // define this before including iconv.h to avoid a mapping of
+ // iconv_open and friends to libicon_open (done by mac ports),
+ // while the symbols without 'lib' are linked from /usr/lib/libiconv
+-#define LIBICONV_PLUG
++//#define LIBICONV_PLUG
+ #endif
+-#endif
++//#endif
+ #include <iconv.h>
  
-         // The following routines are macros rather than e.g. lambda functions,
-         // in order to make them inlined in the function structure, and breakable/resumable.
--	#define CONCAT(a, b) a##b
- 
-         // Bit-by-bit input routine
--        #define DummyGetBits_(line,numbits) do { \
--            auto CONCAT(pd,line) = state.template GetBits<bool(Abortable&Flag_InputAbortable)>(std::forward<InputFunctor>(input), numbits); \
--            if((Abortable & Flag_InputAbortable) && !~CONCAT(pd,line)) return -2; \
-+        #define DummyGetBits(numbits) do { \
-+            auto p = state.template GetBits<bool(Abortable&Flag_InputAbortable)>(std::forward<InputFunctor>(input), numbits); \
-+            if((Abortable & Flag_InputAbortable) && !~p) return -2; \
-         } while(0)
--        #define DummyGetBits(numbits) DummyGetBits_(__LINE__, numbits)
- 
--        #define GetBits_(line,numbits, target) \
--            auto CONCAT(pb,line) = state.template GetBits<bool(Abortable&Flag_InputAbortable)>(std::forward<InputFunctor>(input), numbits); \
--            if((Abortable & Flag_InputAbortable) && !~CONCAT(pb,line)) return -2; \
--            target = CONCAT(pb,line)
--        #define GetBits(numbits, target) GetBits_(__LINE__, numbits, target)
-+        #define GetBits(numbits, target) \
-+            auto p = state.template GetBits<bool(Abortable&Flag_InputAbortable)>(std::forward<InputFunctor>(input), numbits); \
-+            if((Abortable & Flag_InputAbortable) && !~p) return -2; \
-+            target = p
- 
-         // Huffman tree read routine.
--        #define HuffRead_(line, tree, target) \
--            auto CONCAT(ph,line) = state.template HuffRead<bool(Abortable&Flag_InputAbortable)>(std::forward<InputFunctor>(input), tree); \
--            if((Abortable & Flag_InputAbortable) && !~CONCAT(ph,line)) return -2; \
--            target = CONCAT(ph,line)
--        #define HuffRead(tree, target) HuffRead_(__LINE__, tree, target)
-+        #define HuffRead(tree, target) \
-+            auto p = state.template HuffRead<bool(Abortable&Flag_InputAbortable)>(std::forward<InputFunctor>(input), tree); \
-+            if((Abortable & Flag_InputAbortable) && !~p) return -2; \
-+            target = p
- 
-         #define Fail_If(condition) do { \
-             /*assert(!(condition));*/ \
-@@ -1141,21 +1137,21 @@
-             //fprintf(stderr, "both track flag\n");
-             SizeTracker<DeflateTrackBothSize> tracker;
-             return tracker(Gunzip<code & Flag_NoTrackFlagMask>
--                (tracker.template ForwardInput(i), tracker.template ForwardOutput(o), tracker.template ForwardWindow(c), std::forward<B>(b)));
-+                (tracker.template ForwardInput<I>(i), tracker.template ForwardOutput<O>(o), tracker.template ForwardWindow<C>(c), std::forward<B>(b)));
-         }
-         else if constexpr(code & Flag_TrackIn)
-         {
-             //fprintf(stderr, "in track flag\n");
-             SizeTracker<DeflateTrackInSize> tracker;
-             return tracker(Gunzip<code & Flag_NoTrackFlagMask>
--                (tracker.template ForwardInput(i),std::forward<O>(o),std::forward<C>(c),std::forward<B>(b)));
-+                (tracker.template ForwardInput<I>(i),std::forward<O>(o),std::forward<C>(c),std::forward<B>(b)));
-         }
-         else if constexpr(code & Flag_TrackOut)
-         {
-             //fprintf(stderr, "out track flag\n");
-             SizeTracker<DeflateTrackOutSize> tracker;
-             return tracker(Gunzip<code & Flag_NoTrackFlagMask>
--                (std::forward<I>(i), tracker.template ForwardOutput(o), tracker.template ForwardWindow(c), std::forward<B>(b)));
-+                (std::forward<I>(i), tracker.template ForwardOutput<O>(o), tracker.template ForwardWindow<C>(c), std::forward<B>(b)));
-         }
-         else
-         {
+ // These functions are implemented in a C file, because there are different

--- a/10.9-libcxx/stable/main/finkinfo/devel/libfmt10-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/libfmt10-shlibs.info
@@ -1,5 +1,5 @@
-Package: libfmt12-shlibs
-Version: 12.1.0
+Package: libfmt10-shlibs
+Version: 10.2.1
 Revision: 1
 Description: Formatting library
 License: BSD
@@ -10,7 +10,7 @@ BuildDepends: <<
 <<
 Source: https://github.com/fmtlib/fmt/archive/refs/tags/%v.tar.gz
 SourceRename: fmt-%v.tar.gz
-Source-Checksum: SHA256(ea7de4299689e12b6dddd392f9896f08fb0777ac7168897a244a6d6085043fea)
+Source-Checksum: SHA256(1250e4cc58bf06ee631567523f48848dc4596133e163f02615c97f78bab6c811)
 GCC: 4.0
 CompileScript: <<
 	#!/bin/sh -ev
@@ -29,9 +29,9 @@ InfoTest: <<
 InstallScript: <<
 	cd finkbuild; make install DESTDIR=%d
 <<
-Shlibs: %p/lib/libfmt.12.dylib 12.0.0 %n (>= 12.1.0-1)
+Shlibs: %p/lib/libfmt.10.dylib 10.0.0 %n (>= 10.2.1-1)
 SplitOff: <<
-	Package: libfmt12-dev
+	Package: libfmt10-dev
 	Description: Formatting library (dev)
 	Depends: <<
 		%N (= %v-%r)

--- a/10.9-libcxx/stable/main/finkinfo/devel/libfmt12-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/libfmt12-shlibs.info
@@ -1,6 +1,6 @@
-Package: libfmt9-shlibs
-Version: 9.1.0
-Revision: 2
+Package: libfmt12-shlibs
+Version: 12.1.0
+Revision: 1
 Description: Formatting library
 License: BSD
 Maintainer: None <fink-devel@lists.sourceforge.net>
@@ -10,7 +10,7 @@ BuildDepends: <<
 <<
 Source: https://github.com/fmtlib/fmt/archive/refs/tags/%v.tar.gz
 SourceRename: fmt-%v.tar.gz
-Source-Checksum: SHA256(5dea48d1fcddc3ec571ce2058e13910a0d4a6bab4cc09a809d8b1dd1c88ae6f2)
+Source-Checksum: SHA256(ea7de4299689e12b6dddd392f9896f08fb0777ac7168897a244a6d6085043fea)
 GCC: 4.0
 CompileScript: <<
 	#!/bin/sh -ev
@@ -29,9 +29,9 @@ InfoTest: <<
 InstallScript: <<
 	cd finkbuild; make install DESTDIR=%d
 <<
-Shlibs: %p/lib/libfmt.9.dylib 9.0.0 %n (>= 9.1.0-1)
+Shlibs: %p/lib/libfmt.12.dylib 12.0.0 %n (>= 12.1.0-1)
 SplitOff: <<
-	Package: libfmt9-dev
+	Package: libfmt12-dev
 	Description: Formatting library (dev)
 	Depends: <<
 		%N (= %v-%r)
@@ -53,9 +53,9 @@ SplitOff: <<
 		lib/cmake
 		lib/libfmt.dylib
 	<<
-	DocFiles: CONTRIBUTING.md ChangeLog.rst LICENSE.rst README.rst
+	DocFiles: CONTRIBUTING.md ChangeLog.md LICENSE README.md
 <<
-DocFiles: CONTRIBUTING.md ChangeLog.rst LICENSE.rst README.rst
+DocFiles: CONTRIBUTING.md ChangeLog.md LICENSE README.md
 Homepage: https://github.com/fmtlib/fmt
 DescDetail: <<
 {fmt} is an open-source formatting library providing a fast and safe

--- a/10.9-libcxx/stable/main/finkinfo/devel/libfmt9-shlibs.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/libfmt9-shlibs.info
@@ -38,11 +38,13 @@ SplitOff: <<
 	<<
 	Conflicts: <<
 		libfmt9-dev,
+		libfmt10-dev,
 		libfmt12-dev,
 		libfmt15-dev
 	<<
 	Replaces: <<
 		libfmt9-dev,
+		libfmt10-dev,
 		libfmt12-dev,
 		libfmt15-dev
 	<<


### PR DESCRIPTION
Updates doxygen to v1.14.0 for macOS 10.14 and above.
For 10.13 and below, new doxygen 1.9.2 is made available since it's the last release that uses c++14.

* Current 1.9.8 doesn't build on 10.12 because of C++17, so this gives them something that works (closes #1180)
* Current 1.9.8 fails with Xcode 16.3, #1247, so hopefully this fixes that since upstream fix doxygen/doxygen#11537 is in 1.14.0.

@dmacks @htodd @dak180 
I tested both releases on 13.7, but can't test on 10.12 or 14+