### PR TITLE
Maven update version to 3.9.16, reordered PatchFile lines

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/devel/maven.info
+++ b/10.9-libcxx/stable/main/finkinfo/devel/maven.info
@@ -1,5 +1,5 @@
 Package: maven
-Version: 3.8.4
+Version: 3.9.16
 Revision: 1
 Description: Software project management tool
 Type: java(1.7)
@@ -10,11 +10,12 @@ Depends: system-java (>= 1.7-1)
 BuildDepends: fink (>= 0.37)
 
 Source: mirror:apache:%n/maven-3/%v/binaries/apache-%n-%v-bin.tar.gz
-Source-Checksum: SHA256(2cdc9c519427bb20fdc25bef5a9063b790e4abd930e7b14b4e9f4863d6f9f13c)
+Source-Checksum: SHA256(80ffca22aed9e8b9713a232f3394fd81d7f20322df75efdb2b047dbd3e3a23bb)
 SourceDirectory: apache-%n-%v
-PatchScript: sed -e 's,@FINKPREFIX@,%p,g' < %{PatchFile} | patch -p1
 PatchFile: %n.patch
 PatchFile-MD5: c0e3f414adea4341b22df1b0b10c8047
+
+PatchScript: sed -e 's,@FINKPREFIX@,%p,g' < %{PatchFile} | patch -p1
 
 CompileScript: echo "none needed"
 


### PR DESCRIPTION
Tried to build, but source was missing, updated to current version (2.9.16) and hash.  Passed building with -m option on MacOS 26.4.1/Intel system with no other changes.  Don't see any issues with other system versions as long as Java version is installed?  Added @RangerRick as maintainer to review PR.

Moved the patch file definition and hash to before the patch operation.
