### PR TITLE
jupyter-client-py update for use with newer Python

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/jupyter-client-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/jupyter-client-py.info
@@ -31,7 +31,7 @@ Distribution: <<
 <<
 Maintainer: None <fink-devel@lists.sourceforge.net>
 License: BSD
-Type: python (2.7 3.4 3.5 3.6)
+Type: python (2.7 3.4 3.5 3.6 3.7 3.8 3.9 3.10)
 Homepage: https://pypi.org/project/jupyter-client/
 
 Source: https://files.pythonhosted.org/packages/source/j/jupyter_client/jupyter_client-%v.tar.gz


### PR DESCRIPTION
Updated list of python versions for compatibility with Python 3.10.  Passes validation and any testing with fink -m.  Did not update library version.