### PR TITLE
cachetools-py new package

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/cachetools-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/cachetools-py.info
@@ -1,0 +1,47 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info4: <<
+Package: cachetools-py%type_pkg[python]
+Version: 5.5.2
+Revision: 2
+Type: python (3.7 3.8 3.9 3.10)
+Description: Provides memoizing collections and decorators
+License: BSD
+Homepage: https://pypi.org/project/cachetools
+Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
+
+Source: https://files.pythonhosted.org/packages/source/c/cachetools/cachetools-%v.tar.gz
+Source-Checksum: SHA256(1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4)
+
+Depends: <<
+	python%type_pkg[python],
+	types-cachetools-py%type_pkg[python]
+<<
+BuildDepends: <<
+	bootstrap-modules-py%type_pkg[python],
+	setuptools-tng-py%type_pkg[python]
+<<
+
+CompileScript: <<
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m build --wheel --no-isolation --skip-dependency-check
+<<
+
+InfoTest: <<
+	TestDepends: <<
+		pytest-py%type_pkg[python] (>= 4.3.0)
+	<<
+	TestScript: <<
+		PYTHONPATH=%b/src %p/bin/python%type_raw[python] -m pytest -vv || exit 2
+	<<
+<<
+
+InstallScript: <<
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m installer --destdir %d dist/*.whl
+<<
+DocFiles: CHANGELOG.rst LICENSE PKG-INFO README.rst
+DescDetail: <<
+This module provides various memoizing collections
+and decorators, including variants of the Python
+Standard Library's @lru_cache function decorator.
+<<
+#Info4
+<<

--- a/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/types-cachetools-py.info
+++ b/10.9-libcxx/stable/main/finkinfo/libs/pythonmods/types-cachetools-py.info
@@ -1,0 +1,37 @@
+# -*- coding: ascii; tab-width: 4 -*-
+Info4: <<
+Package: types-cachetools-py%type_pkg[python]
+Version: 5.5.0
+Revision: 1
+Type: python (3.7 3.8 3.9 3.10)
+Description: Typing stubs for cachetools
+License: BSD
+Homepage: https://pypi.org/project/types-cachetools
+Maintainer: Scott Hannahs <shannahs@users.sourceforge.net>
+
+Source: https://files.pythonhosted.org/packages/source/t/types-cachetools/types-cachetools-%v.20240820.tar.gz
+Source-Checksum: SHA256(b888ab5c1a48116f7799cd5004b18474cd82b5463acb5ffb2db2fc9c7b053bc0)
+
+Depends: <<
+	python%type_pkg[python]
+<<
+BuildDepends: <<
+	bootstrap-modules-py%type_pkg[python],
+	setuptools-tng-py%type_pkg[python]
+<<
+
+CompileScript: <<
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m build --wheel --no-isolation --skip-dependency-check
+<<
+
+InstallScript: <<
+	PYTHONPATH=%p/share/bootstrap-modules-python%type_pkg[python] %p/bin/python%type_raw[python] -m installer --destdir %d dist/*.whl
+<<
+DocFiles: CHANGELOG.md
+DescDetail: <<
+This module provides various memoizing collections
+and decorators, including variants of the Python
+Standard Library's @lru_cache function decorator.
+<<
+#Info4
+<<


### PR DESCRIPTION
cachetools-py new package to support duplicity.  Passes fink -m testing.