### PR TITLE
telnet: allow building on newer Xcodes (>15?) 

### DIFF
--- a/10.9-libcxx/stable/main/finkinfo/net/telnet.info
+++ b/10.9-libcxx/stable/main/finkinfo/net/telnet.info
@@ -1,7 +1,7 @@
 Package: telnet
 Version: 60
-Revision: 1
-Distribution: 10.13, 10.14, 10.14.5, 10.15, 11.0
+Revision: 2
+Distribution: 10.13, 10.14, 10.14.5, 10.15, 11.0, 11.3, 12.0, 13.0, 14.0, 14.4, 15.0, 26.0
 BuildDepends: xcode.app
 Source: https://github.com/apple-opensource/remote_cmds/archive/refs/tags/%v.tar.gz
 SourceRename: remote_cmds-%v.tar.gz
@@ -10,15 +10,18 @@ Source2: https://github.com/apple-opensource/libtelnet/archive/refs/tags/13.tar.
 Source2Rename: libtelnet-13.tar.gz
 Source2-Checksum: SHA256(4e3c12534ce160fa580f02b9563522f6d73c7a84c30d794a7a7edf50b449c4b0)
 SourceDirectory: remote_cmds-%v/telnet.tproj
+PatchFile: %n.patch
+PatchFile-MD5: a99a867fa0eeb7044141c9331e39f010
 PatchScript: <<
 #!/bin/sh -ev
 perl -pi -e "s|-DFORWARD |-DFORWARD -I.|g" Makefile
-perl -pi -e "s|-ltelnet|../../libtelnet-13/build/Release/libtelnet.a|g" Makefile
+perl -pi -e "s|-ltelnet|../Build/Products/Release/libtelnet.a|g" Makefile
 ln -s ../../libtelnet-13 libtelnet
 perl -pi -e "s|ARCHS_STANDARD_32_64_BIT|ARCHS_STANDARD|g" libtelnet/libtelnet.xcodeproj/project.pbxproj
-echo "RC_ARCHS = x86_64" >> Makefile
+echo "RC_ARCHS = %m" >> Makefile
 cp ../APPLE_LICENSE APPLE_LICENSE
 cp ../../libtelnet-13/LICENSE LICENSE
+patch -p2 < %{PatchFile}
 <<
 CompileScript: <<
 #!/bin/sh -ev
@@ -41,14 +44,14 @@ mkdir -p ../finkbuild/%n
  # Don't use new Xcode build system with Xcode10+
 if [[ $xcodevers -ge 10 ]]; then
     export SDKROOT=`xcrun --show-sdk-path`
-    XCODE_BUILD_FLAG="-UseNewBuildSystem=no"
+    XCODE_BUILD_FLAG="-scheme libtelnet -derivedDataPath `dirname %b` -UseNewBuildSystem=no"
     export MACOSX_DEPLOYMENT_TARGET=`xcrun --show-sdk-version`
 fi
 cd ../../libtelnet-13
-xcodebuild $XCODE_BUILD_FLAG -project libtelnet.xcodeproj -alltargets -configuration Release
+xcodebuild $XCODE_BUILD_FLAG -project libtelnet.xcodeproj -configuration Release
 cd ../remote_cmds-%v/telnet.tproj
 # Doesn't build with Fink's make
-  /usr/bin/make \
+  /usr/bin/make -w \
   SRCROOT=../finkbuild/%n/Sources \
   OBJROOT=../finkbuild/%n/Build \
   SYMROOT=../finkbuild/%n/Debug \

--- a/10.9-libcxx/stable/main/finkinfo/net/telnet.patch
+++ b/10.9-libcxx/stable/main/finkinfo/net/telnet.patch
@@ -1,0 +1,22 @@
+diff -ruN remote_cmds-60-orig/telnet.tproj/commands.c remote_cmds-60/telnet.tproj/commands.c
+--- remote_cmds-60-orig/telnet.tproj/commands.c	2026-08-17 21:16:59
++++ remote_cmds-60/telnet.tproj/commands.c	2026-08-17 21:18:46
+@@ -430,8 +430,7 @@
+ }
+ 
+ static int
+-send_dontcmd(name)
+-    char *name;
++send_dontcmd(char *name)
+ {
+     return(send_tncmd(send_dont, "dont", name));
+ }
+@@ -1356,7 +1355,7 @@
+     setcommandmode();
+ 
+     err_ = (TerminalWindowSize(&oldrows, &oldcols) == 0) ? 1 : 0;
+-    switch(vfork()) {
++    switch(fork()) {
+     case -1:
+ 	perror("Fork failed\n");
+ 	break;


### PR DESCRIPTION
by using -derivedDataPath flag for xcodebuild.

This keeps the build process from trying to write to HOME=/var/empty See #1115
Closes #1296