### PR TITLE
b2sdk-py new package for BackBlaze cloud storage

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/b2sdk-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/b2sdk-py.info
@@ -1,0 +1,88 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info4: <<
+
+Package: b2sdk-py%type_pkg[python]
+Type: python (3.10)
+
+Version: 2.12.0
+Revision: 1
+Description: Client library, utilities to access B2 Cloud
+DescDetail: <<
+A client library and a few handy utilities for easy access to all
+of the capabilities of B2 Cloud Storage.
+B2 command-line tool is an example of how it can be used to provide
+command-line access to the B2 service, but there are many possible
+applications (including FUSE filesystems, storage backend drivers
+for backup applications etc).
+<<
+Source: https://files.pythonhosted.org/packages/source/b/b2sdk/b2sdk-%v.tar.gz
+Source-Checksum: SHA256(da7b65e1af4f59c7de7d079c1e25de6b033aa45090fded4caefe52ded9b13ee6)
+
+#	logfury-py%type_pkg[python] (>=1.0.1),
+Depends: <<
+	python%type_pkg[python],
+	annotated-types-py%type_pkg[python] (>=0.5.0),
+	requests-py%type_pkg[python] (>=2.33.0),
+	typing-extensions-py%type_pkg[python] (>=4.7.1)
+<<
+
+BuildDepends: <<
+        bootstrap-modules-py%type_pkg[python],
+        setuptools-tng-py%type_pkg[python]
+<<
+
+CompileScript: <<
+    PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m build --wheel --no-isolation --skip-dependency-check
+<<
+
+
+#InfoTest: <<
+# needs newer pytest than currently available
+#TestDepends: <<
+#    pytest-py%type_pkg[python],
+#    coverage-py%type_pkg[python] (>=7.13.5,<8),
+#    pytest (9.0.3,<10),
+#    pytest-cov-py%type_pkg[python] (>=7.1.0,<8),
+#    pytest-mock-py%type_pkg[python] (>=3.15.1,<4),
+#    pytest-lazy-fixtures-py%type_pkg[python] (>=1.4.0,<2),
+#    pytest-xdist-py%type_pkg[python] (>=3.8.0,<4),
+#    pytest-timeout-py%type_pkg[python] (>=2.4.0,<3),
+#    pytest-watcher-py%type_pkg[python] (>=0.6.3,<1),
+#    tenacity-py%type_pkg[python] (>=9.1.4,<10),
+#    tqdm-py%type_pkg[python] (<5.0.0,>=4.5.0),
+#    pydantic-py%type_pkg[python] (>=2.0.1,<2.13),
+#    responses-py%type_pkg[python] (>=0.26.0,<1",
+#<<
+#  TestScript: <<
+#    #!/bin/bash -ev
+#    %p/bin/pytest-%type_raw[python] || exit 1
+#  <<
+#<<
+
+InstallScript: <<
+        #!/bin/sh -ev
+        export LC_ALL=en_US.UTF-8
+        PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m installer --destdir %d dist/*.whl
+        for i in  ; do
+                mv %i/bin/$i %i/bin/$i-py%type_pkg[python]
+        done
+<<
+
+PostInstScript: <<
+  update-alternatives --install %p/bin/isort isort %p/bin/isort-py%type_pkg[python] %type_pkg[python]
+<<
+
+PreRmScript: <<
+  if [ $1 != "upgrade" ]
+  then
+    update-alternatives --remove isort %p/bin/isort-py%type_pkg[python]
+  fi
+<<
+
+DocFiles: LICENSE PKG-INFO README.md
+License: OSI-Approved
+Homepage: https://github.com/timothycrosley/isort
+Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
+
+# Info4
+<<


### PR DESCRIPTION
BackBlaze Software Development kit for connecting python to Backblaze storage.  Needed for "duplicity" backend.   Passes fink -m tests.