### PR TITLE
curl4 upstream update.  

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/net/libcurl4.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/libcurl4.info
@@ -1,5 +1,5 @@
 Package: libcurl4
-Version: 8.20.0
+Version: 8.21.0
 Revision: 1
 Description: Lib. for transferring files with URL syntax
 DescDetail: <<
@@ -34,7 +34,7 @@ Homepage: http://curl.se/
 License: BSD
 
 Source: https://curl.se/download/curl-%v.tar.xz
-Source-Checksum: SHA256(63fe2dc148ba0ceae89922ef838f7e5c946272c2e78b7c59fab4b79d3ce2b896)
+Source-Checksum: SHA256(aa1b66a70eace83dc624508745646c08ae561de512ab403adffb93ac87fc72e6)
 
 Depends: %N-shlibs (= %v-%r)
 BuildDepends: <<


### PR DESCRIPTION
No changes to build so should work on OS versions.   Builds with -m options and passes tests.  Should satisfy user request for Medium severity security patches.